### PR TITLE
fix(formatter): preserve comments on rest elements

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -2336,13 +2336,7 @@ impl<'a> AstNode<'a, AssignmentTargetPattern<'a>> {
 impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
-        let following_span_start = self
-            .inner
-            .rest
-            .as_deref()
-            .map(|n| n.span().start)
-            .or(Some(self.following_span_start))
-            .unwrap_or(0);
+        let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
@@ -2353,7 +2347,7 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_span_start = self.following_span_start;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
@@ -2377,13 +2371,7 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
 impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
-        let following_span_start = self
-            .inner
-            .rest
-            .as_deref()
-            .map(|n| n.span().start)
-            .or(Some(self.following_span_start))
-            .unwrap_or(0);
+        let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
@@ -2394,7 +2382,7 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, AssignmentTargetRest<'a>>> {
-        let following_span_start = self.following_span_start;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
@@ -3979,13 +3967,7 @@ impl<'a> AstNode<'a, AssignmentPattern<'a>> {
 impl<'a> AstNode<'a, ObjectPattern<'a>> {
     #[inline]
     pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
-        let following_span_start = self
-            .inner
-            .rest
-            .as_deref()
-            .map(|n| n.span().start)
-            .or(Some(self.following_span_start))
-            .unwrap_or(0);
+        let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
             allocator: self.allocator,
@@ -3996,7 +3978,7 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_span_start = self.following_span_start;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),
@@ -4063,13 +4045,7 @@ impl<'a> AstNode<'a, BindingProperty<'a>> {
 impl<'a> AstNode<'a, ArrayPattern<'a>> {
     #[inline]
     pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
-        let following_span_start = self
-            .inner
-            .rest
-            .as_deref()
-            .map(|n| n.span().start)
-            .or(Some(self.following_span_start))
-            .unwrap_or(0);
+        let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
             allocator: self.allocator,
@@ -4080,7 +4056,7 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
 
     #[inline]
     pub fn rest(&self) -> Option<&AstNode<'a, BindingRestElement<'a>>> {
-        let following_span_start = self.following_span_start;
+        let following_span_start = 0;
         self.allocator
             .alloc(self.inner.rest.as_ref().map(|inner| AstNode {
                 inner: inner.as_ref(),

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/rest_element_comments.js
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/rest_element_comments.js
@@ -1,0 +1,16 @@
+// Type cast comments on rest elements should stay after the comma
+
+// ArrayPattern
+const [a, /** @type {string[]} */ ...rest1] = arr;
+
+// ObjectPattern
+const { a: x, /** @type {object} */ ...rest2 } = obj;
+
+// ArrayAssignmentTarget
+[a, /** @type {string[]} */ ...rest3] = arr;
+
+// ObjectAssignmentTarget
+({ a: x, /** @type {object} */ ...rest4 } = obj);
+
+// Nested patterns
+const [{ a, /** @type {number} */ ...inner }, /** @type {any[]} */ ...outer] = nested;

--- a/crates/oxc_formatter/tests/fixtures/js/typecast/rest_element_comments.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/typecast/rest_element_comments.js.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Type cast comments on rest elements should stay after the comma
+
+// ArrayPattern
+const [a, /** @type {string[]} */ ...rest1] = arr;
+
+// ObjectPattern
+const { a: x, /** @type {object} */ ...rest2 } = obj;
+
+// ArrayAssignmentTarget
+[a, /** @type {string[]} */ ...rest3] = arr;
+
+// ObjectAssignmentTarget
+({ a: x, /** @type {object} */ ...rest4 } = obj);
+
+// Nested patterns
+const [{ a, /** @type {number} */ ...inner }, /** @type {any[]} */ ...outer] = nested;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Type cast comments on rest elements should stay after the comma
+
+// ArrayPattern
+const [a, /** @type {string[]} */ ...rest1] = arr;
+
+// ObjectPattern
+const { a: x, /** @type {object} */ ...rest2 } = obj;
+
+// ArrayAssignmentTarget
+[a, /** @type {string[]} */ ...rest3] = arr;
+
+// ObjectAssignmentTarget
+({ a: x, /** @type {object} */ ...rest4 } = obj);
+
+// Nested patterns
+const [{ a, /** @type {number} */ ...inner }, /** @type {any[]} */ ...outer] =
+  nested;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Type cast comments on rest elements should stay after the comma
+
+// ArrayPattern
+const [a, /** @type {string[]} */ ...rest1] = arr;
+
+// ObjectPattern
+const { a: x, /** @type {object} */ ...rest2 } = obj;
+
+// ArrayAssignmentTarget
+[a, /** @type {string[]} */ ...rest3] = arr;
+
+// ObjectAssignmentTarget
+({ a: x, /** @type {object} */ ...rest4 } = obj);
+
+// Nested patterns
+const [{ a, /** @type {number} */ ...inner }, /** @type {any[]} */ ...outer] = nested;
+
+===================== End =====================

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -25,7 +25,13 @@ pub fn get_node_type(ty: &TokenStream) -> TokenStream {
 ///
 /// This ensures trailing comments are correctly attributed to the last child itself,
 /// rather than being treated as leading comments of a following sibling outside the parent.
-const AST_NODE_WITHOUT_FOLLOWING_NODE_LIST: &[&str] = &["FormalParameters"];
+const AST_NODE_WITHOUT_FOLLOWING_NODE_LIST: &[&str] = &[
+    "FormalParameters",
+    "ArrayPattern",
+    "ObjectPattern",
+    "ArrayAssignmentTarget",
+    "ObjectAssignmentTarget",
+];
 
 const AST_NODE_WITH_FOLLOWING_NODE_LIST: &[&str] = &["Function", "Class"];
 


### PR DESCRIPTION
Same as #18648, handle all nodes that have a `rest` element.