### PR TITLE
test(tasks/coverage/typescript): choose `ModuleKind` similarly to tsc

### DIFF
--- a/.github/scripts/clone-parallel.mjs
+++ b/.github/scripts/clone-parallel.mjs
@@ -11,11 +11,11 @@ import { dirname, join } from "node:path";
 
 // Submodule commit SHAs - updated automatically by .github/workflows/update_submodules.yml
 // NOTE: Prettier version is now pinned to `v3.8.0` (not updated by workflow above), Update manually as needed
-const TEST262_SHA = "fff41f0522ede859d0880acbff066b09fc9c22a5";
+const TEST262_SHA = "3c6180f581e5f468d6767af2f9b1f9c3ca444e77";
 const BABEL_SHA = "6ef16ca449aa76d1f1d689bddc4d63f35e07f574";
 const TYPESCRIPT_SHA = "7f6a84673def7665a4c4bc2bdfaf7bcc8549b276";
 const PRETTIER_SHA = "812a4d0071270f61a7aa549d625b618be7e09d71";
-const ESTREE_CONFORMANCE_SHA = "389cb2a71867fb468fc0f090cd493120c9d84993";
+const ESTREE_CONFORMANCE_SHA = "a22b8f8621dd7cbc07dc24b5ff8ddb8ad91310ed";
 const NODE_COMPAT_TABLE_SHA = "499beb6f1daa36f10c26b85a7f3ec3b3448ded23";
 
 const repoRoot = join(import.meta.dirname, "..", "..");

--- a/tasks/coverage/snapshots/codegen_test262.snap
+++ b/tasks/coverage/snapshots/codegen_test262.snap
@@ -1,5 +1,5 @@
-commit: fff41f05
+commit: 3c6180f5
 
 codegen_test262 Summary:
-AST Parsed     : 46595/46595 (100.00%)
-Positive Passed: 46595/46595 (100.00%)
+AST Parsed     : 46712/46712 (100.00%)
+Positive Passed: 46712/46712 (100.00%)

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,8 +1,8 @@
-commit: fff41f05
+commit: 3c6180f5
 
 estree_test262 Summary:
-AST Parsed     : 46340/46340 (100.00%)
-Positive Passed: 46331/46340 (99.98%)
+AST Parsed     : 46456/46456 (100.00%)
+Positive Passed: 46447/46456 (99.98%)
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js

--- a/tasks/coverage/snapshots/formatter_test262.snap
+++ b/tasks/coverage/snapshots/formatter_test262.snap
@@ -1,8 +1,8 @@
-commit: fff41f05
+commit: 3c6180f5
 
 formatter_test262 Summary:
-AST Parsed     : 46595/46595 (100.00%)
-Positive Passed: 46586/46595 (99.98%)
+AST Parsed     : 46712/46712 (100.00%)
+Positive Passed: 46703/46712 (99.98%)
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR-LF.js
 
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/line-terminator-normalisation-CR.js

--- a/tasks/coverage/snapshots/minifier_test262.snap
+++ b/tasks/coverage/snapshots/minifier_test262.snap
@@ -1,8 +1,8 @@
-commit: fff41f05
+commit: 3c6180f5
 
 minifier_test262 Summary:
-AST Parsed     : 44184/44184 (100.00%)
-Positive Passed: 44181/44184 (99.99%)
+AST Parsed     : 44301/44301 (100.00%)
+Positive Passed: 44298/44301 (99.99%)
 Compress: tasks/coverage/test262/test/intl402/Temporal/PlainDate/prototype/toLocaleString/lone-options-accepted.js
 
 Compress: tasks/coverage/test262/test/intl402/Temporal/PlainMonthDay/prototype/toLocaleString/lone-options-accepted.js

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -1,9 +1,9 @@
-commit: fff41f05
+commit: 3c6180f5
 
 parser_test262 Summary:
-AST Parsed     : 46595/46595 (100.00%)
-Positive Passed: 46595/46595 (100.00%)
-Negative Passed: 4581/4581 (100.00%)
+AST Parsed     : 46712/46712 (100.00%)
+Positive Passed: 46712/46712 (100.00%)
+Negative Passed: 4588/4588 (100.00%)
 
   × '0'-prefixed octal literals and octal escape sequences are deprecated
     ╭─[test262/test/annexB/language/expressions/template-literal/legacy-octal-escape-sequence-strict.js:19:4]
