### PR TITLE
fix(formatter): preserve quote for class property key in TypeScript

### DIFF
--- a/crates/oxc_formatter/src/utils/object.rs
+++ b/crates/oxc_formatter/src/utils/object.rs
@@ -13,9 +13,10 @@ use crate::{
 
 pub fn format_property_key<'a>(key: &AstNode<'a, PropertyKey<'a>>, f: &mut Formatter<'_, 'a>) {
     if let PropertyKey::StringLiteral(s) = key.as_ref() {
-        // `"constructor"` property in the class should be kept quoted
+        // For TypeScript class property declarations, quotes should always be preserved.
+        // https://github.com/prettier/prettier/issues/4516
         let kind = if matches!(key.parent(), AstNodes::PropertyDefinition(_))
-            && matches!(key.as_ref(), PropertyKey::StringLiteral(string) if string.value == "constructor")
+            && f.context().source_type().is_typescript()
         {
             StringLiteralParentKind::Expression
         } else {

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 588/601 (97.84%)
+ts compatibility: 589/601 (98.00%)
 
 # Failed
 
@@ -8,7 +8,6 @@ ts compatibility: 588/601 (97.84%)
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
 | typescript/as/break-after-keyword/18148.ts | 💥 | 82.22% |
 | typescript/class/empty-method-body.ts | 💥 | 80.00% |
-| typescript/class/quoted-property.ts | 💥 | 66.67% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
 | typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |


### PR DESCRIPTION
Preserve the quote for the class property key in TypeScript. Learn more context at https://github.com/prettier/prettier/issues/4516