### PR TITLE
feat(linter/plugins): create `@oxlint/plugins` and `@oxlint/plugins-dev` NPM packages

### DIFF
--- a/npm/oxlint-plugins-dev/CHANGELOG.md
+++ b/npm/oxlint-plugins-dev/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
+
+## [1.42.0] - 2026-01-26
+
+### 🚀 Features
+
+- Initial release of `@oxlint/plugins-dev` package

--- a/npm/oxlint-plugins-dev/README.md
+++ b/npm/oxlint-plugins-dev/README.md
@@ -1,0 +1,35 @@
+# @oxlint/plugins-dev
+
+Development and testing utilities for [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) JS plugins.
+
+This package provides the `RuleTester` class for testing custom Oxlint rules.
+
+## Installation
+
+```bash
+npm install --save-dev @oxlint/plugins-dev
+```
+
+## Usage
+
+API is identical to [ESLint's `RuleTester`](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester).
+
+```typescript
+import { RuleTester } from "@oxlint/plugins-dev";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("my-rule", myRule, {
+  valid: ["const x = 1;"],
+  invalid: [
+    {
+      code: "var x = 1;",
+      errors: [{ message: "Use const instead of var" }],
+    },
+  ],
+});
+```
+
+## Docs
+
+For full documentation, see [Oxlint JS Plugins docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).

--- a/npm/oxlint-plugins-dev/index.d.ts
+++ b/npm/oxlint-plugins-dev/index.d.ts
@@ -1,0 +1,2 @@
+// Re-export development utilities types from `oxlint` package
+export * from "oxlint/plugins-dev";

--- a/npm/oxlint-plugins-dev/index.js
+++ b/npm/oxlint-plugins-dev/index.js
@@ -1,0 +1,2 @@
+// Re-export development utilities from `oxlint` package
+export * from "oxlint/plugins-dev";

--- a/npm/oxlint-plugins-dev/package.json
+++ b/npm/oxlint-plugins-dev/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@oxlint/plugins-dev",
+  "version": "1.42.0",
+  "description": "Development utilities for Oxlint plugins",
+  "keywords": [
+    "oxlint",
+    "plugin",
+    "rule-tester",
+    "testing"
+  ],
+  "homepage": "https://oxc.rs/docs/guide/usage/linter/plugin-system",
+  "bugs": "https://github.com/oxc-project/oxc/issues",
+  "license": "MIT",
+  "author": "Boshen and oxc contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxc-project/oxc.git",
+    "directory": "npm/oxlint-plugins-dev"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/Boshen"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "dependencies": {
+    "oxlint": "^1.42.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/npm/oxlint-plugins/CHANGELOG.md
+++ b/npm/oxlint-plugins/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
+
+## [1.42.0] - 2026-01-26
+
+### 🚀 Features
+
+- Initial release of `@oxlint/plugins` package

--- a/npm/oxlint-plugins/README.md
+++ b/npm/oxlint-plugins/README.md
@@ -1,0 +1,82 @@
+# @oxlint/plugins
+
+Plugin utilities for [Oxlint](https://oxc.rs/docs/guide/usage/linter.html).
+
+This package provides optional functions to assist in creating Oxlint JS plugins and rules.
+
+## Installation
+
+```bash
+npm install @oxlint/plugins
+```
+
+## Usage
+
+### Define functions
+
+Use `definePlugin` and `defineRule` if authoring your plugin in TypeScript for type safety.
+
+```typescript
+import { definePlugin, defineRule } from "@oxlint/plugins";
+
+const myRule = defineRule({
+  create(context) {
+    return {
+      Program(node) {
+        // Rule logic here
+      },
+    };
+  },
+});
+
+export default definePlugin({
+  name: "my-plugin",
+  rules: { "my-rule": myRule },
+});
+```
+
+### Types
+
+This package also includes types for plugins and rules.
+
+```typescript
+import type { Context, Rule, ESTree } from "@oxlint/plugins";
+
+const myRule: Rule = {
+  create(context: Context) {
+    return {
+      Program(node: ESTree.Program) {
+        // Rule logic here
+      },
+    };
+  },
+};
+```
+
+### ESLint compatibility
+
+If your plugin uses Oxlint's [alternative `createOnce` API](https://oxc.rs/docs/guide/usage/linter/js-plugins.html#alternative-api),
+use `eslintCompatPlugin` to convert the plugin so it will also work with ESLint.
+
+```typescript
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+const myRule = {
+  createOnce(context) {
+    return {
+      Program(node) {
+        // Rule logic here
+      },
+    };
+  },
+};
+
+export default eslintCompatPlugin({
+  name: "my-plugin",
+  rules: { "my-rule": myRule },
+});
+```
+
+## Docs
+
+For full documentation, see [Oxlint JS Plugins docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).

--- a/npm/oxlint-plugins/index.d.ts
+++ b/npm/oxlint-plugins/index.d.ts
@@ -1,0 +1,2 @@
+// Re-export plugins types from `oxlint` package
+export * from "oxlint/plugins";

--- a/npm/oxlint-plugins/index.js
+++ b/npm/oxlint-plugins/index.js
@@ -1,0 +1,2 @@
+// Re-export all plugin APIs from `oxlint` package
+export * from "oxlint/plugins";

--- a/npm/oxlint-plugins/package.json
+++ b/npm/oxlint-plugins/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@oxlint/plugins",
+  "version": "1.42.0",
+  "description": "Plugin utilities for Oxlint",
+  "keywords": [
+    "eslint",
+    "linter",
+    "oxlint",
+    "plugin"
+  ],
+  "homepage": "https://oxc.rs/docs/guide/usage/linter/plugin-system",
+  "bugs": "https://github.com/oxc-project/oxc/issues",
+  "license": "MIT",
+  "author": "Boshen and oxc contributors",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oxc-project/oxc.git",
+    "directory": "npm/oxlint-plugins"
+  },
+  "funding": {
+    "url": "https://github.com/sponsors/Boshen"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "dependencies": {
+    "oxlint": "^1.42.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -22,6 +22,8 @@ versioned_files = [
   "crates/oxc_linter/Cargo.toml",
   "editors/vscode/package.json",
   "npm/oxlint/package.json",
+  "npm/oxlint-plugins/package.json",
+  "npm/oxlint-plugins-dev/package.json",
 ]
 
 [[releases]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,18 @@ importers:
 
   npm/oxlint: {}
 
+  npm/oxlint-plugins:
+    dependencies:
+      oxlint:
+        specifier: ^1.42.0
+        version: 1.42.0(oxlint-tsgolint@0.11.4)
+
+  npm/oxlint-plugins-dev:
+    dependencies:
+      oxlint:
+        specifier: ^1.42.0
+        version: 1.42.0(oxlint-tsgolint@0.11.4)
+
   npm/runtime: {}
 
   plugins:


### PR DESCRIPTION
Closes #18610.

Add NPM packages `@oxlint/plugins` and `@oxlint/plugins-dev`.

Add the 2 packages to the `versioned_files` list in `oxc_release.toml`. From what I can understand (and what Claude tells me), that should be all that's needed to bump versions in pre-release workflow, along with the rest.

The release workflow already publishes all packages matching `npm/oxlint*`:

https://github.com/oxc-project/oxc/blob/1d34b426e69a4e0869969cf854f22426e6044e61/.github/workflows/release_apps.yml#L194-L201