### PR TITLE
refactor(linter/plugins): remove deprecated exports from `index` entry point

### DIFF
--- a/apps/oxlint/conformance/snapshots/sonarjs.md
+++ b/apps/oxlint/conformance/snapshots/sonarjs.md
@@ -507,10 +507,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -627,10 +627,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -751,10 +751,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -864,10 +864,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -978,10 +978,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1093,10 +1093,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1206,10 +1206,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1321,10 +1321,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1437,10 +1437,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1550,10 +1550,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1663,10 +1663,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1777,10 +1777,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -1890,10 +1890,10 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 
 
 #### S125 > S125 > Sections of code should not be commented out > invalid
@@ -2005,8 +2005,8 @@ AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
 
 0 !== 1
 
-    at assertErrorCountIsCorrect (apps/oxlint/dist/rule_tester.js)
-    at assertInvalidTestCasePasses (apps/oxlint/dist/rule_tester.js)
-    at runInvalidTestCase (apps/oxlint/dist/rule_tester.js)
-    at apps/oxlint/dist/rule_tester.js
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
 

--- a/apps/oxlint/src-js/index.ts
+++ b/apps/oxlint/src-js/index.ts
@@ -1,21 +1,3 @@
-import { definePlugin as _definePlugin, defineRule as _defineRule } from "./package/define.ts";
-import { RuleTester as _RuleTester } from "./package/rule_tester.ts";
-
-/**
- * @deprecated Import from `oxlint/plugins` instead
- */
-export const definePlugin = _definePlugin;
-
-/**
- * @deprecated Import from `oxlint/plugins` instead
- */
-export const defineRule = _defineRule;
-
-/**
- * @deprecated Import from `oxlint/plugins-dev` instead
- */
-export const RuleTester = _RuleTester;
-
 export { defineConfig } from "./package/config.ts";
 
 export type {

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { RuleTester } from "../src-js/index.ts";
+import { RuleTester } from "../src-js/package/rule_tester.ts";
 
 import type { Rule } from "../src-js/plugins.ts";
 


### PR DESCRIPTION
Remove re-exports of `definePlugin`, `defineRule` and `RuleTester` from main `index` entry point of `oxlint` package.

We want this to be cheap:

```js
import { defineConfig } from "oxlint";
```

But with the deprecated exports, this would eagerly load ~20,000 lines of JS plugins-related code. See `index.js` in `dist` directory before and after this PR in release build. It was the import from `./lint.js` which was massive.

Personally, I don't think we need to keep the deprecated exports, for 3 reasons:

1. We have very clearly said that JS plugins are experimental and that breaking changes are very possible.
2. Given how broken our types are at present, probably few people were using `definePlugin` and `defineRule` anyway!
3. The fix for users who do get broken is trivial:

```diff
- import { definePlugin } from "oxlint";
+ import { definePlugin } from "@oxlint/plugins";
```