### PR TITLE
[DO NOT MERGE] perf(estree,syntax,codegen): Replace `dragonbox_ecma` with `zmij_ecma` for floating point formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,12 +611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dragonbox_ecma"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5577f010d4e1bb3f3c4d6081e05718eb6992cf20119cab4d3abadff198b5ae"
-
-[[package]]
 name = "dtor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1821,7 +1815,6 @@ version = "0.113.0"
 dependencies = [
  "bitflags",
  "cow-utils",
- "dragonbox_ecma",
  "insta",
  "itoa",
  "oxc_allocator",
@@ -1835,6 +1828,7 @@ dependencies = [
  "oxc_syntax",
  "pico-args",
  "rustc-hash",
+ "zmij_ecma",
 ]
 
 [[package]]
@@ -1921,9 +1915,9 @@ dependencies = [
 name = "oxc_estree"
 version = "0.113.0"
 dependencies = [
- "dragonbox_ecma",
  "itoa",
  "oxc_data_structures",
+ "zmij_ecma",
 ]
 
 [[package]]
@@ -2366,7 +2360,6 @@ version = "0.113.0"
 dependencies = [
  "bitflags",
  "cow-utils",
- "dragonbox_ecma",
  "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
@@ -2376,6 +2369,7 @@ dependencies = [
  "phf",
  "serde",
  "unicode-id-start",
+ "zmij_ecma",
 ]
 
 [[package]]
@@ -2964,7 +2958,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3059,7 +3053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3348,7 +3342,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3884,7 +3878,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4215,3 +4209,9 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zmij_ecma"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd49ba5db5c57c0a1139f1ffe31311f38b027d6c88cf73c2c65768172e8ebdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ constcat = "0.6.1" # Const string concatenation
 convert_case = "0.11.0" # Case conversion
 cow-utils = "0.1.3" # Copy-on-write utilities
 criterion2 = { version = "3.0.2", default-features = false } # Benchmarking
-dragonbox_ecma = "0.1.0" # Fast float formatting
+zmij_ecma = "1.0.21" # Fast float formatting
 encoding_rs = "0.8.35" # Character encoding
 encoding_rs_io = "0.1.7" # Encoding I/O
 fast-glob = "1.0.0" # Fast glob matching

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -31,7 +31,7 @@ oxc_syntax = { workspace = true }
 
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
-dragonbox_ecma = { workspace = true }
+zmij_ecma = { workspace = true }
 itoa = { workspace = true }
 rustc-hash = { workspace = true }
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -785,7 +785,7 @@ impl<'a> Codegen<'a> {
 
     fn print_non_negative_float(&mut self, num: f64) {
         // Inline the buffer here to avoid heap allocation on `buffer.format(*self).to_string()`.
-        let mut buffer = dragonbox_ecma::Buffer::new();
+        let mut buffer = zmij_ecma::Buffer::new();
         if num < 1000.0 && num.fract() == 0.0 {
             self.print_str(buffer.format(num));
             self.need_space_before_dot = self.code_len();
@@ -806,7 +806,7 @@ impl<'a> Codegen<'a> {
     // Instead of building all candidates and finding the shortest, we track the shortest as we go
     // and use self.print_str directly instead of returning intermediate strings
     #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
-    fn print_minified_number(&mut self, num: f64, buffer: &mut dragonbox_ecma::Buffer) {
+    fn print_minified_number(&mut self, num: f64, buffer: &mut zmij_ecma::Buffer) {
         if num < 1000.0 && num.fract() == 0.0 {
             self.print_str(buffer.format(num));
             self.need_space_before_dot = self.code_len();

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -25,9 +25,9 @@ oxc_data_structures = { workspace = true, features = [
   "stack",
 ], optional = true }
 
-dragonbox_ecma = { workspace = true, optional = true }
+zmij_ecma = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
 
 [features]
 default = []
-serialize = ["dep:oxc_data_structures", "dep:itoa", "dep:dragonbox_ecma"]
+serialize = ["dep:oxc_data_structures", "dep:itoa", "dep:zmij_ecma"]

--- a/crates/oxc_estree/src/serialize/primitives.rs
+++ b/crates/oxc_estree/src/serialize/primitives.rs
@@ -1,5 +1,5 @@
-use dragonbox_ecma::Buffer as DragonboxBuffer;
 use itoa::Buffer as ItoaBuffer;
+use zmij_ecma::Buffer as ZmijBuffer;
 
 use super::{ESTree, Serializer};
 
@@ -14,7 +14,7 @@ impl ESTree for bool {
 impl ESTree for f64 {
     fn serialize<S: Serializer>(&self, mut serializer: S) {
         if self.is_finite() {
-            let mut buffer = DragonboxBuffer::new();
+            let mut buffer = ZmijBuffer::new();
             let s = buffer.format_finite(*self);
             serializer.buffer_mut().print_str(s);
         } else if self.is_nan() {

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -32,10 +32,10 @@ nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 unicode-id-start = { workspace = true }
 
-dragonbox_ecma = { workspace = true, optional = true }
+zmij_ecma = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 default = []
-to_js_string = ["dep:dragonbox_ecma"]
+to_js_string = ["dep:zmij_ecma"]
 serialize = ["bitflags/serde", "dep:serde", "oxc_estree/serialize"]

--- a/crates/oxc_syntax/src/number.rs
+++ b/crates/oxc_syntax/src/number.rs
@@ -44,7 +44,7 @@ pub trait ToJsString {
 #[cfg(feature = "to_js_string")]
 impl ToJsString for f64 {
     fn to_js_string(&self) -> String {
-        let mut buffer = dragonbox_ecma::Buffer::new();
+        let mut buffer = zmij_ecma::Buffer::new();
         buffer.format(*self).to_string()
     }
 }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE - Performance Tracking PR

This PR is for **performance tracking purposes only** and should **NOT be merged** into the main branch.

### Purpose
Tracking performance comparison between `dragonbox_ecma` and `zmij_ecma` for float-to-string formatting in ECMAScript contexts.

### Status
🚧 **Work in Progress** - `zmij` is still under active development and has not reached stability.

### Changes
- Replaced all `dragonbox_ecma` dependencies with `zmij_ecma`
- Updated affected crates:
  - `oxc_syntax`
  - `oxc_estree`
  - `oxc_codegen`

### Notes
- This PR is intended for benchmarking and evaluation only