### PR TITLE
test(linter/plugins): add `eslint-plugin-sonarjs` to conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -4,6 +4,7 @@ set -e
 ESLINT_SHA="8f360ad6a7a743d33a83eed8973ee4a50731e55b" # 10.0.0-rc.0
 REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
 STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
+SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
 
 # Shallow clone a repo at a specific commit.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -117,6 +118,52 @@ import BABEL_ESLINT from '@babel/eslint-parser';
 import TYPESCRIPT_ESLINT from '@typescript-eslint/parser';
 export { BABEL_ESLINT, TYPESCRIPT_ESLINT };
 EOF
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# SonarJS
+###############################################################################
+
+# Clone SonarJS repo into `submodules/sonarjs`
+clone sonarjs https://github.com/SonarSource/SonarJS.git "$SONAR_SHA"
+
+# Install dependencies
+pnpm install --ignore-workspace
+
+# Build
+# (ignore errors, it's just typecheck fail)
+pnpm run bbf || true
+
+# The tests use `describe` and `it` from `node:test`, but we just need to use global `describe`,
+# and make `it` behave like `describe`
+PATTERN="s/import .* from 'node:test';/const it = describe;/"
+if [[ "$OSTYPE" == darwin* ]]; then
+  find packages/jsts/src/rules -name '*.test.ts' -exec sed -i '' "$PATTERN" {} \;
+else
+  find packages/jsts/src/rules -name '*.test.ts' -exec sed -i "$PATTERN" {} \;
+fi
+
+# Replace `import.meta.dirname` with `__dirname` (`import.meta.dirname` doesn't work after `tsx` transforms to CommonJS)
+PATTERN2="s/import\.meta\.dirname/__dirname/g"
+TESTER_PATH="packages/jsts/tests/tools/testers/rule-tester.ts"
+if [[ "$OSTYPE" == darwin* ]]; then
+  find packages/jsts/src/rules -name '*.test.ts' -exec sed -i '' "$PATTERN2" {} \;
+  sed -i '' "$PATTERN2" "$TESTER_PATH"
+else
+  find packages/jsts/src/rules -name '*.test.ts' -exec sed -i "$PATTERN2" {} \;
+  sed -i "$PATTERN2" "$TESTER_PATH"
+fi
+
+# Replace `import { it } from 'node:test';` with `const it = describe;` in comment-based checker
+PATTERN3="s/import .* from 'node:test';/const it = describe;/"
+CHECKER_PATH="packages/jsts/tests/tools/testers/comment-based/checker.ts"
+if [[ "$OSTYPE" == darwin* ]]; then
+  sed -i '' "$PATTERN3" "$CHECKER_PATH"
+else
+  sed -i "$PATTERN3" "$CHECKER_PATH"
+fi
 
 # Return to `submodules` directory
 cd ..

