### PR TITLE
fix(linter/plugins): ensure `after` hook always runs last in rule converted for ESLint

### DIFF
--- a/apps/oxlint/test/fixtures/eslintCompat/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/eslintCompat/.oxlintrc.json
@@ -4,6 +4,7 @@
   "rules": {
     "eslint-compat-plugin/create": "error",
     "eslint-compat-plugin/create-once": "error",
+    "eslint-compat-plugin/create-once-selector": "error",
     "eslint-compat-plugin/create-once-before-false": "error",
     "eslint-compat-plugin/create-once-before-only": "error",
     "eslint-compat-plugin/create-once-after-only": "error",

--- a/apps/oxlint/test/fixtures/eslintCompat/eslint.config.js
+++ b/apps/oxlint/test/fixtures/eslintCompat/eslint.config.js
@@ -9,6 +9,7 @@ export default [
     rules: {
       "eslint-compat-plugin/create": "error",
       "eslint-compat-plugin/create-once": "error",
+      "eslint-compat-plugin/create-once-selector": "error",
       "eslint-compat-plugin/create-once-before-false": "error",
       "eslint-compat-plugin/create-once-before-only": "error",
       "eslint-compat-plugin/create-once-after-only": "error",

--- a/apps/oxlint/test/fixtures/eslintCompat/eslint.snap.md
+++ b/apps/oxlint/test/fixtures/eslintCompat/eslint.snap.md
@@ -23,6 +23,16 @@ filename: <fixture>/files/1.js                              eslint-compat-plugin
 filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-after-only
   0:1  error  after hook:
 filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-hooks-only
+  0:1  error  after hook:
+filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  *:exit visit fn:
+filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  Program:exit visit fn:
+filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  [body]:exit visit fn:
+filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  [body][body][body]:exit visit fn:
+filename: <fixture>/files/1.js                              eslint-compat-plugin/create-once-selector
   1:5  error  ident visit fn "a":
 filename: <fixture>/files/1.js                              eslint-compat-plugin/create
   1:5  error  ident visit fn "a":
@@ -68,6 +78,16 @@ filename: <fixture>/files/2.js                              eslint-compat-plugin
 filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-after-only
   0:1  error  after hook:
 filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-hooks-only
+  0:1  error  after hook:
+filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  *:exit visit fn:
+filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  Program:exit visit fn:
+filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  [body]:exit visit fn:
+filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-selector
+  1:1  error  [body][body][body]:exit visit fn:
+filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-selector
   1:5  error  ident visit fn "c":
 filename: <fixture>/files/2.js                              eslint-compat-plugin/create
   1:5  error  ident visit fn "c":
@@ -95,7 +115,7 @@ filename: <fixture>/files/2.js                              eslint-compat-plugin
   1:8  error  ident visit fn "d":
 filename: <fixture>/files/2.js                              eslint-compat-plugin/create-once-no-hooks
 
-✖ 39 problems (39 errors, 0 warnings)
+✖ 49 problems (49 errors, 0 warnings)
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/eslintCompat/output.snap.md
+++ b/apps/oxlint/test/fixtures/eslintCompat/output.snap.md
@@ -48,6 +48,41 @@
    : ^
    `----
 
+  x eslint-compat-plugin(create-once-selector): after hook:
+  | filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): *:exit visit fn:
+  | filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): Program:exit visit fn:
+  | filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): [body]:exit visit fn:
+  | filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): [body][body][body]:exit visit fn:
+  | filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let a, b;
+   : ^^^^^^^^^^
+   `----
+
   x eslint-compat-plugin(create): ident visit fn "a":
   | filename: <fixture>/files/1.js
    ,-[files/1.js:1:5]
@@ -172,6 +207,41 @@
    : ^
    `----
 
+  x eslint-compat-plugin(create-once-selector): after hook:
+  | filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): *:exit visit fn:
+  | filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): Program:exit visit fn:
+  | filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): [body]:exit visit fn:
+  | filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^^^^^^^^^^
+   `----
+
+  x eslint-compat-plugin(create-once-selector): [body][body][body]:exit visit fn:
+  | filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let c, d;
+   : ^^^^^^^^^^
+   `----
+
   x eslint-compat-plugin(create): ident visit fn "c":
   | filename: <fixture>/files/2.js
    ,-[files/2.js:1:5]
@@ -258,8 +328,8 @@
    :        ^
    `----
 
-Found 0 warnings and 35 errors.
-Finished in Xms on 2 files with 7 rules using X threads.
+Found 0 warnings and 45 errors.
+Finished in Xms on 2 files with 8 rules using X threads.
 ```
 
 # stderr

--- a/npm/oxlint-plugins/index.cjs
+++ b/npm/oxlint-plugins/index.cjs
@@ -88,10 +88,18 @@ function createContextAndVisitor(rule) {
 	else if (beforeHook !== null && typeof beforeHook != "function") throw Error("`before` property of visitor must be a function if defined");
 	if (afterHook != null) {
 		if (typeof afterHook != "function") throw Error("`after` property of visitor must be a function if defined");
-		let programExit = visitor["Program:exit"];
-		visitor["Program:exit"] = programExit == null ? (_node) => afterHook() : (node) => {
-			programExit(node), afterHook();
-		};
+		let maxAttrs = -1;
+		for (let key in visitor) {
+			if (!Object.hasOwn(visitor, key) || !key.endsWith(":exit")) continue;
+			let end = key.length - 5, count = 0;
+			for (let i = 0; i < end; i++) {
+				let c = key.charCodeAt(i);
+				(c === 91 || c === 46 || c === 58) && count++;
+			}
+			count > maxAttrs && (maxAttrs = count);
+		}
+		let key = `Program${"[type]".repeat(maxAttrs + 1)}:exit`;
+		visitor[key] = (_node) => afterHook();
 	}
 	return {
 		context,

--- a/npm/oxlint-plugins/index.js
+++ b/npm/oxlint-plugins/index.js
@@ -88,10 +88,18 @@ function createContextAndVisitor(rule) {
 	else if (beforeHook !== null && typeof beforeHook != "function") throw Error("`before` property of visitor must be a function if defined");
 	if (afterHook != null) {
 		if (typeof afterHook != "function") throw Error("`after` property of visitor must be a function if defined");
-		let programExit = visitor["Program:exit"];
-		visitor["Program:exit"] = programExit == null ? (_node) => afterHook() : (node) => {
-			programExit(node), afterHook();
-		};
+		let maxAttrs = -1;
+		for (let key in visitor) {
+			if (!Object.hasOwn(visitor, key) || !key.endsWith(":exit")) continue;
+			let end = key.length - 5, count = 0;
+			for (let i = 0; i < end; i++) {
+				let c = key.charCodeAt(i);
+				(c === 91 || c === 46 || c === 58) && count++;
+			}
+			count > maxAttrs && (maxAttrs = count);
+		}
+		let key = `Program${"[type]".repeat(maxAttrs + 1)}:exit`;
+		visitor[key] = (_node) => afterHook();
 	}
 	return {
 		context,


### PR DESCRIPTION
Fix an edge case bug in conversion of a plugin using `createOnce` to an ESLint-compatible plugin.

If a rule's visitor has an `after` hook, it needs to run after all other visitor functions. Previously we achieved this by adding `after` hook as `Program:exit` visitor fn.

However, this will not work properly if the visitor has a selector which matches `Program` but has a higher specificity. e.g.:

```js
const rule = {
  createOnce(context) {
    return {
      "Program[sourceType='module']:exit"(node) {
        // This should run before the `after` hook
      },
      after() {
        // This should run only at very end of walking AST
      }
    };
  },
};
```

In this case `Program[sourceType='module']` has higher specificity than `Program:exit`, so if `after` hook is converted to `Program:exit`, then the `after` hook doesn't run last.

Fix this by creating a more specific selector for the `after` hook - in this case `Program[type][type]`. `Program` always has a `type` property, so the selector always matches `Program`, but it executes last due to its higher specificity.