### PR TITLE
chore(linter): Misc improvements to help prevent merge conflicts for generated files in oxlint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@ crates/oxc_formatter/tests/fixtures/** text=auto eol=lf
 crates/oxc_formatter/tests/fixtures/js/crlf text=auto eol=crlf
 apps/oxfmt/test/**/fixtures/** text=auto eol=lf
 apps/oxlint/test/fixtures/** text=auto eol=lf
+
+# Use 'ours' merge strategy to avoid conflicts.
+# After merging, run `cargo lintgen` to regenerate with the combined rules.
+crates/oxc_linter/src/generated/rules_enum.rs linguist-generated=true merge=ours
+crates/oxc_linter/src/generated/rule_runner_impls.rs linguist-generated=true merge=ours
+crates/oxc_linter/src/generated/assert_layouts.rs linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ just fmt          # Format code (run after modifications)
 just test         # Run unit/integration tests
 just conformance  # Run conformance tests
 just ready        # Run all checks (use after commits)
-
+cargo lintgen     # Regenerate linter rules enum and impls after adding/modifying rules
 # Crate-specific updates
 just ast          # Update generated files (oxc_ast changes)
 just minsize      # Update size snapshots (oxc_minifier changes)

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1,3 +1,6 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To regenerate: `cargo lintgen`
+
 #![expect(
     clippy::default_constructed_unit_structs,
     clippy::semicolon_if_nothing_returned,

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -1,7 +1,7 @@
 //! All registered lint rules.
 //!
 //! New rules need to be added to these `mod` statements.
-//! Then run `cargo run -p oxc_linter_codegen` to regenerate the `RuleEnum`.
+//! Then run `cargo lintgen` to regenerate the RuleEnum and RuleRunnerImpls.
 
 /// <https://github.com/import-js/eslint-plugin-import>
 pub(crate) mod import {

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ ready:
   git diff --exit-code --quiet
   pnpm install
   typos
+  cargo lintgen
   just fmt
   just check
   just test

--- a/tasks/linter_codegen/src/rules_enum.rs
+++ b/tasks/linter_codegen/src/rules_enum.rs
@@ -7,9 +7,6 @@ use crate::rules::RuleEntry;
 /// Generate the RuleEnum and related code that replaces `declare_all_lint_rules!` macro.
 pub fn generate_rules_enum(rule_entries: &[RuleEntry<'_>]) -> String {
     let header = quote! {
-        // Auto-generated code, DO NOT EDIT DIRECTLY!
-        // To regenerate: `cargo run -p oxc_linter_codegen`
-
         #![expect(
             clippy::default_constructed_unit_structs,  // Many rules are unit structs
             clippy::semicolon_if_nothing_returned,     // Match arms in void-returning methods
@@ -42,7 +39,10 @@ pub fn generate_rules_enum(rule_entries: &[RuleEntry<'_>]) -> String {
         #rules_static
     };
 
-    tokens.to_string()
+    // Prepend header comment as a string since `quote!` strips comments
+    let header_comment =
+        "// Auto-generated code, DO NOT EDIT DIRECTLY!\n// To regenerate: `cargo lintgen`\n\n";
+    format!("{header_comment}{tokens}")
 }
 
 /// Create an identifier from a rule entry for the enum variant name.


### PR DESCRIPTION
- The header on rules_enum.rs was being stripped by accident, which was confusing for users. So I fixed that.
- Mark the generated files as generated in `.gitattributes`, for GitHub to understand the diffs are mostly pointless and can be collapsed by default (the CI job enforces that these files be up to date anyway).
- Mark the generated rule files as `merge=ours`. See https://git-scm.com/book/ms/v2/Customizing-Git-Git-Attributes for more info on what that means, but it should make the merge conflicts less problematic.
- Updated `just ready` to include the lintgen command.
- Added `cargo lintgen` to the AGENTS.md file.

AI Disclosure: Used Claude to find the reason for the lack of header comment because I had no idea why it was happening.