### PR TITLE
fix(formatter): externalize prettier

### DIFF
--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
   shims: false,
   fixedExtension: false,
   noExternal: [
-    // Bundle it to control version
-    "prettier",
-
     // We are using patched version, so we must bundle it
     // Also, it internally loads plugins dynamically, so they also must be bundled
     "prettier-plugin-tailwindcss",


### PR DESCRIPTION
This has two benefits:
- it allows `prettier` to be deduplicated by the package manager, so that if users have `prettier` installed via another means they don't end up with both a bundled and unbundled copy
- it's a first step towards #15665 

I left it pinned to a specific version (currently 3.8.1). This isn't the best practice and it would probably be nice to unpin it, but for now I wanted to be conservative and make the smallest change possible