### PR TITLE
refactor(oxfmt): Ensure to destroy worker pool before exit

### DIFF
--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -4,6 +4,7 @@ import {
   formatEmbeddedCode,
   formatFile,
   sortTailwindClasses,
+  disposeExternalFormatter,
 } from "./cli/worker-proxy";
 
 // napi-JS `oxfmt` CLI entry point
@@ -46,6 +47,9 @@ void (async () => {
   }
 
   // Other modes are handled by Rust, just need to set `exitCode`
+
+  // Clean up worker pool to not V8 crashes on process exit
+  await disposeExternalFormatter();
 
   // NOTE: It's recommended to set `process.exitCode` instead of calling `process.exit()`.
   // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -20,6 +20,11 @@ export async function initExternalFormatter(numThreads: number): Promise<string[
   return resolvePlugins();
 }
 
+export async function disposeExternalFormatter(): Promise<void> {
+  await pool?.destroy();
+  pool = null;
+}
+
 export async function formatEmbeddedCode(
   options: Options,
   parserName: string,


### PR DESCRIPTION
In most cases, it should be fine, but this approach is cleaner.