### PR TITLE
chore(ci): Fix oxc.rs workflow trigger.

### DIFF
--- a/.github/workflows/prepare_release_apps.yml
+++ b/.github/workflows/prepare_release_apps.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
       - uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
-          repo: oxc-project/oxc-project.github.io
+          repo: oxc-project/website
           workflow: release.yml
           token: ${{ secrets.OXC_BOT_PAT }}
           ref: main


### PR DESCRIPTION
The repository was renamed and this has greatly angered GitHub Actions, so no update was created for oxc.rs with today's release. This should fix the problem.