### PR TITLE
fix(linter): Fix the behavior of `import/extensions` rule for a file that has multiple extensions.

### DIFF
--- a/crates/oxc_linter/fixtures/import/Component.stories.tsx
+++ b/crates/oxc_linter/fixtures/import/Component.stories.tsx
@@ -1,0 +1,1 @@
+export const Component = () => <div>Component</div>;

--- a/crates/oxc_linter/fixtures/import/helper.spec.js
+++ b/crates/oxc_linter/fixtures/import/helper.spec.js
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper';
+}

--- a/crates/oxc_linter/fixtures/import/utils.test.ts
+++ b/crates/oxc_linter/fixtures/import/utils.test.ts
@@ -1,0 +1,3 @@
+export function testUtil() {
+  return 'test';
+}

--- a/crates/oxc_linter/src/snapshots/import_extensions.snap
+++ b/crates/oxc_linter/src/snapshots/import_extensions.snap
@@ -693,3 +693,24 @@ source: crates/oxc_linter/src/tester.rs
    · ────────────────────────────────────────────
    ╰────
   help: Remove the file extension from this import.
+
+  ⚠ eslint-plugin-import(extensions): File extension "tsx" should not be included in the import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import Component from './Component.stories.tsx';
+   · ────────────────────────────────────────────────
+   ╰────
+  help: Remove the file extension from this import.
+
+  ⚠ eslint-plugin-import(extensions): File extension "ts" should not be included in the import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import Component from './Component.test.ts';
+   · ────────────────────────────────────────────
+   ╰────
+  help: Remove the file extension from this import.
+
+  ⚠ eslint-plugin-import(extensions): File extension "js" should not be included in the import declaration.
+   ╭─[extensions.tsx:1:1]
+ 1 │ import utils from './utils.spec.js';
+   · ────────────────────────────────────
+   ╰────
+  help: Remove the file extension from this import.


### PR DESCRIPTION
See #18918 for details and a test repo. This fixes the problematic behavior of the Oxlint implementation so we match the implementation from the original import plugin.

Basically, we want to have `tsx: never` in the rule config, and in that case it should disallow this:

```tsx
import Foo from "./Foo.stories.tsx";
```

It correctly did that, but if you _removed_ the `tsx` extension, you would end up with an error about not allowing the `stories` extension, which was nonsensical. Now we correctly handle this behavior, so `import Foo from "./Foo.stories";` is allowed for this config setting.

Built with Claude Code, reviewed and tested by me. [Another user also confirmed that this fixes the problem for them](https://github.com/oxc-project/oxc/issues/18681#issuecomment-3848174383).

Fixes #18918 and #18681.