### PR TITLE
refactor(linter): split entry points for custom plugins/config/types

### DIFF
--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -9,7 +9,8 @@ import type {
   LanguageOptions,
   ParserOptions,
 } from "../rule_tester.ts";
-import type { Rule, RuleTester as RuleTesterType } from "#oxlint";
+import type { RuleTester as RuleTesterType } from "#oxlint/rule-tester";
+import type { Rule } from "#oxlint/plugin";
 
 type Config = RuleTesterType.Config;
 

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -4,11 +4,11 @@
 
 // @ts-expect-error - internal module of ESLint with no types
 import eslintGlobals from "../submodules/eslint/conf/globals.js";
-import { RuleTester } from "#oxlint";
+import { RuleTester } from "#oxlint/rule-tester";
 import { describe, it, setCurrentTest } from "./capture.ts";
 import { SHOULD_SKIP_CODE } from "./filter.ts";
 
-import type { Rule } from "#oxlint";
+import type { Rule } from "#oxlint/plugin";
 import type { ParserDetails } from "./index.ts";
 import type {
   LanguageOptionsInternal,

--- a/apps/oxlint/conformance/tester.ts
+++ b/apps/oxlint/conformance/tester.ts
@@ -15,7 +15,7 @@ import { RuleTester as ESLintRuleTester } from "eslint";
 import { builtinRules } from "./submodules/eslint/lib/unsupported-api.js";
 import tsEslintParser from "@typescript-eslint/parser";
 
-import type { Rule } from "#oxlint";
+import type { Rule } from "#oxlint/plugin";
 import type { ValidTestCase, InvalidTestCase } from "./src/rule_tester.ts";
 
 type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & { code?: string };

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -7,7 +7,23 @@
   "type": "module",
   "main": "dist/index.js",
   "imports": {
-    "#oxlint": "./dist/index.js"
+    "#oxlint": "./dist/index.js",
+    "#oxlint/plugin": "./dist/plugin.js",
+    "#oxlint/rule-tester": "./dist/rule-tester.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    },
+    "./rule-tester": {
+      "types": "./dist/rule-tester.d.ts",
+      "default": "./dist/rule-tester.js"
+    }
   },
   "scripts": {
     "build": "pnpm run build-napi-release && pnpm run build-js",

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,60 +1,17 @@
-// Functions and classes
-export { definePlugin, defineRule } from "./package/define.ts";
-export { RuleTester } from "./package/rule_tester.ts";
+import { definePlugin as _definePlugin, defineRule as _defineRule } from "./package/define.ts";
+import { RuleTester as _RuleTester } from "./package/rule_tester.ts";
 
-// ESTree types
-export type * as ESTree from "./generated/types.d.ts";
+/**
+ * @deprecated Import from `oxlint/plugin` instead
+ */
+export const definePlugin = _definePlugin;
 
-// Plugin types
-export type { Context, LanguageOptions } from "./plugins/context.ts";
-export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
-export type { Globals, Envs } from "./plugins/globals.ts";
-export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
-export type { Options, RuleOptionsSchema } from "./plugins/options.ts";
-export type { Diagnostic, DiagnosticData, Suggestion } from "./plugins/report.ts";
-export type {
-  Definition,
-  DefinitionType,
-  Reference,
-  Scope,
-  ScopeManager,
-  ScopeType,
-  Variable,
-} from "./plugins/scope.ts";
-export type { Settings } from "./plugins/settings.ts";
-export type { SourceCode } from "./plugins/source_code.ts";
-export type {
-  CountOptions,
-  FilterFn,
-  RangeOptions,
-  SkipOptions,
-  Token,
-  BooleanToken,
-  IdentifierToken,
-  JSXIdentifierToken,
-  JSXTextToken,
-  KeywordToken,
-  NullToken,
-  NumericToken,
-  PrivateIdentifierToken,
-  PunctuatorToken,
-  RegularExpressionToken,
-  StringToken,
-  TemplateToken,
-} from "./plugins/tokens.ts";
-export type {
-  RuleMeta,
-  RuleDocs,
-  RuleDeprecatedInfo,
-  RuleReplacedByInfo,
-  RuleReplacedByExternalSpecifier,
-} from "./plugins/rule_meta.ts";
-export type { LineColumn, Location, Range, Ranged, Span } from "./plugins/location.ts";
-export type {
-  AfterHook,
-  BeforeHook,
-  Comment,
-  Node,
-  Visitor,
-  VisitorWithHooks,
-} from "./plugins/types.ts";
+/**
+ * @deprecated Import from `oxlint/plugin` instead
+ */
+export const defineRule = _defineRule;
+
+/**
+ * @deprecated Import from `oxlint/rule-tester` instead
+ */
+export const RuleTester = _RuleTester;

--- a/apps/oxlint/src-js/plugin.ts
+++ b/apps/oxlint/src-js/plugin.ts
@@ -1,0 +1,59 @@
+// Entry point for definePlugin and defineRule
+export { definePlugin, defineRule } from "./package/define.ts";
+
+// ESTree types
+export type * as ESTree from "./generated/types.d.ts";
+
+// Plugin types
+export type { Context, LanguageOptions } from "./plugins/context.ts";
+export type { Fix, Fixer, FixFn } from "./plugins/fix.ts";
+export type { Globals, Envs } from "./plugins/globals.ts";
+export type { CreateOnceRule, CreateRule, Plugin, Rule } from "./plugins/load.ts";
+export type { Options, RuleOptionsSchema } from "./plugins/options.ts";
+export type { Diagnostic, DiagnosticData, Suggestion } from "./plugins/report.ts";
+export type {
+  Definition,
+  DefinitionType,
+  Reference,
+  Scope,
+  ScopeManager,
+  ScopeType,
+  Variable,
+} from "./plugins/scope.ts";
+export type { Settings } from "./plugins/settings.ts";
+export type { SourceCode } from "./plugins/source_code.ts";
+export type {
+  CountOptions,
+  FilterFn,
+  RangeOptions,
+  SkipOptions,
+  Token,
+  BooleanToken,
+  IdentifierToken,
+  JSXIdentifierToken,
+  JSXTextToken,
+  KeywordToken,
+  NullToken,
+  NumericToken,
+  PrivateIdentifierToken,
+  PunctuatorToken,
+  RegularExpressionToken,
+  StringToken,
+  TemplateToken,
+} from "./plugins/tokens.ts";
+export type {
+  RuleMeta,
+  RuleDocs,
+  RuleDeprecatedInfo,
+  RuleReplacedByInfo,
+  RuleReplacedByExternalSpecifier,
+} from "./plugins/rule_meta.ts";
+export type { LineColumn, Location, Range, Ranged, Span } from "./plugins/location.ts";
+export type {
+  AfterHook,
+  BeforeHook,
+  Comment,
+  Node,
+  Visitor,
+  VisitorWithHooks,
+} from "./plugins/types.ts";

--- a/apps/oxlint/src-js/rule-tester.ts
+++ b/apps/oxlint/src-js/rule-tester.ts
@@ -1,0 +1,1 @@
+export { RuleTester } from "./package/rule_tester.ts";

--- a/apps/oxlint/test/fixtures/basic/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_many_files/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_many_files/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_no_errors/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_no_errors/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_warn_severity/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/bom/plugin.ts
+++ b/apps/oxlint/test/fixtures/bom/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/cfg/plugin.ts
+++ b/apps/oxlint/test/fixtures/cfg/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule, ESTree } from "#oxlint";
+import type { Plugin, Rule, ESTree } from "#oxlint/plugin";
 
 type Node = ESTree.Node;
 

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Comment, Plugin, Rule } from "#oxlint";
+import type { Comment, Plugin, Rule } from "#oxlint/plugin";
 
 function formatComments(comments: Comment[]): string {
   let text = `${comments.length} comment${comments.length === 1 ? "" : "s"}`;

--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint";
+import type { Node, Plugin, Rule } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule, Context, Diagnostic, Node } from "#oxlint";
+import type { Plugin, Rule, Context, Diagnostic, Node } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint";
+import type { Node, Plugin, Rule } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -1,6 +1,6 @@
-import { definePlugin } from "#oxlint";
+import { definePlugin } from "#oxlint/plugin";
 
