### PR TITLE
refactor(linter): Update JsonOutputFormatter to sort rules when listing them.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -614,6 +614,7 @@ mod test {
 
     use super::CliRunner;
     use crate::{DEFAULT_OXLINTRC, tester::Tester};
+    use oxc_linter::rules::RULES;
 
     // lints the full directory of fixtures,
     // so do not snapshot it, test only
@@ -1285,6 +1286,9 @@ mod test {
             serde_json::from_str(&stdout).expect("Failed to parse JSON");
         assert!(!rules.is_empty(), "The rules list should not be empty");
 
+        // Ensure that the number of rules matches the RULES constant, all rules should be listed.
+        assert_eq!(rules.len(), RULES.len(), "The number of rules should match the RULES constant");
+
         // Validate the structure of JSON objects.
         for rule in &rules {
             let rule_obj = rule.as_object().unwrap();
@@ -1296,6 +1300,16 @@ mod test {
             assert!(rule_obj.contains_key("default"), "Rule should contain 'default' field");
             assert!(rule_obj.contains_key("docs_url"), "Rule should contain 'docs_url' field");
         }
+
+        // Verify that the rules list is sorted by scope and value.
+        let rule_names: Vec<(&str, &str)> = rules
+            .iter()
+            .map(|rule| {
+                let obj = rule.as_object().unwrap();
+                (obj["scope"].as_str().unwrap(), obj["value"].as_str().unwrap())
+            })
+            .collect();
+        assert!(rule_names.is_sorted(), "The rules list should be sorted by scope and value");
     }
 
     #[test]

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -42,25 +42,27 @@ impl InternalFormatter for JsonOutputFormatter {
             .map(oxc_linter::rules::RuleEnum::name)
             .collect();
 
-        let rules_info = RULES.iter().map(|rule| RuleInfoJson {
-            scope: rule.plugin_name(),
-            value: rule.name(),
-            category: rule.category(),
-            type_aware: rule.is_tsgolint_rule(),
-            fix: rule.fix().to_string(),
-            default: default_rules.contains(rule.name()),
-            docs_url: format!(
-                "https://oxc.rs/docs/guide/usage/linter/rules/{}/{}.html",
-                rule.plugin_name(),
-                rule.name()
-            )
-            .into(),
-        });
+        let mut rules_info: Vec<_> = RULES
+            .iter()
+            .map(|rule| RuleInfoJson {
+                scope: rule.plugin_name(),
+                value: rule.name(),
+                category: rule.category(),
+                type_aware: rule.is_tsgolint_rule(),
+                fix: rule.fix().to_string(),
+                default: default_rules.contains(rule.name()),
+                docs_url: format!(
+                    "https://oxc.rs/docs/guide/usage/linter/rules/{}/{}.html",
+                    rule.plugin_name(),
+                    rule.name()
+                )
+                .into(),
+            })
+            .collect();
 
-        Some(
-            serde_json::to_string_pretty(&rules_info.collect::<Vec<_>>())
-                .expect("Failed to serialize"),
-        )
+        rules_info.sort_by_key(|rule| (rule.scope, rule.value));
+
+        Some(serde_json::to_string_pretty(&rules_info).expect("Failed to serialize"))
     }
 
     fn lint_command_info(&self, lint_command_info: &super::LintCommandInfo) -> Option<String> {


### PR DESCRIPTION
This way we can avoid problems with the order of rules changing when we store the full rules list from the output of this formatter. Should make diffs cleaner.

This only applies for `oxlint --rules --format=json`, the JSON output for lint runs is unchanged.

Fixes #18609.

AI Disclosure: Generated with Claude Code, modified and reviewed by me.