### PR TITLE
perf(linter/plugins): reduce cost of workspaces

### DIFF
--- a/apps/oxlint/conformance/snapshots/stylistic.md
+++ b/apps/oxlint/conformance/snapshots/stylistic.md
@@ -231,10 +231,10 @@ Skip: 0 / 217 (0.0%)
 ```
 
 Error: Overlapping token/comments: last end: 75, next start: 24
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 
 
 #### jsx-tag-spacing > valid
@@ -292,10 +292,10 @@ Error: Overlapping token/comments: last end: 75, next start: 24
 ```
 
 Error: Overlapping token/comments: last end: 88, next start: 24
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 
 
 #### jsx-tag-spacing > invalid
@@ -332,10 +332,10 @@ Error: Overlapping token/comments: last end: 88, next start: 24
 ```
 
 Error: Overlapping token/comments: last end: 81, next start: 30
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 
 
 #### jsx-tag-spacing > invalid
@@ -399,10 +399,10 @@ Error: Overlapping token/comments: last end: 81, next start: 30
 ```
 
 Error: Overlapping token/comments: last end: 94, next start: 30
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 
 
 #### jsx-tag-spacing > invalid
@@ -442,10 +442,10 @@ Error: Overlapping token/comments: last end: 94, next start: 30
 ```
 
 Error: Overlapping token/comments: last end: 105, next start: 54
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 
 
 #### jsx-tag-spacing > invalid
@@ -512,8 +512,8 @@ Error: Overlapping token/comments: last end: 105, next start: 54
 ```
 
 Error: Overlapping token/comments: last end: 118, next start: 54
-    at debugCheckValidRanges (apps/oxlint/dist/load.js)
-    at debugCheckTokensAndComments (apps/oxlint/dist/load.js)
-    at initTokensAndComments (apps/oxlint/dist/load.js)
-    at Object.isSpaceBetween (apps/oxlint/dist/load.js)
+    at debugCheckValidRanges (apps/oxlint/dist/lint.js)
+    at debugCheckTokensAndComments (apps/oxlint/dist/lint.js)
+    at initTokensAndComments (apps/oxlint/dist/lint.js)
+    at Object.isSpaceBetween (apps/oxlint/dist/lint.js)
 

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -46,17 +46,23 @@ import type { ModuleKind, Program } from "../generated/types.d.ts";
 export let filePath: string | null = null;
 
 // Current working directory for file being linted.
-// When `null`, indicates that no file is currently being linted (in `createOnce`, or between linting files).
-let cwd: string | null = null;
+// Set by `setOptions` at end of registering all plugins, and may also be changed when switching workspaces.
+export let cwd: string | null = null;
+
+/**
+ * Set CWD. Used when switching workspaces.
+ * @param cwdInput - CWD
+ */
+export function setCwd(cwdInput: string) {
+  cwd = cwdInput;
+}
 
 /**
  * Set up context for linting a file.
  * @param filePathInput - Absolute path of file being linted
- * @param cwdInput - Current working directory for file being linted
  */
