### PR TITLE
fix(oxlint/lsp): disable JS plugins support in LSP except in tests

### DIFF
--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -181,6 +181,10 @@ async fn lint_impl(
 
     // If --lsp flag is set, run the language server
     if command.lsp {
+        // Disable JS plugins support except in tests.
+        // TODO: Remove this line once we have solidified the implementation and thoroughly tested it.
+        let external_linter = if cfg!(feature = "testing") { external_linter } else { None };
+
         crate::lsp::run_lsp(external_linter).await;
         return CliRunResult::LintSucceeded;
     }


### PR DESCRIPTION
#17809 and #17840 add support for JS plugins to LSP. However:

* We don't have much test coverage yet.
* The support for workspaces imposes a perf cost on Oxlint CLI (frequent hash map lookups on JS side).
* I believe there's a bug in JS-side code - https://github.com/oxc-project/oxc/pull/17809#issuecomment-3823145454.

I think it'd be easier to merge this stack and then iterate on it in further PRs to fix the above.

To prevent any breakage for users in the meantime, this PR disables JS plugin support in LSP unless the `testing` Cargo feature is enabled - i.e. it's only enabled in tests for now.