@@ -26678,6 +26678,16 @@ Negative Passed: 4581/4581 (100.00%)
  30 │       throw new Test262Error();
     ╰────
 
+  × Identifier `f` has already been declared
+    ╭─[test262/test/language/statements/await-using/redeclaration-error-from-within-strict-mode-function-await-using.js:15:49]
+ 14 │ $DONOTEVALUATE();
+ 15 │ (async function() { 'use strict'; { await using f = null; var f; } })
+    ·                                                 ┬             ┬
+    ·                                                 │             ╰── It can not be redeclared here
+    ·                                                 ╰── `f` has already been declared here
+ 16 │ 
+    ╰────
+
   × Using declarations may not have binding patterns.
     ╭─[test262/test/language/statements/await-using/syntax/await-using-invalid-arraybindingpattern-after-bindingidentifier.js:18:25]
  17 │ async function f() {
@@ -26728,6 +26738,24 @@ Negative Passed: 4581/4581 (100.00%)
  18 │ }
     ╰────
   help: Try inserting a semicolon here
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[test262/test/language/statements/await-using/syntax/await-using-invalid-switchstatement-caseclause.js:22:7]
+ 21 │     case 0:
+ 22 │       await using _ = null;
+    ·       ─────────────────────
+ 23 │       break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[test262/test/language/statements/await-using/syntax/await-using-invalid-switchstatement-defaultclause.js:22:7]
+ 21 │     default:
+ 22 │       await using _ = null;
+    ·       ─────────────────────
+ 23 │       break;
+    ╰────
+  help: Wrap this declaration in a block statement
 
   × 'using' declarations are not allowed at the top level of a script
     ╭─[test262/test/language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-script.js:23:1]
@@ -39299,6 +39327,32 @@ Negative Passed: 4581/4581 (100.00%)
  26 │   }
     ╰────
 
+  × Identifier `f` has already been declared
+    ╭─[test262/test/language/statements/using/redeclaration-error-from-within-strict-mode-function-using.js:15:37]
+ 14 │ $DONOTEVALUATE();
+ 15 │ (function() { 'use strict'; { using f = null; var f; } })
+    ·                                     ┬             ┬
+    ·                                     │             ╰── It can not be redeclared here
+    ·                                     ╰── `f` has already been declared here
+ 16 │ 
+    ╰────
+
+  × Cannot use `await` as an identifier in an async context
+    ╭─[test262/test/language/statements/using/static-init-await-binding-invalid.js:26:11]
+ 25 │   static {
+ 26 │     using await = null;
+    ·           ─────
+ 27 │   }
+    ╰────
+
+  × Cannot use await in class static initialization block
+    ╭─[test262/test/language/statements/using/static-init-await-binding-invalid.js:26:11]
+ 25 │   static {
+ 26 │     using await = null;
+    ·           ─────
+ 27 │   }
+    ╰────
+
   × Using declarations must have an initializer.
     ╭─[test262/test/language/statements/using/syntax/block-scope-syntax-using-declarations-mixed-with-without-initializer.js:30:19]
  29 │ {
@@ -39365,6 +39419,24 @@ Negative Passed: 4581/4581 (100.00%)
     ·         ──
  19 │ }
     ╰────
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[test262/test/language/statements/using/syntax/using-invalid-switchstatement-caseclause.js:21:5]
+ 20 │   case 0:
+ 21 │     using _ = null;
+    ·     ───────────────
+ 22 │     break;
+    ╰────
+  help: Wrap this declaration in a block statement
+
+  × Using declaration cannot appear in the bare case statement.
+    ╭─[test262/test/language/statements/using/syntax/using-invalid-switchstatement-defaultclause.js:21:5]
+ 20 │   default:
+ 21 │     using _ = null;
+    ·     ───────────────
+ 22 │     break;
+    ╰────
+  help: Wrap this declaration in a block statement
 
   × 'using' declarations are not allowed at the top level of a script
     ╭─[test262/test/language/statements/using/syntax/using-not-allowed-at-top-level-of-script.js:23:1]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,8 +2,8 @@ commit: 7f6a8467
 
 parser_typescript Summary:
 AST Parsed     : 9842/9843 (99.99%)
