### PR TITLE
chore(all): update references from oxc-project.github.io to oxc/website.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     about: For lightweight questions.
 
   - name: Website issues
-    url: https://github.com/oxc-project/oxc-project.github.io
+    url: https://github.com/oxc-project/website
     about: For website issues.

--- a/justfile
+++ b/justfile
@@ -254,8 +254,8 @@ watch-playground:
 
 # ==================== UTILITIES & ADVANCED ====================
 
-# Generate website documentation, intended for updating the oxc-project.github.io site.
-# Path should be the path to your clone of https://github.com/oxc-project/oxc-project.github.io
+# Generate website documentation, intended for updating the oxc.rs website.
+# Path should be the path to your clone of https://github.com/oxc-project/website
 # When testing changes to the website documentation, you may also want to run `pnpm run fmt`
 # in the website directory.
 website path:

--- a/tasks/website_linter/src/rules/doc_page.rs
+++ b/tasks/website_linter/src/rules/doc_page.rs
@@ -1,6 +1,6 @@
 //! Create documentation pages for each rule. Pages are printed as Markdown and
-//! get added to the website.
-//! You can test/run this task with `just website ../oxc-project.github.io`,
+//! get added to the oxc.rs website.
+//! You can test/run this task with `just website ../website`,
 //! assuming you have cloned the oxc website repo next to the oxc repo.
 
 use std::{

--- a/tasks/website_linter/src/rules/mod.rs
+++ b/tasks/website_linter/src/rules/mod.rs
@@ -33,9 +33,9 @@ Arguments:
 /// `print_rules`
 ///
 /// `cargo run -p website linter-rules
-///   --rules-json /path/to/oxc/oxc-project.github.io/.vitepress/data/rules.json
-///   --rule-docs /path/to/oxc/oxc-project.github.io/src/docs/guide/usage/linter/rules
-///   --rule-count /path/to/oxc/oxc-project.github.io/src/docs/guide/usage
+///   --rules-json /path/to/oxc/website/.vitepress/data/rules.json
+///   --rule-docs /path/to/oxc/website/src/docs/guide/usage/linter/rules
+///   --rule-count /path/to/oxc/website/src/docs/guide/usage
 ///   --git-ref dc9dc03872101c15b0d02f05ce45705565665829
 /// `
 /// <https://oxc.rs/docs/guide/usage/linter/rules.html>


### PR DESCRIPTION
Just a cleanup since the repo was renamed.