-import type { Node, Rule } from "#oxlint";
+import type { Node, Rule } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/plugin.ts
@@ -1,6 +1,6 @@
-import { definePlugin, defineRule } from "#oxlint";
+import { definePlugin, defineRule } from "#oxlint/plugin";
 
-import type { Node } from "#oxlint";
+import type { Node } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -1,6 +1,6 @@
-import { defineRule } from "#oxlint";
+import { defineRule } from "#oxlint/plugin";
 
-import type { Node } from "#oxlint";
+import type { Node } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/disable_directives/plugin.ts
+++ b/apps/oxlint/test/fixtures/disable_directives/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert";
 
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/fixes/plugin.ts
+++ b/apps/oxlint/test/fixtures/fixes/plugin.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, Node, Plugin } from "#oxlint";
+import type { Diagnostic, Node, Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/getNodeByRangeIndex/plugin.ts
+++ b/apps/oxlint/test/fixtures/getNodeByRangeIndex/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/globals/plugin.ts
+++ b/apps/oxlint/test/fixtures/globals/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin } from "#oxlint";
+import type { Node, Plugin } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule, Node } from "#oxlint";
+import type { Plugin, Rule, Node } from "#oxlint/plugin";
 
 const testRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/languageOptions/plugin.ts
+++ b/apps/oxlint/test/fixtures/languageOptions/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Node } from "#oxlint";
+import type { Plugin, Node } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/lint_after_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_after_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_before_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_before_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_createOnce_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_createOnce_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_create_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_create_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_fix_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_fix_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_visit_cfg_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_visit_cfg_error/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule, ESTree } from "#oxlint";
+import type { Plugin, Rule, ESTree } from "#oxlint/plugin";
 
 type Node = ESTree.Node;
 

