### PR TITLE
chore(tasks): use cargo insta's diff printing implementation

### DIFF
--- a/tasks/common/Cargo.toml
+++ b/tasks/common/Cargo.toml
@@ -17,6 +17,6 @@ console = { workspace = true }
 oxc_span = { workspace = true }
 
 project-root = { workspace = true }
-similar = { workspace = true }
+similar = { workspace = true, features = ["inline"] }
 
 ureq = { workspace = true, features = ["json", "rustls"] }

--- a/tasks/common/src/diff.rs
+++ b/tasks/common/src/diff.rs
@@ -1,6 +1,7 @@
-use std::collections::VecDeque;
+use std::borrow::Cow;
 
-use console::Style;
+use console::style;
+use similar::Algorithm;
 use similar::{ChangeTag, DiffableStr, TextDiff};
 
 const CONTEXT_LINES: usize = 3;
@@ -14,86 +15,92 @@ const CONTEXT_LINES: usize = 3;
 /// - `...` separator when lines are skipped between hunks
 /// - Colors: red (`-`) for deletions, green (`+`) for insertions, dim for context
 ///
-/// Example output:
-/// ```text
-///     1 │fn main() {
-///     2 │    let x = 1;
-/// -   3 │    let y = 2;
-/// +   3 │    let y = 3;
-///     4 │    println!("{}", x + y);
-///     5 │}
-/// ...
-///    42 │fn other() {
-/// -  43 │    old_code();
-/// +  43 │    new_code();
-///    44 │}
-/// ```
 /// Simple API that creates a diff from two strings and prints it.
 pub fn print_diff_in_terminal(expected: &str, result: &str) {
-    let diff = TextDiff::from_lines(expected, result);
+    let diff = TextDiff::configure().algorithm(Algorithm::Patience).diff_lines(expected, result);
     print_text_diff(&diff);
+}
+
+fn render_invisible(s: &str, newlines_matter: bool) -> Cow<'_, str> {
+    if newlines_matter || s.find(&['\x1b', '\x07', '\x08', '\x7f'][..]).is_some() {
+        Cow::Owned(
+            s.replace('\r', "␍\r")
+                .replace('\n', "␊\n")
+                .replace("␍\r␊\n", "␍␊\r\n")
+                .replace('\x07', "␇")
+                .replace('\x08', "␈")
+                .replace('\x1b', "␛")
+                .replace('\x7f', "␡"),
+        )
+    } else {
+        Cow::Borrowed(s)
+    }
 }
 
 /// Prints an existing `TextDiff` to the terminal.
 /// Use this when you need access to the `TextDiff` for other operations (e.g., `diff.ratio()`).
