### PR TITLE
fix(linter/plugins): implement `context.parserPath`

### DIFF
--- a/apps/oxlint/src-js/package/define.ts
+++ b/apps/oxlint/src-js/package/define.ts
@@ -158,7 +158,7 @@ const FILE_CONTEXT: FileContext = Object.freeze({
     throw new Error("Cannot access `context.parserOptions` in `createOnce`");
   },
 
-  get parserPath(): string {
+  get parserPath(): string | undefined {
     throw new Error("Cannot access `context.parserPath` in `createOnce`");
   },
 });

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -445,9 +445,9 @@ const FILE_CONTEXT = Object.freeze({
    * The path to the parser used to parse this file.
    * @deprecated No longer supported.
    */
-  get parserPath(): string {
-    // TODO: Implement this?
-    throw new Error("`context.parserPath` is unsupported at present (and deprecated)");
+  get parserPath(): string | undefined {
+    if (filePath === null) throw new Error("Cannot access `context.parserPath` in `createOnce`");
+    return undefined;
   },
 });
 

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -12,6 +12,7 @@
   | getPhysicalFilename(): <fixture>/files/1.js
   | cwd: <fixture>
   | getCwd(): <fixture>
+  | parserPath: undefined
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -33,6 +34,7 @@
   | getPhysicalFilename(): <fixture>/files/2.js
   | cwd: <fixture>
   | getCwd(): <fixture>
+  | parserPath: undefined
    ,-[files/2.js:1:1]
  1 | let y;
    : ^

--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -22,7 +22,8 @@ const rule: Rule = {
         `physicalFilename: ${context.physicalFilename}\n` +
         `getPhysicalFilename(): ${context.getPhysicalFilename()}\n` +
         `cwd: ${context.cwd}\n` +
-        `getCwd(): ${context.getCwd()}`,
+        `getCwd(): ${context.getCwd()}\n` +
+        `parserPath: ${context.parserPath}`,
       node: SPAN,
     });
 

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -99,6 +99,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: parserPath error: Cannot access `context.parserPath` in `createOnce`
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: physicalFilename error: Cannot access `context.physicalFilename` in `createOnce`
    ,-[files/1.js:1:1]
  1 | let x;
@@ -273,6 +279,12 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): createOnce: parserPath error: Cannot access `context.parserPath` in `createOnce`
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: physicalFilename error: Cannot access `context.physicalFilename` in `createOnce`
    ,-[files/2.js:1:1]
  1 | let y;
@@ -351,7 +363,7 @@
    :     ^
    `----
 
-Found 0 warnings and 58 errors.
+Found 0 warnings and 60 errors.
 Finished in Xms on 2 files with 6 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -33,6 +33,7 @@ const alwaysRunRule: Rule = {
     const getSourceCodeError = tryCatch(() => context.getSourceCode());
     const settingsError = tryCatch(() => context.settings);
     const parserOptionsError = tryCatch(() => context.parserOptions);
+    const parserPathError = tryCatch(() => context.parserPath);
     const reportError = tryCatch(() => context.report({ message: "oh no", node: SPAN }));
 
     return {
@@ -82,6 +83,10 @@ const alwaysRunRule: Rule = {
         });
         context.report({
           message: `createOnce: parserOptions error: ${parserOptionsError?.message}`,
+          node: SPAN,
+        });
+        context.report({
+          message: `createOnce: parserPath error: ${parserPathError?.message}`,
           node: SPAN,
         });
         context.report({


### PR DESCRIPTION
Closes #18119. Implement `context.parserPath`. It evaluates to `undefined`, same as what ESLint does by default.