### PR TITLE
fix(ci): Use separate comment-id for ecosystem-ci results

### DIFF
--- a/.github/workflows/prepare_release_apps.yml
+++ b/.github/workflows/prepare_release_apps.yml
@@ -80,14 +80,22 @@ jobs:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
 
       - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        id: comment
+        id: comment-oxlint
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ needs.prepare.outputs.pull-request-number }}
           body: |
-            Triggering Ecosystem CI
-            oxlint https://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxlint-ci.yml
-            oxfmt https://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxfmt-ci.yml
+            Triggering Oxlint Ecosystem CI
+            https://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxlint-ci.yml
+
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        id: comment-oxfmt
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ needs.prepare.outputs.pull-request-number }}
+          body: |
+            Triggering Oxfmt Ecosystem CI
+            https://github.com/oxc-project/oxc-ecosystem-ci/actions/workflows/oxfmt-ci.yml
 
       - uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
@@ -95,7 +103,7 @@ jobs:
           workflow: oxlint-ci.yml
           token: ${{ secrets.OXC_BOT_PAT }}
           ref: main
-          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment.outputs.comment-id }}" }'
+          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment-oxlint.outputs.comment-id }}" }'
 
       - uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
@@ -103,7 +111,7 @@ jobs:
           workflow: oxfmt-ci.yml
           token: ${{ secrets.OXC_BOT_PAT }}
           ref: main
-          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment.outputs.comment-id }}" }'
+          inputs: '{ "issue-number": "${{ needs.prepare.outputs.pull-request-number }}", "comment-id": "${{ steps.comment-oxfmt.outputs.comment-id }}" }'
 
   website:
     needs: prepare


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/pull/18843#issuecomment-3833971672

<img width="469" height="188" alt="image" src="https://github.com/user-attachments/assets/c3d8372b-777c-43bb-8909-ebff0de6ce78" />

Since it referenced the same comment ID, it ended up being the later one that took precedence, which was inconvenient to check. 😅 