### PR TITLE
test(linter): Add a test that was commented-out in no-self-assign rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -417,8 +417,7 @@ fn test() {
         ("a['b'] = a['b']", Some(serde_json::json!([{ "props": true }]))),
         ("a[\n    'b'\n] = a[\n    'b'\n]", Some(serde_json::json!([{ "props": true }]))),
         ("this.x = this.x", Some(serde_json::json!([{ "props": true }]))),
-        // TODO: <https://github.com/eslint/eslint/blob/eb3d7946e1e9f70254008744dba2397aaa730114/lib/rules/utils/ast-utils.js#L362>
-        // ("a['/(?<zero>0)/'] = a[/(?<zero>0)/]", Some(serde_json::json!([{ "props": true }]))),
+        ("a['/(?<zero>0)/'] = a[/(?<zero>0)/]", Some(serde_json::json!([{ "props": true }]))),
         ("(a?.b).c = (a?.b).c", None),
         ("a.b = a?.b", None),
         ("class C { #field; foo() { this.#field = this.#field; } }", None),

--- a/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
@@ -241,6 +241,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
+   ╭─[no_self_assign.tsx:1:21]
+ 1 │ a['/(?<zero>0)/'] = a[/(?<zero>0)/]
+   ·                     ───────────────
+   ╰────
+
+  ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ (a?.b).c = (a?.b).c
    ·            ────────


### PR DESCRIPTION
The AST parsing has improved to handle this case correctly, it looks like.