### PR TITLE
refactor(linter/plugins): rename `oxlint/plugin` to `oxlint/plugins`

### DIFF
--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -4,7 +4,7 @@ import { currentRule } from "../capture.ts";
 
 import type { TestGroup } from "../index.ts";
 import type { TestCase, TestCases, ValidTestCase, InvalidTestCase } from "../rule_tester.ts";
-import type { Rule } from "#oxlint/plugin";
+import type { Rule } from "#oxlint/plugins";
 
 const SUBMODULE_NAME = "sonarjs";
 const TEST_FILES_RELATIVE_DIR_PATH = "packages/jsts/src/rules";

--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -10,7 +10,7 @@ import type {
   ParserOptions,
 } from "../rule_tester.ts";
 import type { RuleTester as RuleTesterType } from "#oxlint/rule-tester";
-import type { Rule } from "#oxlint/plugin";
+import type { Rule } from "#oxlint/plugins";
 
 type Config = RuleTesterType.Config;
 type TSEslintParser = typeof import("@typescript-eslint/parser");

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -9,7 +9,7 @@ import { RuleTester } from "#oxlint/rule-tester";
 import { describe, it, currentGroup, setCurrentTest } from "./capture.ts";
 import { SHOULD_SKIP_CODE } from "./filter.ts";
 
