### PR TITLE
fix(linter/capitalized-comments): fix generated rule option docs

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_capitalized_comments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_capitalized_comments.snap
@@ -347,7 +347,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to uppercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
-   ╭─[capitalized_comments.tsx:2:4]
+   ╭─[capitalized_comments.tsx:2:13]
  1 │ foo(a,
  2 │             /* not an inline comment */b);
    ·             ───────────────────────────
@@ -355,7 +355,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to uppercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
-   ╭─[capitalized_comments.tsx:2:4]
+   ╭─[capitalized_comments.tsx:2:13]
  1 │ foo(a,
  2 │             /* not an inline comment */
    ·             ───────────────────────────
@@ -380,7 +380,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to lowercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with an uppercase letter
-   ╭─[capitalized_comments.tsx:2:4]
+   ╭─[capitalized_comments.tsx:2:13]
  1 │ foo(a,
  2 │             /* Not an inline comment */b);
    ·             ───────────────────────────
@@ -388,7 +388,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to lowercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with an uppercase letter
-   ╭─[capitalized_comments.tsx:2:4]
+   ╭─[capitalized_comments.tsx:2:13]
  1 │ foo(a,
  2 │             /* Not an inline comment */
    ·             ───────────────────────────
@@ -411,7 +411,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to lowercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
-   ╭─[capitalized_comments.tsx:4:4]
+   ╭─[capitalized_comments.tsx:4:13]
  3 │             foo();
  4 │             // this comment is now invalid.
    ·             ───────────────────────────────
@@ -435,7 +435,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the first letter of the comment to lowercase
 
   ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
-   ╭─[capitalized_comments.tsx:2:4]
+   ╭─[capitalized_comments.tsx:2:13]
  1 │ // This comment is valid since it is capitalized,
  2 │             // but this one is invalid even if it follows a valid one.
    ·             ──────────────────────────────────────────────────────────

--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -161,7 +161,11 @@ impl Renderer {
                 .properties
                 .iter()
                 .flat_map(|(key, schema)| {
-                    let key = parent_key.map_or_else(|| key.clone(), |k| format!("{k}.{key}"));
+                    // This is necessary to handle config options added via serde(flatten).
+                    let key = match parent_key {
+                        Some(parent) if !parent.is_empty() => format!("{parent}.{key}"),
+                        _ => key.clone(),
+                    };
                     let schema_object = Self::get_schema_object(schema);
 
                     if let Some(subschemas) = &schema_object.subschemas {


### PR DESCRIPTION
Fixes #17191. Previously, the docs were incorrect and a bit confusing for the user to understand. Now it's possible to actually configure the linter rule based on the docs.

AI Disclosure: Change was made with help from Claude Code and also based on the changes originally made with https://github.com/oxc-project/oxc/pull/17208.

Generated docs:

```md

## Configuration

Configuration for the capitalized-comments rule.

The first element specifies whether comments should `"always"` or `"never"`
begin with a capital letter. The second element is an optional object
containing additional options.

### The 1st option

type: `"always" | "never"`

### The 2nd option

This option is an object with the following properties:

#### block

type: `object`

Configuration options specific to block comments.

##### block.ignoreConsecutiveComments

type: `boolean`

If true, consecutive comments will be ignored after the first comment.

##### block.ignoreInlineComments

type: `boolean`

If true, inline comments (comments in the middle of code) will be ignored.

##### block.ignorePattern

type: `string`

A regex pattern. Comments that match the pattern will not cause violations.

#### ignoreConsecutiveComments

type: `boolean`

If true, consecutive comments will be ignored after the first comment.

#### ignoreInlineComments

type: `boolean`

If true, inline comments (comments in the middle of code) will be ignored.

#### ignorePattern

type: `string`

A regex pattern. Comments that match the pattern will not cause violations.

#### line

type: `object`

Configuration options specific to line comments.

##### line.ignoreConsecutiveComments

type: `boolean`

If true, consecutive comments will be ignored after the first comment.

##### line.ignoreInlineComments

type: `boolean`

If true, inline comments (comments in the middle of code) will be ignored.

##### line.ignorePattern

type: `string`

A regex pattern. Comments that match the pattern will not cause violations.
```