### PR TITLE
fix(linter/plugins): support plugins outside of workspace

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -44,7 +44,7 @@ export type JsDestroyWorkspaceCb =
 
 /** JS callback to lint a file. */
 export type JsLintFileCb =
-  ((arg0: string, arg1: number, arg2: Uint8Array | undefined | null, arg3: Array<number>, arg4: Array<number>, arg5: string, arg6: string) => string | null)
+  ((arg0: string, arg1: number, arg2: Uint8Array | undefined | null, arg3: Array<number>, arg4: Array<number>, arg5: string, arg6: string, arg7?: string | undefined | null) => string | null)
 
 /** JS callback to load JavaScript config files. */
 export type JsLoadJsConfigsCb =
@@ -52,7 +52,7 @@ export type JsLoadJsConfigsCb =
 
 /** JS callback to load a JS plugin. */
 export type JsLoadPluginCb =
-  ((arg0: string, arg1: string | undefined | null, arg2: boolean) => Promise<string>)
+  ((arg0: string, arg1: string | undefined | null, arg2: boolean, arg3?: string | undefined | null) => Promise<string>)
 
 /** JS callback to setup configs. */
 export type JsSetupRuleConfigsCb =

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -344,6 +344,11 @@ interface Diagnostic {
 // Default path (without extension) for test cases if not provided
 const DEFAULT_FILENAME_BASE = "file";
 
+// Dummy workspace URI.
+// This just needs to be unique, and we only have a single workspace in existence at any time.
+// It can be anything, so just use empty string.
+const WORKSPACE_URI = "";
+
 // ------------------------------------------------------------------------------
 // `RuleTester` class
 // ------------------------------------------------------------------------------
@@ -999,11 +1004,11 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
     path = pathJoin(cwd, filename);
   }
 
