### PR TITLE
feat(linter/prefer-namespace-keyword): move to correctness

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 92 rules using 1 threads.
+Finished in <variable>ms on 2 files with 93 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 92 rules using 1 threads.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 89 rules using 1 threads.
+Finished in <variable>ms on 1 file with 90 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 92 rules using 1 threads.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 92 rules using 1 threads.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 92 rules using 1 threads.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 89 rules using 1 threads.
+Finished in <variable>ms on 7 files with 90 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -39,7 +39,7 @@ working directory:
   help: Consider using this expression or removing it
 
 Found 3 warnings and 1 error.
-Finished in <variable>ms on 1 file with 65 rules using 1 threads.
+Finished in <variable>ms on 1 file with 66 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -36,7 +36,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 90 rules using 1 threads.
+Finished in <variable>ms on 3 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the `isNaN` function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__js_as_jsx.js@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -34,7 +34,7 @@ working directory:
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__invalid.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__invalid.vue@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Add an initializer (e.g. ` = undefined`) here
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c ./test/eslintrc.json --ignore-pattern *.ts .
 working directory: fixtures/config_ignore_patterns/with_oxlintrc
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cross_module_nested_config_@oxlint.snap
@@ -35,7 +35,7 @@ working directory: fixtures/cross_module_nested_config
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 4 files with 90 rules using 1 threads.
+Finished in <variable>ms on 4 files with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__dot_folder_@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/dot_folder
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Finished in <variable>ms on 1 file with 92 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 90 rules using 1 threads.
+Finished in <variable>ms on 4 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -40,7 +40,7 @@ working directory: fixtures/extends_config
   help: Provide an `href` for the `a` element.
 
 Found 1 warning and 3 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__ignore_patterns_symlink_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_patterns_symlink_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 90 rules using 1 threads.
+Finished in <variable>ms on 0 files with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/import-cycle
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 93 rules using 1 threads.
+Finished in <variable>ms on 2 files with 94 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__issue_10394_-c .oxlintrc.json@oxlint.snap
@@ -15,7 +15,7 @@ working directory: fixtures/issue_10394
   help: Write a meaningful title for your test
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 90 rules using 1 threads.
+Finished in <variable>ms on 1 file with 91 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_with_plugin_-c .oxlintrc.json@oxlint.snap
@@ -42,7 +42,7 @@ working directory: fixtures/overrides_with_plugin
   help: Consider removing this declaration.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives@oxlint.snap
@@ -321,7 +321,7 @@ working directory: fixtures/report_unused_directives
     `----
 
 Found 38 warnings and 0 errors.
-Finished in <variable>ms on 5 files with 91 rules using 1 threads.
+Finished in <variable>ms on 5 files with 92 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_config_error_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_config_error_--type-aware@oxlint.snap
@@ -17,7 +17,7 @@ working directory: fixtures/tsgolint_config_error
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 104 rules using 1 threads.
+Finished in <variable>ms on 1 file with 105 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware --report-unused-disable-directives unused.ts@oxlint.snap
@@ -77,7 +77,7 @@ working directory: fixtures/tsgolint_disable_directives
     `----
 
 Found 8 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 104 rules using 1 threads.
+Finished in <variable>ms on 1 file with 105 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_disable_directives_--type-aware test.ts@oxlint.snap
@@ -96,7 +96,7 @@ working directory: fixtures/tsgolint_disable_directives
   help: The promise must end with a call to .catch, or end with a call to .then with a rejection handler, or be explicitly marked as ignored with the `void` operator.
 
 Found 10 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 104 rules using 1 threads.
+Finished in <variable>ms on 1 file with 105 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_tsconfig_extends_config_err_--type-aware -D no-floating-promises@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/tsgolint_tsconfig_extends_config_err
         See https://github.com/oxc-project/tsgolint/issues/351 for more information.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 104 rules using 1 threads.
+Finished in <variable>ms on 1 file with 105 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 90 rules using 1 threads.
+Finished in <variable>ms on 2 files with 91 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -17,7 +17,7 @@
   help: Remove the debugger statement
 
 Found 1 warning and 1 error.
-Finished in Xms on 1 file with 91 rules using X threads.
+Finished in Xms on 1 file with 92 rules using X threads.
 ```
 
 # stderr

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -14,6 +14,14 @@ use crate::{
 
 fn prefer_namespace_keyword_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use `namespace` instead of `module` to declare custom TypeScript modules.")
+        .with_help("Replace `module` with `namespace` for internal declarations.")
+        .with_note(
+            "`module` for internal declarations is no longer supported: treat it as a hard \
+             error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: \
+             https://github.com/microsoft/TypeScript/issues/54500, \
+             https://github.com/microsoft/TypeScript/issues/62211, \
+             https://github.com/microsoft/TypeScript/pull/62876.",
+        )
         .with_label(span)
 }
 
@@ -44,7 +52,7 @@ declare_oxc_lint!(
     /// ```
     PreferNamespaceKeyword,
     typescript,
-    style,
+    correctness,
     fix
 );
 

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_namespace_keyword.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_namespace_keyword.snap
@@ -6,21 +6,24 @@ source: crates/oxc_linter/src/tester.rs
  1 │ module foo {}
    · ─────────────
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.
 
   ⚠ typescript-eslint(prefer-namespace-keyword): Use `namespace` instead of `module` to declare custom TypeScript modules.
    ╭─[prefer_namespace_keyword.tsx:1:1]
  1 │ module A.B {}
    · ─────────────
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.
 
   ⚠ typescript-eslint(prefer-namespace-keyword): Use `namespace` instead of `module` to declare custom TypeScript modules.
    ╭─[prefer_namespace_keyword.tsx:1:1]
  1 │ declare module foo {}
    · ─────────────────────
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.
 
   ⚠ typescript-eslint(prefer-namespace-keyword): Use `namespace` instead of `module` to declare custom TypeScript modules.
    ╭─[prefer_namespace_keyword.tsx:2:9]
@@ -30,7 +33,8 @@ source: crates/oxc_linter/src/tester.rs
  4 │ ╰─▶         }
  5 │             
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.
 
   ⚠ typescript-eslint(prefer-namespace-keyword): Use `namespace` instead of `module` to declare custom TypeScript modules.
    ╭─[prefer_namespace_keyword.tsx:3:11]
@@ -39,7 +43,8 @@ source: crates/oxc_linter/src/tester.rs
    ·           ─────────────────────
  4 │         }
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.
 
   ⚠ typescript-eslint(prefer-namespace-keyword): Use `namespace` instead of `module` to declare custom TypeScript modules.
    ╭─[prefer_namespace_keyword.tsx:3:13]
@@ -48,4 +53,5 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────
  4 │         }
    ╰────
-  help: Replace `module` with `namespace`.
+  help: Replace `module` with `namespace` for internal declarations.
+  note: `module` for internal declarations is no longer supported: treat it as a hard error. Expect it to become a parse error in a future version of TypeScript and Oxlint. See: https://github.com/microsoft/TypeScript/issues/54500, https://github.com/microsoft/TypeScript/issues/62211, https://github.com/microsoft/TypeScript/pull/62876.


### PR DESCRIPTION
this is going to be a hard parser error in a future release, so lets move this rule to correctness to allow people to take advantage of the fixer and migrate their code