--- a/apps/oxlint/test/fixtures/lint_visit_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_visit_error/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 // Aim of this test is:
 //

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
@@ -1,6 +1,6 @@
 "use strict";
 
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const MESSAGE_ID_ERROR = "no-var/error";
 const messages = {

--- a/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/nested_config/plugin.ts
+++ b/apps/oxlint/test/fixtures/nested_config/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/plugin.ts
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin } from "#oxlint";
+import type { Node, Plugin } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/options_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/options_invalid/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/overrides/plugin.ts
+++ b/apps/oxlint/test/fixtures/overrides/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/overrides_missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/overrides_missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parent/plugin.ts
+++ b/apps/oxlint/test/fixtures/parent/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Node } from "#oxlint";
+import type { Plugin, Node } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/plugin_name/plugins/jsdoc.ts
+++ b/apps/oxlint/test/fixtures/plugin_name/plugins/jsdoc.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/plugin_name/plugins/no_name.ts
+++ b/apps/oxlint/test/fixtures/plugin_name/plugins/no_name.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   // No name defined

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   rules: {

--- a/apps/oxlint/test/fixtures/plugin_name_alias_reserved/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_reserved/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/plugin_name_missing/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_missing/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   // No name defined

--- a/apps/oxlint/test/fixtures/plugin_name_reserved/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_reserved/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/scope_manager/plugin.ts
+++ b/apps/oxlint/test/fixtures/scope_manager/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Node, Plugin, Rule, Scope } from "#oxlint";
+import type { Node, Plugin, Rule, Scope } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -1,4 +1,4 @@
-import type { ESTree, Plugin, Visitor } from "#oxlint";
+import type { ESTree, Plugin, Visitor } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/settings/plugin.ts
+++ b/apps/oxlint/test/fixtures/settings/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint";
+import type { Node, Plugin, Rule } from "#oxlint/plugin";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { ESTree, Node, Plugin, Rule } from "#oxlint";
+import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugin";
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { ESTree, Node, Plugin, Rule } from "#oxlint";
+import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugin";
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 const STANDARD_TOKEN_KEYS = new Set(["type", "value", "start", "end", "range", "loc"]);
 

--- a/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import type { Plugin, Rule } from "#oxlint";
+import type { Plugin, Rule } from "#oxlint/plugin";
 
 const unicodeCommentsRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
+++ b/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
@@ -1,6 +1,6 @@
 // oxlint-disable typescript/restrict-template-expressions
 
-import type { Plugin } from "#oxlint";
+import type { Plugin } from "#oxlint/plugin";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RuleTester } from "../src-js/index.ts";
 
-import type { Rule } from "../src-js/index.ts";
+import type { Rule } from "../src-js/plugin.ts";
 
 /**
  * Test case.

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -37,7 +37,7 @@ export default defineConfig([
   // Main build
   {
     ...commonConfig,
-    entry: ["src-js/cli.ts", "src-js/index.ts"],
+    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugin.ts", "src-js/rule-tester.ts"],
     format: "esm",
     external: [
       // External native bindings

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -34,6 +34,20 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    },
+    "./rule-tester": {
+      "types": "./dist/rule-tester.d.ts",
+      "default": "./dist/rule-tester.js"
+    }
+  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }


### PR DESCRIPTION
This is technically breaking (only for types), but custom plugins are experimental.



The ruletester/defineRule/definePlugin are re-exported but with a `@deprecated` tag which I think is a good enough trade off



I want to avoid users bringing in a ton of custom plugin code when doing `import { defineConfig } from 'oxlint'`