### PR TITLE
chore(ci): Upgrade Node in release job to 24.

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -463,7 +463,7 @@ jobs:
           - os: windows-latest
           - os: ubuntu-latest
           - os: ubuntu-latest
-            container: node:18-alpine # musl
+            container: node:24-alpine # musl
           - os: macos-latest
     name: Smoke Test ${{ matrix.os }} ${{ matrix.container }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Node 18 is not supported by oxlint/oxfmt. I *think* 24-alpine still uses musl? I assume there wasn't a particular reason 18 was being used? The job warns about an incompatible engine but doesn't fail right now: https://github.com/oxc-project/oxc/actions/runs/21361615059/job/61486769673