### PR TITLE
fix(linter/dynamic-config): set `ExternalPlugin.config_dir` to fix js plugins loading

### DIFF
--- a/apps/oxlint/src/js_config.rs
+++ b/apps/oxlint/src/js_config.rs
@@ -105,6 +105,30 @@ fn parse_js_config_response(json: &str) -> Result<Vec<JsConfigResult>, Vec<OxcDi
                     }
 
                     oxlintrc.path.clone_from(&path);
+
+                    if let Some(config_dir) = oxlintrc.path.parent() {
+                        if let Some(external_plugins) = &mut oxlintrc.external_plugins {
+                            *external_plugins = std::mem::take(external_plugins)
+                                .into_iter()
+                                .map(|mut entry| {
+                                    entry.config_dir = config_dir.to_path_buf();
+                                    entry
+                                })
+                                .collect();
+                        }
+
+                        for override_config in oxlintrc.overrides.iter_mut() {
+                            if let Some(external_plugins) = &mut override_config.external_plugins {
+                                *external_plugins = std::mem::take(external_plugins)
+                                    .into_iter()
+                                    .map(|mut entry| {
+                                        entry.config_dir = config_dir.to_path_buf();
+                                        entry
+                                    })
+                                    .collect();
+                            }
+                        }
+                    }
                     configs.push(JsConfigResult { path, config: oxlintrc });
 
                     (configs, errors)

--- a/apps/oxlint/test/fixtures/js_config_js_plugins/files/test.js
+++ b/apps/oxlint/test/fixtures/js_config_js_plugins/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/js_config_js_plugins/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_js_plugins/output.snap.md
@@ -1,0 +1,18 @@
+# Exit code
+1
+
+# stdout
+```
+  x basic-custom-plugin(no-debugger): Unexpected Debugger Statement
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/js_config_js_plugins/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_js_plugins/oxlint.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  categories: {
+    correctness: "off",
+  },
+  jsPlugins: ["./plugin.ts"],
+  rules: {
+    "basic-custom-plugin/no-debugger": "error",
+  },
+});

--- a/apps/oxlint/test/fixtures/js_config_js_plugins/plugin.ts
+++ b/apps/oxlint/test/fixtures/js_config_js_plugins/plugin.ts
@@ -1,0 +1,23 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "basic-custom-plugin",
+  },
+  rules: {
+    "no-debugger": {
+      create(context) {
+        return {
+          DebuggerStatement(debuggerStatement) {
+            context.report({
+              message: "Unexpected Debugger Statement",
+              node: debuggerStatement,
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/18850