### PR TITLE
feat(oxfmt): add Svelte file support

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "prettier": "3.8.1",
+    "prettier-plugin-svelte": "^3.4.1",
     "prettier-plugin-tailwindcss": "0.7.2",
     "tinypool": "2.1.0"
   },

--- a/apps/oxfmt/src-js/libs/prettier.ts
+++ b/apps/oxfmt/src-js/libs/prettier.ts
@@ -91,10 +91,31 @@ export async function formatFile({
   // But some plugins rely on `filepath`, so we set it too
   options.filepath = fileName;
 
+  // Enable Svelte plugin for .svelte files
+  if (parserName === "svelte") {
+    const sveltePlugin = await loadSveltePlugin();
+    options.plugins = options.plugins || [];
+    options.plugins.push(sveltePlugin as Plugin);
+  }
+
   // Enable Tailwind CSS plugin for non-JS files if needed
   await setupTailwindPlugin(options);
 
   return prettier.format(code, options);
+}
+
+// ---
+// Svelte support
+// ---
+
+// Shared cache for prettier-plugin-svelte
+let sveltePluginCache: typeof import("prettier-plugin-svelte");
+
+async function loadSveltePlugin(): Promise<typeof import("prettier-plugin-svelte")> {
+  if (sveltePluginCache) return sveltePluginCache;
+
+  sveltePluginCache = await import("prettier-plugin-svelte");
+  return sveltePluginCache;
 }
 
 // ---
@@ -116,7 +137,7 @@ async function loadTailwindPlugin(): Promise<typeof import("prettier-plugin-tail
 
 // ---
 
-const TAILWIND_RELEVANT_PARSERS = new Set(["html", "vue", "angular", "glimmer"]);
+const TAILWIND_RELEVANT_PARSERS = new Set(["html", "vue", "angular", "glimmer", "svelte"]);
 
 /**
  * Set up Tailwind CSS plugin for Prettier when:

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -188,6 +188,34 @@ pub struct FormatConfig {
     pub vue_indent_script_and_style: Option<bool>,
 
     // ============================================================================================
+    // Prettier compatible options for Svelte (prettier-plugin-svelte)
+    // ============================================================================================
+    /// Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.
+    ///
+    /// Join the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.
+    ///
+    /// - Default: `"options-scripts-markup-styles"`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svelte_sort_order: Option<String>,
+    /// Put the `>` of a multiline element on a new line.
+    ///
+    /// Deprecated: Use Prettier's `bracketSameLine` option instead.
+    ///
+    /// - Default: `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svelte_bracket_new_line: Option<bool>,
+    /// Enable/disable component attribute shorthand if the attribute name and expression are the same.
+    ///
+    /// - Default: `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svelte_allow_shorthand: Option<bool>,
+    /// Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.
+    ///
+    /// - Default: `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svelte_indent_script_and_style: Option<bool>,
+
+    // ============================================================================================
     // Below are our own extensions, handled by Oxfmt
     // ============================================================================================
     /// Whether to insert a final newline at the end of the file.

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -188,6 +188,9 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     if extension == Some("vue") {
         return Some("vue");
     }
+    if extension == Some("svelte") {
+        return Some("svelte");
+    }
     if extension == Some("mjml") {
         return Some("mjml");
     }
@@ -384,6 +387,8 @@ mod tests {
             ("email.mjml", Some("mjml")),
             // Vue
             ("App.vue", Some("vue")),
+            // Svelte
+            ("App.svelte", Some("svelte")),
             // CSS
             ("styles.css", Some("css")),
             ("app.wxss", Some("css")),

--- a/apps/oxfmt/test/api/api.test.ts
+++ b/apps/oxfmt/test/api/api.test.ts
@@ -71,6 +71,70 @@ describe("API Tests", () => {
 `.trimStart(),
     );
     expect(result3.errors).toStrictEqual([]);
+
+    // Svelte
+    const svelteCode = `
+<script>let count=0;function increment(){count+=1;}</script>
+<button on:click={increment}>{count}</button>
+<style>.btn{color:red;}</style>
+`.trim();
+    const result4 = await format("Counter.svelte", svelteCode);
+    expect(result4.code).toBe(
+      `
+<script>
+  let count = 0;
+  function increment() {
+    count += 1;
+  }
+</script>
+
+<button on:click={increment}>{count}</button>
+
+<style>
+  .btn {
+    color: red;
+  }
+</style>
+`.trimStart(),
+    );
+    expect(result4.errors).toStrictEqual([]);
+
+    // Svelte 5 runes
+    const svelte5Code = `
+<script lang="ts">let count=$state(0);let doubled=$derived(count*2);</script>
+<button onclick={()=>count++}>{count} x 2 = {doubled}</button>
+`.trim();
+    const result5 = await format("Counter.svelte", svelte5Code);
+    expect(result5.code).toBe(
+      `
+<script lang="ts">
+  let count = $state(0);
+  let doubled = $derived(count * 2);
+</script>
+
+<button onclick={() => count++}>{count} x 2 = {doubled}</button>
+`.trimStart(),
+    );
+    expect(result5.errors).toStrictEqual([]);
+
+    // Svelte with svelteIndentScriptAndStyle: false
+    const svelteNoIndent = `
+<script>let x=1;</script>
+<div>{x}</div>
+`.trim();
+    const result6 = await format("Test.svelte", svelteNoIndent, {
+      svelteIndentScriptAndStyle: false,
+    });
+    expect(result6.code).toBe(
+      `
+<script>
+let x = 1;
+</script>
+
+<div>{x}</div>
+`.trimStart(),
+    );
+    expect(result6.errors).toStrictEqual([]);
   });
 
   test("should sort imports with customGroups", async () => {

--- a/apps/oxfmt/test/cli/external_formatter_with_config/__snapshots__/external_formatter_with_config.test.ts.snap
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/__snapshots__/external_formatter_with_config.test.ts.snap
@@ -1,6 +1,42 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`external_formatter_with_config > should pass config options to prettier 1`] = `
+exports[`external_formatter_with_config > should pass config options to prettier for Svelte 1`] = `
+"--- FILE -----------
+test.svelte
+--- BEFORE ---------
+<script>
+let count=0;function increment(){count+=1;}
+</script>
+
+<button on:click={increment}>{count}</button>
+
+<style>
+.btn{color:red;background:blue}
+</style>
+
+--- AFTER ----------
+<script>
+	let count = 0;
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<button on:click={increment}
+	>{count}</button
+>
+
+<style>
+	.btn {
+		color: red;
+		background: blue;
+	}
+</style>
+
+--------------------"
+`;
+
+exports[`external_formatter_with_config > should pass config options to prettier for Vue 1`] = `
 "--- FILE -----------
 test.vue
 --- BEFORE ---------

--- a/apps/oxfmt/test/cli/external_formatter_with_config/external_formatter_with_config.test.ts
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/external_formatter_with_config.test.ts
@@ -5,8 +5,13 @@ import { runWriteModeAndSnapshot } from "../utils";
 const fixturesDir = join(import.meta.dirname, "fixtures");
 
 describe("external_formatter_with_config", () => {
-  it("should pass config options to prettier", async () => {
+  it("should pass config options to prettier for Vue", async () => {
     const snapshot = await runWriteModeAndSnapshot(fixturesDir, ["test.vue"]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it("should pass config options to prettier for Svelte", async () => {
+    const snapshot = await runWriteModeAndSnapshot(fixturesDir, ["test.svelte"]);
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/test.svelte
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/test.svelte
@@ -1,0 +1,9 @@
+<script>
+let count=0;function increment(){count+=1;}
+</script>
+
+<button on:click={increment}>{count}</button>
+
+<style>
+.btn{color:red;background:blue}
+</style>

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     // We are using patched version, so we must bundle it
     // Also, it internally loads plugins dynamically, so they also must be bundled
     "prettier-plugin-tailwindcss",
+    "prettier-plugin-svelte",
     /^prettier\/plugins\//,
 
     // Cannot bundle: `cli-worker.js` runs in separate thread and can't resolve bundled chunks

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -212,6 +212,38 @@
       ],
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
     },
+    "svelteAllowShorthand": {
+      "description": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`"
+    },
+    "svelteBracketNewLine": {
+      "description": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`"
+    },
+    "svelteIndentScriptAndStyle": {
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`"
+    },
+    "svelteSortOrder": {
+      "description": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`",
+      "type": [
+        "string",
+        "null"
+      ],
+      "markdownDescription": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`"
+    },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
       "type": [
@@ -484,6 +516,38 @@
             "null"
           ],
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+        },
+        "svelteAllowShorthand": {
+          "description": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`"
+        },
+        "svelteBracketNewLine": {
+          "description": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`"
+        },
+        "svelteIndentScriptAndStyle": {
+          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`"
+        },
+        "svelteSortOrder": {
+          "description": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`",
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,12 @@ importers:
       prettier:
         specifier: 3.8.1
         version: 3.8.1
+      prettier-plugin-svelte:
+        specifier: ^3.4.1
+        version: 3.4.1(prettier@3.8.1)(svelte@5.49.0)
       prettier-plugin-tailwindcss:
         specifier: 0.7.2
-        version: 0.7.2(patch_hash=85d2396832ac55f5f0187f4ba0a7b8bf22d7d117e33f75c1290670eb9a8c55af)(prettier@3.8.1)
+        version: 0.7.2(patch_hash=85d2396832ac55f5f0187f4ba0a7b8bf22d7d117e33f75c1290670eb9a8c55af)(prettier-plugin-svelte@3.4.1(prettier@3.8.1)(svelte@5.49.0))(prettier@3.8.1)
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -2692,6 +2695,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.8':
+    resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@textlint/ast-node-types@15.5.0':
     resolution: {integrity: sha512-K0LEuuTo4rza8yDrlYkRdXLao8Iz/QBMsQdIxRrOOrLYb4HAtZaypZ78c+J6rDA1UlGxadZVLmkkiv4KV5fMKQ==}
 
@@ -3029,6 +3037,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -3049,6 +3061,10 @@ packages:
 
   axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -3530,6 +3546,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devalue@5.6.2:
+    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
@@ -3695,6 +3714,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3702,6 +3724,9 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.2:
+    resolution: {integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -4137,6 +4162,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -4275,6 +4303,9 @@ packages:
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4758,6 +4789,12 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-svelte@3.4.1:
+    resolution: {integrity: sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
   prettier-plugin-tailwindcss@0.7.2:
     resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
     engines: {node: '>=20.19'}
@@ -5235,6 +5272,10 @@ packages:
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
+
+  svelte@5.49.0:
+    resolution: {integrity: sha512-Fn2mCc3XX0gnnbBYzWOTrZHi5WnF9KvqmB1+KGlUWoJkdioPmFYtg2ALBr6xl2dcnFTz3Vi7/mHpbKSVg/imVg==}
+    engines: {node: '>=18'}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -5748,6 +5789,9 @@ packages:
 
   yup@1.7.1:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
 
@@ -7896,6 +7940,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
+    dependencies:
+      acorn: 8.15.0
+
   '@textlint/ast-node-types@15.5.0': {}
 
   '@textlint/linter-formatter@15.5.0':
@@ -8450,6 +8498,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.2: {}
+
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
@@ -8471,6 +8521,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   azure-devops-node-api@12.5.0:
     dependencies:
@@ -8964,6 +9016,8 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
+  devalue@5.6.2: {}
+
   dezalgo@1.0.4:
     dependencies:
       asap: 2.0.6
@@ -9159,6 +9213,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.15.0
@@ -9168,6 +9224,10 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   esrecurse@4.3.0:
     dependencies:
@@ -9608,6 +9668,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-stream@4.0.1: {}
 
   is-unicode-supported@0.1.0: {}
@@ -9749,6 +9813,8 @@ snapshots:
   lit@https://codeload.github.com/lit/dist/tar.gz/2d8c023d796e1884e53ad527d3c68214c866a9e1: {}
 
   load-esm@1.0.3: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -10250,9 +10316,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.7.2(patch_hash=85d2396832ac55f5f0187f4ba0a7b8bf22d7d117e33f75c1290670eb9a8c55af)(prettier@3.8.1):
+  prettier-plugin-svelte@3.4.1(prettier@3.8.1)(svelte@5.49.0):
     dependencies:
       prettier: 3.8.1
+      svelte: 5.49.0
+
+  prettier-plugin-tailwindcss@0.7.2(patch_hash=85d2396832ac55f5f0187f4ba0a7b8bf22d7d117e33f75c1290670eb9a8c55af)(prettier-plugin-svelte@3.4.1(prettier@3.8.1)(svelte@5.49.0))(prettier@3.8.1):
+    dependencies:
+      prettier: 3.8.1
+    optionalDependencies:
+      prettier-plugin-svelte: 3.4.1(prettier@3.8.1)(svelte@5.49.0)
 
   prettier@3.8.1: {}
 
@@ -10761,6 +10834,24 @@ snapshots:
       has-flag: 4.0.0
       supports-color: 7.2.0
 
+  svelte@5.49.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      acorn: 8.15.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.6.2
+      esm-env: 1.2.2
+      esrap: 2.2.2
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+
   table@6.9.0:
     dependencies:
       ajv: 8.17.1
@@ -11260,3 +11351,5 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+  zimmerframe@1.1.4: {}

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -216,6 +216,38 @@ expression: json
       ],
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
     },
+    "svelteAllowShorthand": {
+      "description": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`"
+    },
+    "svelteBracketNewLine": {
+      "description": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`"
+    },
+    "svelteIndentScriptAndStyle": {
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`"
+    },
+    "svelteSortOrder": {
+      "description": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`",
+      "type": [
+        "string",
+        "null"
+      ],
+      "markdownDescription": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`"
+    },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
       "type": [
@@ -488,6 +520,38 @@ expression: json
             "null"
           ],
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+        },
+        "svelteAllowShorthand": {
+          "description": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Enable/disable component attribute shorthand if the attribute name and expression are the same.\n\n- Default: `true`"
+        },
+        "svelteBracketNewLine": {
+          "description": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Put the `>` of a multiline element on a new line.\n\nDeprecated: Use Prettier's `bracketSameLine` option instead.\n\n- Default: `true`"
+        },
+        "svelteIndentScriptAndStyle": {
+          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.\n\n- Default: `true`"
+        },
+        "svelteSortOrder": {
+          "description": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`",
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.\n\nJoin the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.\n\n- Default: `\"options-scripts-markup-styles\"`"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -1004,6 +1004,50 @@ For JSX, you can set the `jsxSingleQuote` option.
 - Default: `false`
 
 
+##### overrides[n].options.svelteAllowShorthand
+
+type: `boolean`
+
+
+Enable/disable component attribute shorthand if the attribute name and expression are the same.
+
+- Default: `true`
+
+
+##### overrides[n].options.svelteBracketNewLine
+
+type: `boolean`
+
+
+Put the `>` of a multiline element on a new line.
+
+Deprecated: Use Prettier's `bracketSameLine` option instead.
+
+- Default: `true`
+
+
+##### overrides[n].options.svelteIndentScriptAndStyle
+
+type: `boolean`
+
+
+Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.
+
+- Default: `true`
+
+
+##### overrides[n].options.svelteSortOrder
+
+type: `string`
+
+
+Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.
+
+Join the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.
+
+- Default: `"options-scripts-markup-styles"`
+
+
 ##### overrides[n].options.tabWidth
 
 type: `integer`
@@ -1115,6 +1159,50 @@ Use single quotes instead of double quotes.
 For JSX, you can set the `jsxSingleQuote` option.
 
 - Default: `false`
+
+
+## svelteAllowShorthand
+
+type: `boolean`
+
+
+Enable/disable component attribute shorthand if the attribute name and expression are the same.
+
+- Default: `true`
+
+
+## svelteBracketNewLine
+
+type: `boolean`
+
+
+Put the `>` of a multiline element on a new line.
+
+Deprecated: Use Prettier's `bracketSameLine` option instead.
+
+- Default: `true`
+
+
+## svelteIndentScriptAndStyle
+
+type: `boolean`
+
+
+Whether or not to indent the code inside `<script>` and `<style>` tags in Svelte files.
+
+- Default: `true`
+
+
+## svelteSortOrder
+
+type: `string`
+
+
+Sort order for `<script>`, `<style>`, markup, and module context in Svelte files.
+
+Join the keywords `options`, `scripts`, `markup`, `styles` with a `-` in the order you want.
+
+- Default: `"options-scripts-markup-styles"`
 
 
 ## tabWidth


### PR DESCRIPTION
I assume that @leaysgur has already considered this approach and decided not to adopt it, so I don’t expect this PR to be merged, but I’m submitting it anyway. At the moment, how are you planning to support Svelte?

For Svelte users, being able to support formatting of Svelte files would be convenient, since it would allow a full migration to oxfmt.

---

Add support for formatting `.svelte` files using prettier-plugin-svelte.

Changes:
- Bundle prettier-plugin-svelte alongside prettier
- Add `.svelte` extension mapping to "svelte" parser
- Add Svelte-specific options:
  - `svelteSortOrder`: element ordering in components
  - `svelteAllowShorthand`: attribute shorthand syntax
  - `svelteIndentScriptAndStyle`: indentation in script/style tags
- Add tests for Svelte formatting including Svelte 5 runes