### PR TITLE
fix(linter/plugins): pass all args to CFG event handlers when 2 rules use same handler

### DIFF
--- a/apps/oxlint/test/fixtures/cfg/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/cfg/.oxlintrc.json
@@ -2,6 +2,7 @@
   "jsPlugins": ["./plugin.ts"],
   "categories": { "correctness": "off" },
   "rules": {
-    "error-plugin/error": "error"
+    "cfg-plugin/cfg": "error",
+    "cfg-plugin/noop": "error"
   }
 }

--- a/apps/oxlint/test/fixtures/cfg/options.json
+++ b/apps/oxlint/test/fixtures/cfg/options.json
@@ -1,3 +1,0 @@
-{
-  "singleThread": true
-}

--- a/apps/oxlint/test/fixtures/cfg/output.snap.md
+++ b/apps/oxlint/test/fixtures/cfg/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-  x error-plugin(error): Visited nodes:
+  x cfg-plugin(cfg): Visited nodes:
   | * onCodePathStart                     Program
   | * onCodePathSegmentStart              Program
   | * onCodePathSegmentEnd                Literal
@@ -21,7 +21,7 @@
    `----
 
 Found 0 warnings and 1 error.
-Finished in Xms on 1 file with 1 rules using X threads.
+Finished in Xms on 1 file with 2 rules using X threads.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/cfg/plugin.ts
+++ b/apps/oxlint/test/fixtures/cfg/plugin.ts
@@ -44,12 +44,27 @@ const rule: Rule = {
   },
 };
 
+// Purpose of this 2nd rule is to ensure that all arguments are passed to the CFG event handler functions
+// when 2 event handler functions are merged into a single function.
+// https://github.com/oxc-project/oxc/issues/18555
+const rule2: Rule = {
+  // @ts-expect-error - TODO: Make the types for CFG events work
+  create(_context) {
+    return {
+      onCodePathSegmentLoop(_fromSegment: any, _toSegment: any, _node: Node) {
+        // Do nothing
+      },
+    };
+  },
+};
+
 const plugin: Plugin = {
   meta: {
-    name: "error-plugin",
+    name: "cfg-plugin",
   },
   rules: {
-    error: rule,
+    cfg: rule,
+    noop: rule2,
   },
 };
 


### PR DESCRIPTION
Fix #18555.

CFG event handlers receive multiple arguments (unlike standard AST node visit functions which only receive `node`). The code which merges multiple visitors into one was built on assumption that all visit functions take a single argument so merges 2 function like this:

```js
fn merge(visit1, visit2) {
  return (node) => {
    visit1(node);
    visit2(node);
  };
}
```

This works well for AST node visit functions, but not for CFG event handlers - `visit1` and `visit2` only get called with the first argument, and the remaining arguments are lost.

Fix this by adding a 2nd function for merging CFG event handlers, which passes through all arguments:

```js
fn mergeCfg(handle1, handle2) {
  return (...args) => {
    handle1(...args);
    handle2(...args);
  };
}
```