### PR TITLE
refactor(linter/plugins): remove experimental warning

### DIFF
--- a/apps/oxlint/test/fixtures/basic/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic/output.snap.md
@@ -22,6 +22,4 @@ Finished in Xms on 1 file with 92 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_many_files/output.snap.md
@@ -269,6 +269,4 @@ Finished in Xms on 20 files with 56 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/output.snap.md
@@ -38,6 +38,4 @@ Finished in Xms on 1 file with 4 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_no_errors/output.snap.md
@@ -9,6 +9,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/output.snap.md
@@ -22,6 +22,4 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/bom/output.snap.md
+++ b/apps/oxlint/test/fixtures/bom/output.snap.md
@@ -139,6 +139,4 @@ Finished in Xms on 4 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/cfg/output.snap.md
+++ b/apps/oxlint/test/fixtures/cfg/output.snap.md
@@ -26,6 +26,4 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/comments/output.snap.md
@@ -461,6 +461,4 @@ Finished in Xms on 3 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/context_properties/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_properties/output.snap.md
@@ -53,6 +53,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
+++ b/apps/oxlint/test/fixtures/context_wrapping/output.snap.md
@@ -69,6 +69,4 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -369,6 +369,4 @@ Finished in Xms on 2 files with 6 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/definePlugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin/output.snap.md
@@ -264,6 +264,4 @@ Finished in Xms on 2 files with 7 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/definePlugin_and_defineRule/output.snap.md
@@ -264,6 +264,4 @@ Finished in Xms on 2 files with 7 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/defineRule/output.snap.md
+++ b/apps/oxlint/test/fixtures/defineRule/output.snap.md
@@ -264,6 +264,4 @@ Finished in Xms on 2 files with 7 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/output.snap.md
@@ -38,6 +38,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/disable_directives/output.snap.md
+++ b/apps/oxlint/test/fixtures/disable_directives/output.snap.md
@@ -48,6 +48,4 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/estree/output.snap.md
+++ b/apps/oxlint/test/fixtures/estree/output.snap.md
@@ -151,6 +151,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/fixable_boolean/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixable_boolean/fix.snap.md
@@ -16,8 +16,6 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```
 
 # File altered: files/index.js

--- a/apps/oxlint/test/fixtures/fixable_boolean/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixable_boolean/output.snap.md
@@ -23,6 +23,4 @@ Finished in Xms on 1 file with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -9,8 +9,6 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```
 
 # File altered: files/index.js