-pub fn print_text_diff<T: DiffableStr + ?Sized>(diff: &TextDiff<T>) {
-    let mut context_buffer: VecDeque<_> = VecDeque::with_capacity(CONTEXT_LINES);
-    let mut trailing_remaining = 0;
-    let mut has_printed = false;
-    let mut had_gap = false;
-    let mut needs_separator = false;
-
-    for change in diff.ops().iter().flat_map(|op| diff.iter_changes(op)) {
-        let tag = change.tag();
-
-        if tag == ChangeTag::Equal {
-            if trailing_remaining > 0 {
-                print_line(tag, change.new_index(), &change.to_string());
-                trailing_remaining -= 1;
-                needs_separator = true;
-            } else {
-                if context_buffer.len() == CONTEXT_LINES {
-                    context_buffer.pop_front();
-                    had_gap = true;
+///
+/// # Panics
+///
+/// Panics if the output cannot be printed to the terminal.
+///
+/// Based on [Cargo insta diff printing](https://github.com/mitsuhiko/insta/blob/8a5b77531f89bc78d00cab17f2ac8b2c69ceadab/insta/src/output.rs#L238-L296).
+pub fn print_text_diff<'a, T: DiffableStr + ?Sized>(diff: &'a TextDiff<'a, 'a, 'a, T>) {
+    for group in &diff.grouped_ops(CONTEXT_LINES) {
+        for op in group {
+            for change in diff.iter_inline_changes(op) {
+                let missing_newline = change.missing_newline();
+                match change.tag() {
+                    ChangeTag::Insert => {
+                        print!(
+                            "{:>5} {:>5} │{}",
+                            "",
+                            style(change.new_index().unwrap() + 1).cyan().dim().bold(),
+                            style("+").green(),
+                        );
+                        for &(emphasized, change) in change.values() {
+                            let change =
+                                render_invisible(change.as_str().unwrap(), missing_newline);
+                            if emphasized {
+                                print!("{}", style(change).green().underlined());
+                            } else {
+                                print!("{}", style(change).green());
+                            }
+                        }
+                    }
+                    ChangeTag::Delete => {
+                        print!(
+                            "{:>5} {:>5} │{}",
+                            style(change.old_index().unwrap() + 1).cyan().dim(),
+                            "",
+                            style("-").red(),
+                        );
+                        for &(emphasized, change) in change.values() {
+                            let change =
+                                render_invisible(change.as_str().unwrap(), missing_newline);
+                            if emphasized {
+                                print!("{}", style(change).red().underlined());
+                            } else {
+                                print!("{}", style(change).red());
+                            }
+                        }
+                    }
+                    ChangeTag::Equal => {
+                        print!(
+                            "{:>5} {:>5} │ ",
+                            style(change.old_index().unwrap() + 1).cyan().dim(),
+                            style(change.new_index().unwrap() + 1).cyan().dim().bold(),
+                        );
+                        for &(_, change) in change.values() {
+                            let change = render_invisible(change.as_str().unwrap(), false);
+                            print!("{}", style(change).dim());
+                        }
+                    }
                 }
-                context_buffer.push_back((tag, change.new_index(), change.to_string()));
-            }
-            continue;
-        }
-
-        if has_printed && (needs_separator || !context_buffer.is_empty()) {
-            if had_gap {
-                println!("{}", Style::new().cyan().apply_to("..."));
-            } else {
-                println!();
+                if change.missing_newline() {
+                    println!();
+                }
             }
         }
-
-        while let Some((tag, line_num, content)) = context_buffer.pop_front() {
-            print_line(tag, line_num, &content);
-        }
-
-        let line_num =
-            if tag == ChangeTag::Delete { change.old_index() } else { change.new_index() };
-        print_line(tag, line_num, &change.to_string());
-
-        has_printed = true;
-        had_gap = false;
-        needs_separator = false;
-        trailing_remaining = CONTEXT_LINES;
     }
-}
-
-fn print_line(tag: ChangeTag, line_num: Option<usize>, content: &str) {
-    let (sign, style) = match tag {
-        ChangeTag::Delete => ("-", Style::new().red()),
-        ChangeTag::Insert => ("+", Style::new().green()),
-        ChangeTag::Equal => (" ", Style::new().dim()),
-    };
-    print!(
-        "{}{} │{}",
-        style.apply_to(sign).bold(),
-        Style::new().dim().apply_to(format!("{:>4}", line_num.map_or(0, |n| n + 1))),
-        style.apply_to(content)
-    );
 }


### PR DESCRIPTION
The previous implementation is easily confusing, as the old line index and the new line index are in the same column.

The new implementation is based on [Cargo insta diff printing](https://github.com/mitsuhiko/insta/blob/8a5b77531f89bc78d00cab17f2ac8b2c69ceadab/insta/src/output.rs#L238-L296).

### Example

```shell
❯ cargo run -p oxc_prettier_conformance   -- --filter "typescript/union/comments/18106.ts"            
Failed ❌
   26    26 │   | [string, ExpressionNode, ExpressionNode]
   27    27 │   | [string, ExpressionNode, ExpressionNode, ObjectExpression] = 1;
   28    28 │ 
   29       │-type A2 =
   30       │-  /* block comment */
         29 │+type A2 = /* block comment */
   31    30 │   | [string]
   32    31 │   | [string, ExpressionNode]
   33    32 │   | [string, ExpressionNode, ExpressionNode]
   34    33 │   | [string, ExpressionNode, ExpressionNode, ObjectExpression];
   35    34 │ 
   36       │-type A3 =
   37       │-  /* block comment
         35 │+type A3 = /* block comment
   38    36 │    */
   39    37 │   | [string]
   40    38 │   | [string, ExpressionNode]

```
