### PR TITLE
refactor(oxfmt): Use `ResolvedOptions` directly for `format()` API

### DIFF
--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -7,6 +7,8 @@ pub mod utils;
 #[cfg(feature = "napi")]
 mod external_formatter;
 
+#[cfg(feature = "napi")]
+pub use config::resolve_options_from_value;
 pub use config::{
     ConfigResolver, ResolvedOptions, resolve_editorconfig_path, resolve_oxfmtrc_path,
 };


### PR DESCRIPTION
For the use case of the Node.js API for `format()`, there are no overrides, editorconfigs, etc.

Let's simplify by resolving `ResolvedOptions` from raw `options` JSON.