-Positive Passed: 9837/9843 (99.94%)
-Negative Passed: 1510/2555 (59.10%)
+Positive Passed: 9838/9843 (99.95%)
+Negative Passed: 1509/2555 (59.06%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -1468,6 +1468,8 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emit.ts
 
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts
+
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelModuleDeclarationAndFile.ts
@@ -2117,15 +2119,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asy
      ·             ╰── It can not be redeclared here
  132 │     }
      ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
-
-  × Cannot assign to 'arguments' in strict mode
-   ╭─[typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts:2:10]
- 1 │ var p1 = import("./0");
- 2 │ function arguments() { } // this is allow as the file doesn't have implicit "use strict"
-   ·          ─────────
-   ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 
@@ -19860,20 +19853,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ╰────
 
   × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts:3:8]
- 2 │ declare var require: any;
- 3 │ import await = require("./other");
-   ·        ─────
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts:3:8]
- 2 │ declare var require: any;
- 3 │ import await = require("./other");
-   ·        ─────
-   ╰────
-
-  × Cannot use `await` as an identifier in an async context
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.12.ts:5:8]
  4 │ // await disallowed in import=namespace when in a module
  5 │ import await = foo.await;
@@ -19945,25 +19924,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │ }
    ╰────
 
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.7.ts:2:13]
- 1 │ // await disallowed in namespace import
- 2 │ import * as await from "./other";
-   ·             ─────
-   ╰────
-
   × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.7.ts:2:13]
  1 │ // await disallowed in namespace import
  2 │ import * as await from "./other";
    ·             ─────
-   ╰────
-
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.8.ts:2:8]
- 1 │ // await disallowed in default import
- 2 │ import await from "./other";
-   ·        ─────
    ╰────
 
   × The keyword 'await' is reserved
@@ -21183,36 +21148,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │     }
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.classMethods.es2018.ts:2:15]
- 1 │ class C4 {
- 2 │     async * f(await) {
-   ·               ─────
- 3 │     }
-   ╰────
-
   × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:18]
- 1 │ async function * await() {
-   ·                  ─────
- 2 │ }
-   ╰────
-
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:18]
- 1 │ async function * await() {
-   ·                  ─────
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionDeclarations.es2018.ts:1:21]
+ 1 │ async function * f4(await) {
+   ·                     ─────
  2 │ }
    ╰────
 
   × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionExpressions.es2018.ts:1:29]
- 1 │ const f2 = async function * await() {
-   ·                             ─────
- 2 │ };
-   ╰────
-
-  × The keyword 'await' is reserved
    ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.functionExpressions.es2018.ts:1:29]
  1 │ const f2 = async function * await() {
    ·                             ─────
@@ -21227,21 +21170,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  3 │     }
    ╰────
 
-  × The keyword 'await' is reserved
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/asyncGenerators/parser.asyncGenerators.objectLiteralMethods.es2018.ts:2:15]
- 1 │ const o4 = {
- 2 │     async * f(await) {
-   ·               ─────
- 3 │     }
-   ╰────
-
-  × await can only be used in conjunction with `for...of` statements
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/forAwait/parser.forAwait.es2018.ts:1:1]
- 1 │ for await (const x in y) {
-   · ────────────────────────
+  × `await` is only allowed within async functions and at the top levels of modules
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript2018/forAwait/parser.forAwait.es2018.ts:1:5]
+ 1 │ for await (const x of y) {
+   ·     ─────
  2 │ }
    ╰────
-  help: Did you mean to use a for...of statement?
+  help: Either remove this `await` or add the `async` keyword to the enclosing function
 
   × Invalid Character `
   │ `
@@ -24514,13 +24449,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerUnicodeEscapeInKeyword1.ts:1:1]
  1 │ \u0076ar x = "hello";
    · ────────
