### PR TITLE
refactor(linter/plugins): remove unnecessary debug assertions

### DIFF
--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -37,7 +37,6 @@ function loadPluginWrapper(
       return loadPlugin(path, pluginName, pluginNameIsAlias, workspaceUri);
     });
   }
-  debugAssertIsNonNull(loadPlugin);
   return loadPlugin(path, pluginName, pluginNameIsAlias, workspaceUri);
 }
 
@@ -111,7 +110,6 @@ function createWorkspaceWrapper(workspace: string): Promise<undefined> {
       return createWorkspace(workspace);
     });
   }
-  debugAssertIsNonNull(createWorkspace);
   return Promise.resolve(createWorkspace(workspace));
 }
 


### PR DESCRIPTION
Pure refactor. Remove 2 unnecessary `debugAssertIsNonNull` calls. In both cases the `null` check already happens directly above.