-import type { Rule } from "#oxlint/plugin";
+import type { Rule } from "#oxlint/plugins";
 import type { ParserDetails } from "./index.ts";
 import type {
   LanguageOptionsInternal,

--- a/apps/oxlint/conformance/tester.ts
+++ b/apps/oxlint/conformance/tester.ts
@@ -15,7 +15,7 @@ import { RuleTester as ESLintRuleTester } from "eslint";
 import { builtinRules } from "./submodules/eslint/lib/unsupported-api.js";
 import tsEslintParser from "@typescript-eslint/parser";
 
-import type { Rule } from "#oxlint/plugin";
+import type { Rule } from "#oxlint/plugins";
 import type { ValidTestCase, InvalidTestCase } from "./src/rule_tester.ts";
 
 type ValidTestCaseWithoutCode = Omit<ValidTestCase, "code"> & { code?: string };

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "imports": {
     "#oxlint": "./dist/index.js",
-    "#oxlint/plugin": "./dist/plugin.js",
+    "#oxlint/plugins": "./dist/plugins.js",
     "#oxlint/rule-tester": "./dist/rule-tester.js"
   },
   "exports": {
@@ -16,9 +16,9 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./plugin": {
-      "types": "./dist/plugin.d.ts",
-      "default": "./dist/plugin.js"
+    "./plugins": {
+      "types": "./dist/plugins.d.ts",
+      "default": "./dist/plugins.js"
     },
     "./rule-tester": {
       "types": "./dist/rule-tester.d.ts",

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -2,12 +2,12 @@ import { definePlugin as _definePlugin, defineRule as _defineRule } from "./pack
 import { RuleTester as _RuleTester } from "./package/rule_tester.ts";
 
 /**
- * @deprecated Import from `oxlint/plugin` instead
+ * @deprecated Import from `oxlint/plugins` instead
  */
 export const definePlugin = _definePlugin;
 
 /**
- * @deprecated Import from `oxlint/plugin` instead
+ * @deprecated Import from `oxlint/plugins` instead
  */
 export const defineRule = _defineRule;
 

--- a/apps/oxlint/src-js/plugins.ts
+++ b/apps/oxlint/src-js/plugins.ts
@@ -3,7 +3,7 @@ export { definePlugin, defineRule } from "./package/define.ts";
 export { eslintCompatPlugin } from "./package/compat.ts";
 
 // ESTree types
-export type * as ESTree from "./generated/types.d.ts";
+export type * as ESTree from "./generated/types";
 
 // Plugin types
 export type { Context, LanguageOptions } from "./plugins/context.ts";

--- a/apps/oxlint/test/fixtures/basic/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_many_files/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_many_files/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_multiple_rules/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_multiple_rules/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_no_errors/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_no_errors/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/basic_warn_severity/plugin.ts
+++ b/apps/oxlint/test/fixtures/basic_warn_severity/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/bom/plugin.ts
+++ b/apps/oxlint/test/fixtures/bom/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/cfg/plugin.ts
+++ b/apps/oxlint/test/fixtures/cfg/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule, ESTree } from "#oxlint/plugin";
+import type { Plugin, Rule, ESTree } from "#oxlint/plugins";
 
 type Node = ESTree.Node;
 

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Comment, Plugin, Rule } from "#oxlint/plugin";
+import type { Comment, Plugin, Rule } from "#oxlint/plugins";
 
 function formatComments(comments: Comment[]): string {
   let text = `${comments.length} comment${comments.length === 1 ? "" : "s"}`;

--- a/apps/oxlint/test/fixtures/context_properties/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_properties/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint/plugin";
+import type { Node, Plugin, Rule } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
+++ b/apps/oxlint/test/fixtures/context_wrapping/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule, Context, Diagnostic, Node } from "#oxlint/plugin";
+import type { Plugin, Rule, Context, Diagnostic, Node } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/createOnce/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint/plugin";
+import type { Node, Plugin, Rule } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/definePlugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/definePlugin/plugin.ts
@@ -1,6 +1,6 @@
-import { definePlugin } from "#oxlint/plugin";
+import { definePlugin } from "#oxlint/plugins";
 
-import type { Rule } from "#oxlint/plugin";
+import type { Rule } from "#oxlint/plugins";
 
 const createRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/defineRule/plugin.ts
+++ b/apps/oxlint/test/fixtures/defineRule/plugin.ts
@@ -1,4 +1,4 @@
-import { defineRule } from "#oxlint/plugin";
+import { defineRule } from "#oxlint/plugins";
 
 const createRule = defineRule({
   create(context) {

--- a/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
+++ b/apps/oxlint/test/fixtures/diagnostic_loc/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/disable_directives/plugin.ts
+++ b/apps/oxlint/test/fixtures/disable_directives/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/eslintCompat/plugin.ts
+++ b/apps/oxlint/test/fixtures/eslintCompat/plugin.ts
@@ -1,6 +1,6 @@
-import { eslintCompatPlugin } from "#oxlint/plugin";
+import { eslintCompatPlugin } from "#oxlint/plugins";
 
-import type { Node, Rule } from "#oxlint/plugin";
+import type { Node, Rule } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/estree/plugin.ts
+++ b/apps/oxlint/test/fixtures/estree/plugin.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert";
 
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/fixable_boolean/plugin.ts
+++ b/apps/oxlint/test/fixtures/fixable_boolean/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 // Test backward compatibility for `meta.fixable: true` and `meta.fixable: false`
 // which some ESLint plugins use instead of "code" or "whitespace"

--- a/apps/oxlint/test/fixtures/fixes/plugin.ts
+++ b/apps/oxlint/test/fixtures/fixes/plugin.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, Node, Plugin } from "#oxlint/plugin";
+import type { Diagnostic, Node, Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/getNodeByRangeIndex/plugin.ts
+++ b/apps/oxlint/test/fixtures/getNodeByRangeIndex/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/globals/plugin.ts
+++ b/apps/oxlint/test/fixtures/globals/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin } from "#oxlint/plugin";
+import type { Node, Plugin } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule, Node } from "#oxlint/plugin";
+import type { Plugin, Rule, Node } from "#oxlint/plugins";
 
 const testRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/languageOptions/plugin.ts
+++ b/apps/oxlint/test/fixtures/languageOptions/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Node } from "#oxlint/plugin";
+import type { Plugin, Node } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/lint_after_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_after_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_before_hook_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_before_hook_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_createOnce_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_createOnce_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_create_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_create_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_fix_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_fix_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/lint_visit_cfg_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_visit_cfg_error/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule, ESTree } from "#oxlint/plugin";
+import type { Plugin, Rule, ESTree } from "#oxlint/plugins";
 
 type Node = ESTree.Node;
 