-export function setupFileContext(filePathInput: string, cwdInput: string): void {
+export function setupFileContext(filePathInput: string): void {
   filePath = filePathInput;
-  cwd = cwdInput;
 }
 
 /**
@@ -68,7 +74,6 @@ export function setupFileContext(filePathInput: string, cwdInput: string): void 
  */
 export function resetFileContext(): void {
   filePath = null;
-  cwd = null;
 }
 
 // ECMAScript version. This matches ESLint's default.
@@ -367,7 +372,8 @@ const FILE_CONTEXT = Object.freeze({
    */
   get cwd(): string {
     // Note: If we change this implementation, also change `getCwd` method below
-    if (cwd === null) throw new Error("Cannot access `context.cwd` in `createOnce`");
+    if (filePath === null) throw new Error("Cannot access `context.cwd` in `createOnce`");
+    debugAssertIsNonNull(cwd, "`cwd` should not be null");
     return cwd;
   },
 
@@ -377,7 +383,8 @@ const FILE_CONTEXT = Object.freeze({
    * @deprecated Use `context.cwd` property instead.
    */
   getCwd(): string {
-    if (cwd === null) throw new Error("Cannot call `context.getCwd` in `createOnce`");
+    if (filePath === null) throw new Error("Cannot call `context.getCwd` in `createOnce`");
+    debugAssertIsNonNull(cwd, "`cwd` should not be null");
     return cwd;
   },
 

--- a/apps/oxlint/src-js/plugins/workspace.ts
+++ b/apps/oxlint/src-js/plugins/workspace.ts
@@ -1,0 +1,33 @@
+import { setCwd } from "./context.ts";
+import { setRegisteredRules } from "./load.ts";
+import { setAllOptions } from "./options.ts";
+import {
+  workspaces,
+  currentWorkspace,
+  currentWorkspaceUri,
+  setCurrentWorkspace,
+} from "../workspace/index.ts";
+import { debugAssertIsNonNull } from "../utils/asserts.ts";
+
+export { currentWorkspace };
+
+export function switchWorkspace(workspaceUri: string): void {
+  // If requested workspace is already the current one, nothing to do.
+  //
+  // This is a fast path for common cases:
+  // 1. Only a single workspace exists (most common).
+  // 2. When user does have multiple workspaces, but works in one workspace for a lengthy period.
+  if (currentWorkspaceUri === workspaceUri) return;
+
+  // Get workspace
+  const workspace = workspaces.get(workspaceUri);
+  debugAssertIsNonNull(workspace, `Workspace "${workspaceUri}" does not exist`);
+
+  // Change global state to that of the workspace
+  setCwd(workspace.cwd);
+  setRegisteredRules(workspace.rules);
+  setAllOptions(workspace.allOptions);
+
+  // Set this workspace as the current one
+  setCurrentWorkspace(workspace, workspaceUri);
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -190,19 +190,6 @@ impl CliRunner {
 
         let base_ignore_patterns = oxlintrc.ignore_patterns.clone();
 
-        // Setup JS workspace before loading any configs (config parsing can load JS plugins).
-        if let Some(external_linter) = &external_linter {
-            // Workspace URI doesn't need to be a valid URI, it just needs to be unique.
-            // In CLI we only have a single workspace in existence at any time, so it can be anything.
-            // So just use empty string.
-            let res = (external_linter.create_workspace)(String::new());
-
-            if let Err(err) = res {
-                print_and_flush_stdout(stdout, &format!("Failed to setup JS workspace:\n{err}\n"));
-                return CliRunResult::JsPluginWorkspaceSetupFailed;
-            }
-        }
-
         let config_builder = match ConfigStoreBuilder::from_oxlintrc(
             false,
             oxlintrc.clone(),

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -25,10 +25,9 @@ import type { Program } from "../src-js/generated/types.d.ts";
  * @returns AST
  */
 function parse(filename: string, sourceText: string, options?: ParseOptions): Program {
-  // Set file path and CWD
-  const cwd = import.meta.dirname;
-  const path = pathJoin(cwd, filename);
-  setupFileContext(path, cwd);
+  // Set file path
+  const path = pathJoin(import.meta.dirname, filename);
+  setupFileContext(path);
 
   // Parse source, writing source text and AST into buffer
   parseRaw(path, sourceText, options);

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -54,11 +54,10 @@ function setup(sourceText: string) {
   resetFileContext();
   resetSourceAndAst();
 
-  // Set file path and CWD
+  // Set file path
   const filename = "dummy.js";
-  const cwd = import.meta.dirname;
-  const path = pathJoin(cwd, filename);
-  setupFileContext(path, cwd);
+  const path = pathJoin(import.meta.dirname, filename);
+  setupFileContext(path);
 
   // Parse source text into buffer
   parseRaw(path, sourceText);


### PR DESCRIPTION
Workspaces support (#17809) added overhead on JS side of hashmap lookups. Every call to `lintFile` has to look up details (e.g. registered rules, rule options) from hashmaps keyed by workspace URI.

### Perf

Take a different approach which is optimized for common case of there being only 1 workspace:

* At any time there's 1 "current workspace".
* Store rules, options, and CWD in top-level vars (back to how it was before #17809).
* Switch workspaces only when required. Switching reassigns the values in these top level vars.

Before:

* Get rules, options, and CWD from hashmaps keyed by workspace URI.

After:

* Quick check "is the current workspace the one we need?".
* If so, do nothing - the top-level vars `registeredRules`, `allOptions`, and `cwd` elready contain the right settings for the desired workspace.
* If current workspace is not the right one, look up the details for desired workspace in `workspaces` hash map and write them into the top-level vars.

In CLI, `workspaceUri` passed to `lintFile` etc is `null`, so the quick "in the right workspace?" check is particularly cheap - just `null === null`. So this reduces the overhead that workspace support adds to CLI to just that 1 instruction.

Add of these functions are entirely synchronous, so there's no possibility of a race where 1 call switches out the values in the top-level vars, while another call is busy using them.

### CLI: No call to `createWorkspace`

CLI now doesn't need to call `createWorkspace` at all. The "are we in right workspace?" check always succeeds, so it's irrelevant whether a workspace has been created or not - `workspaces` hashmap is never accessed.

So workspaces is now an LSP-only thing.

### Bundle

This PR also removes all imports from other files from `src-js/workspace/index.ts`. It now only imports `debugAssert`, which is optimized out in release build., leaving no imports at all.

Previously, the imports from other files were causing most of the JS plugins code to get loaded on first call to `createWorkspace`, which broke the lazy loading optimization - Oxlint CLI and LSP were both loading all the JS plugins code eagerly even if the user doesn't use JS plugins.

With this change, the lazy loading optimization is restored. This is visible in the conformance snapshot change in this PR.