### PR TITLE
fix(linter/plugins): `filename` option takes precedence over `parserOptions.lang` in `RuleTester`

### DIFF
--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -194,15 +194,19 @@ function modifyTestCase(test: TestCase): void {
   }
 
   if (parserDetails !== null) {
-    let { lang } = parserDetails;
-    if (parserOptions.ecmaFeatures?.jsx === true) {
-      if (lang === "ts") {
-        lang = "tsx";
-      } else if (lang === "js") {
-        lang = "jsx";
+    // If test case provides a filename, that takes precedence over the parser's default language.
+    // Don't set `lang` option, to allow Rust-side code to determine language from file extension.
+    if (test.filename == null) {
+      let { lang } = parserDetails;
+      if (parserOptions.ecmaFeatures?.jsx === true) {
+        if (lang === "ts") {
+          lang = "tsx";
+        } else if (lang === "js") {
+          lang = "jsx";
+        }
       }
+      parserOptions.lang = lang;
     }
-    parserOptions.lang = lang;
 
     // Store parser details in test case so tests using different parsers don't get detected as duplicates.
     // Store in stored test case so they appear in snapshot.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -179,6 +179,9 @@ interface ParserOptions {
   ecmaFeatures?: EcmaFeatures;
   /**
    * Language variant to parse file as.
+   *
+   * If test case provides a filename, that takes precedence over `lang` option.
+   * Language will be inferred from file extension.
    */
   lang?: Language;
   /**
@@ -1090,12 +1093,14 @@ function getParseOptions(test: TestCase): ParseOptions {
     // Handle `parserOptions.ignoreNonFatalErrors`
     if (parserOptions.ignoreNonFatalErrors === true) parseOptions.ignoreNonFatalErrors = true;
 
-    // Handle `parserOptions.lang`
-    const { lang } = parserOptions;
-    if (lang != null) {
-      parseOptions.lang = lang;
-    } else if (parserOptions.ecmaFeatures?.jsx === true) {
-      parseOptions.lang = "jsx";
+    // Handle `parserOptions.lang`. `filename` takes precedence over `lang` if provided.
+    if (test.filename == null) {
+      const { lang } = parserOptions;
+      if (lang != null) {
+        parseOptions.lang = lang;
+      } else if (parserOptions.ecmaFeatures?.jsx === true) {
+        parseOptions.lang = "jsx";
+      }
     }
   }
 

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -2205,6 +2205,46 @@ describe("RuleTester", () => {
           ]
         `);
       });
+
+      it("is overridden by `filename`", () => {
+        const tester = new RuleTester();
+        tester.run("no-foo", simpleRule, {
+          valid: [
+            {
+              code: "let x: number;",
+              filename: "foo.ts",
+              languageOptions: { parserOptions: { lang: "js" } },
+            },
+            {
+              code: "<div />",
+              filename: "foo.jsx",
+              languageOptions: { parserOptions: { lang: "ts" } },
+            },
+          ],
+          invalid: [
+            {
+              code: "let x: number;",
+              filename: "foo.jsx",
+              languageOptions: { parserOptions: { lang: "ts" } },
+              errors: 1,
+            },
+            {
+              code: "<div />",
+              filename: "foo.ts",
+              languageOptions: { parserOptions: { lang: "jsx" } },
+              errors: 1,
+            },
+          ],
+        });
+        expect(runCases()).toMatchInlineSnapshot(`
+          [
+            null,
+            null,
+            [Error: Parsing failed],
+            [Error: Parsing failed],
+          ]
+        `);
+      });
     });
 
     describe("ecmaFeatures.jsx", () => {


### PR DESCRIPTION
Fix `RuleTester`' s behavior when test case defines both `filename` and `parserOptions.lang`. `filename` takes precedence.