### PR TITLE
fix(linter/plugins): handle error from `destroyWorkspace`

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -301,7 +301,11 @@ impl ToolBuilder for ServerLinterBuilder {
     fn shutdown(&self, root_uri: &Uri) {
         // Destroy JS workspace
         if let Some(external_linter) = &self.external_linter {
-            (external_linter.destroy_workspace)(root_uri.as_str().to_string());
+            let res = (external_linter.destroy_workspace)(root_uri.as_str().to_string());
+
+            if let Err(err) = res {
+                error!("Failed to destroy JS workspace:\n{err}\n");
+            }
         }
     }
 }

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -12,7 +12,8 @@ use crate::{
 pub type ExternalLinterCreateWorkspaceCb =
     Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>;
 
-pub type ExternalLinterDestroyWorkspaceCb = Arc<Box<dyn Fn(String) + Send + Sync>>;
+pub type ExternalLinterDestroyWorkspaceCb =
+    Arc<Box<dyn Fn(String) -> Result<(), String> + Send + Sync>>;
 
 pub type ExternalLinterLoadPluginCb = Arc<
     Box<


### PR DESCRIPTION
`destroyWorkspace` on JS side can throw an error, at least to debug build. Handle any such errors, rather than ignoring them. This will also catch any NAPI errors.