### PR TITLE
refactor(parser): consolidate module syntax detection methods

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1539,7 +1539,7 @@ impl<'a> ParserImpl<'a> {
 
             if self.ctx.has_top_level() {
                 // At top level - upgrade to ESM immediately (like Babel's `sawUnambiguousESM`)
-                self.module_record_builder.found_unambiguous_await();
+                self.module_record_builder.set_module_syntax();
                 // Defer error - will be discarded when we upgrade to ESM
                 self.error_on_script(diagnostics::await_expression(self.cur_token().span()));
             } else {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -402,7 +402,7 @@ impl<'a> ParserImpl<'a> {
         let expression = self.parse_assignment_expression_or_higher();
         self.asi();
         if self.ctx.has_top_level() {
-            self.module_record_builder.found_ts_export();
+            self.module_record_builder.set_module_syntax();
         }
         self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression)
     }
@@ -416,7 +416,7 @@ impl<'a> ParserImpl<'a> {
         let id = self.parse_identifier_name();
         self.asi();
         if self.ctx.has_top_level() {
-            self.module_record_builder.found_ts_export();
+            self.module_record_builder.set_module_syntax();
         }
         self.ast.alloc_ts_namespace_export_declaration(self.end_span(start_span), id)
     }

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -384,13 +384,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record.has_module_syntax = true;
     }
 
-    pub fn found_ts_export(&mut self) {
-        self.module_record.has_module_syntax = true;
-    }
-
-    /// Mark the file as ESM when unambiguous top-level await is detected.
-    /// This is similar to Babel's `sawUnambiguousESM` flag.
-    pub fn found_unambiguous_await(&mut self) {
+    pub fn set_module_syntax(&mut self) {
         self.module_record.has_module_syntax = true;
     }
 }


### PR DESCRIPTION
## Summary
- Merge `found_ts_export()` and `found_unambiguous_await()` into a single `set_module_syntax()` method
- Both methods had identical implementations (setting `has_module_syntax = true`)
- Updates all call sites in expression.rs and module.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)