### PR TITLE
refactor(linter/plugins): remove `Workspace` and `WorkspaceIdentifier` types

### DIFF
--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -10,7 +10,6 @@ import type { Context } from "./context.ts";
 import type { Options, SchemaValidator } from "./options.ts";
 import type { RuleMeta } from "./rule_meta.ts";
 import type { AfterHook, BeforeHook, Visitor, VisitorWithHooks } from "./types.ts";
-import type { WorkspaceIdentifier } from "../workspace/index.ts";
 import type { SetNullable } from "../utils/types.ts";
 
 /**
@@ -83,7 +82,7 @@ interface CreateOnceRuleDetails extends RuleDetailsBase {
 
 // Rule objects for loaded rules.
 // Indexed by `ruleId`, which is passed to `lintFile`.
-export const registeredRules: Map<WorkspaceIdentifier, RuleDetails[]> = new Map();
+export const registeredRules: Map<string, RuleDetails[]> = new Map();
 
 // `before` hook which makes rule never run.
 const neverRunBeforeHook: BeforeHook = () => false;
@@ -433,7 +432,7 @@ function conformHookFn<H>(hookFn: H | null | undefined, hookName: string): H | n
   return hookFn;
 }
 
-export function setupPluginSystemForWorkspace(workspace: WorkspaceIdentifier) {
+export function setupPluginSystemForWorkspace(workspace: string) {
   debugAssert(
     !registeredRules.has(workspace),
     "Workspace must not already have registered rules array",
@@ -444,6 +443,6 @@ export function setupPluginSystemForWorkspace(workspace: WorkspaceIdentifier) {
 /**
  * Remove all plugins and rules associated with a workspace.
  */
-export function removePluginsInWorkspace(workspace: WorkspaceIdentifier) {
+export function removePluginsInWorkspace(workspace: string) {
   registeredRules.delete(workspace);
 }

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -9,7 +9,7 @@ import metaSchema from "ajv/lib/refs/json-schema-draft-04.json" with { type: "js
 import { registeredRules } from "./load.ts";
 import { deepCloneJsonValue, deepFreezeJsonArray } from "./json.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
-import { getCliWorkspace, WorkspaceIdentifier } from "../workspace/index.ts";
+import { getCliWorkspace } from "../workspace/index.ts";
 
 import type { JSONSchema4 } from "json-schema";
 import type { Writable } from "type-fest";
@@ -50,10 +50,10 @@ export const DEFAULT_OPTIONS: Readonly<Options> = Object.freeze([]);
 // All rule options.
 // `lintFile` is called with an array of options IDs, which are indices into this array.
 // First element is irrelevant - never accessed - because 0 index is a sentinel meaning default options.
-export const allOptions: Map<WorkspaceIdentifier, Readonly<Options>[]> = new Map();
+export const allOptions: Map<string, Readonly<Options>[]> = new Map();
 
 // Mapping from workspace URIs to CWD paths
-export const cwds: Map<WorkspaceIdentifier, string> = new Map();
+export const cwds: Map<string, string> = new Map();
 
 // Index into `allOptions` for default options
 export const DEFAULT_OPTIONS_ID = 0;
@@ -391,7 +391,7 @@ function mergeValues(configValue: JsonValue, defaultValue: JsonValue): JsonValue
  *
  * @param workspace the workspace identifier
  */
-export function setupOptionsForWorkspace(workspace: WorkspaceIdentifier) {
+export function setupOptionsForWorkspace(workspace: string) {
   debugAssert(
     !allOptions.has(workspace),
     "Workspace must not already have registered options array",
@@ -402,7 +402,7 @@ export function setupOptionsForWorkspace(workspace: WorkspaceIdentifier) {
 /**
  * Remove all options associated with a workspace.
  */
-export function removeOptionsInWorkspace(workspace: WorkspaceIdentifier) {
+export function removeOptionsInWorkspace(workspace: string) {
   allOptions.delete(workspace);
   cwds.delete(workspace);
 }

--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -13,26 +13,14 @@ import { removeOptionsInWorkspace, setupOptionsForWorkspace } from "../plugins/o
 import { debugAssert } from "../utils/asserts";
 
 /**
- * Type representing a workspace ID.
- * Currently, this is just a string representing the workspace root directory as `file://` URL.
- */
-export type WorkspaceIdentifier = string;
-
-/**
- * Type representing a workspace.
- * Currently it only contains the workspace root directory as `file://` URL.
- */
-export type Workspace = WorkspaceIdentifier;
-
-/**
  * Set of workspace IDs.
  */
-const workspaces = new Set<Workspace>();
+const workspaces = new Set<string>();
 
 /**
  * Create a new workspace.
  */
-export function createWorkspace(workspace: WorkspaceIdentifier): undefined {
+export function createWorkspace(workspace: string): undefined {
   debugAssert(!workspaces.has(workspace), `Workspace "${workspace.toString()}" already exists`);
   workspaces.add(workspace);
   setupPluginSystemForWorkspace(workspace);
@@ -43,7 +31,7 @@ export function createWorkspace(workspace: WorkspaceIdentifier): undefined {
  * Destroy a workspace.
  * Unloads all plugin data associated with this workspace.
  */
-export function destroyWorkspace(workspace: WorkspaceIdentifier): undefined {
+export function destroyWorkspace(workspace: string): undefined {
   debugAssert(workspaces.has(workspace), `Workspace "${workspace.toString()}" does not exist`);
 
   workspaces.delete(workspace);
@@ -55,7 +43,7 @@ export function destroyWorkspace(workspace: WorkspaceIdentifier): undefined {
  * Gets the CLI workspace ID.
  * In CLI mode, there is exactly one workspace (the CWD), so this returns that workspace ID.
  */
-export function getCliWorkspace(): Workspace {
+export function getCliWorkspace(): string {
   debugAssert(
     workspaces.size === 1,
     "getCliWorkspace should only be used in CLI mode with 1 workspace",


### PR DESCRIPTION
Pure refactor. Remove these 2 types which were both just aliases for `string`.

In Rust type wrappers can be useful (e.g. `ScopeId`) but in TS they don't add type safety, and IMO make the code less readable.