### PR TITLE
fix(formatter): follow Prettier's approach for for-in initializer parentheses

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 741/753 (98.41%)
+js compatibility: 742/753 (98.54%)
 
 # Failed
 
@@ -11,7 +11,6 @@ js compatibility: 741/753 (98.41%)
 | js/comments/return-statement.js | 💥💥 | 98.85% |
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 80.00% |
 | js/for/9812-unstable.js | 💥 | 63.64% |
-| js/for/for-in-with-initializer.js | 💥 | 31.25% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |


### PR DESCRIPTION
Refactored the parentheses handling for for-in statement initializers to follow
Prettier's cleaner approach:

1. `is_in_for_initializer` now ONLY checks ForStatement, not ForInStatement
2. Added `is_for_in_statement_init` - wraps ANY expression that is the init
   of a VariableDeclarator when that VariableDeclaration is the LEFT of a
   ForInStatement
3. Removed complex recursive helpers: `is_direct_for_in_init`, `is_for_in_var_init`,
   `contains_in_expression`, `binding_contains_in`

This fixes the `js/for/for-in-with-initializer.js` Prettier conformance test.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>