### PR TITLE
fix(formatter/detect_code_removal): Do not count `TemplateLiteral` content

### DIFF
--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -263,6 +263,12 @@ impl StatsCollector {
         }
 
         let count_key = match kind {
+            // `TemplateLiteral` content may change when formatted as embedded template (html, css, etc.).
+            // The number of quasis is already tracked via `TemplateElement` nodes,
+            // so we only need to count `TemplateLiteral` instances without content.
+            AstKind::TemplateLiteral(t) => {
+                format!("TEMPLATE_LITERAL({},{})", t.quasis.len(), t.expressions.len())
+            }
             // `JSXText` may contain redundant whitespaces.
             // e.g. `<p>World    </p>` -> `<p>World </p>`
             // Redundant whitespaces can be truncated even if they are inside.


### PR DESCRIPTION
Fixes the unintended panic like https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/21584562357/job/62189841066