### PR TITLE
refactor(linter/plugins): `cwd` set per file

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -41,19 +41,22 @@ import type { Settings } from "./settings.ts";
 import type { SourceCode } from "./source_code.ts";
 import type { ModuleKind, Program } from "../generated/types.d.ts";
 
-// Cached current working directory
-let cwd: string | null = null;
-
 // Absolute path of file being linted.
 // When `null`, indicates that no file is currently being linted (in `createOnce`, or between linting files).
 export let filePath: string | null = null;
 
+// Current working directory for file being linted.
+// When `null`, indicates that no file is currently being linted (in `createOnce`, or between linting files).
+let cwd: string | null = null;
+
 /**
  * Set up context for linting a file.
  * @param filePathInput - Absolute path of file being linted
+ * @param cwdInput - Current working directory for file being linted
  */
-export function setupFileContext(filePathInput: string): void {
+export function setupFileContext(filePathInput: string, cwdInput: string): void {
   filePath = filePathInput;
+  cwd = cwdInput;
 }
 
 /**
@@ -65,6 +68,7 @@ export function setupFileContext(filePathInput: string): void {
  */
 export function resetFileContext(): void {
   filePath = null;
+  cwd = null;
 }
 
 // ECMAScript version. This matches ESLint's default.
@@ -363,8 +367,7 @@ const FILE_CONTEXT = Object.freeze({
    */
   get cwd(): string {
     // Note: If we change this implementation, also change `getCwd` method below
-    if (filePath === null) throw new Error("Cannot access `context.cwd` in `createOnce`");
-    if (cwd === null) cwd = process.cwd();
+    if (cwd === null) throw new Error("Cannot access `context.cwd` in `createOnce`");
     return cwd;
   },
 
@@ -374,8 +377,7 @@ const FILE_CONTEXT = Object.freeze({
    * @deprecated Use `context.cwd` property instead.
    */
   getCwd(): string {
-    if (filePath === null) throw new Error("Cannot call `context.getCwd` in `createOnce`");
-    if (cwd === null) cwd = process.cwd();
+    if (cwd === null) throw new Error("Cannot call `context.getCwd` in `createOnce`");
     return cwd;
   },
 

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -29,6 +29,9 @@ import { walkProgram, ancestors } from "../generated/walk.js";
 
 import type { AfterHook, BufferWithArrays } from "./types.ts";
 
+// CWD. Currently the same for all files, but that will change in the future.
+const CWD = process.cwd();
+
 // Buffers cache.
 //
 // All buffers sent from Rust are stored in this array, indexed by `bufferId` (also sent from Rust).
@@ -141,8 +144,8 @@ export function lintFileImpl(
     "`ruleIds` and `optionsIds` should be same length",
   );
 
-  // Pass file path to context module, so `Context`s know what file is being linted
-  setupFileContext(filePath);
+  // Pass file path and CWD to context module, so `Context`s know what file is being linted
+  setupFileContext(filePath, CWD);
 
   // Pass buffer to source code module, so it can decode source text and deserialize AST on demand.
   //

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import { join as pathJoin } from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 import { parse as parseRaw } from "../src-js/package/parse.ts";
 import { setupFileContext, resetFileContext } from "../src-js/plugins/context.ts";
@@ -18,14 +19,16 @@ import type { Program } from "../src-js/generated/types.d.ts";
 /**
  * Parse source text into AST using Oxc parser.
  * Set up global state, as if was linting the provided file.
- * @param path - File path
+ * @param filename - Filename
  * @param sourceText - Source text
  * @param options - Parse options
  * @returns AST
  */
-function parse(path: string, sourceText: string, options?: ParseOptions): Program {
-  // Set file path
-  setupFileContext(path);
+function parse(filename: string, sourceText: string, options?: ParseOptions): Program {
+  // Set file path and CWD
+  const cwd = import.meta.dirname;
+  const path = pathJoin(cwd, filename);
+  setupFileContext(path, cwd);
 
   // Parse source, writing source text and AST into buffer
   parseRaw(path, sourceText, options);

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -1,3 +1,4 @@
+import { join as pathJoin } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getTokens,
@@ -53,9 +54,11 @@ function setup(sourceText: string) {
   resetFileContext();
   resetSourceAndAst();
 
-  // Set file path
-  const path = "dummy.js";
-  setupFileContext(path);
+  // Set file path and CWD
+  const filename = "dummy.js";
+  const cwd = import.meta.dirname;
+  const path = pathJoin(cwd, filename);
+  setupFileContext(path, cwd);
 
   // Parse source text into buffer
   parseRaw(path, sourceText);


### PR DESCRIPTION
Pass `cwd` into `setupFileContext`, so it can be set per file, rather than being a global setting.

This is preamble to #17809. This PR is some of the changes from that one split off, so the diff on #17809 is focused just on that one change.

This PR does nothing in itself, as currently `process.cwd()` is always passed to `setupFileContext`.