### PR TITLE
feat(linter): enforce exporting an object with `defineConfig`

### DIFF
--- a/apps/oxlint/src-js/js_config.ts
+++ b/apps/oxlint/src-js/js_config.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage } from "./utils/utils.ts";
+import { isDefineConfig } from "./package/config.ts";
 import { JSONStringify } from "./utils/globals.ts";
 
 interface JsConfigResult {
@@ -34,6 +35,12 @@ export async function loadJsConfigs(paths: string[]): Promise<string> {
 
         if (typeof config !== "object" || config === null || Array.isArray(config)) {
           throw new Error(`Configuration file must have a default export that is an object.`);
+        }
+
+        if (!isDefineConfig(config)) {
+          throw new Error(
+            `Configuration file must wrap its default export with defineConfig() from "oxlint".`,
+          );
         }
 
         return { path, config };

--- a/apps/oxlint/src-js/package/config.ts
+++ b/apps/oxlint/src-js/package/config.ts
@@ -34,6 +34,8 @@ export type OxlintConfig = Oxlintrc;
 
 export type { OxlintOverride };
 
+const DEFINE_CONFIG_REGISTRY = new WeakSet<object>();
+
 /**
  * Define an Oxlint configuration with type inference.
  *
@@ -41,5 +43,12 @@ export type { OxlintOverride };
  * @returns Config unchanged
  */
 export function defineConfig<T extends OxlintConfig>(config: T): T {
+  DEFINE_CONFIG_REGISTRY.add(config as object);
   return config;
+}
+
+export function isDefineConfig(config: unknown): boolean {
+  return (
+    typeof config === "object" && config !== null && DEFINE_CONFIG_REGISTRY.has(config as object)
+  );
 }

--- a/apps/oxlint/test/fixtures/js_config_basic/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_basic/oxlint.config.ts
@@ -1,7 +1,9 @@
 // Basic test for oxlint.config.ts support
-export default {
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
   rules: {
     "no-debugger": "error",
     eqeqeq: "warn",
   },
-};
+});

--- a/apps/oxlint/test/fixtures/js_config_missing_define_config/files/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_missing_define_config/files/oxlint.config.ts
@@ -1,0 +1,3 @@
+export default {
+  rules: {},
+};

--- a/apps/oxlint/test/fixtures/js_config_missing_define_config/files/test.js
+++ b/apps/oxlint/test/fixtures/js_config_missing_define_config/files/test.js
@@ -1,0 +1,1 @@
+console.log("ok");

--- a/apps/oxlint/test/fixtures/js_config_missing_define_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_missing_define_config/output.snap.md
@@ -1,0 +1,15 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse oxlint configuration file.
+
+  x Failed to load config: <fixture>/files/oxlint.config.ts
+  | 
+  | Error: Configuration file must wrap its default export with defineConfig() from "oxlint".
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/js_config_nested_conflict/files/nested/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_nested_conflict/files/nested/oxlint.config.ts
@@ -1,1 +1,3 @@
-export default { rules: {} };
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({ rules: {} });

--- a/apps/oxlint/test/fixtures/js_config_overrides/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_overrides/oxlint.config.ts
@@ -1,5 +1,7 @@
 // Test that overrides work in oxlint.config.ts
-export default {
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
   rules: {
     "no-debugger": "off",
   },
@@ -11,4 +13,4 @@ export default {
       },
     },
   ],
-};
+});

--- a/apps/oxlint/test/fixtures/js_config_throws_err/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_throws_err/output.snap.md
@@ -8,7 +8,7 @@ Failed to parse oxlint configuration file.
   x Failed to load config: <fixture>/oxlint.config.ts
   | 
   | Error: This is a test error
-  |     at <fixture>/oxlint.config.ts:1:7
+  |     at <fixture>/oxlint.config.ts:3:7
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_throws_err/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/js_config_throws_err/oxlint.config.ts
@@ -1,3 +1,5 @@
+import { defineConfig } from "#oxlint";
+
 throw new Error("This is a test error");
 
-export default {};
+export default defineConfig({});


### PR DESCRIPTION
This isn't technically needed at this point in time, but if we consider the following, when we have support for extends

- config A extends config B (lets assume this in DIR A)
- config B specifies a JS plugin (relative path pointing to DIR C)

Without using defineConfig, and setting the paths, we have no way of knowing the directory of B.



By enforcing the use of defineConfig, we can mutate the config, to add the config dir property so the relative paths are resolved properly