### PR TITLE
fix(parser): allow conditional types in function type parameters

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -47,8 +47,9 @@ impl<'a> ParserImpl<'a> {
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
         let type_parameters = self.parse_ts_type_parameters();
-        let (this_param, params) =
-            self.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
+        let (this_param, params) = self.context_remove(Context::DisallowConditionalTypes, |p| {
+            p.parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature)
+        });
         let return_type = {
             let return_type_span = self.start_span();
             let return_type = self.parse_return_type();

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,8 +1,8 @@
 commit: 92c052dc
 
 parser_babel Summary:
-AST Parsed     : 2223/2224 (99.96%)
-Positive Passed: 2210/2224 (99.37%)
+AST Parsed     : 2224/2224 (100.00%)
+Positive Passed: 2211/2224 (99.42%)
 Negative Passed: 1656/1689 (98.05%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
@@ -302,16 +302,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/declare-pattern-parameters/input.ts:1:25]
  1 │ declare function f([]?, {})
    ·                         ──
-   ╰────
-
-Panicked: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
-
-  × Expected `,` or `)` but found `extends`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts:1:31]
- 1 │ type Equals = A extends (x: B extends C ? D : E) => 0 ? F : G;
-   ·                         ┬     ───┬───
-   ·                         │        ╰── `,` or `)` expected
-   ·                         ╰── Opened here
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -739,7 +739,9 @@ after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-param/input.ts
-Expected `,` or `)` but found `extends`
+Unresolved references mismatch:
+after transform: ["A", "B", "C", "D", "E", "F", "G"]
+rebuilt        : []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/nested-extends-in-arrow-type-return/input.ts
 Unresolved references mismatch:


### PR DESCRIPTION
## Summary

- Allow conditional types inside function type parameter annotations, even when the function type itself is being parsed in a `DisallowConditionalTypes` context
- Wrap `parse_formal_parameters` in `parse_function_or_constructor_type` with `context_remove(DisallowConditionalTypes, ...)`

This fixes parsing of nested conditional types like:
```typescript
type Equals = A extends (x: B extends C ? D : E) => 0 ? F : G;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)