### PR TITLE
test(vscode): wait some ms for server update

### DIFF
--- a/editors/vscode/tests/integration/code_actions.spec.ts
+++ b/editors/vscode/tests/integration/code_actions.spec.ts
@@ -158,6 +158,7 @@ suite("code actions", () => {
       .getConfiguration("oxc", fixturesWorkspaceUri())
       .update("fixKind", "dangerous_fix", ConfigurationTarget.WorkspaceFolder);
     await workspace.saveAll();
+    await sleep(500);
 
     const codeActionsWithFix: ProviderResult<Array<CodeAction>> = await commands.executeCommand(
       "vscode.executeCodeActionProvider",

--- a/editors/vscode/tests/integration/e2e_server_linter.spec.ts
+++ b/editors/vscode/tests/integration/e2e_server_linter.spec.ts
@@ -297,7 +297,7 @@ suite("E2E Server Linter", () => {
 
     await workspace.getConfiguration("oxc").update("tsConfigPath", "fixtures/deep/tsconfig.json");
     await workspace.saveAll();
-    await waitForDiagnosticChange();
+    await sleep(500);
 
     const secondDiagnostics = await getDiagnostics("deep/src/dep-a.ts");
     strictEqual(secondDiagnostics.length, 1);
@@ -326,6 +326,7 @@ suite("E2E Server Linter", () => {
 
   testSingleFolderMode("changing oxc.enable will update the client status", async () => {
     await loadFixture("changing_enable");
+    await sleep(500);
 
     const firstDiagnostics = await getDiagnostics("debugger.js");
     strictEqual(firstDiagnostics.length, 1);


### PR DESCRIPTION
The tests in CI somehow needs more time now. I guess this has something do to with `jsPlugin`.
Locally, they are all passed. 