### PR TITLE
test(linter/plugins): conformance tester shorten `filename` in test cases in snapshots

### DIFF
--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -337,6 +337,13 @@ function formatTestCase(testCase: TestCase | null, code: string): string | null 
   // Remove `code` property if it's the same as the test case's code
   if (testCase.code === code) (testCase as { code?: string }).code = undefined;
 
+  // Shorten `filename` if it's a full path
+  let { filename } = testCase;
+  if (filename != null) {
+    if (filename.startsWith(ROOT_DIR_PATH)) filename = filename.slice(ROOT_DIR_PATH.length);
+    testCase.filename = normalizeSlashes(filename);
+  }
+
   try {
     return JSON.stringify(testCase, null, 2);
   } catch {


### PR DESCRIPTION
`eslint-plugin-sonarjs` sets `filename` property of test cases to an absolute path. Potentially other plugins do this too.

In snapshots, convert to a path relative to repo root, so that snapshot contents will be the same on any machine it's run on. Also conform to unix-style `/`s.