-   ╰────
-
-  × Cannot use `await` as an identifier in an async context
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerUnicodeEscapeInKeyword2.ts:1:5]
- 1 │ var \u0061wait = 12; // ok
-   ·     ──────────
- 2 │ async function main() {
    ╰────
 
   × Keywords cannot contain escape characters

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -1,8 +1,8 @@
-commit: fff41f05
+commit: 3c6180f5
 
 semantic_test262 Summary:
-AST Parsed     : 46595/46595 (100.00%)
-Positive Passed: 44959/46595 (96.49%)
+AST Parsed     : 46712/46712 (100.00%)
+Positive Passed: 45032/46712 (96.40%)
 semantic Error: tasks/coverage/test262/test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-iterator-next-rejected-promise-close.js
 Bindings mismatch:
 after transform: ScopeId(4): []
@@ -6751,6 +6751,278 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
 
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/await-using-allows-null-initializer.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/await-using-allows-undefined-initializer.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/block-local-closure-get-before-initialization.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "f", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): ["f", "x"]
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/block-local-use-before-initialization-in-declaration-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/block-local-use-before-initialization-in-prior-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/fn-name-arrow.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "arrow"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(3): ["arrow"]
+Symbol scope ID mismatch for "arrow":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/fn-name-class.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "cls", "xCls", "xCls2"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(9): []
+rebuilt        : ScopeId(2): ["cls", "xCls", "xCls2"]
+Symbol scope ID mismatch for "xCls":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+Symbol scope ID mismatch for "cls":
+after transform: SymbolId(2): ScopeId(1)
+rebuilt        : SymbolId(5): ScopeId(2)
+Symbol scope ID mismatch for "xCls2":
+after transform: SymbolId(3): ScopeId(1)
+rebuilt        : SymbolId(6): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/fn-name-cover.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "cover", "xCover"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(3): ["cover", "xCover"]
+Symbol scope ID mismatch for "xCover":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "cover":
+after transform: SymbolId(1): ScopeId(2)
+rebuilt        : SymbolId(4): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/fn-name-fn.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "fn", "xFn"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(3): ["fn", "xFn"]
+Symbol scope ID mismatch for "xFn":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "fn":
+after transform: SymbolId(2): ScopeId(2)
+rebuilt        : SymbolId(5): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/fn-name-gen.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "gen", "xGen"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(3): ["gen", "xGen"]
+Symbol scope ID mismatch for "xGen":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "gen":
+after transform: SymbolId(2): ScopeId(2)
+rebuilt        : SymbolId(5): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/function-local-closure-get-before-initialization.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "f", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): ["f", "x"]
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/function-local-use-before-initialization-in-declaration-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/function-local-use-before-initialization-in-prior-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/global-closure-get-before-initialization.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "f", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): ["f", "x"]
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/global-use-before-initialization-in-declaration-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/global-use-before-initialization-in-prior-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncfunctionbody.js
+Bindings mismatch:
+after transform: ScopeId(6): ["_", "_usingCtx"]
+rebuilt        : ScopeId(9): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(8): []
+rebuilt        : ScopeId(10): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(11): ScopeId(6)
+rebuilt        : SymbolId(16): ScopeId(10)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-at-end-of-asyncgeneratorbody.js
+Bindings mismatch:
+after transform: ScopeId(4): ["_", "_usingCtx"]
+rebuilt        : ScopeId(7): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(6): []
+rebuilt        : ScopeId(8): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(5): ScopeId(4)
+rebuilt        : SymbolId(12): ScopeId(8)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.asyncDispose-called-if-subsequent-initializer-throws.js
+Bindings mismatch:
+after transform: ScopeId(4): ["_1", "_2", "_usingCtx"]
+rebuilt        : ScopeId(5): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(6): []
+rebuilt        : ScopeId(6): ["_1", "_2"]
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(2): ScopeId(4)
+rebuilt        : SymbolId(6): ScopeId(6)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(3): ScopeId(4)
+rebuilt        : SymbolId(7): ScopeId(6)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncfunctionbody.js
+Bindings mismatch:
+after transform: ScopeId(6): ["_", "_usingCtx"]
+rebuilt        : ScopeId(8): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(7): []
+rebuilt        : ScopeId(9): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(11): ScopeId(6)
+rebuilt        : SymbolId(15): ScopeId(9)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.dispose-called-at-end-of-asyncgeneratorbody.js
+Bindings mismatch:
+after transform: ScopeId(4): ["_", "_usingCtx"]
+rebuilt        : ScopeId(6): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(7): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(5): ScopeId(4)
+rebuilt        : SymbolId(11): ScopeId(7)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/initializer-Symbol.dispose-called-if-subsequent-initializer-throws.js
+Bindings mismatch:
+after transform: ScopeId(4): ["_1", "_2", "_usingCtx"]
+rebuilt        : ScopeId(4): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(5): ["_1", "_2"]
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(2): ScopeId(4)
+rebuilt        : SymbolId(5): ScopeId(5)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(3): ScopeId(4)
+rebuilt        : SymbolId(6): ScopeId(5)
+
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/syntax/await-using-allows-bindingidentifier.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "x"]
@@ -6775,6 +7047,193 @@ rebuilt        : SymbolId(5): ScopeId(4)
 Symbol scope ID mismatch for "y":
 after transform: SymbolId(2): ScopeId(1)
 rebuilt        : SymbolId(6): ScopeId(4)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-error-as-is-if-only-one-error-during-disposal.js
