### PR TITLE
fix(linter): no-useless-constructor should allow argument transformation

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -228,13 +228,14 @@ fn is_only_simple_params(params: &FormalParameters) -> bool {
 /// This ensures we don't flag constructors that transform arguments before passing to super,
 /// such as `super(...args.map(x => x))`.
 fn is_spread_arguments(super_args: &[Argument<'_>]) -> bool {
-    if super_args.len() != 1 {
-        return false;
+    if super_args.len() == 1
+        && let Argument::SpreadElement(spread) = &super_args[0]
+        && spread.argument.is_specific_id("arguments")
+    {
+        return true;
     }
-    let Argument::SpreadElement(spread) = &super_args[0] else {
-        return false;
-    };
-    matches!(&spread.argument, Expression::Identifier(ident) if ident.name == "arguments")
+
+    false
 }
 
 fn is_passing_through<'a>(

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -222,8 +222,19 @@ fn is_only_simple_params(params: &FormalParameters) -> bool {
         && params.items.iter().all(|param| param.initializer.is_none())
 }
 
+/// Check if the super call is just spreading the `arguments` object, i.e., `super(...arguments)`.
+///
+/// Returns `true` only if there is exactly one spread argument that is the `arguments` identifier.
+/// This ensures we don't flag constructors that transform arguments before passing to super,
+/// such as `super(...args.map(x => x))`.
 fn is_spread_arguments(super_args: &[Argument<'_>]) -> bool {
-    super_args.len() == 1 && super_args[0].is_spread()
+    if super_args.len() != 1 {
+        return false;
+    }
+    let Argument::SpreadElement(spread) = &super_args[0] else {
+        return false;
+    };
+    matches!(&spread.argument, Expression::Identifier(ident) if ident.name == "arguments")
 }
 
 fn is_passing_through<'a>(
@@ -339,6 +350,13 @@ fn test() {
         //     }
         // }
         // ",
+        // Argument transformation: constructor is not useless when arguments are processed/transformed
+        // https://github.com/oxc-project/oxc/issues/17469
+        "class A extends B { constructor(...args) { super(...args.map(x => x)); } }",
+        "class A extends B { constructor(...args) { super(...args.filter(x => x)); } }",
+        "class A extends B { constructor(...args) { super(...args.slice(1)); } }",
+        "class A extends B { constructor(...args) { super(...transform(args)); } }",
+        "class A extends B { constructor(...args) { super(...[...args, extra]); } }",
     ];
 
     let pass_typescript = vec![


### PR DESCRIPTION
## Summary
Fixes the `no-useless-constructor` rule to correctly allow constructors that transform arguments before passing to `super()`.

Fixes #17469

## Problem
The rule was incorrectly flagging constructors as "useless" when they transform arguments:

```javascript
class A extends B {
  constructor(...args) {
    super(...args.map((v, idx) => (idx === metricsIndex ? v.child(name) : v)));
  }
}
```

## Solution
Changed `is_spread_arguments` to explicitly check for the `arguments` identifier rather than accepting any spread expression.

## Test plan
- [x] Added 5 test cases for argument transformation patterns
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)