### PR TITLE
perf(linter): remove string allocation

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -584,7 +584,7 @@ impl ConfigStoreBuilder {
 
         // Convert path to a `file://...` URL, as required by `import(...)` on JS side.
         // Note: `unwrap()` here is infallible as `plugin_path` is an absolute path.
-        let plugin_url = Url::from_file_path(&plugin_path).unwrap().as_str().to_string();
+        let plugin_url = String::from(Url::from_file_path(&plugin_path).unwrap());
 
         let result = (external_linter.load_plugin)(plugin_url, plugin_name, alias.is_some())
             .map_err(|error| ConfigBuilderError::PluginLoadFailed {


### PR DESCRIPTION
Small optimization. Remove 1 unnecessary string allocation from `load_external_plugin`. `Url` contains an owned `String` internally and `String::from` just extracts it without copying or allocating a new `String`, unlike `.as_str().to_string()` which clones the `String`.

`.into_string()` would be more idiomatic, but that method of `Url` is deprecated.