### PR TITLE
fix(linter/plugins): do not destroy workspaces

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -303,7 +303,12 @@ impl ToolBuilder for ServerLinterBuilder {
         Box::new(self.build(root_uri, options))
     }
 
+    #[expect(unused)]
     fn shutdown(&self, root_uri: &Uri) {
+        // We don't currently destroy workspaces.
+        // See comment in `destroyWorkspace` in `src-js/workspace/index.ts` for explanation.
+        return;
+
         // Destroy JS workspace
         if let Some(external_linter) = &self.external_linter {
             let res = (external_linter.destroy_workspace)(root_uri.as_str().to_string());


### PR DESCRIPTION
This PR is prompted by comments from @Sysix on Discord:

> Found one weird bug, where ⁨`createWorkspace`⁩ is called before the old workspace instance is cleared. TBH I do not know how to fix this (or if this is `vscode-test-cli` problem).

I am also unclear how to fix this. So this PR just disables destroying workspaces for now.

It'd be ideal if we did remove `Workspace` objects to free up memory, but it's not *so* important for 2 reasons:

1. Usually workspace destruction only happens when you reload workspace, so it'll get discarded within seconds when `createWorkspace` over-writes it anyway.
2. Most of the data in the workspace is persisted anyway in NodeJS module cache, so destroying workspace doesn't free that much memory.

IMO it's better to hold onto a little memory unnecessarily (and it will be only a little) than to risk LSP getting broken in the common scenario of reloading a workspace.

Note: This could happen even when user is not using workspaces in their project. A non-workspace project is treated as a project with a single workspace.