### PR TITLE
fix(parser): handle `<<` as two `<` tokens in type argument contexts

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -803,7 +803,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn try_parse_type_arguments(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
-        if self.at(Kind::LAngle) {
+        if self.re_lex_ts_l_angle() {
             let span = self.start_span();
             let opening_span = self.cur_token().span();
             self.expect(Kind::LAngle);

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,8 +1,8 @@
 commit: 92c052dc
 
 parser_babel Summary:
-AST Parsed     : 2220/2224 (99.82%)
-Positive Passed: 2207/2224 (99.24%)
+AST Parsed     : 2223/2224 (99.96%)
+Positive Passed: 2210/2224 (99.37%)
 Negative Passed: 1655/1689 (97.99%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
@@ -314,32 +314,6 @@ Panicked: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/re
    ·                         ┬     ───┬───
    ·                         │        ╰── `,` or `)` expected
    ·                         ╰── Opened here
-   ╰────
-
-Panicked: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage/input.ts
-
-  × Expected `{` but found `<<`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage/input.ts:1:17]
- 1 │ (class extends f<<T>(v: T) => void> {});
-   ·                 ─┬
-   ·                  ╰── `{` expected
-   ╰────
-
-Panicked: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/interface-heritage/input.ts
-
-  × Expected `{` but found `<<`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/interface-heritage/input.ts:1:22]
- 1 │ interface I extends f<<T>(v: T) => void> {};
-   ·                      ─┬
-   ·                       ╰── `{` expected
-   ╰────
-
-Panicked: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx:1:11]
- 1 │ <Component<<T>(v: T) => void> />
-   ·           ──
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 92c052dc
 
 semantic_babel Summary:
 AST Parsed     : 2224/2224 (100.00%)
-Positive Passed: 2022/2224 (90.92%)
+Positive Passed: 2024/2224 (91.01%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -1311,14 +1311,10 @@ Unresolved references mismatch:
 after transform: ["T", "f", "x"]
 rebuilt        : ["f", "x"]
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage/input.ts
-Expected `{` but found `<<`
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/interface-heritage/input.ts
-Expected `{` but found `<<`
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx
-Unexpected token
+Unresolved references mismatch:
+after transform: ["f"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/export-type-only-as-as-keyword/input.ts
 Unresolved references mismatch:


### PR DESCRIPTION
## Summary

- Fix parsing of type arguments that start with `<` (generic function types), which creates what looks like a bit-shift-left operator (`<<`)
- Call `re_lex_ts_l_angle()` in `try_parse_type_arguments()` to re-lex `<<` back to a single `<`, matching the behavior already used in `parse_type_arguments_of_type_reference()`

This fixes parsing of:
- `class extends f<<T>(v: T) => void>`
- `interface I extends f<<T>(v: T) => void>`
- `<Component<<T>(v: T) => void> />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)