### PR TITLE
fix(oxfmt): Use `empty_line` IR for empty xxx-in-js line

### DIFF
--- a/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
@@ -16,6 +16,27 @@ const mixedTemplate = html\`<div><h1>Title</h1></div>\`;
 const mixedDocs = md\`#Documentation
 This is **important**.\`;
 
+// Multi-line with blank lines - should preserve blank lines without trailing whitespace
+const multilineCSS = css\`
+  .foo {
+    color: red;
+  }
+
+  .bar {
+    color: blue;
+  }
+\`;
+
+const multilineGQL = gql\`
+  type Foo {
+    name: String!
+  }
+
+  type Bar {
+    value: Int!
+  }
+\`;
+
 // Empty - Regular template literals retain newlines and spaces, but embedded ones are condensed
 const empty = css\`\`;
 const empty2 = styled\`
@@ -56,6 +77,27 @@ const mixedTemplate = html\`
 const mixedDocs = md\`
   #Documentation
   This is **important**.
+\`;
+
+// Multi-line with blank lines - should preserve blank lines without trailing whitespace
+const multilineCSS = css\`
+  .foo {
+    color: red;
+  }
+
+  .bar {
+    color: blue;
+  }
+\`;
+
+const multilineGQL = gql\`
+  type Foo {
+    name: String!
+  }
+
+  type Bar {
+    value: Int!
+  }
 \`;
 
 // Empty - Regular template literals retain newlines and spaces, but embedded ones are condensed

--- a/apps/oxfmt/test/cli/embedded_languages/fixtures/mixed.js
+++ b/apps/oxfmt/test/cli/embedded_languages/fixtures/mixed.js
@@ -10,6 +10,27 @@ const mixedTemplate = html`<div><h1>Title</h1></div>`;
 const mixedDocs = md`#Documentation
 This is **important**.`;
 
+// Multi-line with blank lines - should preserve blank lines without trailing whitespace
+const multilineCSS = css`
+  .foo {
+    color: red;
+  }
+
+  .bar {
+    color: blue;
+  }
+`;
+
+const multilineGQL = gql`
+  type Foo {
+    name: String!
+  }
+
+  type Bar {
+    value: Int!
+  }
+`;
+
 // Empty - Regular template literals retain newlines and spaces, but embedded ones are condensed
 const empty = css``;
 const empty2 = styled`

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -822,7 +822,11 @@ fn format_embedded_template<'a>(
     let format_content = format_with(|f: &mut Formatter<'_, 'a>| {
         let content = f.context().allocator().alloc_str(&formatted);
         for line in content.split('\n') {
-            write!(f, [text(line), hard_line_break()]);
+            if line.is_empty() {
+                write!(f, [empty_line()]);
+            } else {
+                write!(f, [text(line), hard_line_break()]);
+            }
         }
     });
 


### PR DESCRIPTION
Fixes #18040

