### PR TITLE
build(oxlint): simplify building `@oxlint/plugins`

### DIFF
--- a/apps/oxlint/scripts/build.ts
+++ b/apps/oxlint/scripts/build.ts
@@ -10,6 +10,10 @@ const oxlintDirPath = join(import.meta.dirname, ".."),
   distPkgPluginsDirPath = join(oxlintDirPath, "dist-pkg-plugins"),
   pkgPluginsDirPath = join(oxlintDirPath, "../../npm/oxlint-plugins");
 
+// Delete `dist-pkg-plugins` directory
+console.log("Deleting `dist-pkg-plugins` directory...");
+rmSync(distPkgPluginsDirPath, { recursive: true, force: true });
+
 // Build with tsdown
 console.log("Building with tsdown...");
 execSync("pnpm tsdown", { stdio: "inherit", cwd: oxlintDirPath });
@@ -28,17 +32,9 @@ for (const filename of readdirSync(srcDirPath)) {
 
 // Copy files to `@oxlint/plugins` package
 console.log("Moving files to `@oxlint/plugins` package...");
-
-const files = [
-  { src: "esm/index.js", dest: "index.js" },
-  { src: "esm/index.d.ts", dest: "index.d.ts" },
-  { src: "cjs/index.cjs", dest: "index.cjs" },
-];
-
-for (const { src, dest } of files) {
-  copyFileSync(join(distPkgPluginsDirPath, src), join(pkgPluginsDirPath, dest));
+for (const filename of readdirSync(distPkgPluginsDirPath)) {
+  copyFileSync(join(distPkgPluginsDirPath, filename), join(pkgPluginsDirPath, filename));
 }
-
 rmSync(distPkgPluginsDirPath, { recursive: true });
 
 console.log("Build complete!");

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -47,6 +47,10 @@ const pluginsPkgConfig = defineConfig({
   entry: {
     index: "src-js/plugins.ts",
   },
+  outDir: "dist-pkg-plugins",
+  // `build.ts` deletes the directory before TSDown runs.
+  // This allows generating the ESM and CommonJS builds in the same directory.
+  clean: false,
   target: "node12",
   minify: minifyConfig,
   define: {
@@ -103,13 +107,11 @@ export default defineConfig([
   // `scripts/build.ts` moves built files in `dist-pkg-plugins` to `npm/oxlint-plugins`.
   {
     ...pluginsPkgConfig,
-    outDir: "dist-pkg-plugins/esm",
     format: "esm",
     dts: true,
   },
   {
     ...pluginsPkgConfig,
-    outDir: "dist-pkg-plugins/cjs",
     format: "commonjs",
     dts: false,
   },


### PR DESCRIPTION
Follow-on after #18824. Refactor only.

Simplify building `@oxlint/plugins` package. Generate both the ESM and CommonJS builds in the same directory.