--- a/apps/oxlint/conformance/snapshots/sonarjs.md
+++ b/apps/oxlint/conformance/snapshots/sonarjs.md
@@ -1,0 +1,2012 @@
+# Conformance test results - sonarjs
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |   360 | 100.0% |
+| Fully passing     |   359 |  99.7% |
+| Partially passing |     1 |   0.3% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |  4482 | 100.0% |
+| Passing     |  3937 |  87.8% |
+| Failing     |    14 |   0.3% |
+| Skipped     |   531 |  11.8% |
+
+## Fully Passing Rules
+
+- `function-name (S100)` (12 tests)
+- `class-name (S101)` (6 tests)
+- `max-lines (S104)` (3 tests)
+- `no-tab (S105)` (6 tests)
+- `no-collapsible-if (S1066)` (8 tests)
+- `expression-complexity (S1067)` (20 tests)
+- `no-unused-private-class-members (S1068)` (7 tests)
+- `max-params (S107)` (14 tests)
+- `alt-text (S1077)` (1 tests) (1 skipped)
+- `mouse-events-a11y (S1082)` (2 tests) (2 skipped)
+- `no-magic-numbers (S109)` (2 tests) (2 skipped)
+- `brace-style (S1105)` (1 tests) (1 skipped)
+- `no-redundant-parentheses (S1110)` (21 tests)
+- `no-extra-semi (S1116)` (5 tests) (1 skipped)
+- `no-labels (S1119)` (2 tests)
+- `no-nested-assignment (S1121)` (60 tests)
+- `no-redundant-boolean (S1125)` (33 tests)
+- `prefer-single-boolean-return (S1126)` (19 tests)
+- `unused-import (S1128)` (1 tests) (1 skipped)
+- `unused-import (S1128)` (55 tests) (10 skipped)
+- `fixme-tag (S1134)` (6 tests)
+- `todo-tag (S1135)` (9 tests) (1 skipped)
+- `useless-string-operation (S1154)` (9 tests) (4 skipped)
+- `variable-name (S117)` (17 tests)
+- `no-unused-function-argument (S1172)` (37 tests) (1 skipped)
+- `no-empty-function (S1186)` (23 tests)
+- `no-duplicate-string (S1192)` (26 tests)
+- `no-case-label-in-switch (S1219)` (8 tests)
+- `no-parameter-reassignment (S1226)` (13 tests)
+- `comment-regex (S124)` (9 tests)
+- `elseif-without-else (S126)` (7 tests)
+- `prefer-while (S1264)` (12 tests)
+- `no-fallthrough (S128)` (16 tests)
+- `no-sonar-comments (S1291)` (12 tests)
+- `no-small-switch (S1301)` (6 tests)
+- `switch-without-default (S131)` (7 tests) (3 skipped)
+- `no-hardcoded-ip (S1313)` (7 tests)
+- `nested-control-flow (S134)` (6 tests)
+- `too-many-break-or-continue-in-loop (S135)` (24 tests)
+- `max-lines-per-function (S138)` (13 tests)
+- `semi (S1438)` (1 tests) (1 skipped)
+- `label-position (S1439)` (8 tests)
+- `public-static-readonly (S1444)` (1 tests) (1 skipped)
+- `public-static-readonly (S1444)` (1 tests)
+- `file-header (S1451)` (19 tests)
+- `call-argument-line (S1472)` (18 tests)
+- `max-switch-cases (S1479)` (5 tests)
+- `no-unused-vars (S1481)` (7 tests)
+- `prefer-immediate-return (S1488)` (35 tests) (2 skipped)
+- `function-inside-loop (S1515)` (16 tests)
+- `code-eval (S1523)` (21 tests)
+- `no-variable-usage-before-declaration (S1526)` (13 tests)
+- `future-reserved-words (S1527)` (2 tests) (1 skipped)
+- `array-constructor (S1528)` (14 tests)
+- `bitwise-operators (S1529)` (17 tests) (4 skipped)
+- `no-function-declaration-in-block (S1530)` (5 tests)
+- `no-primitive-wrappers (S1533)` (14 tests)
+- `no-dupe-keys (S1534)` (1 tests) (1 skipped)
+- `no-dupe-keys (S1534)` (6 tests)
+- `for-in (S1535)` (8 tests)
+- `cyclomatic-complexity (S1541)` (26 tests)
+- `no-skipped-tests (S1607)` (1 tests)
+- `no-unreachable-loop (S1751)` (31 tests)
+- `no-unreachable (S1763)` (3 tests)
+- `no-identical-expressions (S1764)` (35 tests)
+- `default-param-last (S1788)` (1 tests) (1 skipped)
+- `no-nested-switch (S1821)` (6 tests)
+- `constructor-for-side-effects (S1848)` (32 tests)
+- `no-dead-store (S1854)` (41 tests)
+- `no-identical-conditions (S1862)` (36 tests)
+- `no-duplicated-branches (S1871)` (24 tests)
+- `deprecation (S1874)` (1 tests) (1 skipped)
+- `no-inverted-boolean-check (S1940)` (17 tests)
+- `misplaced-loop-counter (S1994)` (3 tests)
+- `no-nested-functions (S2004)` (1 tests) (1 skipped)
+- `no-nested-functions (S2004)` (6 tests)
+- `no-hardcoded-passwords (S2068)` (20 tests)
+- `sql-queries (S2077)` (28 tests)
+- `insecure-cookie (S2092)` (42 tests)
+- `no-useless-increment (S2123)` (9 tests)
+- `no-globals-shadowing (S2137)` (28 tests)
+- `no-undefined-assignment (S2138)` (14 tests)
+- `no-empty-test-file (S2187)` (12 tests)
+- `no-infinite-loop (S2189)` (33 tests)
+- `no-ignored-return (S2201)` (13 tests) (6 skipped)
+- `no-wildcard-import (S2208)` (4 tests)
+- `arguments-order (S2234)` (13 tests) (3 skipped)
+- `pseudo-random (S2245)` (7 tests)
+- `for-loop-increment-sign (S2251)` (84 tests)
+- `cookies (S2255)` (15 tests)
+- `null-dereference (S2259)` (40 tests) (11 skipped)
+- `no-selector-parameter (S2301)` (18 tests) (5 skipped)
+- `updated-loop-counter (S2310)` (14 tests)
+- `accessor-pairs (S2376)` (7 tests)
+- `block-scoped-var (S2392)` (5 tests)
+- `no-built-in-override (S2424)` (19 tests)
+- `prefer-object-literal (S2428)` (18 tests)
+- `new-cap (S2430)` (4 tests)
+- `no-ignored-exceptions (S2486)` (1 tests) (1 skipped)
+- `no-gratuitous-expressions (S2589)` (15 tests)
+- `file-uploads (S2598)` (10 tests)
+- `file-permissions (S2612)` (32 tests)
+- `no-empty-character-class (S2639)` (1 tests) (1 skipped)
+- `no-unenclosed-multiline-block (S2681)` (20 tests)
+- `use-isnan (S2688)` (1 tests) (1 skipped)
+- `index-of-compare-to-positive-number (S2692)` (8 tests) (3 skipped)
+- `assertions-in-tests (S2699)` (10 tests) (10 skipped)
+- `assertions-in-tests (S2699)` (27 tests)
+- `no-implicit-global (S2703)` (14 tests)
+- `no-useless-catch (S2737)` (10 tests)
+- `xml-parser-xxe (S2755)` (22 tests) (2 skipped)
+- `non-existent-operator (S2757)` (6 tests)
+- `no-redeclare (S2814)` (4 tests)
+- `web-sql-database (S2817)` (9 tests) (3 skipped)
+- `post-message (S2819)` (25 tests) (12 skipped)
+- `no-array-delete (S2870)` (1 tests) (1 skipped)
+- `no-alphabetical-sort (S2871)` (69 tests) (38 skipped)
+- `no-incomplete-assertions (S2970)` (1 tests) (1 skipped)
+- `no-global-this (S2990)` (26 tests)
+- `new-operator-misuse (S2999)` (19 tests) (6 skipped)
+- `no-delete-var (S3001)` (24 tests)
+- `strings-comparison (S3003)` (13 tests) (5 skipped)
+- `file-name-differ-from-class (S3317)` (23 tests)
+- `cookie-no-httponly (S3330)` (42 tests)
+- `prefer-const (S3353)` (4 tests)
+- `no-nested-conditional (S3358)` (13 tests)
+- `no-incorrect-string-concat (S3402)` (17 tests) (5 skipped)
+- `different-types-comparison (S3403)` (31 tests) (5 skipped)
+- `inverted-assertion-arguments (S3415)` (1 tests) (1 skipped)
+- `object-shorthand (S3498)` (4 tests)
+- `shorthand-property-grouping (S3499)` (4 tests)
+- `updated-const-var (S3500)` (2 tests)
+- `no-var (S3504)` (2 tests) (2 skipped)
+- `prefer-template (S3512)` (7 tests)
+- `arguments-usage (S3513)` (2 tests)
+- `destructuring-assignment-syntax (S3514)` (5 tests)
+- `no-invariant-returns (S3516)` (13 tests)
+- `arrow-function-convention (S3524)` (9 tests)
+- `class-prototype (S3525)` (11 tests) (2 skipped)
+- `generator-without-yield (S3531)` (16 tests)
+- `no-require-or-define (S3533)` (19 tests) (6 skipped)
+- `no-associative-arrays (S3579)` (9 tests) (4 skipped)
+- `comma-or-logical-or-case (S3616)` (6 tests)
+- `no-redundant-jump (S3626)` (10 tests)
+- `inconsistent-function-call (S3686)` (7 tests)
+- `no-throw-literal (S3696)` (7 tests)
+- `no-use-of-empty-return-value (S3699)` (40 tests)
+- `enforce-trailing-comma (S3723)` (2 tests)
+- `void-use (S3735)` (20 tests) (5 skipped)
+- `operation-returning-nan (S3757)` (12 tests) (5 skipped)
+- `values-not-convertible-to-numbers (S3758)` (23 tests) (6 skipped)
+- `non-number-in-arithmetic-expression (S3760)` (17 tests) (13 skipped)
+- `cognitive-complexity (S3776)` (39 tests)
+- `argument-type (S3782)` (15 tests) (6 skipped)
+- `in-operator-type-error (S3785)` (9 tests) (5 skipped)
+- `array-callback-without-return (S3796)` (32 tests) (22 skipped)
+- `declarations-in-global-scope (S3798)` (28 tests)
+- `function-return-type (S3800)` (1 tests) (1 skipped)
+- `function-return-type (S3800)` (36 tests) (11 skipped)
+- `no-inconsistent-returns (S3801)` (27 tests) (10 skipped)
+- `no-reference-error (S3827)` (1 tests) (1 skipped)
+- `no-reference-error (S3827)` (13 tests)
+- `super-invocation (S3854)` (3 tests)
+- `no-all-duplicated-branches (S3923)` (25 tests)
+- `no-same-line-conditional (S3972)` (14 tests)
+- `conditional-indentation (S3973)` (13 tests)
+- `no-collection-size-mischeck (S3981)` (13 tests) (1 skipped)
+- `no-unthrown-error (S3984)` (10 tests)
+- `no-empty-interface (S4023)` (4 tests)
+- `no-unused-collection (S4030)` (17 tests)
+- `no-os-command-from-path (S4036)` (1 tests) (1 skipped)
+- `no-misleading-array-reverse (S4043)` (19 tests) (13 skipped)
+- `media-has-caption (S4084)` (1 tests) (1 skipped)
+- `await-thenable (S4123)` (19 tests) (7 skipped)
+- `prefer-for-of (S4138)` (11 tests)
+- `no-for-in-iterable (S4139)` (14 tests) (11 skipped)
+- `no-element-overwrite (S4143)` (20 tests)
+- `no-identical-functions (S4144)` (10 tests)
+- `prefer-namespace-keyword (S4156)` (1 tests) (1 skipped)
+- `no-empty-collection (S4158)` (33 tests)
+- `no-redundant-assignments (S4165)` (44 tests)
+- `no-accessor-field-mismatch (S4275)` (56 tests)
+- `prefer-type-guard (S4322)` (25 tests)
+- `use-type-alias (S4323)` (12 tests)
+- `no-return-type-any (S4324)` (21 tests) (10 skipped)
+- `no-this-alias (S4327)` (1 tests) (1 skipped)
+- `no-implicit-dependencies (S4328)` (43 tests) (2 skipped)
+- `no-useless-intersection (S4335)` (15 tests) (9 skipped)
+- `weak-ssl (S4423)` (1 tests) (1 skipped)
+- `weak-ssl (S4423)` (16 tests)
+- `no-weak-keys (S4426)` (11 tests)
+- `csrf (S4502)` (8 tests)
+- `production-debug (S4507)` (6 tests)
+- `prefer-default-last (S4524)` (5 tests)
+- `no-in-misuse (S4619)` (9 tests) (5 skipped)
+- `no-duplicate-in-composite (S4621)` (17 tests)
+- `max-union-size (S4622)` (16 tests)
+- `no-undefined-argument (S4623)` (14 tests) (7 skipped)
+- `no-nested-template-literals (S4624)` (10 tests)
+- `prefer-promise-shorthand (S4634)` (9 tests)
+- `os-command (S4721)` (18 tests)
+- `no-redundant-optional (S4782)` (13 tests) (11 skipped)
+- `regular-expr (S4784)` (16 tests)
+- `encryption (S4787)` (18 tests)
+- `hashing (S4790)` (1 tests) (1 skipped)
+- `bool-param-default (S4798)` (14 tests)
+- `xpath (S4817)` (20 tests)
+- `sockets (S4818)` (5 tests)
+- `no-try-promise (S4822)` (14 tests) (8 skipped)
+- `process-argv (S4823)` (6 tests)
+- `standard-input (S4829)` (6 tests)
+- `unverified-certificate (S4830)` (12 tests)
+- `no-unsafe-unzip (S5042)` (15 tests)
+- `cors (S5122)` (4 tests) (4 skipped)
+- `link-with-target-blank (S5148)` (1 tests) (1 skipped)
+- `disabled-auto-escaping (S5247)` (1 tests) (1 skipped)
+- `html-has-lang (S5254)` (1 tests) (1 skipped)
+- `table-header (S5256)` (1 tests) (1 skipped)
+- `no-table-as-layout (S5257)` (1 tests) (1 skipped)
+- `table-header-reference (S5260)` (1 tests) (1 skipped)
+- `object-alt-content (S5264)` (1 tests) (1 skipped)
+- `no-clear-text-protocols (S5332)` (1 tests) (1 skipped)
+- `no-clear-text-protocols (S5332)` (25 tests)
+- `publicly-writable-directories (S5443)` (3 tests)
+- `unverified-hostname (S5527)` (26 tests)
+- `encryption-secure-mode (S5542)` (68 tests)
+- `no-weak-cipher (S5547)` (8 tests)
+- `no-intrusive-permissions (S5604)` (26 tests)
+- `insecure-jwt-token (S5659)` (42 tests)
+- `x-powered-by (S5689)` (26 tests)
+- `hidden-files (S5691)` (3 tests)
+- `content-length (S5693)` (11 tests)
+- `disabled-resource-integrity (S5725)` (12 tests) (2 skipped)
+- `content-security-policy (S5728)` (11 tests)
+- `no-mixed-content (S5730)` (12 tests)
+- `frame-ancestors (S5732)` (14 tests)
+- `no-mime-sniff (S5734)` (15 tests)
+- `no-referrer-policy (S5736)` (13 tests)
+- `strict-transport-security (S5739)` (14 tests)
+- `certificate-transparency (S5742)` (13 tests)
+- `dns-prefetching (S5743)` (8 tests)
+- `confidential-information-logging (S5757)` (10 tests)
+- `no-ip-forward (S5759)` (9 tests)
+- `empty-string-repetition (S5842)` (37 tests)
+- `regex-complexity (S5843)` (45 tests) (1 skipped)
+- `anchor-precedence (S5850)` (1 tests) (1 skipped)
+- `anchor-precedence (S5850)` (20 tests)
+- `slow-regex (S5852)` (6 tests)
+- `no-invalid-regexp (S5856)` (10 tests) (1 skipped)
+- `unused-named-groups (S5860)` (52 tests) (26 skipped)
+- `no-same-argument-assert (S5863)` (1 tests) (1 skipped)
+- `no-same-argument-assert (S5863)` (2 tests)
+- `unicode-aware-regex (S5867)` (20 tests)
+- `no-misleading-character-class (S5868)` (107 tests)
+- `duplicates-in-character-class (S5869)` (55 tests)
+- `session-regeneration (S5876)` (7 tests)
+- `test-check-exception (S5958)` (1 tests) (1 skipped)
+- `no-empty-after-reluctant (S6019)` (8 tests)
+- `single-character-alternation (S6035)` (18 tests)
+- `no-code-after-done (S6079)` (1 tests) (1 skipped)
+- `disabled-timeout (S6080)` (1 tests) (1 skipped)
+- `chai-determinate-assertion (S6092)` (1 tests) (1 skipped)
+- `chai-determinate-assertion (S6092)` (2 tests)
+- `aws-s3-bucket-server-encryption (S6245)` (1 tests) (1 skipped)
+- `aws-s3-bucket-insecure-http (S6249)` (1 tests) (1 skipped)
+- `aws-s3-bucket-versioning (S6252)` (1 tests) (1 skipped)
+- `aws-s3-bucket-granted-access (S6265)` (1 tests) (1 skipped)
+- `no-angular-bypass-sanitization (S6268)` (4 tests)
+- `aws-iam-public-access (S6270)` (1 tests) (1 skipped)
+- `aws-ec2-unencrypted-ebs-volume (S6275)` (1 tests) (1 skipped)
+- `aws-s3-bucket-public-access (S6281)` (1 tests) (1 skipped)
+- `no-vue-bypass-sanitization (S6299)` (15 tests) (4 skipped)
+- `aws-iam-all-privileges (S6302)` (1 tests) (1 skipped)
+- `aws-rds-unencrypted-databases (S6303)` (1 tests) (1 skipped)
+- `aws-iam-all-resources-accessible (S6304)` (1 tests) (1 skipped)
+- `aws-opensearchservice-domain (S6308)` (1 tests) (1 skipped)
+- `aws-iam-privilege-escalation (S6317)` (1 tests) (1 skipped)
+- `aws-sagemaker-unencrypted-notebook (S6319)` (1 tests) (1 skipped)
+- `aws-restricted-ip-admin-access (S6321)` (1 tests) (1 skipped)
+- `no-empty-alternatives (S6323)` (19 tests)
+- `no-control-regex (S6324)` (30 tests)
+- `no-regex-spaces (S6326)` (10 tests)
+- `aws-sns-unencrypted-topics (S6327)` (1 tests) (1 skipped)
+- `existing-groups (S6328)` (29 tests) (10 skipped)
+- `aws-ec2-rds-dms-public (S6329)` (1 tests) (1 skipped)
+- `aws-sqs-unencrypted-queue (S6330)` (1 tests) (1 skipped)
+- `no-empty-group (S6331)` (13 tests)
+- `aws-efs-unencrypted (S6332)` (1 tests) (1 skipped)
+- `aws-apigateway-public-api (S6333)` (1 tests) (1 skipped)
+- `stateful-regex (S6351)` (39 tests)
+- `concise-regex (S6353)` (32 tests)
+- `single-char-in-character-classes (S6397)` (1 tests) (1 skipped)
+- `no-hardcoded-secrets (S6418)` (1 tests) (1 skipped)
+- `no-hardcoded-secrets (S6418)` (1 tests)
+- `no-exclusive-tests (S6426)` (1 tests) (1 skipped)
+- `hardcoded-secret-signatures (S6437)` (1 tests) (1 skipped)
+- `jsx-no-leaked-render (S6439)` (1 tests) (1 skipped)
+- `jsx-no-leaked-render (S6439)` (10 tests) (6 skipped)
+- `rules-of-hooks (S6440)` (1 tests) (1 skipped)
+- `no-unused-class-component-methods (S6441)` (1 tests) (1 skipped)
+- `no-hook-setter-in-body (S6442)` (1 tests) (1 skipped)
+- `no-useless-react-setstate (S6443)` (1 tests) (1 skipped)
+- `no-unstable-nested-components (S6478)` (1 tests) (1 skipped)
+- `no-unstable-nested-components (S6478)` (6 tests)
+- `no-array-index-key (S6479)` (7 tests)
+- `jsx-no-constructed-context-values (S6481)` (1 tests) (1 skipped)
+- `no-uniq-key (S6486)` (1 tests) (1 skipped)
+- `unnecessary-character-escapes (S6535)` (1 tests) (1 skipped)
+- `no-misused-promises (S6544)` (4 tests) (4 skipped)
+- `no-base-to-string (S6551)` (1 tests) (1 skipped)
+- `prefer-string-starts-ends-with (S6557)` (3 tests) (2 skipped)
+- `redundant-type-aliases (S6564)` (1 tests) (1 skipped)
+- `no-redundant-type-constituents (S6571)` (1 tests) (1 skipped)
+- `prefer-enum-initializers (S6572)` (1 tests) (1 skipped)
+- `prefer-optional-chain (S6582)` (1 tests) (1 skipped)
+- `prefer-optional-chain (S6582)` (1 tests)
+- `prefer-regexp-exec (S6594)` (1 tests) (1 skipped)
+- `prefer-function-type (S6598)` (2 tests)
+- `prefer-nullish-coalescing (S6606)` (9 tests) (1 skipped)
+- `no-internal-api-use (S6627)` (1 tests) (1 skipped)
+- `no-extend-native (S6643)` (1 tests) (1 skipped)
+- `no-useless-constructor (S6647)` (2 tests) (2 skipped)
+- `no-useless-constructor (S6647)` (2 tests) (1 skipped)
+- `no-lonely-if (S6660)` (3 tests)
+- `prefer-object-spread (S6661)` (5 tests)
+- `prefer-spread (S6666)` (3 tests)
+- `no-useless-call (S6676)` (9 tests)
+- `no-self-compare (S6679)` (8 tests)
+- `jsx-no-useless-fragment (S6749)` (2 tests)
+- `hook-use-state (S6754)` (9 tests)
+- `prefer-read-only-props (S6759)` (1 tests) (1 skipped)
+- `prefer-read-only-props (S6759)` (9 tests) (2 skipped)
+- `no-find-dom-node (S6788)` (2 tests)
+- `no-unsafe (S6791)` (2 tests)
+- `prefer-tag-over-role (S6819)` (25 tests)
+- `anchor-has-content (S6827)` (1 tests) (1 skipped)
+- `anchor-is-valid (S6844)` (1 tests) (1 skipped)
+- `label-has-associated-control (S6853)` (1 tests) (1 skipped)
+- `no-deprecated-react (S6957)` (1 tests) (1 skipped)
+- `no-deprecated-react (S6957)` (10 tests)
+- `no-literal-call (S6958)` (28 tests)
+- `reduce-initial-value (S6959)` (1 tests) (1 skipped)
+- `reduce-initial-value (S6959)` (5 tests)
+- `no-async-constructor (S7059)` (1 tests) (1 skipped)
+- `no-self-import (S7060)` (1 tests) (1 skipped)
+- `review-blockchain-mnemonic (S7639)` (1 tests) (1 skipped)
+- `catch-error-name (S7718)` (38 tests) (38 skipped)
+- `no-array-callback-reference (S7727)` (13 tests) (6 skipped)
+- `no-array-for-each (S7728)` (9 tests) (3 skipped)
+- `no-array-method-this-argument (S7729)` (7 tests) (2 skipped)
+- `prefer-at (S7755)` (3 tests) (1 skipped)
+- `prefer-export-from (S7763)` (10 tests)
+- `prefer-native-coercion-functions (S7770)` (4 tests)
+- `prefer-top-level-await (S7785)` (3 tests)
+- `dynamically-constructed-templates (S7790)` (2 tests) (2 skipped)
+- `no-nested-incdec (S881)` (24 tests)
+- `no-equals-in-for-termination (S888)` (1 tests) (1 skipped)
+- `no-unused-expressions (S905)` (11 tests)
+- `no-extra-arguments (S930)` (16 tests)
+
+## Rules with Failures
+
+- `no-commented-code (S125)` - 4 / 18 (22.2%)
+
+## Rules with Failures Detail
+
+### `no-commented-code (S125)`
+
+Pass: 4 / 18 (22.2%)
+Fail: 14 / 18 (77.8%)
+Skip: 0 / 18 (0.0%)
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// if (something) {}
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "message": "Remove this commented out code.",
+      "line": 1,
+      "endLine": 1,
+      "column": 1,
+      "endColumn": 21,
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// // nested comment
+// foo(a, function(){
+//     doSmth();
+// });
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "message": "Remove this commented out code.",
+      "line": 1,
+      "column": 1,
+      "endLine": 4,
+      "endColumn": 7,
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+/* // nested comment
+@annotation
+class MyClass {}
+
+foo(a, function(){
+   doSmth();
+   const a = <bv></bv>
+});*/
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "message": "Remove this commented out code.",
+      "line": 1,
+      "column": 1,
+      "endLine": 8,
+      "endColumn": 6,
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// return foo().bar();
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// foo();
+// bar();
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+/* foo();
+bar(); */
+const a = 1;
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": "\nconst a = 1;"
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+/* throw foo().bar(); */
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// if (condition) {
+//   while (condition) {
+//     doSomething();
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+//   while (condition) {
+//     doSomething();
+//   }
+// }
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// }}
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// {{
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+//   }
+// }
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": ""
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+let x = /* let x = 42; */ 0;
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": "let x =  0;"
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+
+
+#### S125 > S125 > Sections of code should not be commented out > invalid
+
+```js
+// if (value == 42) {
+//   value++
+let x = 0;
+```
+
+```json
+{
+  "files": [
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "languageOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "globals": {
+      "AggregateError": false,
+      "Array": false,
+      "ArrayBuffer": false,
+      "Atomics": false,
+      "BigInt": false,
+      "BigInt64Array": false,
+      "BigUint64Array": false,
+      "Boolean": false,
+      "DataView": false,
+      "Date": false,
+      "decodeURI": false,
+      "decodeURIComponent": false,
+      "encodeURI": false,
+      "encodeURIComponent": false,
+      "Error": false,
+      "escape": false,
+      "eval": false,
+      "EvalError": false,
+      "FinalizationRegistry": false,
+      "Float16Array": false,
+      "Float32Array": false,
+      "Float64Array": false,
+      "Function": false,
+      "globalThis": false,
+      "Infinity": false,
+      "Int16Array": false,
+      "Int32Array": false,
+      "Int8Array": false,
+      "Intl": false,
+      "isFinite": false,
+      "isNaN": false,
+      "Iterator": false,
+      "JSON": false,
+      "Map": false,
+      "Math": false,
+      "NaN": false,
+      "Number": false,
+      "Object": false,
+      "parseFloat": false,
+      "parseInt": false,
+      "Promise": false,
+      "Proxy": false,
+      "RangeError": false,
+      "ReferenceError": false,
+      "Reflect": false,
+      "RegExp": false,
+      "Set": false,
+      "SharedArrayBuffer": false,
+      "String": false,
+      "Symbol": false,
+      "SyntaxError": false,
+      "TypeError": false,
+      "Uint16Array": false,
+      "Uint32Array": false,
+      "Uint8Array": false,
+      "Uint8ClampedArray": false,
+      "undefined": false,
+      "unescape": false,
+      "URIError": false,
+      "WeakMap": false,
+      "WeakRef": false,
+      "WeakSet": false
+    },
+    "parserOptions": {
+      "disallowAutomaticSingleRunInference": true,
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    }
+  },
+  "errors": [
+    {
+      "messageId": "commentedCode",
+      "suggestions": [
+        {
+          "desc": "Remove this commented out code",
+          "output": "\nlet x = 0;"
+        }
+      ]
+    }
+  ],
+  "filename": "apps/oxlint/conformance/submodules/sonarjs/packages/jsts/tests/tools/testers/fixtures/placeholder.tsx"
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
+    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
+    at apps/oxlint/dist/rule_tester.js
+

--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -43,7 +43,7 @@ export function setCurrentGroup(group: TestGroup): void {
 }
 
 // Current rule being tested
-let currentRule: RuleResult | null = null;
+export let currentRule: RuleResult | null = null;
 
 /**
  * Set the current rule being tested.

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -3,5 +3,6 @@ import type { TestGroup } from "../index.ts";
 import eslint from "./eslint.ts";
 import reactHooks from "./react_hooks.ts";
 import stylistic from "./stylistic.ts";
+import sonarjs from "./sonarjs.ts";
 
-export const TEST_GROUPS: TestGroup[] = [eslint, reactHooks, stylistic];
+export const TEST_GROUPS: TestGroup[] = [eslint, reactHooks, stylistic, sonarjs];

--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -1,0 +1,159 @@
+import { createRequire } from "node:module";
+import { join as pathJoin } from "node:path";
+import { currentRule } from "../capture.ts";
+
+import type { TestGroup } from "../index.ts";
+import type { TestCase, TestCases, ValidTestCase, InvalidTestCase } from "../rule_tester.ts";
+import type { Rule } from "#oxlint/plugin";
+
+const SUBMODULE_NAME = "sonarjs";
+const TEST_FILES_RELATIVE_DIR_PATH = "packages/jsts/src/rules";
+const TEST_FILES_DIR_PATH = pathJoin(
+  import.meta.dirname,
+  "../../submodules",
+  SUBMODULE_NAME,
+  TEST_FILES_RELATIVE_DIR_PATH,
+);
+
+const group: TestGroup = {
+  name: "sonarjs",
+
+  submoduleName: SUBMODULE_NAME,
+  testFilesDirPath: TEST_FILES_RELATIVE_DIR_PATH,
+
+  transformTestFilename(filename: string) {
+    // Each rule has its own directory in `packages/jsts/src/rules`, each dir named `Sxxx` e.g. `S100`.
+    // Test files are in those subdirectories.
+    // e.g. `packages/jsts/src/rules/S100/unit.test.ts`
+    if (!filename.endsWith(".test.ts")) return null;
+    const parts = filename.split("/");
+    if (parts.length !== 2) return null;
+
+    // Get rule name from `meta.js` file in test file's directory
+    const requireFromTest = createRequire(pathJoin(TEST_FILES_DIR_PATH, filename));
+    const meta = requireFromTest(`./meta.js`);
+    return `${meta.eslintId} (${parts[0]})`;
+  },
+
+  prepare(require: NodeJS.Require, _mock: (path: string, value: unknown) => void) {
+    // Patch SonarJS's rule tester classes.
+    // Internally they use ESLint's `RuleTester`, which is already patched to use conformance `RuleTester`,
+    // but we need to apply further patches.
+
+    // Load module, clone and write clone into module cache.
+    // Can't mutate the original module object because it's transformed from ESM and is frozen.
+    const path = require.resolve("../../tests/tools/testers/rule-tester.ts");
+    let testerModule = require(path);
+    testerModule = { ...testerModule };
+    Object.defineProperty(testerModule, "__esModule", { value: true });
+    require.cache[path]!.exports = testerModule;
+
+    // Patch type-aware rule tester, to add `_isTypeAware` property to test cases.
+    // This is used to skip test cases which fail, because Oxlint can't support type-aware rules.
+    testerModule.RuleTester = class extends testerModule.RuleTester {
+      run(name: string, rule: Rule, tests: TestCases): void {
+        tests = {
+          valid: tests.valid.map((test) => {
+            if (typeof test === "string") test = { code: test };
+            return { ...test, _isTypeAware: true } as ValidTestCase;
+          }),
+          invalid: tests.invalid.map(
+            (test) => ({ ...test, _isTypeAware: true }) as InvalidTestCase,
+          ),
+        };
+        super.run(name, rule, tests);
+      }
+    };
+
+    // Patch non-type-aware rule tester, to fix some test cases which contain JSX syntax with a `.js` filename.
+    // Change filename to `.jsx` to allow them to be parsed.
+    testerModule.NoTypeCheckingRuleTester = class extends testerModule.NoTypeCheckingRuleTester {
+      run(name: string, rule: Rule, tests: TestCases): void {
+        if (currentRule?.ruleName === "no-deprecated-react (S6957)") {
+          tests = {
+            valid: tests.valid.map((test) =>
+              fixTestIfJsx(typeof test === "string" ? { code: test } : test),
+            ),
+            invalid: tests.invalid.map(fixTestIfJsx),
+          };
+        }
+
+        super.run(name, rule, tests);
+      }
+    };
+
+    // Fix a bug with `tsx`
+    const unicornPath = require.resolve("eslint-plugin-unicorn");
+    const unicornRequire = createRequire(unicornPath);
+    const validatorIdentifier = unicornRequire("@babel/helper-validator-identifier");
+    validatorIdentifier.default = validatorIdentifier;
+  },
+
+  shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
+    // Skip test cases which include `// eslint-disable` comments.
+    // These are not handled by `RuleTester`.
+    if (code.match(/\/[/*]\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
+
+    // Faulty test cases - valid test cases with `errors` property
+    if (ruleName === "S2755" && err.message === "Valid test case must not have `errors` property") {
+      return true;
+    }
+
+    // Only valid code in ES3, and Oxc parser does not support ES3
+    if (
+      ruleName === "S1527" &&
+      code.includes("var implements;") &&
+      (test.languageOptions?.parserOptions as any)?.ecmaVersion === 3 &&
+      err.message === "Parsing failed"
+    ) {
+      return true;
+    }
+
+    // Test cases' options contain `RegExp`s, which are not JSON-serializable.
+    // This isn't possible in Oxlint, because Oxlint config is JSON.
+    if (ruleName === "S7718" && err.message.startsWith("Options validation failed for rule ")) {
+      return true;
+    }
+
+    // Unit tests which don't use `RuleTester` - not relevant
+    if (
+      err.message === "Test case was not run with `RuleTester`" &&
+      ((ruleName === "S1116" && code === "S1116 handles null nodes") ||
+        (ruleName === "S1172" && code === "should handle incomplete AST") ||
+        (ruleName === "S6647" && code === "should crash with decorated rule"))
+    ) {
+      return true;
+    }
+
+    // We cannot support type-aware rules
+    if ((test as any)._isTypeAware) return true;
+
+    /*
+    // "Sections of code should not be commented out" rule uses `context.languageOptions.parser.parse` to parse code.
+    // This is not implemented yet. We should be able to pass these tests once we implement it.
+    if (ruleName === "S125") {
+      return true;
+    }
+    */
+
+    return false;
+  },
+
+  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+
+  parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
+};
+
+export default group;
+
+/**
+ * If test case contains JSX syntax with a `.js` filename, convert filename to `.jsx` to allow them to be parsed.
+ * @param test - Test case
+ * @returns - Amended test case
+ */
+function fixTestIfJsx<T extends TestCase>(test: T): T {
+  if (test.code.match(/<[a-zA-Z_$][a-zA-Z0-9_$]*(\s* \/)?>/) && test.filename?.endsWith(".js")) {
+    return { ...test, filename: `${test.filename}x` };
+  }
+  return test;
+}

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -17,7 +17,7 @@ import type {
 
 type DescribeFn = RuleTester.DescribeFn;
 type ItFn = RuleTester.ItFn;
-type TestCases = RuleTester.TestCases;
+export type TestCases = RuleTester.TestCases;
 type Globals = RuleTester.Globals;
 export type Language = RuleTester.Language;
 export type LanguageOptions = LanguageOptionsInternal;


### PR DESCRIPTION
Add `eslint-plugin-sonarjs` to conformance tests.

This was largely motivated by trying to track down the CFG malfunctions reported in #18555. But there are none to be found!

99.7% pass rate. The last 0.3% (14 tests) is rules which use `context.languageOptions.parser.parse`, which we haven't implemented yet.

Failing test cases for rules which are type-aware are skipped (385 tests), as we cannot support them.

