### PR TITLE
chore(linter): disable correctness rules in two snapshot test

### DIFF
--- a/apps/oxlint/fixtures/config_ignore_patterns/ignore_extension/eslintrc.json
+++ b/apps/oxlint/fixtures/config_ignore_patterns/ignore_extension/eslintrc.json
@@ -1,5 +1,11 @@
 {
   "ignorePatterns": [
     "*.js"
-  ]
+  ],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "unicorn/no-empty-file": "error"
+  }
 }

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -6,13 +6,13 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 
-  ! eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
+  x eslint-plugin-unicorn(no-empty-file): Empty files are not allowed.
    ,-[fixtures/config_ignore_patterns/ignore_extension/main.ts:1:1]
    `----
   help: Delete this file or add some code to it.
 
-Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 91 rules using 1 threads.
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
 ----------
-CLI result: LintSucceeded
+CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fix
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 91 rules using 1 threads.
+Finished in <variable>ms on 0 files with 1 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/snapshots/unicorn_relative_url_style.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_relative_url_style.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("./foo", base)

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_expect_type_of.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-vitest(prefer-expect-type-of): Type assertions should be done using `expectTypeOf`.
    ╭─[prefer_expect_type_of.tsx:1:1]
  1 │ expect(typeof 12).toBe("number")


### PR DESCRIPTION
Simple little update to avoid correctness rules in two snaps. Also updated two other snaps to match the newly-updated format from insta.