### PR TITLE
fix(parser): error on property access after instantiation expression

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -647,6 +647,14 @@ pub fn ts_empty_type_argument_list(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn ts_instantiation_expression_cannot_be_followed_by_property_access(
+    span: Span,
+) -> OxcDiagnostic {
+    ts_error("1477", "An instantiation expression cannot be followed by a property access.")
+        .with_label(span)
+}
+
+#[cold]
 pub fn ts_string_literal_expected(span: Span) -> OxcDiagnostic {
     ts_error("1141", "String literal expected.").with_label(span)
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -830,11 +830,25 @@ impl<'a> ParserImpl<'a> {
             };
 
             if is_property_access {
+                if matches!(lhs, Expression::TSInstantiationExpression(_)) {
+                    self.error(
+                        diagnostics::ts_instantiation_expression_cannot_be_followed_by_property_access(
+                            self.end_span(lhs_span),
+                        ),
+                    );
+                }
                 lhs = self.parse_static_member_expression(lhs_span, lhs, question_dot);
                 continue;
             }
 
             if (question_dot || !self.ctx.has_decorator()) && self.at(Kind::LBrack) {
+                if matches!(lhs, Expression::TSInstantiationExpression(_)) {
+                    self.error(
+                        diagnostics::ts_instantiation_expression_cannot_be_followed_by_property_access(
+                            self.end_span(lhs_span),
+                        ),
+                    );
+                }
                 lhs = self.parse_computed_member_expression(lhs_span, lhs, question_dot);
                 continue;
             }

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 92c052dc
 parser_babel Summary:
 AST Parsed     : 2223/2224 (99.96%)
 Positive Passed: 2210/2224 (99.37%)
-Negative Passed: 1655/1689 (97.99%)
+Negative Passed: 1656/1689 (98.05%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2026/explicit-resource-management/invalid-for-using-of-no-initializer/input.js
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
@@ -59,8 +59,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/module-identifier-invalid/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/keyword-qualified-type-2/input.ts
-
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts
 
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters-invalid/input.ts
 
@@ -14071,6 +14069,37 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ let a: Foo<>;
    ·           ──
    ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts:2:1]
+ 1 │ // invalid
+ 2 │ a<b>.c;
+   · ─────
+ 3 │ a<b>?.c;
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts:3:1]
+ 2 │ a<b>.c;
+ 3 │ a<b>?.c;
+   · ──────
+ 4 │ a<b>?.[c];
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts:4:1]
+ 3 │ a<b>?.c;
+ 4 │ a<b>?.[c];
+   · ──────
+ 5 │ 
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts:13:1]
+ 12 │ // longer, invalid
+ 13 │ a?.b<c>.d
+    · ────────
+    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-missing-semicolon/input.ts:1:9]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 95e3aaa9
 parser_typescript Summary:
 AST Parsed     : 9842/9843 (99.99%)
 Positive Passed: 9838/9843 (99.95%)
-Negative Passed: 1511/2557 (59.09%)
+Negative Passed: 1514/2557 (59.21%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -715,8 +715,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/omitTypeTest
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/omittedExpressionForOfLoop.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/operationsAvailableOnPromisedType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams2.ts
 
@@ -1773,10 +1771,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration6.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration7.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessOffOfGenericType1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration5.ts
 
@@ -6510,6 +6504,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ╰────
   help: Allowed modifiers are: declare, async
 
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/compiler/genericCallWithoutArgs.ts:4:1]
+ 3 │ 
+ 4 │ f<number,string>.
+   · ─────────────────
+   ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/genericCallWithoutArgs.ts:4:18]
  3 │ 
@@ -8989,6 +8990,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
  9 │ var b = (x, y?:number = 2) => { x; };
    ·             ─
    ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+    ╭─[typescript/tests/cases/compiler/optionalChainWithInstantiationExpression1.ts:12:1]
+ 11 │ 
+ 12 │ a?.b<c>.d;
+    · ────────
+ 13 │ 
+    ╰────
 
   × Identifier `C1M5` has already been declared
     ╭─[typescript/tests/cases/compiler/optionalParamArgsTest.ts:31:12]
@@ -22430,6 +22439,27 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    · ─
    ╰────
 
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts:3:1]
+ 2 │ Foo.Bar<T>();
+ 3 │ Foo<T>.Bar();
+   · ───────
+ 4 │ Foo<T>.Bar<T>();
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts:4:1]
+ 3 │ Foo<T>.Bar();
+ 4 │ Foo<T>.Bar<T>();
+   · ───────
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessOffOfGenericType1.ts:1:9]
+ 1 │ var v = List<number>.makeChild();
+   ·         ─────────────
+   ╰────
+
   × Expected `;` but found `[`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration10.ts:2:18]
  1 │ class C {
@@ -26746,6 +26776,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
     ·       ╰── It can not be redeclared here
  12 │ 
     ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts:7:12]
+ 6 │ const a2 = f.g<number>;  // () => number
+ 7 │ const a3 = f<number>.g;  // <U>() => U
+   ·            ──────────
+ 8 │ const a4 = f<number>.g<number>;  // () => number
+   ╰────
+
+  × TS(1477): An instantiation expression cannot be followed by a property access.
+   ╭─[typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts:8:12]
+ 7 │ const a3 = f<number>.g;  // <U>() => U
+ 8 │ const a4 = f<number>.g<number>;  // () => number
+   ·            ──────────
+ 9 │ const a5 = f['g']<number>;  // () => number
+   ╰────
 
   × Unexpected token
     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts:18:29]


### PR DESCRIPTION
## Summary

- Add TypeScript error TS1477: "An instantiation expression cannot be followed by a property access"
- Check for `TSInstantiationExpression` before parsing property access (static `.` or computed `[]`)

This fixes parsing of invalid syntax like:
- `a<b>.c` (static member access)
- `a<b>?.c` (optional static member access)  
- `a<b>?.[c]` (optional computed member access)
- `a?.b<c>.d` (chained)

Valid syntax like `a<b>?.(c)` (optional call) and `(a<b>).c` (parenthesized) are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)