### PR TITLE
test(formatter): add regression test for member chain with rest params

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-16177.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-16177.ts
@@ -1,0 +1,16 @@
+{
+  {
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: Element,
+      ...args
+    ) {
+      return {
+        ...originalGetBoundingClientRect.bind(this)(...args),
+        top: canvasTop,
+        left: canvasLeft,
+        width: canvasWidth,
+        height: canvasHeight,
+      };
+    });
+  }
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-16177.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/member-chains/issue-16177.ts.snap
@@ -1,0 +1,62 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+{
+  {
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: Element,
+      ...args
+    ) {
+      return {
+        ...originalGetBoundingClientRect.bind(this)(...args),
+        top: canvasTop,
+        left: canvasLeft,
+        width: canvasWidth,
+        height: canvasHeight,
+      };
+    });
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+{
+  {
+    jest
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element, ...args) {
+        return {
+          ...originalGetBoundingClientRect.bind(this)(...args),
+          top: canvasTop,
+          left: canvasLeft,
+          width: canvasWidth,
+          height: canvasHeight,
+        };
+      });
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+{
+  {
+    jest.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (
+      this: Element,
+      ...args
+    ) {
+      return {
+        ...originalGetBoundingClientRect.bind(this)(...args),
+        top: canvasTop,
+        left: canvasLeft,
+        width: canvasWidth,
+        height: canvasHeight,
+      };
+    });
+  }
+}
+
+===================== End =====================


### PR DESCRIPTION
Closes #16177

## Summary
- Adds a regression test for issue #16177

## Details

The issue was that member chains would incorrectly break when a function expression had rest parameters:

**Before (incorrect):**
```ts
jest
  .spyOn(Element.prototype, "getBoundingClientRect")
  .mockImplementation(function (this: Element, ...args) {
```

**After (correct - matches Prettier):**
```ts
jest.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (
  this: Element,
  ...args
) {
```

This was fixed by #17354, which ensures the `rest` parameter is not considered "simple", allowing the member chain to stay hugged while function parameters break vertically.

🤖 Generated with [Claude Code](https://claude.ai/code)