+Bindings mismatch:
+after transform: ScopeId(3): ["_1", "_2", "_usingCtx"]
+rebuilt        : ScopeId(3): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(12): []
+rebuilt        : ScopeId(4): ["_1", "_2"]
+Bindings mismatch:
+after transform: ScopeId(6): ["_1", "_2", "_usingCtx3"]
+rebuilt        : ScopeId(11): ["_usingCtx3"]
+Bindings mismatch:
+after transform: ScopeId(17): []
+rebuilt        : ScopeId(12): ["_1", "_2"]
+Bindings mismatch:
+after transform: ScopeId(9): ["_1", "_2", "_usingCtx4"]
+rebuilt        : ScopeId(19): ["_usingCtx4"]
+Bindings mismatch:
+after transform: ScopeId(22): []
+rebuilt        : ScopeId(20): ["_1", "_2"]
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(1): ScopeId(3)
+rebuilt        : SymbolId(4): ScopeId(4)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(2): ScopeId(3)
+rebuilt        : SymbolId(5): ScopeId(4)
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(3): ScopeId(6)
+rebuilt        : SymbolId(8): ScopeId(12)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(4): ScopeId(6)
+rebuilt        : SymbolId(9): ScopeId(12)
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(5): ScopeId(9)
+rebuilt        : SymbolId(12): ScopeId(20)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(6): ScopeId(9)
+rebuilt        : SymbolId(13): ScopeId(20)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-null.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-is-undefined.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.asyncDispose-property-not-callable.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(7): []
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["_usingCtx3", "x"]
+rebuilt        : ScopeId(7): ["_usingCtx3"]
+Bindings mismatch:
+after transform: ScopeId(11): []
+rebuilt        : ScopeId(8): ["x"]
+Bindings mismatch:
+after transform: ScopeId(4): ["_usingCtx4", "x"]
+rebuilt        : ScopeId(12): ["_usingCtx4"]
+Bindings mismatch:
+after transform: ScopeId(15): []
+rebuilt        : ScopeId(13): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["_usingCtx5", "x"]
+rebuilt        : ScopeId(17): ["_usingCtx5"]
+Bindings mismatch:
+after transform: ScopeId(19): []
+rebuilt        : ScopeId(18): ["x"]
+Bindings mismatch:
+after transform: ScopeId(6): ["_usingCtx6", "x"]
+rebuilt        : ScopeId(22): ["_usingCtx6"]
+Bindings mismatch:
+after transform: ScopeId(23): []
+rebuilt        : ScopeId(23): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(3)
+rebuilt        : SymbolId(6): ScopeId(8)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(2): ScopeId(4)
+rebuilt        : SymbolId(9): ScopeId(13)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(3): ScopeId(5)
+rebuilt        : SymbolId(12): ScopeId(18)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(5): ScopeId(6)
+rebuilt        : SymbolId(16): ScopeId(23)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-null.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-Symbol.dispose-property-not-callable.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(7): []
+rebuilt        : ScopeId(3): ["x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["_usingCtx3", "x"]
+rebuilt        : ScopeId(7): ["_usingCtx3"]
+Bindings mismatch:
+after transform: ScopeId(11): []
+rebuilt        : ScopeId(8): ["x"]
+Bindings mismatch:
+after transform: ScopeId(4): ["_usingCtx4", "x"]
+rebuilt        : ScopeId(12): ["_usingCtx4"]
+Bindings mismatch:
+after transform: ScopeId(15): []
+rebuilt        : ScopeId(13): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["_usingCtx5", "x"]
+rebuilt        : ScopeId(17): ["_usingCtx5"]
+Bindings mismatch:
+after transform: ScopeId(19): []
+rebuilt        : ScopeId(18): ["x"]
+Bindings mismatch:
+after transform: ScopeId(6): ["_usingCtx6", "x"]
+rebuilt        : ScopeId(22): ["_usingCtx6"]
+Bindings mismatch:
+after transform: ScopeId(23): []
+rebuilt        : ScopeId(23): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(3)
+rebuilt        : SymbolId(6): ScopeId(8)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(2): ScopeId(4)
+rebuilt        : SymbolId(9): ScopeId(13)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(3): ScopeId(5)
+rebuilt        : SymbolId(12): ScopeId(18)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(5): ScopeId(6)
+rebuilt        : SymbolId(16): ScopeId(23)
+
+semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-missing-both-Symbol.asyncDispose-and-Symbol.dispose.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
 
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/throws-if-initializer-not-object.js
 Bindings mismatch:
@@ -13655,6 +14114,229 @@ rebuilt        : SymbolId(4): []
 Reference symbol mismatch for "x":
 after transform: SymbolId(1) "x"
 rebuilt        : SymbolId(1) "x"
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/function-local-closure-get-before-initialization.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "f", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(2): ["f", "x"]
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(2)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/function-local-use-before-initialization-in-declaration-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(2): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/function-local-use-before-initialization-in-prior-statement.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx", "x"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(2)
+rebuilt        : SymbolId(2): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/initializer-disposed-at-end-of-asyncfunctionbody.js
+Bindings mismatch:
+after transform: ScopeId(6): ["_", "_usingCtx"]
+rebuilt        : ScopeId(8): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(7): []
+rebuilt        : ScopeId(9): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(11): ScopeId(6)
+rebuilt        : SymbolId(15): ScopeId(9)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/initializer-disposed-at-end-of-asyncgeneratorbody.js
+Bindings mismatch:
+after transform: ScopeId(4): ["_", "_usingCtx"]
+rebuilt        : ScopeId(6): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(5): []
+rebuilt        : ScopeId(7): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(5): ScopeId(4)
+rebuilt        : SymbolId(11): ScopeId(7)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/initializer-disposed-at-end-of-functionbody.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_", "_usingCtx"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(2): ScopeId(2)
+rebuilt        : SymbolId(4): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/initializer-disposed-at-end-of-generatorbody.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_", "_usingCtx"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(3): []
+rebuilt        : ScopeId(3): ["_"]
+Symbol scope ID mismatch for "_":
+after transform: SymbolId(2): ScopeId(2)
+rebuilt        : SymbolId(4): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/initializer-disposed-if-subsequent-initializer-throws.js
+Bindings mismatch:
+after transform: ScopeId(3): ["_1", "_2", "_usingCtx"]
+rebuilt        : ScopeId(3): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(4): ["_1", "_2"]
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(2): ScopeId(3)
+rebuilt        : SymbolId(4): ScopeId(4)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(3): ScopeId(3)
+rebuilt        : SymbolId(5): ScopeId(4)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/static-init-await-binding-valid.js
+Bindings mismatch:
+after transform: ScopeId(3): ["_usingCtx", "await"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(3): ["await"]
+Symbol scope ID mismatch for "await":
+after transform: SymbolId(1): ScopeId(3)
+rebuilt        : SymbolId(3): ScopeId(3)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/throws-error-as-is-if-only-one-error-during-disposal.js
+Bindings mismatch:
+after transform: ScopeId(2): ["_1", "_2", "_usingCtx"]
+rebuilt        : ScopeId(2): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(11): []
+rebuilt        : ScopeId(3): ["_1", "_2"]
+Bindings mismatch:
+after transform: ScopeId(5): ["_1", "_2", "_usingCtx3"]
+rebuilt        : ScopeId(9): ["_usingCtx3"]
+Bindings mismatch:
+after transform: ScopeId(15): []
+rebuilt        : ScopeId(10): ["_1", "_2"]
+Bindings mismatch:
+after transform: ScopeId(8): ["_1", "_2", "_usingCtx4"]
+rebuilt        : ScopeId(16): ["_usingCtx4"]
+Bindings mismatch:
+after transform: ScopeId(19): []
+rebuilt        : ScopeId(17): ["_1", "_2"]
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(1): ScopeId(2)
+rebuilt        : SymbolId(3): ScopeId(3)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(2): ScopeId(2)
+rebuilt        : SymbolId(4): ScopeId(3)
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(3): ScopeId(5)
+rebuilt        : SymbolId(7): ScopeId(10)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(4): ScopeId(5)
+rebuilt        : SymbolId(8): ScopeId(10)
+Symbol scope ID mismatch for "_1":
+after transform: SymbolId(5): ScopeId(8)
+rebuilt        : SymbolId(11): ScopeId(17)
+Symbol scope ID mismatch for "_2":
+after transform: SymbolId(6): ScopeId(8)
+rebuilt        : SymbolId(12): ScopeId(17)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-null.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-is-undefined.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(2)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/throws-if-initializer-Symbol.dispose-property-not-callable.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(6): []
+rebuilt        : ScopeId(2): ["x"]
+Bindings mismatch:
+after transform: ScopeId(2): ["_usingCtx3", "x"]
+rebuilt        : ScopeId(6): ["_usingCtx3"]
+Bindings mismatch:
+after transform: ScopeId(10): []
+rebuilt        : ScopeId(7): ["x"]
+Bindings mismatch:
+after transform: ScopeId(3): ["_usingCtx4", "x"]
+rebuilt        : ScopeId(11): ["_usingCtx4"]
+Bindings mismatch:
+after transform: ScopeId(14): []
+rebuilt        : ScopeId(12): ["x"]
+Bindings mismatch:
+after transform: ScopeId(4): ["_usingCtx5", "x"]
+rebuilt        : ScopeId(16): ["_usingCtx5"]
+Bindings mismatch:
+after transform: ScopeId(18): []
+rebuilt        : ScopeId(17): ["x"]
+Bindings mismatch:
+after transform: ScopeId(5): ["_usingCtx6", "x"]
+rebuilt        : ScopeId(21): ["_usingCtx6"]
+Bindings mismatch:
+after transform: ScopeId(22): []
+rebuilt        : ScopeId(22): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(2)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(1): ScopeId(2)
+rebuilt        : SymbolId(5): ScopeId(7)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(2): ScopeId(3)
+rebuilt        : SymbolId(8): ScopeId(12)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(3): ScopeId(4)
+rebuilt        : SymbolId(11): ScopeId(17)
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(5): ScopeId(5)
+rebuilt        : SymbolId(15): ScopeId(22)
+
+semantic Error: tasks/coverage/test262/test/language/statements/using/throws-if-initializer-missing-Symbol.dispose.js
+Bindings mismatch:
+after transform: ScopeId(1): ["_usingCtx", "x"]
+rebuilt        : ScopeId(1): ["_usingCtx"]
+Bindings mismatch:
+after transform: ScopeId(2): []
+rebuilt        : ScopeId(2): ["x"]
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(2)
 
 semantic Error: tasks/coverage/test262/test/language/statements/using/throws-if-initializer-not-object.js
 Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 7f6a8467
 
 semantic_typescript Summary:
 AST Parsed     : 6126/6126 (100.00%)
-Positive Passed: 3339/6126 (54.51%)
+Positive Passed: 3340/6126 (54.52%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -266,7 +266,7 @@ rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInIndexerOfClass.ts
 Symbol reference IDs mismatch for "moduleA":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
-rebuilt        : SymbolId(1): [ReferenceId(2)]
+rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
 Symbol reference IDs mismatch for "moduleA":
@@ -287,6 +287,9 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/ambientClassDecla
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "d"]
 rebuilt        : ScopeId(0): ["D", "d"]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "D":
 after transform: SymbolId(3): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -1506,8 +1509,8 @@ Reference symbol mismatch for "Err":
 after transform: SymbolId(0) "Err"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Err"]
+after transform: ["require"]
+rebuilt        : ["Err", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
 Scope flags mismatch:
@@ -4545,7 +4548,7 @@ after transform: ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "ctor", "f1
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "f1", "f2", "f3", "f4", "foo", "goo"]
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(8): [ReferenceId(36), ReferenceId(37), ReferenceId(38)]
-rebuilt        : SymbolId(9): [ReferenceId(29), ReferenceId(32)]
+rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(33)]
 Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
@@ -4556,11 +4559,11 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Promise", "Set"]
-rebuilt        : ["Promise", "Set", "ctor", "x"]
+after transform: ["Function", "Promise", "Set", "require"]
+rebuilt        : ["Promise", "Set", "ctor", "require", "x"]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(28), ReferenceId(30), ReferenceId(33)]
-rebuilt        : [ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(18), ReferenceId(22), ReferenceId(25)]
+rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 Symbol reference IDs mismatch for "A":
@@ -12430,8 +12433,8 @@ rebuilt        : ["expect", "fooFn"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Unresolved references mismatch:
-after transform: ["CallableExtention"]
-rebuilt        : []
+after transform: ["CallableExtention", "require"]
+rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/generics3.ts
 Symbol reference IDs mismatch for "C":
@@ -12686,12 +12689,18 @@ after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "WhichThing"]
 rebuilt        : ScopeId(4): ["WhichThing"]
 Scope flags mismatch:
