### PR TITLE
docs(linter/plugins): alter JS plugins example

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -174,7 +174,7 @@ export interface Oxlintrc {
    *
    * ```json
    * {
-   * "jsPlugins": ["./eslint-plugin-custom.js"],
+   * "jsPlugins": ["./custom-plugin.js"],
    * "rules": {
    * "custom/rule-name": "warn"
    * }
@@ -233,7 +233,7 @@ export interface Oxlintrc {
   rules?: DummyRuleMap;
   /**
    * Plugin-specific configuration for both built-in and custom plugins.
-   * This includes settings for built-in plugins such as  `react` and `jsdoc`
+   * This includes settings for built-in plugins such as `react` and `jsdoc`
    * as well as configuring settings for JS custom plugins loaded via `jsPlugins`.
    */
   settings?: OxlintPluginSettings;

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -96,7 +96,7 @@ pub struct Oxlintrc {
     ///
     /// ```json
     /// {
-    ///   "jsPlugins": ["./eslint-plugin-custom.js"],
+    ///   "jsPlugins": ["./custom-plugin.js"],
     ///   "rules": {
     ///     "custom/rule-name": "warn"
     ///   }
@@ -141,7 +141,7 @@ pub struct Oxlintrc {
     /// rules.
     pub rules: OxlintRules,
     /// Plugin-specific configuration for both built-in and custom plugins.
-    /// This includes settings for built-in plugins such as  `react` and `jsdoc`
+    /// This includes settings for built-in plugins such as `react` and `jsdoc`
     /// as well as configuring settings for JS custom plugins loaded via `jsPlugins`.
     pub settings: OxlintSettings,
     /// Environments enable and disable collections of global variables.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -60,7 +60,7 @@
       "markdownDescription": "Globs to ignore during linting. These are resolved from the configuration file path."
     },
     "jsPlugins": {
-      "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./eslint-plugin-custom.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
+      "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
       "anyOf": [
         {
           "type": "null"
@@ -73,7 +73,7 @@
           "uniqueItems": true
         }
       ],
-      "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./eslint-plugin-custom.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
+      "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
     },
     "overrides": {
       "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
@@ -108,7 +108,7 @@
       "markdownDescription": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules."
     },
     "settings": {
-      "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as  `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
+      "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
       "default": {
         "jsx-a11y": {
           "polymorphicPropName": null,
@@ -143,7 +143,7 @@
           "$ref": "#/definitions/OxlintSettings"
         }
       ],
-      "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as  `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
+      "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
     }
   },
   "additionalProperties": false,

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -64,7 +64,7 @@ expression: json
       "markdownDescription": "Globs to ignore during linting. These are resolved from the configuration file path."
     },
     "jsPlugins": {
-      "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./eslint-plugin-custom.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
+      "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
       "anyOf": [
         {
           "type": "null"
@@ -77,7 +77,7 @@ expression: json
           "uniqueItems": true
         }
       ],
-      "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./eslint-plugin-custom.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
+      "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\nThey are not supported in the language server (and thus editor integrations) at present.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
     },
     "overrides": {
       "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
@@ -112,7 +112,7 @@ expression: json
       "markdownDescription": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules."
     },
     "settings": {
-      "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as  `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
+      "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
       "default": {
         "jsx-a11y": {
           "polymorphicPropName": null,
@@ -147,7 +147,7 @@ expression: json
           "$ref": "#/definitions/OxlintSettings"
         }
       ],
-      "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as  `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
+      "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
     }
   },
   "additionalProperties": false,

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -230,7 +230,7 @@ Basic usage with a local plugin path.
 
 ```json
 {
-"jsPlugins": ["./eslint-plugin-custom.js"],
+"jsPlugins": ["./custom-plugin.js"],
 "rules": {
 "custom/rule-name": "warn"
 }


### PR DESCRIPTION
Follow-on after #18671. 2 small changes to the doc comments.

1. Name the plugin in example `custom-plugin.js` instead of `eslint-plugin-custom.js`. It's not really related to ESLint.
2. Fix double-space which the pedant AI spotted.