### PR TITLE
fix(linter/plugins): clear state when reloading workspace

### DIFF
--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -42,15 +42,19 @@ export let currentWorkspaceUri: string | null = null;
 export function createWorkspace(workspaceUri: string): undefined {
   debugAssert(!workspaces.has(workspaceUri), `Workspace "${workspaceUri}" already exists`);
 
-  const workspace = {
+  workspaces.set(workspaceUri, {
     cwd: "",
     allOptions: [],
     rules: [],
-  };
+  });
 
-  workspaces.set(workspaceUri, workspace);
-  currentWorkspace = workspace;
-  currentWorkspaceUri = workspaceUri;
+  // Set current workspace to `null` to force switching workspace in the next call to `loadPlugin`.
+  // Otherwise, if the new workspace has same URI as a previous workspace (which it does when reloading a workspace),
+  // `cwd`, `registeredRules` and `allOptions` will still contain the state from the old version of the workspace.
+  // This means `registeredRules` does not get replaced with an empty array before loading plugins again.
+  // Forcing a switch to the new workspace overwrites the stale state.
+  currentWorkspace = null;
+  currentWorkspaceUri = null;
 }
 
 /**


### PR DESCRIPTION
Fixes #18802.

When a workspace is reloaded, previously:

* `destroyWorkspace` sets `currentWorkspaceUri` to `null`.
* `createWorkspace` sets `currentWorkspaceUri` back to the URL of the workspace (same value as before).
* Next call to `loadPlugin` checks if `currentWorkspaceUri === workspaceUri`.
* The two match, so it doesn't perform a workspace switch. Global state (including `registeredRules`) stays as it was before (`registeredRules` is not empty).
* `loadPlugin` adds rules to `registeredRules` but **without removing the old entries first**.
* Panic in `register_plugin` because number of registered rules on JS side and on Rust side are out of sync.

Fix this by setting `currentWorkspaceUri` to `null` in `createWorkspace`. On next call to `loadPlugin`, it forces a workspace switch, which replaces `registeredRules` with an empty array before rules start being added to it again.