### PR TITLE
fix(formatter): quote numeric property keys with `quoteProps: consistent`

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 744/753 (98.80%)
+js compatibility: 746/753 (99.07%)
 
 # Failed
 
@@ -11,5 +11,3 @@ js compatibility: 744/753 (98.80%)
 | js/explicit-resource-management/valid-await-using-comments.js | 💥 | 80.00% |
 | js/for/9812-unstable.js | 💥 | 63.64% |
 | js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 22.22% |
-| js/quote-props/objects.js | 💥💥✨✨ | 48.04% |
-| js/quote-props/with_numbers.js | 💥💥✨✨ | 46.43% |


### PR DESCRIPTION
When `quoteProps: "consistent"` is set and an object has a property key that requires quotes (like `"a-"` or `"foo-bar"`), numeric literal keys like `1` and `1.5` should also be quoted for consistency.

This follows Prettier's `shouldQuotePropertyKey` logic:
- Only quote "simple" numbers (digits only, or digits.digits)
- Verify the value matches the formatted representation
- Skip quoting for TypeScript (where it changes the type)

Fixes the failing quote-props conformance tests:
- `js/quote-props/objects.js`
- `js/quote-props/with_numbers.js`