### PR TITLE
feat(minifier): default `invalid_import_side_effects` to `false`

### DIFF
--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -194,7 +194,7 @@ pub struct TreeShakeOptions {
     /// Accessing a non-existing import name will throw an error.
     /// Also import statements that cannot be resolved will throw an error.
     ///
-    /// Default `true`
+    /// Default `false`
     pub invalid_import_side_effects: bool,
 }
 
@@ -205,7 +205,7 @@ impl Default for TreeShakeOptions {
             manual_pure_functions: vec![],
             property_read_side_effects: PropertyReadSideEffects::default(),
             unknown_global_side_effects: true,
-            invalid_import_side_effects: true,
+            invalid_import_side_effects: false,
         }
     }
 }

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -130,16 +130,20 @@ fn keep_in_script_mode() {
 
 #[test]
 fn remove_unused_import_specifiers() {
-    let options = CompressOptions {
-        treeshake: TreeShakeOptions {
-            invalid_import_side_effects: false,
-            ..TreeShakeOptions::default()
-        },
-        ..CompressOptions::smallest()
-    };
+    let options = CompressOptions::smallest();
 
     test_options("import a from 'a'", "import 'a';", &options);
     test_options("import a from 'a'; foo()", "import 'a'; foo();", &options);
+    test_same_options(
+        "import a from 'a'",
+        &CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: true,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        },
+    );
 
     test_options("import { a } from 'a'", "import 'a';", &options);
     test_options("import { a, b } from 'a'", "import 'a';", &options);
@@ -197,31 +201,39 @@ fn remove_unused_import_specifiers() {
 
 #[test]
 fn remove_unused_import_source_statement() {
-    let options = CompressOptions {
-        treeshake: TreeShakeOptions {
-            invalid_import_side_effects: false,
-            ..TreeShakeOptions::default()
-        },
-        ..CompressOptions::smallest()
-    };
+    let options = CompressOptions::smallest();
 
     test_options("import source a from 'a'", "", &options);
     test_options("import source a from 'a'; if (false) { console.log(a) }", "", &options);
     test_same_options("import source a from 'a'; foo(a);", &options);
+    test_same_options(
+        "import source a from 'a'",
+        &CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: true,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        },
+    );
 }
 
 #[test]
 fn remove_unused_import_defer_statements() {
-    let options = CompressOptions {
-        treeshake: TreeShakeOptions {
-            invalid_import_side_effects: false,
-            ..TreeShakeOptions::default()
-        },
-        ..CompressOptions::smallest()
-    };
+    let options = CompressOptions::smallest();
 
     test_options("import defer * as a from 'a'", "", &options);
     test_options("import defer * as a from 'a'; if (false) { console.log(a.foo) }", "", &options);
     test_same_options("import defer * as a from 'a'; foo(a);", &options);
     test_same_options("import defer * as a from 'a'; foo(a.bar);", &options);
+    test_same_options(
+        "import defer * as a from 'a'",
+        &CompressOptions {
+            treeshake: TreeShakeOptions {
+                invalid_import_side_effects: true,
+                ..TreeShakeOptions::default()
+            },
+            ..CompressOptions::smallest()
+        },
+    );
 }

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -4,7 +4,7 @@ checker.ts                 | 2.92 MB        ||           4128 |           1669 |
 
 cal.com.tsx                | 1.06 MB        ||          21098 |            474 ||          37138 |           4586
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             58 |              3 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             58 |              0 ||             30 |              6
 
 pdf.mjs                    | 567.30 kB      ||           4691 |            569 ||          47462 |           7734
 


### PR DESCRIPTION
These sideeffects are commonly ignored, so I think we should ignore them by default.

- [Rollup REPL](https://rollupjs.org/repl/?version=4.57.1&shareable=eyJleGFtcGxlIjpudWxsLCJtb2R1bGVzIjpbeyJjb2RlIjoiaW1wb3J0IHsgZm9vIH0gZnJvbSAndW5rbm93bidcbmlmIChmYWxzZSkge1xuICBjb25zb2xlLmxvZyhmb28pXG59IiwiaXNFbnRyeSI6dHJ1ZSwibmFtZSI6Im1haW4uanMifV0sIm9wdGlvbnMiOnt9fQ==)
- [esbuild try](https://esbuild.github.io/try/#dAAwLjI3LjIALS1taW5pZnkAaW1wb3J0IHsgZm9vIH0gZnJvbSAndW5rbm93bicKaWYgKGZhbHNlKSB7CiAgY29uc29sZS5sb2coZm9vKQp9)
- [SWC playground](https://play.swc.rs/?version=1.15.11&code=H4sIAAAAAAAAAw3LMQ6AIBAEwP6S%2B8N2YOOfjOEMEW4NaCwIf9fpJ9eL7caAkZiwxorw%2BOl8PahkQ7St9LRgqAA7vbOktfCI%2F1hUpsoHV0iLrEQAAAA%3D&config=H4sIAAAAAAAAA41VS47bMAzd5xSB111MB0VR9ADd9QyCYlGOMrJoiFQ%2BGOTupRU7k5nQRjdBzKdHiuQj9b7ZbpsDtc3v7bv8lY%2FBZoJ8%2FxYLXRLbs1gaaHtLbQ4DN99m9EAj5G0kqKbrDWnY5g64suj15fXHxGgiIsHMmGx9SMFfHmO22A8ZiB5sYhWXpYfE9Jk%2FYRlPI8C5PNp3iBFsWkGMJRMSQwdZc9xijHYgMEebFS%2FjTW0OhFqIESwMzgwZBxVPLnDAJDGfUQfWmRYdKFDI0HI4gkaTWEJLJOkp%2BVTYwa50Xe3zFzYcbSyWlZhwri2R2ype9xiIjS9JK%2BENXKjBDZyK%2B5UZvMnAJadn3gFDWujJG4BUIFqiZHvQ%2FNYTXvS0xParzJC8SJYvCi761rJM0ElRTQheqexYGcgctG5mcKWFsbKtdp0JXigfBQcGvBetKK7pFLjda0H5MgB6BZD%2BWq%2Bp6gaY%2BxQu4ONArMB%2FJEvWBTad6C3vl1G69DuMKwF64D26lQPSCsZlOMuWOA%2FLeEkORBrg1COFKvC8BGQAGE2s%2B%2FJJGzIe4tF0EXcfa2I6cL3v4d6mrs77w75kHCIcIS7J%2BD9GZBWVux1HVc%2BT%2FTS98EsTpZXBC99fPj0bkspm%2Fq1JNT268pBQ1eTtOfnZfByaX465ak2gvzNRKv6W8JSazfUfly9ihugGAAA%3D)

This was originally set to `true` (https://github.com/oxc-project/oxc/pull/17300) for Rolldown (https://github.com/rolldown/rolldown/pull/7512#issuecomment-3682642929), but that should be instead handled on Rolldown side (https://github.com/rolldown/rolldown/pull/8194).
