### PR TITLE
fix(formatter): handle leading comments in arrow function sequence expressions

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -150,8 +150,9 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                                 formatted_signature,
                                 group(&format_args!(indent(&format_args!(
                                     hard_line_break(),
+                                    format_leading_comments(sequence.span()),
                                     token("("),
-                                    soft_block_indent(&format_body),
+                                    format_body,
                                     token(")")
                                 ))))
                             ))]
@@ -568,8 +569,9 @@ impl<'a> Format<'a> for ArrowChain<'a, '_> {
                         f,
                         [group(&format_args!(indent(&format_args!(
                             hard_line_break(),
+                            format_leading_comments(sequence.span()),
                             token("("),
-                            soft_block_indent(&format_tail_body),
+                            format_tail_body,
                             token(")")
                         ))))]
                     );

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,10 +1,9 @@
-js compatibility: 742/753 (98.54%)
+js compatibility: 743/753 (98.67%)
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| js/arrows/comment.js | 💥💥 | 88.89% |
 | js/comments/15661.js | 💥💥 | 55.17% |
 | js/comments/empty-statements.js | 💥💥 | 90.91% |
 | js/comments/function-declaration.js | 💥💥 | 92.80% |
@@ -14,4 +13,4 @@ js compatibility: 742/753 (98.54%)
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
 | js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
 | js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |
-| js/sequence-expression/ignored.js | 💥 | 25.00% |
+| js/sequence-expression/ignored.js | 💥 | 66.67% |


### PR DESCRIPTION
Fixes `js/arrows/comment.js` prettier test