### PR TITLE
fix(oxlint/plugins): use `fileURLToPath` when searching for plugins workspace

### DIFF
--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -10,6 +10,7 @@
 import { default as assert, AssertionError } from "node:assert";
 import { join as pathJoin, isAbsolute as isAbsolutePath, dirname } from "node:path";
 import util from "node:util";
+import { pathToFileURL } from "node:url";
 import stableJsonStringify from "json-stable-stringify-without-jsonify";
 import { ecmaFeaturesOverride, setEcmaVersion, ECMA_VERSION } from "../plugins/context.ts";
 import { registerPlugin } from "../plugins/load.ts";
@@ -1003,7 +1004,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
 
   try {
     // Register plugin. This adds rule to `registeredRules` array.
-    registerPlugin(path, plugin, null, false);
+    registerPlugin(pathToFileURL(path).toString(), plugin, null, false);
 
     // Set up options
     const optionsId = setupOptions(test, cwd);

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { getResponsibleWorkspace, isWorkspaceResponsible } from "../workspace/index.ts";
 import { createContext } from "./context.ts";
 import { deepFreezeJsonArray } from "./json.ts";
@@ -151,7 +152,7 @@ export function registerPlugin(
   // TODO: Use a validation library to assert the shape of the plugin, and of rules
 
   pluginName = getPluginName(plugin, pluginName, pluginNameIsAlias);
-  const workspace = getResponsibleWorkspace(url.replace(/^file:\/\//, ""));
+  const workspace = getResponsibleWorkspace(fileURLToPath(url));
   debugAssertIsNonNull(workspace, "Plugin url must belong to a workspace");
   debugAssert(registeredRules.has(workspace), "Workspace must have registered rules array");
 
@@ -450,7 +451,7 @@ export function setupPluginSystemForWorkspace(workspace: WorkspaceIdentifier) {
  */
 export function removePluginsInWorkspace(workspace: WorkspaceIdentifier) {
   for (const url of registeredPluginUrls) {
-    if (isWorkspaceResponsible(workspace, url.replace(/^file:\/\//, ""))) {
+    if (isWorkspaceResponsible(workspace, fileURLToPath(url))) {
       registeredPluginUrls.delete(url);
     }
   }


### PR DESCRIPTION
Fixes the napi windows CI on main.
On windows the file URL is with forward slash separated. The workspaces are paths which is using `\` as a separator.
This would fail to find the right workspace for the plugin.
See passed tests here: https://github.com/oxc-project/oxc/actions/runs/21544647263/job/62084198121?pr=18765