### PR TITLE
refactor(linter/plugins): simplify implementation of `sourceCode.parserServices`

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -39,9 +39,6 @@ export const buffers: (BufferWithArrays | null)[] = [];
 // Array of `after` hooks to run after traversal. This array reused for every file.
 const afterHooks: AfterHook[] = [];
 
-// Default parser services object (empty object).
-const PARSER_SERVICES_DEFAULT: Record<string, unknown> = Object.freeze({});
-
 /**
  * Lint a file.
  *
@@ -156,8 +153,7 @@ export function lintFileImpl(
   // But... source text and AST can be accessed in body of `create` method, or `before` hook, via `context.sourceCode`.
   // So we pass the buffer to source code module here, so it can decode source text / deserialize AST on demand.
   const hasBOM = buffer[HAS_BOM_FLAG_POS] === 1;
-  const parserServices = PARSER_SERVICES_DEFAULT; // TODO: Set this correctly
-  setupSourceForFile(buffer, hasBOM, parserServices);
+  setupSourceForFile(buffer, hasBOM);
 
   // Pass settings and globals JSON to modules that handle them
   setSettingsForFile(settingsJSON);

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -44,23 +44,14 @@ let sourceStartPos: number = 0;
 let sourceByteLen: number = 0;
 export let ast: Program | null = null;
 
-// Parser services object. Set before linting a file by `setupSourceForFile`.
-let parserServices: Record<string, unknown> | null = null;
-
 /**
  * Set up source for the file about to be linted.
  * @param bufferInput - Buffer containing AST
  * @param hasBOMInput - `true` if file's original source text has Unicode BOM
- * @param parserServicesInput - Parser services object for the file
  */
-export function setupSourceForFile(
-  bufferInput: BufferWithArrays,
-  hasBOMInput: boolean,
-  parserServicesInput: Record<string, unknown>,
-): void {
+export function setupSourceForFile(bufferInput: BufferWithArrays, hasBOMInput: boolean): void {
   buffer = bufferInput;
   hasBOM = hasBOMInput;
-  parserServices = parserServicesInput;
 }
 
 /**
@@ -142,7 +133,6 @@ export function resetSourceAndAst(): void {
   buffer = null;
   sourceText = null;
   ast = null;
-  parserServices = null;
   resetBuffer();
   resetLines();
   resetScopeManager();
@@ -227,11 +217,10 @@ export const SOURCE_CODE = Object.freeze({
 
   /**
    * Parser services for the file.
+   *
+   * Oxlint does not offer any parser services.
    */
-  get parserServices(): Record<string, unknown> {
-    debugAssertIsNonNull(parserServices);
-    return parserServices;
-  },
+  parserServices: Object.freeze({} as Record<string, unknown>),
 
   /**
    * Source text as array of lines, split according to specification's definition of line breaks.

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -33,7 +33,7 @@ function parse(path: string, sourceText: string, options?: ParseOptions): Progra
   // Set buffer (`parseRaw` adds buffer containing AST to `buffers` at index 0)
   const buffer = buffers[0];
   debugAssertIsNonNull(buffer);
-  setupSourceForFile(buffer, /* hasBOM */ false, /* parserServices */ {});
+  setupSourceForFile(buffer, /* hasBOM */ false);
 
   // Deserialize AST from buffer
   initAst();

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -63,7 +63,7 @@ function setup(sourceText: string) {
   // Set buffer (`parseRaw` adds buffer containing AST to `buffers` at index 0)
   const buffer = buffers[0];
   debugAssertIsNonNull(buffer);
-  setupSourceForFile(buffer, /* hasBOM */ false, /* parserServices */ {});
+  setupSourceForFile(buffer, /* hasBOM */ false);
 
   // Initialize source text (deserialize from buffer)
   initSourceText();


### PR DESCRIPTION
Pure refactor. No point passing an object around through functions, when `parserServices` is always an empty object, as Oxlint provides no parser services. Just define it as an empty object inline.