### PR TITLE
refactor(linter/plugins): simplify callback functions for create/destroy workspace

### DIFF
--- a/apps/oxlint/src-js/bindings.d.ts
+++ b/apps/oxlint/src-js/bindings.d.ts
@@ -36,11 +36,11 @@ export declare function getBufferOffset(buffer: Uint8Array): number
 
 /** JS callback to create a workspace. */
 export type JsCreateWorkspaceCb =
-  ((arg0: string) => Promise<undefined>)
+  ((arg: string) => Promise<undefined>)
 
 /** JS callback to destroy a workspace. */
 export type JsDestroyWorkspaceCb =
-  ((arg0: string) => void)
+  ((arg: string) => void)
 
 /** JS callback to lint a file. */
 export type JsLintFileCb =

--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -312,9 +312,8 @@ fn wrap_create_workspace(cb: JsCreateWorkspaceCb) -> ExternalLinterCreateWorkspa
     Arc::new(Box::new(move |workspace_uri| {
         let cb = &cb;
         let res = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async move {
-                cb.call_async(FnArgs::from((workspace_uri,))).await?.into_future().await
-            })
+            tokio::runtime::Handle::current()
+                .block_on(async move { cb.call_async(workspace_uri).await?.into_future().await })
         });
 
         match res {
@@ -328,7 +327,7 @@ fn wrap_create_workspace(cb: JsCreateWorkspaceCb) -> ExternalLinterCreateWorkspa
 
 /// Wrap `destroyWorkspace` JS callback as a normal Rust function.
 fn wrap_destroy_workspace(cb: JsDestroyWorkspaceCb) -> ExternalLinterDestroyWorkspaceCb {
-    Arc::new(Box::new(move |workspace_uri: String| {
-        let _ = cb.call(FnArgs::from((workspace_uri,)), ThreadsafeFunctionCallMode::Blocking);
+    Arc::new(Box::new(move |workspace_uri| {
+        let _ = cb.call(workspace_uri, ThreadsafeFunctionCallMode::Blocking);
     }))
 }

--- a/apps/oxlint/src/run.rs
+++ b/apps/oxlint/src/run.rs
@@ -85,11 +85,11 @@ pub type JsSetupRuleConfigsCb = ThreadsafeFunction<
 #[napi]
 pub type JsCreateWorkspaceCb = ThreadsafeFunction<
     // Arguments
-    FnArgs<(String,)>, // Workspace URI
+    String, // Workspace URI
     // Return value
     Promise<()>,
     // Arguments (repeated)
-    FnArgs<(String,)>,
+    String,
     // Error status
     Status,
     // CalleeHandled
@@ -100,11 +100,11 @@ pub type JsCreateWorkspaceCb = ThreadsafeFunction<
 #[napi]
 pub type JsDestroyWorkspaceCb = ThreadsafeFunction<
     // Arguments
-    FnArgs<(String,)>, // Workspace URI
+    String, // Workspace URI
     // Return value
     (),
     // Arguments (repeated)
-    FnArgs<(String,)>,
+    String,
     // Error status
     Status,
     // CalleeHandled


### PR DESCRIPTION
Simple refactor. When a NAPI function has only a single param, no need to use `FnArgs`.