### PR TITLE
refactor(oxfmt): Handle all options in Rust to reduce JSON payload size

### DIFF
--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -133,19 +133,14 @@ async function loadTailwindPlugin(): Promise<typeof import("prettier-plugin-tail
 
 // ---
 
-const TAILWIND_RELEVANT_PARSERS = new Set(["html", "vue", "angular", "glimmer"]);
-
 /**
- * Load Tailwind CSS plugin lazily for Prettier when:
- * - Option flag is set (by Rust side)
- * - And, the `parser` is relevant for Tailwind CSS
+ * Load Tailwind CSS plugin lazily when `options._useTailwindPlugin` flag is set.
+ * The flag is added by Rust side only for relevant parsers.
  *
- * Option mapping (experimentalTailwindcss.xxx → tailwindXxx) is done in Rust side.
+ * Option mapping (experimentalTailwindcss.xxx → tailwindXxx) is also done in Rust side.
  */
 async function setupTailwindPlugin(options: Options): Promise<void> {
   if ("_useTailwindPlugin" in options === false) return;
-  // PERF: Skip loading Tailwind plugin for parsers that don't use it
-  if (!TAILWIND_RELEVANT_PARSERS.has(options.parser as string)) return;
 
   const tailwindPlugin = await loadTailwindPlugin();
 
@@ -162,8 +157,7 @@ export interface SortTailwindClassesArgs {
 }
 
 /**
- * Process Tailwind CSS classes found in JSX attributes.
- * Option mapping (`experimentalTailwindcss.xxx` → `tailwindXxx`) is done in Rust side.
+ * Process Tailwind CSS classes found in JS/TS files in batch.
  * @param args - Object containing filepath, classes, and options
  * @returns Array of sorted class strings (same order/length as input)
  */
@@ -210,20 +204,12 @@ async function loadOxfmtPlugin(): Promise<Plugin> {
 
 // ---
 
-// Parsers that can embed JS/TS code
-const OXFMT_RELEVANT_PARSERS = new Set([
-  // "html",
-  // "angular",
-  // "vue",
-  // "lwc",
-  // "mjml",
-  "markdown",
-  "mdx",
-]);
-
+/**
+ * Load oxfmt plugin for js-in-xxx parsers when `options._oxfmtPluginOptionsJson` is set.
+ * The flag is added by Rust side only for relevant parsers.
+ */
 async function setupOxfmtPlugin(options: Options): Promise<void> {
-  // Skip loading oxfmt plugin for parsers that don't embed JS/TS
-  if (!OXFMT_RELEVANT_PARSERS.has(options.parser as string)) return;
+  if ("_oxfmtPluginOptionsJson" in options === false) return;
 
   const oxcPlugin = await loadOxfmtPlugin();
 

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -10,6 +10,8 @@ use oxc_formatter::{
 };
 use oxc_toml::Options as TomlFormatterOptions;
 
+use super::FormatFileStrategy;
+
 /// Configuration options for the Oxfmt.
 ///
 /// Most options are the same as Prettier's options, but not all of them.
@@ -798,7 +800,7 @@ pub struct OxfmtOptions {
     pub insert_final_newline: bool,
 }
 
-/// Populates the raw config JSON with resolved `FormatOptions` values.
+/// Syncs resolved `FormatOptions` values into the raw config JSON.
 /// This ensures `external_formatter`(Prettier) receives the same options that `oxc_formatter` uses.
 ///
 /// Only options that meet one of these criteria need to be mapped:
@@ -810,8 +812,9 @@ pub struct OxfmtOptions {
 ///   - `indent_style` -> `useTabs`
 ///   - `indent_size` -> `tabWidth`
 ///
-/// Also, for (j|t)s-in-xxx embedded formatting, prepare options for `prettier-plugin-oxfmt`
-pub fn populate_prettier_config(options: &FormatOptions, config: &mut Value) {
+/// This function should be called once during config caching.
+/// For strategy-specific options (plugin flags), use [`finalize_external_options()`] separately.
+pub fn sync_external_options(config: &mut Value, options: &FormatOptions) {
     let Some(obj) = config.as_object_mut() else {
         return;
     };
@@ -837,43 +840,88 @@ pub fn populate_prettier_config(options: &FormatOptions, config: &mut Value) {
         }),
     );
 
-    // Flags for JS side to know which external Prettier plugins should be loaded
-    if obj.contains_key("experimentalTailwindcss") {
+    // Any other fields are preserved as-is.
+    // - e.g. `htmlWhitespaceSensitivity`, `vueIndentScriptAndStyle`, etc.
+    //   - Defined in `Oxfmtrc`, but only used by Prettier
+    // - e.g. `plugins`
+    //   - It does not mean plugin works correctly with Oxfmt
+    //   - Oxfmt still not aware of any plugin-defined languages
+    // Other options defined independently by plugins are also left as they are.
+}
+
+/// Parsers that can embed JS/TS code and benefit from Tailwind plugin
+#[cfg(feature = "napi")]
+static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
+    "html",
+    "vue",
+    "angular",
+    "glimmer",
+};
+
+/// Parsers that can embed JS/TS code and benefit from oxfmt plugin.
+/// For now, expressions are not supported.
+/// - e.g. `__vue_expression` in `vue`
+/// - e.g. `__ng_directive` in `angular`
+#[cfg(feature = "napi")]
+static OXFMT_PARSERS: phf::Set<&'static str> = phf::phf_set! {
+    // "html",
+    // "vue",
+    "markdown",
+    "mdx",
+};
+
+/// Finalizes external options by adding plugin-specific flags based on the formatting strategy.
+/// This should be called during `resolve()` after getting cached config.
+///
+/// - `_useTailwindPlugin`: Flag for JS side to load Tailwind plugin
+/// - `_oxfmtPluginOptionsJson`: Bundled options for `prettier-plugin-oxfmt`
+///
+/// Also removes Prettier-unaware options to minimize payload size.
+pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrategy) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+
+    // Determine if Tailwind plugin should be used based on config and strategy
+    let use_tailwind = obj.contains_key("experimentalTailwindcss")
+        && match strategy {
+            FormatFileStrategy::OxcFormatter { .. } => true,
+            #[cfg(feature = "napi")]
+            FormatFileStrategy::ExternalFormatter { parser_name, .. } => {
+                TAILWIND_PARSERS.contains(parser_name)
+            }
+            _ => false,
+        };
+
+    // Add Tailwind plugin flag and map options
+    // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
+    if use_tailwind {
+        if let Some(tailwind) =
+            obj.get("experimentalTailwindcss").and_then(|v| v.as_object()).cloned()
+        {
+            for (src, dst) in [
+                ("config", "tailwindConfig"),
+                ("stylesheet", "tailwindStylesheet"),
+                ("functions", "tailwindFunctions"),
+                ("attributes", "tailwindAttributes"),
+                ("preserveWhitespace", "tailwindPreserveWhitespace"),
+                ("preserveDuplicates", "tailwindPreserveDuplicates"),
+            ] {
+                if let Some(v) = tailwind.get(src) {
+                    obj.insert(dst.to_string(), v.clone());
+                }
+            }
+        }
         obj.insert("_useTailwindPlugin".to_string(), Value::Number(1.into()));
     }
 
-    // Map `experimentalTailwindcss` options to Prettier's tailwind plugin format,
-    // by adding `tailwind` prefix to each field.
-    // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
-    if let Some(tailwind) = obj.get("experimentalTailwindcss")
-        && let Some(tailwind) = tailwind.as_object().cloned()
-    {
-        for (src, dst) in [
-            ("config", "tailwindConfig"),
-            ("stylesheet", "tailwindStylesheet"),
-            ("functions", "tailwindFunctions"),
-            ("attributes", "tailwindAttributes"),
-            ("preserveWhitespace", "tailwindPreserveWhitespace"),
-            ("preserveDuplicates", "tailwindPreserveDuplicates"),
-        ] {
-            if let Some(v) = tailwind.get(src) {
-                obj.insert(dst.to_string(), v.clone());
-            }
-        }
-    }
-
-    // Bundle all related options into a single JSON string for `prettier-plugin-oxfmt`.
-    // Reasons are:
-    // - During `embed()` processing, Prettier's option normalization adds many internal options
-    //   - Like `originalText`, `rangeXxx` that we don't use
-    // - Prettier plugin option does not support nested object
-    //   - If flatten, need to enumerate all fields as `plugin.options`
-    //
-    // So, we explicitly list and pack what we need.
-    // Although this could be done on the JS side,
-    // keep all option-related processing here and make it explicit.
+    // Build oxfmt plugin options JSON for js-in-xxx parsers
+    #[cfg(feature = "napi")]
+    if let FormatFileStrategy::ExternalFormatter { parser_name, .. } = strategy
+        && OXFMT_PARSERS.contains(parser_name)
     {
         let mut oxfmt_plugin_options = serde_json::Map::new();
+
         for key in [
             "printWidth",
             "useTabs",
@@ -911,14 +959,6 @@ pub fn populate_prettier_config(options: &FormatOptions, config: &mut Value) {
     ] {
         obj.remove(key);
     }
-
-    // Any other fields are preserved as-is.
-    // - e.g. `htmlWhitespaceSensitivity`, `vueIndentScriptAndStyle`, etc.
-    //   - Defined in `Oxfmtrc`, but only used by Prettier
-    // - e.g. `plugins`
-    //   - It does not mean plugin works correctly with Oxfmt
-    //   - Oxfmt still not aware of any plugin-defined languages
-    // Other options defined independently by plugins are also left as they are.
 }
 
 // ---
@@ -1125,24 +1165,24 @@ mod tests {
 }
 
 #[cfg(test)]
-mod tests_populate_prettier_config {
+mod tests_sync_external_options {
     use super::*;
 
     #[test]
-    fn test_populate_prettier_config_defaults() {
+    fn test_sync_external_options_defaults() {
         let json_string = r"{}";
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
         let config: FormatConfig = serde_json::from_str(json_string).unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
 
-        populate_prettier_config(&oxfmt_options.format_options, &mut raw_config);
+        sync_external_options(&mut raw_config, &oxfmt_options.format_options);
 
         let obj = raw_config.as_object().unwrap();
         assert_eq!(obj.get("printWidth").unwrap(), 100);
     }
 
     #[test]
-    fn test_populate_prettier_config_with_user_values() {
+    fn test_sync_external_options_with_user_values() {
         let json_string = r#"{
             "printWidth": 80,
             "ignorePatterns": ["*.min.js"],
@@ -1152,14 +1192,15 @@ mod tests_populate_prettier_config {
         let config: FormatConfig = serde_json::from_str(json_string).unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
 
-        populate_prettier_config(&oxfmt_options.format_options, &mut raw_config);
+        sync_external_options(&mut raw_config, &oxfmt_options.format_options);
 
         let obj = raw_config.as_object().unwrap();
         // User-specified value is preserved via FormatOptions
         assert_eq!(obj.get("printWidth").unwrap(), 80);
-        // oxfmt extensions are removed
-        assert!(!obj.contains_key("ignorePatterns"));
-        assert!(!obj.contains_key("experimentalSortImports"));
+        // oxfmt extensions are preserved (for caching)
+        // They will be removed later by `finalize_external_options()`
+        assert!(obj.contains_key("ignorePatterns"));
+        assert!(obj.contains_key("experimentalSortImports"));
     }
 
     #[test]
@@ -1197,7 +1238,7 @@ mod tests_populate_prettier_config {
     }
 
     #[test]
-    fn test_populate_prettier_config_removes_overrides() {
+    fn test_sync_external_options_preserves_overrides() {
         let json_string = r#"{
             "tabWidth": 2,
             "overrides": [
@@ -1208,10 +1249,41 @@ mod tests_populate_prettier_config {
         let oxfmtrc: Oxfmtrc = serde_json::from_str(json_string).unwrap();
         let oxfmt_options = oxfmtrc.format_config.into_oxfmt_options().unwrap();
 
-        populate_prettier_config(&oxfmt_options.format_options, &mut raw_config);
+        sync_external_options(&mut raw_config, &oxfmt_options.format_options);
 
         let obj = raw_config.as_object().unwrap();
+        // Overrides are preserved (for caching)
+        // They will be removed later by `finalize_external_options()`
+        assert!(obj.contains_key("overrides"));
+    }
+
+    #[test]
+    fn test_finalize_external_options_removes_oxfmt_extensions() {
+        use std::path::PathBuf;
+
+        use oxc_span::SourceType;
+
+        let json_string = r#"{
+            "tabWidth": 2,
+            "overrides": [
+                { "files": ["*.test.js"], "options": { "tabWidth": 4 } }
+            ],
+            "ignorePatterns": ["*.min.js"],
+            "experimentalSortImports": { "order": "asc" }
+        }"#;
+        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
+
+        let strategy = super::super::FormatFileStrategy::OxcFormatter {
+            path: PathBuf::from("test.js"),
+            source_type: SourceType::mjs(),
+        };
+        finalize_external_options(&mut raw_config, &strategy);
+
+        let obj = raw_config.as_object().unwrap();
+        // oxfmt extensions are removed by finalize_external_options
         assert!(!obj.contains_key("overrides"));
+        assert!(!obj.contains_key("ignorePatterns"));
+        assert!(!obj.contains_key("experimentalSortImports"));
     }
 }
 


### PR DESCRIPTION
Follow up on #18373 

Aims to reduce:

- Rust -> JS payload size
- Logic itself in JS side

by handling all options in Rust side.

Before:
- Plugin options handled globally during config caching
- All files received full JSON
- JS side filtered by `parser` name to decide plugin loading

After:
- Plugin options added per-file in `finalize_external_options()` if needed
- Only relevant files receive plugin flags based on `FormatFileStrategy`
- JS side just checks flag existence (`parser` knowledge not needed)