--- a/apps/oxlint/test/fixtures/lint_visit_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/lint_visit_error/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 // Aim of this test is:
 //

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin4.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin5.cts
@@ -1,6 +1,6 @@
 "use strict";
 
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
+++ b/apps/oxlint/test/fixtures/load_paths/plugins/plugin6.mts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_error/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_error/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_id_plugin/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const MESSAGE_ID_ERROR = "no-var/error";
 const messages = {

--- a/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
+++ b/apps/oxlint/test/fixtures/message_interpolation/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/nested_config/plugin.ts
+++ b/apps/oxlint/test/fixtures/nested_config/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/nested_config_duplicate/plugin.ts
+++ b/apps/oxlint/test/fixtures/nested_config_duplicate/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/options/plugin.ts
+++ b/apps/oxlint/test/fixtures/options/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin } from "#oxlint/plugin";
+import type { Node, Plugin } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/options_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/options_invalid/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/overrides/plugin.ts
+++ b/apps/oxlint/test/fixtures/overrides/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/overrides_missing_rule/plugin.ts
+++ b/apps/oxlint/test/fixtures/overrides_missing_rule/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parent/plugin.ts
+++ b/apps/oxlint/test/fixtures/parent/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/parser_services/plugin.ts
+++ b/apps/oxlint/test/fixtures/parser_services/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Node } from "#oxlint/plugin";
+import type { Plugin, Node } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/plugin_name/plugins/jsdoc.ts
+++ b/apps/oxlint/test/fixtures/plugin_name/plugins/jsdoc.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/plugin_name/plugins/no_name.ts
+++ b/apps/oxlint/test/fixtures/plugin_name/plugins/no_name.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   // No name defined

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   rules: {

--- a/apps/oxlint/test/fixtures/plugin_name_alias_reserved/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_reserved/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/plugin_name_missing/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_missing/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   // No name defined

--- a/apps/oxlint/test/fixtures/plugin_name_reserved/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_name_reserved/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/plugin_outside_cwd/plugin.ts
+++ b/apps/oxlint/test/fixtures/plugin_outside_cwd/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 // This test checks that a plugin which is outside the current working directory can be loaded.
 // `cwd` is set to `files/subdirectory` in `options.json`, and the plugin is outside that directory.

--- a/apps/oxlint/test/fixtures/scope_manager/plugin.ts
+++ b/apps/oxlint/test/fixtures/scope_manager/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Node, Plugin, Rule, Scope } from "#oxlint/plugin";
+import type { Node, Plugin, Rule, Scope } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/selector/plugin.ts
+++ b/apps/oxlint/test/fixtures/selector/plugin.ts
@@ -1,4 +1,4 @@
-import type { ESTree, Plugin, Visitor } from "#oxlint/plugin";
+import type { ESTree, Plugin, Visitor } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/fixtures/settings/plugin.ts
+++ b/apps/oxlint/test/fixtures/settings/plugin.ts
@@ -1,4 +1,4 @@
-import type { Node, Plugin, Rule } from "#oxlint/plugin";
+import type { Node, Plugin, Rule } from "#oxlint/plugins";
 
 const SPAN: Node = {
   start: 0,

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugin";
+import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugins";
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_late_access/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugin";
+import type { ESTree, Node, Plugin, Rule } from "#oxlint/plugins";
 
 type Program = ESTree.Program;
 

--- a/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_scope_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode_token_methods/plugin.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 const rule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 const STANDARD_TOKEN_KEYS = new Set(["type", "value", "start", "end", "range", "loc"]);
 

--- a/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/unicode_comments/plugin.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import type { Plugin, Rule } from "#oxlint/plugin";
+import type { Plugin, Rule } from "#oxlint/plugins";
 
 const unicodeCommentsRule: Rule = {
   create(context) {

--- a/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
+++ b/apps/oxlint/test/fixtures/utf16_offsets/plugin.ts
@@ -1,6 +1,6 @@
 // oxlint-disable typescript/restrict-template-expressions
 
-import type { Plugin } from "#oxlint/plugin";
+import type { Plugin } from "#oxlint/plugins";
 
 const plugin: Plugin = {
   meta: {

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RuleTester } from "../src-js/index.ts";
 
-import type { Rule } from "../src-js/plugin.ts";
+import type { Rule } from "../src-js/plugins.ts";
 
 /**
  * Test case.

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -37,7 +37,7 @@ export default defineConfig([
   // Main build
   {
     ...commonConfig,
-    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugin.ts", "src-js/rule-tester.ts"],
+    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugins.ts", "src-js/rule-tester.ts"],
     format: "esm",
     external: [
       // External native bindings

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -39,9 +39,9 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./plugin": {
-      "types": "./dist/plugin.d.ts",
-      "default": "./dist/plugin.js"
+    "./plugins": {
+      "types": "./dist/plugins.d.ts",
+      "default": "./dist/plugins.js"
     },
     "./rule-tester": {
       "types": "./dist/rule-tester.d.ts",


### PR DESCRIPTION
Part of #18610.

Our intent is to move `definePlugin`, `defineRule`, and `eslintCompatPlugin` to a separate package `@oxlint/plugins` (plural to avoid confusion with naming convention for plugins `oxlint-plugin-xxx`).

So rename the current entry point which exports these functions from `oxlint/plugin` to `oxlint/plugins` (plural).