### PR TITLE
fix(formatter,oxfmt): Handle CRLF with embedded formatting

### DIFF
--- a/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
@@ -506,6 +506,297 @@ const readme = markdown\`
 --------------------"
 `;
 
+exports[`embedded_languages > should format with CLRF 1`] = `
+"--- FILE -----------
+css.js
+--- BEFORE ---------
+// Tagged template literals with css and styled tags
+const styles = css\`.button{color:red;background:blue;padding:10px 20px;}\`;
+
+const styledComponent = styled\`background-color:#ffffff;border-radius:4px;\`;
+
+// Member expression tags
+const cssGlobal = css.global\`.reset{margin:0;padding:0;}\`;
+
+const styledDiv = styled.div\`width:100%;height:100vh;\`;
+
+const styledLink = styled["a"]\`text-decoration:none;color:#007bff;\`;
+
+const styledButton = styled(Button)\`font-size:16px;color:#333;\`;
+
+// CSS prop and styled-jsx
+const cssProp = <div css={\`display: flex; align-items: center;\`}>Hello</div>;
+
+const styledJsx = <style jsx>{\`display: flex; align-items: center;\`}</style>;
+
+// Multi-line templates with inherited indentation (dedent before formatting)
+const documented = styled.div\`
+  /**
+   * @description This is a documented section
+   * @param {number} value - Some value
+   */
+  padding: 16px;
+\`;
+
+
+--- AFTER ----------
+// Tagged template literals with css and styled tags
+const styles = css\`
+  .button {
+    color: red;
+    background: blue;
+    padding: 10px 20px;
+  }
+\`;
+
+const styledComponent = styled\`
+  background-color: #ffffff;
+  border-radius: 4px;
+\`;
+
+// Member expression tags
+const cssGlobal = css.global\`
+  .reset {
+    margin: 0;
+    padding: 0;
+  }
+\`;
+
+const styledDiv = styled.div\`
+  width: 100%;
+  height: 100vh;
+\`;
+
+const styledLink = styled["a"]\`
+  text-decoration: none;
+  color: #007bff;
+\`;
+
+const styledButton = styled(Button)\`
+  font-size: 16px;
+  color: #333;
+\`;
+
+// CSS prop and styled-jsx
+const cssProp = (
+  <div
+    css={\`
+      display: flex;
+      align-items: center;
+    \`}
+  >
+    Hello
+  </div>
+);
+
+const styledJsx = (
+  <style jsx>{\`
+    display: flex;
+    align-items: center;
+  \`}</style>
+);
+
+// Multi-line templates with inherited indentation (dedent before formatting)
+const documented = styled.div\`
+  /**
+   * @description This is a documented section
+   * @param {number} value - Some value
+   */
+  padding: 16px;
+\`;
+
+--------------------
+
+--- FILE -----------
+graphql.js
+--- BEFORE ---------
+// Tagged template literals with gql and graphql tags
+const query = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
+
+const mutation = graphql\`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}\`;
+
+--- AFTER ----------
+// Tagged template literals with gql and graphql tags
+const query = gql\`
+  query GetUser($id: ID!) {
+    user(id: $id) {
+      name
+      email
+    }
+  }
+\`;
+
+const mutation = graphql\`
+  mutation CreatePost($input: PostInput!) {
+    createPost(input: $input) {
+      id
+      title
+    }
+  }
+\`;
+
+--------------------
+
+--- FILE -----------
+html.js
+--- BEFORE ---------
+// Tagged template literals with html tag
+const template = html\`<div class="container"><h1>Hello</h1><p>World</p></div>\`;
+
+const component = html\`<button type="button" onclick="handleClick()">Click</button>\`;
+
+--- AFTER ----------
+// Tagged template literals with html tag
+const template = html\`
+  <div class="container">
+    <h1>Hello</h1>
+    <p>World</p>
+  </div>
+\`;
+
+const component = html\`
+  <button type="button" onclick="handleClick()">Click</button>
+\`;
+
+--------------------
+
+--- FILE -----------
+markdown.js
+--- BEFORE ---------
+// Tagged template literals with md and markdown tags
+const documentation = md\`#Heading
+This is **bold**.
+-Item 1
+-Item 2\`;
+
+const readme = markdown\`##Installation
+\\\`\\\`\\\`bash
+npm install package
+\\\`\\\`\\\`\`;
+
+--- AFTER ----------
+// Tagged template literals with md and markdown tags
+const documentation = md\`
+  #Heading
+  This is **bold**.
+  -Item 1
+  -Item 2
+\`;
+
+const readme = markdown\`
+  ##Installation
+  \\\`\\\`\\\`bash
+  npm install package
+  \\\`\\\`\\\`
+\`;
+
+--------------------
+
+--- FILE -----------
+angular.ts
+--- BEFORE ---------
+// Angular @Component decorator - direct template and styles
+// Uses Angular-specific syntax: interpolation, directives, bindings
+@Component({
+    selector: 'app-root',
+    template: \`
+        <h1>{{    title    }}</h1>
+        <div *ngIf="isVisible"    [class.active]="isActive"     (click)="onClick()">
+            <span>{{ count     }}</span>
+        </div>
+        <ul><li *ngFor="let item of items">{{item.name}}</li></ul>
+    \`,
+    styles: \`h1 { color: blue }\`
+})
+export class AppComponent1 {}
+
+// Array form styles
+@Component({
+       selector: 'app-test',
+  template: \`<ul>   <li>test</li>
+  </ul>
+  \`,
+  styles: [   \`
+
+ :host {
+   color: red;
+ }
+ div { background: blue
+ }
+\`
+
+]
+})
+class     TestComponent {}
+
+// Computed properties - should NOT be formatted
+const styles = "foobar";
+const template = "foobar";
+
+@Component({
+    selector: 'app-computed',
+    [template]: \`<h1>{{       hello }}</h1>\`,
+    [styles]: \`h1 { color: blue }\`
+})
+export class AppComponent2 {}
+
+--- AFTER ----------
+// Angular @Component decorator - direct template and styles
+// Uses Angular-specific syntax: interpolation, directives, bindings
+@Component({
+  selector: "app-root",
+  template: \`
+    <h1>{{ title }}</h1>
+    <div *ngIf="isVisible" [class.active]="isActive" (click)="onClick()">
+      <span>{{ count }}</span>
+    </div>
+    <ul>
+      <li *ngFor="let item of items">{{ item.name }}</li>
+    </ul>
+  \`,
+  styles: \`
+    h1 {
+      color: blue;
+    }
+  \`,
+})
+export class AppComponent1 {}
+
+// Array form styles
+@Component({
+  selector: "app-test",
+  template: \`
+    <ul>
+      <li>test</li>
+    </ul>
+  \`,
+  styles: [
+    \`
+      :host {
+        color: red;
+      }
+      div {
+        background: blue;
+      }
+    \`,
+  ],
+})
+class TestComponent {}
+
+// Computed properties - should NOT be formatted
+const styles = "foobar";
+const template = "foobar";
+
+@Component({
+  selector: "app-computed",
+  [template]: \`<h1>{{       hello }}</h1>\`,
+  [styles]: \`h1 { color: blue }\`,
+})
+export class AppComponent2 {}
+
+--------------------"
+`;
+
 exports[`embedded_languages > should not format any language (off) 1`] = `
 "--- FILE -----------
 css.js

--- a/apps/oxfmt/test/cli/embedded_languages/embedded_languages.test.ts
+++ b/apps/oxfmt/test/cli/embedded_languages/embedded_languages.test.ts
@@ -19,6 +19,14 @@ describe("embedded_languages", () => {
     expect(snapshot).toMatchSnapshot();
   });
 
+  it("should format with CLRF", async () => {
+    const snapshot = await runWriteModeAndSnapshot(fixturesDir, languages, [
+      "--config",
+      "crlf_embedded.json",
+    ]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
   describe("Misc", () => {
     it("should format multiple embedded languages in one file", async () => {
       const snapshot = await runWriteModeAndSnapshot(fixturesDir, ["mixed.js"]);

--- a/apps/oxfmt/test/cli/embedded_languages/fixtures/crlf_embedded.json
+++ b/apps/oxfmt/test/cli/embedded_languages/fixtures/crlf_embedded.json
@@ -1,0 +1,4 @@
+{
+  "endOfLine": "crlf",
+  "embeddedLanguageFormatting": "auto"
+}

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -5,6 +5,7 @@ use std::cmp;
 use oxc_allocator::{Allocator, StringBuilder, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
     IndentWidth,
@@ -821,7 +822,7 @@ fn format_embedded_template<'a>(
     // - Closing backtick
     let format_content = format_with(|f: &mut Formatter<'_, 'a>| {
         let content = f.context().allocator().alloc_str(&formatted);
-        for line in content.split('\n') {
+        for line in LineTerminatorSplitter::new(content) {
             if line.is_empty() {
                 write!(f, [empty_line()]);
             } else {


### PR DESCRIPTION
Fixes #18663 , but not related to Angular.

Actually, before this fix, when performing embedded formatting with `endOfLine: crlf` specified, it seemed to panic in debug builds.

https://github.com/oxc-project/oxc/blob/e440b78fd4a925c06547815406d45eb02e0aa370/crates/oxc_formatter/src/formatter/builders.rs#L342

`Text` can not contain `\r`.

Since this check is disabled in release builds, it simply resulted in extra line breaks.
