### PR TITLE
fix(formatter): incorrect comments placement for union type in TSTypeAliasDeclaration

### DIFF
--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -138,11 +138,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
                 f,
                 [
                     ((has_own_line_comment && !only_type)
-                        || (has_end_of_line_comment && only_type))
-                        .then(soft_line_break),
+                        || (has_end_of_line_comment
+                            && (only_type
+                                || matches!(self.parent(), AstNodes::TSTypeAliasDeclaration(_)))))
+                    .then(soft_line_break),
                     FormatLeadingComments::Comments(leading_comments),
-                    (!has_end_of_line_comment && has_own_line_comment && only_type)
-                        .then(soft_line_break),
+                    (!has_end_of_line_comment && has_own_line_comment).then(soft_line_break),
                     group(&content)
                 ]
             );

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 587/601 (97.67%)
+ts compatibility: 588/601 (97.84%)
 
 # Failed
 
@@ -14,7 +14,6 @@ ts compatibility: 587/601 (97.67%)
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
-| typescript/union/comments/18106.ts | 💥 | 92.68% |
 | typescript/union/comments/18379.ts | 💥 | 87.27% |
 | typescript/union/comments/18389.ts | 💥 | 51.28% |
 | typescript/union/single-type/single-type.ts | 💥 | 66.67% |


### PR DESCRIPTION
Align Prettier's output

Input:
```ts
type A2 = /* block comment */
  | [string]
  | [string, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode, ObjectExpression]
```

Before output: (Same as Input)
```ts
type A2 = /* block comment */
  | [string]
  | [string, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode, ObjectExpression]
```

After output:
```ts
type A2 =
  /* block comment */
  | [string]
  | [string, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode]
  | [string, ExpressionNode, ExpressionNode, ObjectExpression];
```

I found out that the new output is actually inconsistent with the union in the class property. See [Oxc Playground](https://playground.oxc.rs/?t=formatter&formatterPanels=output%2Cprettier&code=class+A+%7B%0A++property%3A+%2F*+block+comment+*%2F%0A++%7C+%5Bstring%5D%0A++%7C+%5Bstring%2C+ExpressionNode%5D%0A++%7C+%5Bstring%2C+ExpressionNode%2C+ExpressionNode%5D%0A++%7C+%5Bstring%2C+ExpressionNode%2C+ExpressionNode%2C+ObjectExpression%5D%0A%7D)

Not sure if it is an intentional behavior in Prettier.