--- a/apps/oxlint/test/fixtures/fixes/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/output.snap.md
@@ -103,6 +103,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
+++ b/apps/oxlint/test/fixtures/getNodeByRangeIndex/output.snap.md
@@ -361,6 +361,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/globals/output.snap.md
+++ b/apps/oxlint/test/fixtures/globals/output.snap.md
@@ -71,6 +71,4 @@ Finished in Xms on 3 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/import_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/import_error/output.snap.md
@@ -12,6 +12,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -218,6 +218,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/languageOptions/output.snap.md
+++ b/apps/oxlint/test/fixtures/languageOptions/output.snap.md
@@ -830,6 +830,4 @@ Finished in Xms on 4 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_after_hook_error/output.snap.md
@@ -14,6 +14,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_before_hook_error/output.snap.md
@@ -14,6 +14,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
@@ -12,6 +12,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_create_error/output.snap.md
@@ -14,6 +14,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_fix_error/output.snap.md
@@ -15,6 +15,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_cfg_error/output.snap.md
@@ -26,6 +26,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_visit_error/output.snap.md
@@ -20,6 +20,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/load_paths/output.snap.md
+++ b/apps/oxlint/test/fixtures/load_paths/output.snap.md
@@ -112,6 +112,4 @@ Finished in Xms on 1 file with 17 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/message_id_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_error/output.snap.md
@@ -14,6 +14,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/output.snap.md
@@ -63,6 +63,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_id_plugin/output.snap.md
@@ -23,6 +23,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
+++ b/apps/oxlint/test/fixtures/message_interpolation/output.snap.md
@@ -63,6 +63,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/missing_plugin/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_plugin/output.snap.md
@@ -11,6 +11,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/missing_rule/output.snap.md
@@ -10,6 +10,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/nested_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/nested_config/output.snap.md
@@ -15,6 +15,4 @@ Finished in Xms on 1 file using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/output.snap.md
@@ -15,6 +15,4 @@ Finished in Xms on 1 file using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/options/output.snap.md
+++ b/apps/oxlint/test/fixtures/options/output.snap.md
@@ -281,6 +281,4 @@ Finished in Xms on 2 files with 8 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/options_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/options_invalid/output.snap.md
@@ -15,6 +15,4 @@ Errors:
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/overrides/output.snap.md
+++ b/apps/oxlint/test/fixtures/overrides/output.snap.md
@@ -15,6 +15,4 @@ Finished in Xms on 1 file with 0 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/overrides_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/overrides_missing_rule/output.snap.md
@@ -10,6 +10,4 @@ Failed to build configuration.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/parent/output.snap.md
+++ b/apps/oxlint/test/fixtures/parent/output.snap.md
@@ -105,6 +105,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/parser_services/output.snap.md
+++ b/apps/oxlint/test/fixtures/parser_services/output.snap.md
@@ -16,6 +16,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name/output.snap.md
@@ -94,6 +94,4 @@ Finished in Xms on 1 file with 12 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
@@ -11,6 +11,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
@@ -25,6 +25,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_missing/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_missing/output.snap.md
@@ -11,6 +11,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_missing2/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_missing2/output.snap.md
@@ -11,6 +11,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_reserved/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_reserved/output.snap.md
@@ -25,6 +25,4 @@ Failed to parse oxlint configuration file.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/output.snap.md
@@ -15,6 +15,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/scope_manager/output.snap.md
+++ b/apps/oxlint/test/fixtures/scope_manager/output.snap.md
@@ -92,6 +92,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/selector/output.snap.md
+++ b/apps/oxlint/test/fixtures/selector/output.snap.md
@@ -198,6 +198,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/settings/output.snap.md
+++ b/apps/oxlint/test/fixtures/settings/output.snap.md
@@ -33,6 +33,4 @@ Finished in Xms on 2 files using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/sourceCode/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode/output.snap.md
@@ -266,6 +266,4 @@ Finished in Xms on 2 files with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/output.snap.md
@@ -143,6 +143,4 @@ Finished in Xms on 2 files with 2 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/output.snap.md
@@ -297,6 +297,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/output.snap.md
@@ -427,6 +427,4 @@ Finished in Xms on 2 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -1077,6 +1077,4 @@ Finished in Xms on 4 files with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
@@ -134,6 +134,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
+++ b/apps/oxlint/test/fixtures/utf16_offsets/output.snap.md
@@ -55,6 +55,4 @@ Finished in Xms on 1 file with 1 rules using X threads.
 
 # stderr
 ```
-WARNING: JS plugins are experimental and not subject to semver.
-Breaking changes are possible while JS plugins support is under development.
 ```

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -528,14 +528,6 @@ impl ConfigStoreBuilder {
         external_plugin_store: &mut ExternalPluginStore,
         workspace_uri: Option<&str>,
     ) -> Result<(), ConfigBuilderError> {
-        // Print warning on 1st attempt to load a plugin
-        #[expect(clippy::print_stderr)]
-        if external_plugin_store.is_empty() {
-            eprintln!(
-                "WARNING: JS plugins are experimental and not subject to semver.\nBreaking changes are possible while JS plugins support is under development."
-            );
-        }
-
         // Resolve the specifier relative to the config directory
         let resolved = resolver.resolve(resolve_dir, plugin_specifier).map_err(|e| {
             ConfigBuilderError::PluginLoadFailed {


### PR DESCRIPTION
As we prepare for alpha release of JS plugins, it feels like we can remove the warning logged to stderr.

```
WARNING: JS plugins are experimental and not subject to semver.
Breaking changes are possible while JS plugins support is under development.
```

They do still remain experimental, but I don't think we need to shout that quite as loudly now.