### PR TITLE
test(linter/plugins): remove directives when parsing as ES3

### DIFF
--- a/apps/oxlint/conformance/snapshots/eslint.md
+++ b/apps/oxlint/conformance/snapshots/eslint.md
@@ -18,9 +18,9 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests | 33159 | 100.0% |
-| Passing     | 32873 |  99.1% |
+| Passing     | 32881 |  99.2% |
 | Failing     |     0 |   0.0% |
-| Skipped     |   286 |   0.9% |
+| Skipped     |   278 |   0.8% |
 
 ## Fully Passing Rules
 
@@ -137,7 +137,7 @@
 - `no-empty-static-block` (10 tests)
 - `no-empty` (35 tests)
 - `no-eq-null` (5 tests)
-- `no-eval` (101 tests) (1 skipped)
+- `no-eval` (101 tests)
 - `no-ex-assign` (8 tests)
 - `no-extend-native` (40 tests)
 - `no-extra-bind` (43 tests)
@@ -156,7 +156,7 @@
 - `no-inline-comments` (49 tests)
 - `no-inner-declarations` (68 tests)
 - `no-invalid-regexp` (108 tests)
-- `no-invalid-this` (562 tests) (4 skipped)
+- `no-invalid-this` (562 tests) (1 skipped)
 - `no-irregular-whitespace` (280 tests)
 - `no-iterator` (9 tests)
 - `no-label-var` (5 tests)
@@ -237,7 +237,7 @@
 - `no-unsafe-finally` (28 tests)
 - `no-unsafe-negation` (29 tests)
 - `no-unsafe-optional-chaining` (187 tests)
-- `no-unused-expressions` (124 tests) (4 skipped)
+- `no-unused-expressions` (124 tests)
 - `no-unused-labels` (26 tests)
 - `no-unused-private-class-members` (39 tests)
 - `no-unused-vars` (448 tests) (21 skipped)

--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -23,17 +23,6 @@ const group: TestGroup = {
     // These are not handled by `RuleTester`.
     if (code.match(/\/\/\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
 
-    // Tests rely on directives being parsed as plain `StringLiteral`s in ES3.
-    // Oxc parser does not support parsing as ES3.
-    if (
-      (ruleName === "no-eval" ||
-        ruleName === "no-invalid-this" ||
-        ruleName === "no-unused-expressions") &&
-      test.languageOptions?.ecmaVersion === 3
-    ) {
-      return true;
-    }
-
     // Test relies on scope analysis to follow ES5 semantics where function declarations in blocks are bound in parent scope.
     // TS-ESLint scope manager does not support ES5. Oxc also doesn't support parsing/semantic as ES5.
     if (

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -265,7 +265,7 @@ const LANGUAGE_OPTIONS = {
 // In conformance build, replace `LANGUAGE_OPTIONS.ecmaVersion` with a getter which returns value of local var.
 // This is to allow changing the ECMAScript version in conformance tests.
 // Some of ESLint's rules change behavior based on the version, and ESLint's tests rely on this.
-let ecmaVersion = ECMA_VERSION;
+export let ecmaVersion = ECMA_VERSION;
 
 export function setEcmaVersion(version: number): void {
   if (!CONFORMANCE) throw new Error("Should be unreachable in release or debug builds");

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -12,6 +12,7 @@ import { deserializeProgramOnly, resetBuffer } from "../generated/deserialize.js
 
 import visitorKeys from "../generated/keys.ts";
 import * as commentMethods from "./comments.ts";
+import { ecmaVersion } from "./context.ts";
 import * as locationMethods from "./location.ts";
 import { getNodeLoc, initLines, lines, lineStartIndices, resetLines } from "./location.ts";
 import { resetScopeManager, SCOPE_MANAGER } from "./scope.ts";
@@ -83,7 +84,48 @@ export function initAst(): void {
   debugAssertIsNonNull(buffer);
 
   ast = deserializeProgramOnly(buffer, sourceText, sourceStartPos, sourceByteLen, getNodeLoc);
+
+  // In conformance tests, fix AST when parsing as ES3
+  if (CONFORMANCE) fixES3Ast();
+
   debugAssertIsNonNull(ast);
+}
+
+/**
+ * Fix AST for conformance tests.
+ *
+ * Oxc parser always parses as latest ECMAScript version.
+ * Some conformance tests request parsing with `ecmaVersion: 3`, and expect directives to be parsed as string literals.
+ * When using ES3, traverse the AST and remove the `directive` property from `ExpressionStatement`s.
+ *
+ * This function is only called in conformance tests. In standard builds, minifier removes this function entirely.
+ */
+function fixES3Ast(): void {
+  if (!CONFORMANCE) throw new Error("Should be unreachable outside of conformance tests");
+
+  debugAssertIsNonNull(ast);
+  if (ecmaVersion === 3) fixES3NodesArray(ast.body);
+}
+
+function fixES3NodesArray(nodes: any[]): void {
+  for (const node of nodes) {
+    if (node !== null) fixES3Node(node);
+  }
+}
+
+function fixES3Node(node: any): void {
+  if (node.type === "ExpressionStatement") node.directive = null;
+
+  for (const key in node) {
+    if (key === "parent" || key === "range" || key === "loc") continue;
+
+    const child = node[key];
+    if (Array.isArray(child)) {
+      fixES3NodesArray(child);
+    } else if (typeof child === "object" && child !== null) {
+      fixES3Node(child);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
In ES3, directives didn't exist yet, and therefore `"use strict"` is treated as a standard string literal, rather than a directive.

In conformance tests, when test case specifies ES3, walk the AST and set `directive` property of all `ExpressionStatement`s to `null`. This transforms any directives in AST into plain string literals.

Combined with #18632 which fixed `"use strict"` processing in TS-ESLint, this means there are 8 ESLint test cases we no longer have to skip. More importantly, we're less likely to run into erroneous test failures when testing other plugins, which are laborious to diagnose.