### PR TITLE
ci(pr): use native `case` function instead of shell script

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,38 +43,17 @@ jobs:
             style
             test
 
-      - name: Get category label from PR title
-        id: get-category
-        env:
-          PR_TYPE: ${{ steps.pr-title.outputs.type }}
-        run: |
-          case "$PR_TYPE" in
-            "feat")
-              CATEGORY="C-enhancement"
-              ;;
-            "fix")
-              CATEGORY="C-bug"
-              ;;
-            "test")
-              CATEGORY="C-test"
-              ;;
-            "refactor" | "chore" | "style")
-              CATEGORY="C-cleanup"
-              ;;
-            "docs")
-              CATEGORY="C-docs"
-              ;;
-            "perf")
-              CATEGORY="C-performance"
-              ;;
-            *)
-              CATEGORY=""
-              ;;
-          esac
-          echo "CATEGORY=$CATEGORY" >> $GITHUB_OUTPUT
-
       - name: Add category label
         uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
-        if: ${{ steps.get-category.outputs.CATEGORY != '' }}
+        env:
+          CATEGORY: ${{ case(
+            steps.pr-title.outputs.type == 'feat', 'C-enhancement',
+            steps.pr-title.outputs.type == 'fix', 'C-bug',
+            steps.pr-title.outputs.type == 'test', 'C-test',
+            contains(fromJson('["refactor", "chore", "style"]'), steps.pr-title.outputs.type), 'C-cleanup',
+            steps.pr-title.outputs.type == 'docs', 'C-docs',
+            steps.pr-title.outputs.type == 'perf', 'C-performance',
+            '') }}
+        if: ${{ env.CATEGORY != '' }}
         with:
-          labels: ${{ steps.get-category.outputs.CATEGORY }}
+          labels: ${{ env.CATEGORY }}


### PR DESCRIPTION
## Summary

- Replace shell `case` statement with GitHub Actions' new native `case` function for mapping PR types to category labels
- Reduces workflow from 81 lines to 60 lines by eliminating a shell script step
- Enables better editor support with expression validation and autocomplete

Reference: https://github.blog/changelog/2026-01-29-github-actions-smarter-editing-clearer-debugging-and-a-new-case-function

🤖 Generated with [Claude Code](https://claude.com/claude-code)