### PR TITLE
fix(linter/no-html-link-for-pages): handle `target=_blank` correctly

### DIFF
--- a/crates/oxc_linter/src/snapshots/nextjs_no_html_link_for_pages.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_html_link_for_pages.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 411
 ---
   ⚠ eslint-plugin-next(no-html-link-for-pages): Do not use `<a>` elements to navigate between Next.js pages.
    ╭─[no_html_link_for_pages.tsx:1:1]
@@ -44,16 +43,8 @@ assertion_line: 411
 
   ⚠ eslint-plugin-next(no-html-link-for-pages): Do not use `<a>` elements to navigate between Next.js pages.
    ╭─[no_html_link_for_pages.tsx:1:1]
- 1 │ <a href={dynamicLink}>Dynamic</a>
-   · ───────────┬──────────
-   ·            ╰── Replace with `<Link>` from `next/link`
-   ╰────
-  help: Use `<Link />` from `next/link` instead for internal navigation. See https://nextjs.org/docs/messages/no-html-link-for-pages
-
-  ⚠ eslint-plugin-next(no-html-link-for-pages): Do not use `<a>` elements to navigate between Next.js pages.
-   ╭─[no_html_link_for_pages.tsx:1:1]
- 1 │ <a href={`/user/${userId}`}>User Profile</a>
-   · ──────────────┬─────────────
-   ·               ╰── Replace with `<Link>` from `next/link`
+ 1 │ <a href='/'>Home</a>
+   · ──────┬─────
+   ·       ╰── Replace with `<Link>` from `next/link`
    ╰────
   help: Use `<Link />` from `next/link` instead for internal navigation. See https://nextjs.org/docs/messages/no-html-link-for-pages


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/18676