### PR TITLE
refactor(span)!: `SourceType::with_module(false)` no longer sets script mode

### DIFF
--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -63,7 +63,7 @@ fn test_top_level_strict() {
     }
     "#,
     )
-    .with_module(false)
+    .with_script(true)
     .has_root_symbol("foo")
     .in_scope(ScopeFlags::Top | ScopeFlags::StrictMode)
     .test();
@@ -76,7 +76,7 @@ fn test_top_level_strict() {
     }
     ",
     )
-    .with_module(false)
+    .with_script(true)
     .has_root_symbol("foo")
     .in_scope(ScopeFlags::Top)
     .not_in_scope(ScopeFlags::StrictMode)
@@ -94,7 +94,7 @@ fn test_function_level_strict() {
     }
     "#,
     )
-    .with_module(false);
+    .with_script(true);
 
     tester
         .has_some_symbol("x")

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -95,6 +95,12 @@ impl<'a> SemanticTester<'a> {
         self
     }
 
+    /// Mark the [`SourceType`] as a script.
+    pub fn with_script(mut self, yes: bool) -> Self {
+        self.source_type = self.source_type.with_script(yes);
+        self
+    }
+
     /// Enable or disable building a [`ControlFlowGraph`].
     ///
     /// [`ControlFlowGraph`]: oxc_cfg::ControlFlowGraph

--- a/crates/oxc_span/src/source_type.rs
+++ b/crates/oxc_span/src/source_type.rs
@@ -255,6 +255,25 @@ impl SourceType {
         }
     }
 
+    /// Creates a [`SourceType`] representing a [`JavaScript`] script (non-module).
+    ///
+    /// ## Example
+    /// ```
+    /// # use oxc_span::SourceType;
+    ///
+    /// let script = SourceType::script();
+    /// assert!(script.is_script());
+    /// assert!(script.is_javascript());
+    /// ```
+    /// [`JavaScript`]: Language::JavaScript
+    pub const fn script() -> Self {
+        Self {
+            language: Language::JavaScript,
+            module_kind: ModuleKind::Script,
+            variant: LanguageVariant::Standard,
+        }
+    }
+
     /// A [`SourceType`] that will be treated as a module if it contains ESM syntax.
     ///
     /// After a file is parsed with an `unambiguous` source type, it will have a final
@@ -437,8 +456,6 @@ impl SourceType {
     pub const fn with_module(mut self, yes: bool) -> Self {
         if yes {
             self.module_kind = ModuleKind::Module;
-        } else {
-            self.module_kind = ModuleKind::Script;
         }
         self
     }


### PR DESCRIPTION
## Summary

- Add `SourceType::script()` constructor for creating script source types
- `with_module(bool)` now only sets module mode when `true`, does nothing when `false`
- This aligns with the pattern of other `with_*` methods like `with_script()`, `with_jsx()`, etc.

### Migration

Before:
```rust
// This used to set script mode when is_module is false
let source_type = SourceType::default().with_module(is_module);
```

After:
```rust
// Start from script and upgrade to module when needed
let source_type = SourceType::script().with_module(is_module);
```

🤖 Generated with [Claude Code](https://claude.ai/code)