### PR TITLE
docs(linter): Mark `react/jsx-uses-react` as an unsupported rule.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -26,6 +26,7 @@
     "jsx-a11y/no-onchange": "Deprecated, based on behavior of very old browsers, and so no longer necessary.",
     "eslint/camelcase": "Superseded by `@typescript-eslint/naming-convention`, which accomplishes the same behavior with more flexibility.",
     "eslint/no-invalid-this": "Superseded by TypeScript's [`noImplicitThis`](https://www.typescriptlang.org/tsconfig/#noImplicitThis) compiler option (enabled by `strict` mode).",
+    "react/jsx-uses-react": "It is unnecessary to import React for JSX/TSX files with React 17+ when using the new JSX transform. This rule is also not easy to implement in Oxlint as it modifies the behavior of another rule.",
 
     "n/prefer-node-protocol": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",


### PR DESCRIPTION
This rule is no longer necessary with React 17+ (which released in 2020) and the new JSX transform, it also modifies the behavior of no-unused-vars which would be complicated to add.

See more here: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports

Original rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md