### PR TITLE
refactor(linter): More miscellaneous improvements for React rules

### DIFF
--- a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
+++ b/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
     /// var React = require('react');
     ///
     /// var Component = React.forwardRef((props) => (
-    ///     <div />
+    ///   <div />
     /// ));
     /// ```
     ///
@@ -47,15 +47,15 @@ declare_oxc_lint!(
     /// var React = require('react');
     ///
     /// var Component = React.forwardRef((props, ref) => (
-    ///    <div ref={ref} />
+    ///   <div ref={ref} />
     /// ));
     ///
     /// var Component = React.forwardRef((props, ref) => (
-    ///    <div />
+    ///   <div />
     /// ));
     ///
     /// function Component(props) {
-    ///    return <div />;
+    ///   return <div />;
     /// };
     /// ```
     ForwardRefUsesRef,

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -56,9 +56,8 @@ fn duplicate_key_prop(key_value: &str, span: Span) -> OxcDiagnostic {
 #[schemars(transparent)]
 pub struct JsxKey(Box<JsxKeyConfig>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-#[derive(Default)]
 pub struct JsxKeyConfig {
     /// When true, require key prop to be placed before any spread props
     #[serde(default = "default_true")]

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -10,8 +10,8 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_danger_with_children_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Only set one of `children` or `props.dangerouslySetInnerHTML`")
-			.with_help("`dangerouslySetInnerHTML` is not compatible with also passing children and React will throw a warning at runtime.")
-			.with_label(span)
+            .with_help("`dangerouslySetInnerHTML` is not compatible with also passing children and React will throw a warning at runtime.")
+            .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
@@ -9,6 +9,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
+    rules::ContextHost,
     utils::{is_es5_component, is_es6_component},
 };
 
@@ -83,9 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDidMountSetState {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .unwrap_or_default()
-            .into_inner())
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -150,6 +149,10 @@ impl Rule for NoDidMountSetState {
         }
 
         ctx.diagnostic(no_did_mount_set_state_diagnostic(call_expr.callee.span()));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 
 fn no_is_mounted_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use `isMounted`")
-        .with_help("`isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.")
+    OxcDiagnostic::warn("Do not use `isMounted`.")
+        .with_help("`isMounted` is not supported in modern React, and does not work in class or function components.")
         .with_label(span)
 }
 
@@ -21,12 +21,12 @@ pub struct NoIsMounted;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule prevents using `isMounted` in classes.
+    /// This rule prevents using `isMounted` in class components.
     ///
     /// ### Why is this bad?
     ///
-    /// `isMounted` is an anti-pattern, is not available when using classes,
-    /// and it is on its way to being officially deprecated.
+    /// `isMounted` is an anti-pattern, and is not available
+    /// when using classes or function components.
     ///
     /// ### Examples
     ///
@@ -34,14 +34,14 @@ declare_oxc_lint!(
     ///
     /// ```jsx
     /// class Hello extends React.Component {
-    ///     someMethod() {
-    ///         if (!this.isMounted()) {
-    ///             return;
-    ///         }
+    ///   someMethod() {
+    ///     if (!this.isMounted()) {
+    ///       return;
     ///     }
-    ///     render() {
-    ///         return <div onClick={this.someMethod.bind(this)}>Hello</div>;
-    ///     }
+    ///   }
+    ///   render() {
+    ///     return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+    ///   }
     /// };
     /// ```
     NoIsMounted,

--- a/crates/oxc_linter/src/rules/react/no_will_update_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_will_update_set_state.rs
@@ -10,6 +10,7 @@ use crate::{
     config::ReactVersion,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
+    rules::ContextHost,
     utils::{is_es5_component, is_es6_component},
 };
 
@@ -23,7 +24,6 @@ fn no_will_update_set_state_diagnostic(span: Span) -> OxcDiagnostic {
 #[serde(rename_all = "kebab-case")]
 pub enum NoWillUpdateSetStateConfig {
     #[default]
-    #[serde(skip)]
     Allowed,
     DisallowInFunc,
 }
@@ -158,6 +158,10 @@ impl Rule for NoWillUpdateSetState {
         }
 
         ctx.diagnostic(no_will_update_set_state_diagnostic(call_expr.callee.span()));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -13,22 +13,22 @@ use crate::{
 };
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use createClass instead of an ES2015 class.")
+    OxcDiagnostic::warn("Components should use `createReactClass` instead of an ES2015 class.")
         .with_label(span)
 }
 
 fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Components should use an ES2015 class instead of createClass.")
+    OxcDiagnostic::warn("Components should use an ES2015 class instead of `createReactClass`.")
         .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 enum PreferES6ClassOptionType {
-    /// Always prefer ES6 class-style components
+    /// Always prefer ES2015 class-style components.
     #[default]
     Always,
-    /// Do not allow ES6 class-style
+    /// Do not allow ES2015 class-style, prefer `createReactClass`.
     Never,
 }
 
@@ -38,8 +38,11 @@ pub struct PreferEs6Class(PreferES6ClassOptionType);
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// React offers you two ways to create traditional components: using the ES5
-    /// create-react-class module or the new ES2015 class system.
+    /// React offers you two ways to create traditional components: using the
+    /// `create-react-class` package or the newer ES2015 class system.
+    ///
+    /// Note that function components are preferred over class components in modern React,
+    /// and it is _especially_ discouraged to use `createReactClass` in modern React.
     ///
     /// ### Why is this bad?
     ///
@@ -47,7 +50,7 @@ declare_oxc_lint!(
     ///
     /// ### Examples
     ///
-    /// Examples of **incorrect** code for this rule:
+    /// Examples of **incorrect** code for this rule by default:
     /// ```jsx
     /// var Hello = createReactClass({
     ///   render: function() {

--- a/crates/oxc_linter/src/snapshots/react_no_is_mounted.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_is_mounted.snap
@@ -1,29 +1,29 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`.
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 componentDidUpdate: function() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.
+  help: `isMounted` is not supported in modern React, and does not work in class or function components.
 
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`.
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod: function() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.
+  help: `isMounted` is not supported in modern React, and does not work in class or function components.
 
-  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`
+  ⚠ eslint-plugin-react(no-is-mounted): Do not use `isMounted`.
    ╭─[no_is_mounted.tsx:4:24]
  3 │                 someMethod() {
  4 │                   if (!this.isMounted()) {
    ·                        ────────────────
  5 │                     return;
    ╰────
-  help: `isMounted` is on its way to being officially deprecated. You can use an `_isMounted` property to track the mounted status yourself.
+  help: `isMounted` is not supported in modern React, and does not work in class or function components.

--- a/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of `createReactClass`.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │               displayName: 'Hello',
    ╰────
 
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of createClass.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of `createReactClass`.
    ╭─[prefer_es6_class.tsx:2:25]
  1 │ 
  2 │             var Hello = createReactClass({
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │               render: function() {
    ╰────
 
-  ⚠ eslint-plugin-react(prefer-es6-class): Components should use createClass instead of an ES2015 class.
+  ⚠ eslint-plugin-react(prefer-es6-class): Components should use `createReactClass` instead of an ES2015 class.
    ╭─[prefer_es6_class.tsx:2:19]
  1 │ 
  2 │             class Hello extends React.Component {


### PR DESCRIPTION
Mainly just cleaning things up.

Only a few real changes:

- Update `isMounted` docs to clarify that isMounted has been removed from React entirely for a while.
- Update `react/no-did-mount-set-state` to enforce config option validation _and_ only run on JSX/TSX code.
- Update `react/no-will-update-set-state` to only run on JSX/TSX code.
- Update `react/prefer-es6-class` docs and diagnostics to note outdatedness of both React patterns.