### PR TITLE
fix(formatter): keep decorated function pattern hugged when params break

### DIFF
--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 589/601 (98.00%)
+ts compatibility: 590/601 (98.17%)
 
 # Failed
 
@@ -10,7 +10,6 @@ ts compatibility: 589/601 (98.00%)
 | typescript/class/empty-method-body.ts | 💥 | 80.00% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |
-| typescript/last-argument-expansion/decorated-function.tsx | 💥 | 29.06% |
 | typescript/mapped-type/issue-11098.ts | 💥 | 97.03% |
 | typescript/property-signature/consistent-with-flow/comments.ts | 💥 | 80.00% |
 | typescript/union/comments/18106.ts | 💥 | 92.68% |


### PR DESCRIPTION
Related issue: https://github.com/prettier/prettier/issues/18388

For the "decorated function" pattern like `decorator("name")((props: {...}) => {...})`, the arrow function should be kept hugged to the opening parenthesis even when its parameter types break across multiple lines.

Before this fix, oxfmt was incorrectly breaking the arrow function onto a new line:
```js
const Counter = decorator("my-counter")(
  (props: { initialCount?: number; label?: string }) => { ... },
);
```

After this fix, oxfmt matches Prettier's output:
```js
const Counter = decorator("my-counter")((props: {
  initialCount?: number;
  label?: string;
}) => { ... });
```

This is done by detecting the decorated function pattern and:
1. Skipping the fallback to expanded layout when parameters break
2. Keeping the original cached element (with soft lines) so parameters
   can break vertically while staying hugged

Fixes the failing conformance test:
- typescript/last-argument-expansion/decorated-function.tsx

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>