-after transform: ScopeId(4): ScopeFlags(StrictMode)
-rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+after transform: ScopeId(4): ScopeFlags(0x0)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "My":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -23366,6 +23375,9 @@ after transform: ["TemplateStringsArray"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "n":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -28494,8 +28506,8 @@ Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["arguments"]
-rebuilt        : ["arguments", "console"]
+after transform: ["arguments", "require"]
+rebuilt        : ["arguments", "console", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
 Bindings mismatch:
@@ -28536,8 +28548,8 @@ rebuilt        : ["getPath"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS2.ts
 Unresolved references mismatch:
-after transform: ["Promise", "arguments"]
-rebuilt        : ["arguments"]
+after transform: ["Promise", "arguments", "require"]
+rebuilt        : ["arguments", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
 Unresolved references mismatch:
@@ -28569,9 +28581,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["arguments"]
 rebuilt        : ["arguments", "console"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
-Cannot assign to 'arguments' in strict mode
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 Bindings mismatch:
@@ -30976,8 +30985,8 @@ Reference symbol mismatch for "dec":
 after transform: SymbolId(0) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Number", "Object"]
-rebuilt        : ["Function", "Number", "Object", "dec"]
+after transform: ["Function", "Number", "Object", "require"]
+rebuilt        : ["Function", "Number", "Object", "dec", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 Bindings mismatch:
@@ -36373,6 +36382,9 @@ after transform: ["Object", "require"]
 rebuilt        : ["require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36471,6 +36483,9 @@ after transform: SymbolId(0): [Span { start: 5, end: 13 }, Span { start: 43, end
 rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36593,6 +36608,15 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Root":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -36613,6 +36637,12 @@ after transform: SymbolId(3): Span { start: 157, end: 162 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
@@ -47661,8 +47691,8 @@ rebuilt        : ["f1", "f2", "f3", "s"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 Unresolved references mismatch:
-after transform: ["Partial", "Record", "require"]
-rebuilt        : ["require"]
+after transform: ["Partial", "Record"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/transformer_test262.snap
+++ b/tasks/coverage/snapshots/transformer_test262.snap
@@ -1,5 +1,5 @@
-commit: fff41f05
+commit: 3c6180f5
 
 transformer_test262 Summary:
-AST Parsed     : 46595/46595 (100.00%)
-Positive Passed: 46595/46595 (100.00%)
+AST Parsed     : 46712/46712 (100.00%)
+Positive Passed: 46712/46712 (100.00%)


### PR DESCRIPTION
Aligned the behavior a bit to https://www.typescriptlang.org/tsconfig/#moduleDetection.

close #15543
needs https://github.com/oxc-project/estree-conformance/pull/160