-  createWorkspace(cwd);
+  createWorkspace(WORKSPACE_URI);
 
   try {
     // Register plugin. This adds rule to `registeredRules` array.
-    registerPlugin(path, plugin, null, false);
+    registerPlugin(plugin, null, false, null);
 
     // Set up options
     const optionsId = setupOptions(test, cwd);
@@ -1021,7 +1026,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
 
     // Lint file.
     // Buffer is stored already, at index 0. No need to pass it.
-    lintFileImpl(path, 0, null, [0], [optionsId], settingsJSON, globalsJSON);
+    lintFileImpl(path, 0, null, [0], [optionsId], settingsJSON, globalsJSON, null);
 
     // Return diagnostics
     const ruleId = `${plugin.meta!.name!}/${Object.keys(plugin.rules)[0]}`;
@@ -1061,7 +1066,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
     });
   } finally {
     // Reset state
-    destroyWorkspace(cwd);
+    destroyWorkspace(WORKSPACE_URI);
 
     // Even if there hasn't been an error, do a full reset of state just to be sure.
     // This includes emptying `diagnostics`.
@@ -1237,6 +1242,7 @@ function setupOptions(test: TestCase, cwd: string): number {
       options: allOptions,
       ruleIds: allRuleIds,
       cwd,
+      workspaceUri: null,
     });
   } catch (err) {
     throw new Error(`Failed to serialize options: ${err}`);

--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -13,19 +13,19 @@ import { removeOptionsInWorkspace, setupOptionsForWorkspace } from "../plugins/o
 import { debugAssert } from "../utils/asserts";
 
 /**
- * Type representing a workspace identifier.
- * Currently, this is just a string representing the workspace root directory.
+ * Type representing a workspace ID.
+ * Currently, this is just a string representing the workspace root directory as `file://` URL.
  */
 export type WorkspaceIdentifier = string;
 
 /**
  * Type representing a workspace.
- * Currently it only contains the identifier.
+ * Currently it only contains the workspace root directory as `file://` URL.
  */
 export type Workspace = WorkspaceIdentifier;
 
 /**
- * Set of workspace root directories.
+ * Set of workspace IDs.
  */
 const workspaces = new Set<Workspace>();
 
@@ -52,31 +52,13 @@ export function destroyWorkspace(workspace: WorkspaceIdentifier): undefined {
 }
 
 /**
- * Get a workspace by its identifier.
+ * Gets the CLI workspace ID.
+ * In CLI mode, there is exactly one workspace (the CWD), so this returns that workspace ID.
  */
-export function getWorkspace(workspace: WorkspaceIdentifier): Workspace | null {
-  return workspaces.has(workspace) ? workspace : null;
-}
-
-/**
- * Checks if a filePath is responsible for a workspace.
- */
-export const isWorkspaceResponsible = (workspace: WorkspaceIdentifier, url: string): boolean => {
-  return getResponsibleWorkspace(url) === workspace;
-};
-
-/**
- * Gets the workspace responsible for a given filePath.
- * Returns `null` if no workspace is responsible.
- *
- * This function is kept in sync with Rust's `WorkspaceWorker::is_responsible_for_file` (`oxc_language_server` crate).
- * Changing this function requires a corresponding change in Rust implementation.
- */
-export const getResponsibleWorkspace = (filePath: string): Workspace | null => {
-  return (
-    [...workspaces.keys()]
-      .filter((ws) => filePath.startsWith(ws))
-      // Get the longest matching workspace path
-      .sort((a, b) => b.length - a.length)[0] ?? null
+export function getCliWorkspace(): Workspace {
+  debugAssert(
+    workspaces.size === 1,
+    "getCliWorkspace should only be used in CLI mode with 1 workspace",
   );
-};
+  return workspaces.values().next().value;
+}

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -161,6 +161,7 @@ pub struct ConfigLoader<'a> {
     external_linter: Option<&'a ExternalLinter>,
     external_plugin_store: &'a mut ExternalPluginStore,
     filters: &'a [LintFilter],
+    workspace_uri: Option<&'a str>,
 }
 
 impl<'a> ConfigLoader<'a> {
@@ -170,12 +171,14 @@ impl<'a> ConfigLoader<'a> {
     /// * `external_linter` - Optional external linter for plugin support
     /// * `external_plugin_store` - Store for external plugins
     /// * `filters` - Lint filters to apply to configs
+    /// * `workspace_uri` - Workspace URI  - only `Some` in LSP, `None` in CLI
     pub fn new(
         external_linter: Option<&'a ExternalLinter>,
         external_plugin_store: &'a mut ExternalPluginStore,
         filters: &'a [LintFilter],
+        workspace_uri: Option<&'a str>,
     ) -> Self {
-        Self { external_linter, external_plugin_store, filters }
+        Self { external_linter, external_plugin_store, filters, workspace_uri }
     }
 
     /// Load a single config from a file path
@@ -191,6 +194,7 @@ impl<'a> ConfigLoader<'a> {
             oxlintrc,
             self.external_linter,
             self.external_plugin_store,
+            self.workspace_uri,
         )
         .map_err(|e| ConfigLoadError::Build { path: path.to_path_buf(), error: e.to_string() })?;
 

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -20,7 +20,7 @@ use crate::{
 #[napi]
 pub type JsCreateWorkspaceCb = ThreadsafeFunction<
     // Arguments
-    FnArgs<(String,)>, // Workspace directory
+    FnArgs<(String,)>, // Workspace URI
     // Return value
     Promise<()>,
     // Arguments (repeated)
@@ -35,7 +35,7 @@ pub type JsCreateWorkspaceCb = ThreadsafeFunction<
 #[napi]
 pub type JsDestroyWorkspaceCb = ThreadsafeFunction<
     // Arguments
-    FnArgs<(String,)>, // Workspace directory
+    FnArgs<(String,)>, // Workspace URI
     // Return value
     (),
     // Arguments (repeated)
@@ -58,11 +58,14 @@ pub type JsLoadPluginCb = ThreadsafeFunction<
         Option<String>,
         // `true` if plugin name is an alias (takes priority over name that plugin defines itself)
         bool,
+        // Workspace URI (e.g. `file:///path/to/workspace`).
+        // `None` in CLI mode (single workspace), `Some` in LSP mode.
+        Option<String>,
     )>,
     // Return value
     Promise<String>, // `PluginLoadResult`, serialized to JSON
     // Arguments (repeated)
-    FnArgs<(String, Option<String>, bool)>,
+    FnArgs<(String, Option<String>, bool, Option<String>)>,
     // Error status
     Status,
     // CalleeHandled
@@ -81,11 +84,12 @@ pub type JsLintFileCb = ThreadsafeFunction<
         Vec<u32>,           // Array of options IDs
         String,             // Settings for the file, as JSON string
         String,             // Globals for the file, as JSON string
+        Option<String>,     // Workspace URI (`None` in CLI mode, `Some` in LSP mode)
     )>,
     // Return value
     Option<String>, // `Vec<LintFileResult>`, serialized to JSON, or `None` if no diagnostics
     // Arguments (repeated)
-    FnArgs<(String, u32, Option<Uint8Array>, Vec<u32>, Vec<u32>, String, String)>,
+    FnArgs<(String, u32, Option<Uint8Array>, Vec<u32>, Vec<u32>, String, String, Option<String>)>,
     // Error status
     Status,
     // CalleeHandled

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/files/subdirectory/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/files/subdirectory/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "jsPlugins": ["../../plugin.ts"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "basic-custom-plugin/no-debugger": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/files/subdirectory/files/index.js
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/files/subdirectory/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/options.json
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/options.json
@@ -1,0 +1,3 @@
+{
+  "cwd": "files/subdirectory"
+}

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/output.snap.md
@@ -1,0 +1,20 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+WARNING: JS plugins are experimental and not subject to semver.
+Breaking changes are possible while JS plugins support is under development.
+```

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/plugin.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from "#oxlint/plugin";
+
+// This test checks that a plugin which is outside the current working directory can be loaded.
+// `cwd` is set to `files/subdirectory` in `options.json`, and the plugin is outside that directory.
+
+const plugin: Plugin = {
+  meta: {
+    name: "basic-custom-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -24,6 +24,9 @@ pub type ExternalLinterLoadPluginCb = Arc<
                 Option<String>,
                 // `true` if plugin name is an alias (takes priority over name that plugin defines itself)
                 bool,
+                // Workspace URI (e.g. `file:///path/to/workspace`).
+                // `None` in CLI mode (single workspace), `Some` in LSP mode.
+                Option<String>,
             ) -> Result<LoadPluginResult, String>
             + Send
             + Sync,
@@ -46,6 +49,9 @@ pub type ExternalLinterLintFileCb = Arc<
                 String,
                 // Globals JSON
                 String,
+                // Workspace URI (e.g. `file:///path/to/workspace`).
+                // `None` in CLI mode (single workspace), `Some` in LSP mode.
+                Option<String>,
                 // Allocator
                 &Allocator,
             ) -> Result<Vec<LintFileResult>, String>

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -166,9 +166,10 @@ impl ExternalPluginStore {
     pub fn setup_rule_configs(
         &self,
         cwd: String,
+        workspace_uri: Option<&str>,
         external_linter: &ExternalLinter,
     ) -> Result<(), String> {
-        let json = serde_json::to_string(&ConfigSer::new(cwd, self));
+        let json = serde_json::to_string(&ConfigSer::new(cwd, workspace_uri, self));
         match json {
             Ok(options_json) => (external_linter.setup_rule_configs)(options_json),
             Err(err) => Err(format!("Failed to serialize external plugin options: {err}")),
@@ -203,14 +204,20 @@ impl ExternalPluginStore {
 #[serde(rename_all = "camelCase")]
 struct ConfigSer<'s> {
     cwd: String,
+    workspace_uri: Option<&'s str>,
     rule_ids: ConfigSerRuleIds<'s>,
     options: ConfigSerOptions<'s>,
 }
 
 impl<'s> ConfigSer<'s> {
-    fn new(cwd: String, external_plugin_store: &'s ExternalPluginStore) -> Self {
+    fn new(
+        cwd: String,
+        workspace_uri: Option<&'s str>,
+        external_plugin_store: &'s ExternalPluginStore,
+    ) -> Self {
         Self {
             cwd,
+            workspace_uri,
             rule_ids: ConfigSerRuleIds(external_plugin_store),
             options: ConfigSerOptions(external_plugin_store),
         }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     path::Path,
     ptr::{self, NonNull},
     rc::Rc,
+    string::ToString,
 };
 
 use oxc_allocator::{Allocator, AllocatorPool, CloneIn};
@@ -112,6 +113,7 @@ pub struct Linter {
     options: LintOptions,
     config: ConfigStore,
     external_linter: Option<ExternalLinter>,
+    workspace_uri: Option<Box<str>>,
 }
 
 impl Linter {
@@ -120,7 +122,13 @@ impl Linter {
         config: ConfigStore,
         external_linter: Option<ExternalLinter>,
     ) -> Self {
-        Self { options, config, external_linter }
+        Self { options, config, external_linter, workspace_uri: None }
+    }
+
+    #[must_use]
+    pub fn with_workspace_uri(mut self, workspace_uri: Option<&str>) -> Self {
+        self.workspace_uri = workspace_uri.map(Box::from);
+        self
     }
 
     /// Set the kind of auto fixes to apply.
@@ -607,6 +615,7 @@ impl Linter {
             external_rules.iter().map(|(_, options_id, _)| options_id.raw()).collect(),
             settings_json,
             globals_json,
+            self.workspace_uri.as_ref().map(ToString::to_string),
             allocator,
         );
         match result {

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -566,6 +566,7 @@ impl Tester {
                             Oxlintrc::deserialize(v).unwrap(),
                             None,
                             &mut external_plugin_store,
+                            None,
                         )
                         .unwrap()
                     })

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -399,6 +399,7 @@ impl Oxc {
                     oxlintrc,
                     None,
                     &mut external_plugin_store,
+                    None,
                 )
                 .unwrap_or_default();
                 config_builder.build(&mut external_plugin_store)


### PR DESCRIPTION
## The problem

### 1. Bug with plugins outside of workspace directory

There was a bug in workspaces implementation. `loadPlugin` was assuming that the plugin file is within the workspace, but that's not necessarily the case. e.g.:

* Workspace 1: `/path/to/project/packages/foo`
* Workspace 2: `/path/to/project/packages/bar`
* JS plugin: `/path/to/project/node_modules/eslint-plugin-whatever`

This problem arises because `loadPlugin` is determining which workspace to load a plugin for by search for the workspace whose root directory contains the plugin file.

### 2. Performance

Every call to `loadPlugin`, `setupRuleConfigs`, or `lintFile` was first searching through all workspaces to find the right one (`getResponsibleWorkspace`).

This is really expensive when there are lots of workspaces, and quite expensive even when there's only 1 because iterating hashsets is relatively slow.

## This PR

This PR separates out CWD and workspace identifiers into 2 different concerns.

* Each workspace has an ID which is unique.
* Each workspace has a CWD (path to root directory as a file path).

The workspace ID is currently the workspace's root directory as a `file://...` URL. Using that as it's guaranteed unique, even for paths which are not valid UTF-8 (`Path::to_string_lossy` can produce the same `&str` for different paths). But ID it doesn't have to be the URI - we could change it later to an integer ID if we want.

Rust-side code passes the workspace ID to every call to `loadPlugin`, `setupRuleConfigs`, or `lintFile`.

In CLI, it just passes `null` as the ID. There's only ever 1 workspace in CLI, so no point in the expense of passing a `String` on every call.

These functions look up the CWD from the workspace ID in the `cwds` map.

Separating these 2 concerns solves both problems listed above:

1. Plugins can be outside of the workspace's CWD (see added test).
2. `getResponsibleWorkspace` is removed, solving the perf issue.

Note: The multiple hashmap lookups on each call to `lintFile` remain a perf drain. This is addressed in a later PR in this stack.