### PR TITLE
feat(span): store file extension in `SourceType`

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -9,7 +9,7 @@ use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    // Padding: 1 bytes
+    // Padding: 0 bytes
     assert!(size_of::<Program>() == 128);
     assert!(align_of::<Program>() == 8);
     assert!(offset_of!(Program, span) == 0);
@@ -1631,7 +1631,7 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
-    // Padding: 1 bytes
+    // Padding: 0 bytes
     assert!(size_of::<Program>() == 88);
     assert!(align_of::<Program>() == 4);
     assert!(offset_of!(Program, span) == 0);

--- a/crates/oxc_span/src/generated/assert_layouts.rs
+++ b/crates/oxc_span/src/generated/assert_layouts.rs
@@ -16,11 +16,12 @@ const _: () = {
     assert!(offset_of!(Span, end) == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<SourceType>() == 3);
+    assert!(size_of::<SourceType>() == 4);
     assert!(align_of::<SourceType>() == 1);
     assert!(offset_of!(SourceType, language) == 0);
     assert!(offset_of!(SourceType, module_kind) == 1);
     assert!(offset_of!(SourceType, variant) == 2);
+    assert!(offset_of!(SourceType, extension) == 3);
 
     assert!(size_of::<Language>() == 1);
     assert!(align_of::<Language>() == 1);
@@ -30,6 +31,9 @@ const _: () = {
 
     assert!(size_of::<LanguageVariant>() == 1);
     assert!(align_of::<LanguageVariant>() == 1);
+
+    assert!(size_of::<FileExtension>() == 1);
+    assert!(align_of::<FileExtension>() == 1);
 };
 
 #[cfg(target_pointer_width = "32")]
@@ -41,11 +45,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(Span, end) == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<SourceType>() == 3);
+    assert!(size_of::<SourceType>() == 4);
     assert!(align_of::<SourceType>() == 1);
     assert!(offset_of!(SourceType, language) == 0);
     assert!(offset_of!(SourceType, module_kind) == 1);
     assert!(offset_of!(SourceType, variant) == 2);
+    assert!(offset_of!(SourceType, extension) == 3);
 
     assert!(size_of::<Language>() == 1);
     assert!(align_of::<Language>() == 1);
@@ -55,6 +60,9 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
 
     assert!(size_of::<LanguageVariant>() == 1);
     assert!(align_of::<LanguageVariant>() == 1);
+
+    assert!(size_of::<FileExtension>() == 1);
+    assert!(align_of::<FileExtension>() == 1);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/crates/oxc_span/src/generated/derive_dummy.rs
+++ b/crates/oxc_span/src/generated/derive_dummy.rs
@@ -16,6 +16,7 @@ impl<'a> Dummy<'a> for SourceType {
             language: Dummy::dummy(allocator),
             module_kind: Dummy::dummy(allocator),
             variant: Dummy::dummy(allocator),
+            extension: Dummy::dummy(allocator),
         }
     }
 }
@@ -47,5 +48,15 @@ impl<'a> Dummy<'a> for LanguageVariant {
     #[inline(always)]
     fn dummy(allocator: &'a Allocator) -> Self {
         Self::Standard
+    }
+}
+
+impl<'a> Dummy<'a> for FileExtension {
+    /// Create a dummy [`FileExtension`].
+    ///
+    /// Does not allocate any data into arena.
+    #[inline(always)]
+    fn dummy(allocator: &'a Allocator) -> Self {
+        Self::Js
     }
 }


### PR DESCRIPTION
## Summary

Store the original file extension in `SourceType` when parsed from a path. This allows downstream code to distinguish between e.g. `.mts` and `.ts` files that resolved to `ModuleKind::Module`.

- Adds `extension: Option<FileExtension>` field to `SourceType`
- Adds `FileExtension` to AST schema with `#[ast]` attribute
- Adds `SourceType::extension()` getter method

related https://github.com/oxc-project/oxc/issues/15184

🤖 Generated with [Claude Code](https://claude.com/claude-code)