### PR TITLE
refactor(linter/plugins): remove `oxlint/plugins` export

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -8,17 +8,13 @@
   "main": "dist/index.js",
   "imports": {
     "#oxlint": "./dist/index.js",
-    "#oxlint/plugins": "./dist/plugins.js",
+    "#oxlint/plugins": "./dist-pkg-plugins/index.js",
     "#oxlint/plugins-dev": "./dist/plugins-dev.js"
   },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    },
-    "./plugins": {
-      "types": "./dist/plugins.d.ts",
-      "default": "./dist/plugins.js"
     },
     "./plugins-dev": {
       "types": "./dist/plugins-dev.d.ts",

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -40,6 +40,13 @@ const minifyConfig = {
   codegen: { removeWhitespace: false },
 };
 
+// Defined globals.
+// `DEBUG: false` allows minifier to remove debug assertions and debug-only code in release build.
+const definedGlobals = {
+  DEBUG: DEBUG ? "true" : "false",
+  CONFORMANCE: CONFORMANCE ? "true" : "false",
+};
+
 // Base config for `@oxlint/plugins` package.
 // "node12" target to match `engines` field of last ESLint 8 release (8.57.1).
 const pluginsPkgConfig = defineConfig({
@@ -53,10 +60,7 @@ const pluginsPkgConfig = defineConfig({
   clean: false,
   target: "node12",
   minify: minifyConfig,
-  define: {
-    DEBUG: "false",
-    CONFORMANCE: "false",
-  },
+  define: definedGlobals,
 });
 
 // Plugins.
@@ -69,7 +73,7 @@ export default defineConfig([
   // Main build
   {
     ...commonConfig,
-    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugins.ts", "src-js/plugins-dev.ts"],
+    entry: ["src-js/cli.ts", "src-js/index.ts", "src-js/plugins-dev.ts"],
     format: "esm",
     external: [
       // External native bindings
@@ -79,10 +83,7 @@ export default defineConfig([
     minify: minifyConfig,
     dts: true,
     attw: { profile: "esm-only" },
-    define: {
-      DEBUG: DEBUG ? "true" : "false",
-      CONFORMANCE: CONFORMANCE ? "true" : "false",
-    },
+    define: definedGlobals,
     plugins,
     inputOptions: {
       // For `replaceAssertsPlugin` and `replaceGlobalsPlugin`

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -39,10 +39,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./plugins": {
-      "types": "./dist/plugins.d.ts",
-      "default": "./dist/plugins.js"
-    },
     "./plugins-dev": {
       "types": "./dist/plugins-dev.d.ts",
       "default": "./dist/plugins-dev.js"


### PR DESCRIPTION
Continuation of #18824, #18828, #18903.

Remove the `oxlint/plugins` export and the `plugins.ts` entry point. These are now only used in tests, where the files can be loaded from `dist-pkg-plugins` instead.

We don't want to encourage people to use `oxlint/plugins` in their plugins - they should be using `@oxlint/plugins` package instead to avoid their plugin having a dependency on `oxlint`.

Due to less shared dependencies between files, this results in 5 less files in `dist` directory in release build.

This also allows re-enabling the debug assertions in this code in tests.