### PR TITLE
fix(linter/prefer-expect-type-of): handle computed elements in fixer correctly

### DIFF
--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
@@ -49,3 +49,10 @@ source: crates/oxc_linter/src/tester.rs
    · ───────────────────────────────────────
    ╰────
   help: Substitute the assertion with `expectTypeOf(value).not.toBeString()`.
+
+  ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
+   ╭─[prefer_expect_type_of.tsx:1:1]
+ 1 │ expect(typeof value)["not"].toBe("string")
+   · ──────────────────────────────────────────
+   ╰────
+  help: Substitute the assertion with `expectTypeOf(value)["not"].toBeString()`.


### PR DESCRIPTION
Handle computed modifier access (e.g. ["not"]) in prefer-expect-type-of autofix and add regression test.