### PR TITLE
fix(vscode): normalize paths on Windows

### DIFF
--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -21,6 +21,16 @@ export class ConfigService implements IDisposable {
 
   private workspaceConfigs: Map<string, WorkspaceConfig> = new Map();
 
+  /**
+   * Normalize workspace URI path for consistent map key lookup.
+   * On Windows, drive letter casing can vary (e.g., `/c:/` vs `/C:/`),
+   * causing Map lookups to fail. Normalize to lowercase on Windows.
+   */
+  private normalizeWorkspacePath(uri: Uri): string {
+    const path = uri.path;
+    return process.platform === "win32" ? path.toLowerCase() : path;
+  }
+
   public onConfigChange:
     | ((this: ConfigService, config: ConfigurationChangeEvent) => Promise<void>)
     | undefined;
@@ -66,15 +76,15 @@ export class ConfigService implements IDisposable {
   }
 
   public addWorkspaceConfig(workspace: WorkspaceFolder): void {
-    this.workspaceConfigs.set(workspace.uri.path, new WorkspaceConfig(workspace));
+    this.workspaceConfigs.set(this.normalizeWorkspacePath(workspace.uri), new WorkspaceConfig(workspace));
   }
 
   public removeWorkspaceConfig(workspace: WorkspaceFolder): void {
-    this.workspaceConfigs.delete(workspace.uri.path);
+    this.workspaceConfigs.delete(this.normalizeWorkspacePath(workspace.uri));
   }
 
   public getWorkspaceConfig(workspace: Uri): WorkspaceConfig | undefined {
-    return this.workspaceConfigs.get(workspace.path);
+    return this.workspaceConfigs.get(this.normalizeWorkspacePath(workspace));
   }
 
   public effectsWorkspaceConfigChange(event: ConfigurationChangeEvent): boolean {


### PR DESCRIPTION
fix https://github.com/oxc-project/oxc/issues/18514

The fix was **vibecoded by Claude Code**

How I tested:

1. `$ cd editors/vscode`
1. `$ pnpm run compile`
2. `$ pnpm run package`
3. install the extension from the vsix
4. check on [test-utils.ts](https://github.com/excalidraw/excalidraw/blob/master/packages/excalidraw/tests/test-utils.ts) which was previously failing

https://github.com/user-attachments/assets/975edbc6-e7df-4c13-a8c7-1af5fa2dd9af


