### PR TITLE
test(linter/plugins): conformance tester keep other module exports when mocking `RuleTester` modules

### DIFF
--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -48,7 +48,7 @@ const group: TestGroup = {
     return false;
   },
 
-  ruleTesters: ["../../../lib/rule-tester/rule-tester.js"],
+  ruleTesters: [{ specifier: "../../../lib/rule-tester/rule-tester.js", propName: null }],
   parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
 };
 

--- a/apps/oxlint/conformance/src/groups/react_hooks.ts
+++ b/apps/oxlint/conformance/src/groups/react_hooks.ts
@@ -60,7 +60,11 @@ const group: TestGroup = {
     return false;
   },
 
-  ruleTesters: ["eslint-v7", "eslint-v8", "eslint-v9"],
+  ruleTesters: [
+    { specifier: "eslint-v7", propName: "RuleTester" },
+    { specifier: "eslint-v8", propName: "RuleTester" },
+    { specifier: "eslint-v9", propName: "RuleTester" },
+  ],
 
   parsers: [
     { specifier: "babel-eslint", lang: "jsx" },


### PR DESCRIPTION
When mocking modules containing `RuleTester`, don't replace the whole module, just alter the `RuleTester` property within it. e.g. when mocking the `RuleTester` export of `eslint` package, leave all package's other exports unchanged.