### PR TITLE
fix(formatter): correctly expand JSX returned from arrow callbacks in JSX expression containers

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-callback.jsx
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-callback.jsx
@@ -1,0 +1,53 @@
+// Arrow functions returning JSX inside JSX expression containers
+// The multiline structure should be preserved when the arrow body is JSX
+
+// https://github.com/oxc-project/oxc/issues/18738
+// Arrow returning JSX in attribute callback
+[
+  {
+    baz: () => {
+      return <Tooltip
+        title={[].map(name => (
+          <Foo>{name}</Foo>
+        ))}
+      >
+        Foo
+      </Tooltip>
+    }
+  }
+];
+
+// Simpler attribute case
+<Component
+  items={data.map(item => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+/>;
+
+// JSX as child
+<div>
+  {items.map(item => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+</div>;
+
+// Multiple attributes with callback returning JSX
+<DataGrid
+  columns={columns.map(col => (
+    <Column key={col.id}>{col.label}</Column>
+  ))}
+  rows={rows.map(row => (
+    <Row key={row.id}>{row.data}</Row>
+  ))}
+/>;
+
+// Nested JSX in attribute
+<Outer
+  render={items.map(item => (
+    <Inner
+      content={subitems.map(sub => (
+        <Leaf>{sub.name}</Leaf>
+      ))}
+    />
+  ))}
+/>;

--- a/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-callback.jsx.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/jsx/arrow-callback.jsx.snap
@@ -1,0 +1,178 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Arrow functions returning JSX inside JSX expression containers
+// The multiline structure should be preserved when the arrow body is JSX
+
+// https://github.com/oxc-project/oxc/issues/18738
+// Arrow returning JSX in attribute callback
+[
+  {
+    baz: () => {
+      return <Tooltip
+        title={[].map(name => (
+          <Foo>{name}</Foo>
+        ))}
+      >
+        Foo
+      </Tooltip>
+    }
+  }
+];
+
+// Simpler attribute case
+<Component
+  items={data.map(item => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+/>;
+
+// JSX as child
+<div>
+  {items.map(item => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+</div>;
+
+// Multiple attributes with callback returning JSX
+<DataGrid
+  columns={columns.map(col => (
+    <Column key={col.id}>{col.label}</Column>
+  ))}
+  rows={rows.map(row => (
+    <Row key={row.id}>{row.data}</Row>
+  ))}
+/>;
+
+// Nested JSX in attribute
+<Outer
+  render={items.map(item => (
+    <Inner
+      content={subitems.map(sub => (
+        <Leaf>{sub.name}</Leaf>
+      ))}
+    />
+  ))}
+/>;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Arrow functions returning JSX inside JSX expression containers
+// The multiline structure should be preserved when the arrow body is JSX
+
+// https://github.com/oxc-project/oxc/issues/18738
+// Arrow returning JSX in attribute callback
+[
+  {
+    baz: () => {
+      return (
+        <Tooltip
+          title={[].map((name) => (
+            <Foo>{name}</Foo>
+          ))}
+        >
+          Foo
+        </Tooltip>
+      );
+    },
+  },
+];
+
+// Simpler attribute case
+<Component
+  items={data.map((item) => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+/>;
+
+// JSX as child
+<div>
+  {items.map((item) => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+</div>;
+
+// Multiple attributes with callback returning JSX
+<DataGrid
+  columns={columns.map((col) => (
+    <Column key={col.id}>{col.label}</Column>
+  ))}
+  rows={rows.map((row) => (
+    <Row key={row.id}>{row.data}</Row>
+  ))}
+/>;
+
+// Nested JSX in attribute
+<Outer
+  render={items.map((item) => (
+    <Inner
+      content={subitems.map((sub) => (
+        <Leaf>{sub.name}</Leaf>
+      ))}
+    />
+  ))}
+/>;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Arrow functions returning JSX inside JSX expression containers
+// The multiline structure should be preserved when the arrow body is JSX
+
+// https://github.com/oxc-project/oxc/issues/18738
+// Arrow returning JSX in attribute callback
+[
+  {
+    baz: () => {
+      return (
+        <Tooltip
+          title={[].map((name) => (
+            <Foo>{name}</Foo>
+          ))}
+        >
+          Foo
+        </Tooltip>
+      );
+    },
+  },
+];
+
+// Simpler attribute case
+<Component
+  items={data.map((item) => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+/>;
+
+// JSX as child
+<div>
+  {items.map((item) => (
+    <Item key={item.id}>{item.name}</Item>
+  ))}
+</div>;
+
+// Multiple attributes with callback returning JSX
+<DataGrid
+  columns={columns.map((col) => (
+    <Column key={col.id}>{col.label}</Column>
+  ))}
+  rows={rows.map((row) => (
+    <Row key={row.id}>{row.data}</Row>
+  ))}
+/>;
+
+// Nested JSX in attribute
+<Outer
+  render={items.map((item) => (
+    <Inner
+      content={subitems.map((sub) => (
+        <Leaf>{sub.name}</Leaf>
+      ))}
+    />
+  ))}
+/>;
+
+===================== End =====================


### PR DESCRIPTION
close: #18738 