### PR TITLE
fix(linter/plugins): use non-blocking mode when calling `destroyWorkspace`

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -328,6 +328,6 @@ fn wrap_create_workspace(cb: JsCreateWorkspaceCb) -> ExternalLinterCreateWorkspa
 /// Wrap `destroyWorkspace` JS callback as a normal Rust function.
 fn wrap_destroy_workspace(cb: JsDestroyWorkspaceCb) -> ExternalLinterDestroyWorkspaceCb {
     Arc::new(Box::new(move |workspace_uri| {
-        let _ = cb.call(workspace_uri, ThreadsafeFunctionCallMode::Blocking);
+        let _ = cb.call(workspace_uri, ThreadsafeFunctionCallMode::NonBlocking);
     }))
 }


### PR DESCRIPTION
`ThreadsafeFunctionCallMode::Blocking` doesn't make the call blocking, it only makes *registering the call* blocking. It can therefore fail if there's no room in NAPI's function call queue.

Switch to `ThreadsafeFunctionCallMode::NonBlocking` in `wrap_destroy_workspace` to fix this.