### PR TITLE
test(linter/plugins): fix `impliedStrict` in ES3

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -1255,7 +1255,9 @@ function setEcmaVersionAndFeatures(test: TestCase) {
   // Set `globalReturn` and `impliedStrict` in scope analyzer options
   const ecmaFeatures = languageOptions?.parserOptions?.ecmaFeatures;
   ecmaFeaturesOverride.globalReturn = ecmaFeatures?.globalReturn ?? null;
-  ecmaFeaturesOverride.impliedStrict = ecmaFeatures?.impliedStrict ?? null;
+  // Strict mode does not exist in ES3
+  ecmaFeaturesOverride.impliedStrict =
+    ecmaVersion === 3 ? false : (ecmaFeatures?.impliedStrict ?? null);
 }
 
 // Regex to match other control characters (except tab, newline, carriage return)


### PR DESCRIPTION
Fix strict/sloppy mode of scopes in conformance tests where test case options specify ES3. Strict mode did not exist before ES5, so files are always sloppy mode in ES3.