### PR TITLE
fix(oxfmt): Handle vue expression parts which uses `babel(-ts)`

### DIFF
--- a/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
+++ b/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
@@ -71,3 +71,128 @@ const count = ref(0);
 
 --------------------"
 `;
+
+exports[`js-in-xxx > should handle v-for, v-slot, generic attributes correctly 1`] = `
+"--- FILE -----------
+vue-directives.vue
+--- BEFORE ---------
+<!-- Case: __isEmbeddedTypescriptGenericParameters -->
+<script setup lang="ts" generic="T extends Record<string  ,   unknown>, U">
+import B from "./b.vue";
+import { defineComponent } from "vue";
+import { Route } from "router";
+
+// Case: __isVueBindings (defineProps/defineEmits)
+const { foo,
+  bar } = defineProps<{ foo: string;    bar: number }>();
+const emit = defineEmits<{ change:
+  [value: T] }>();
+
+// oxfmt-ignore
+const x =                 1;
+</script>
+
+<template>
+  <ul>
+    <!-- Case: __isVueForBindingLeft (v-for) -->
+    <li v-for="item in    items" :key="item.id">
+      {{ item.name }}
+    </li>
+    <li v-for="(item,    index) in items" :key="index">
+      {{ index }}: {{ item.name }}
+    </li>
+    <li v-for="{ id, name     } in items" :key="id">
+      {{ name }}
+    </li>
+    <li v-for="(value, key,     index) in object" :key="key">
+      {{ index }}: {{ key }} = {{ value }}
+    </li>
+    <!-- Case: __isInHtmlAttribute (string literals in v-for) -->
+    <li v-for="{ name = 'default'   } in items" :key="name">
+      {{ name }}
+    </li>
+
+    <!-- Case: __isVueBindings (v-slot) -->
+    <MyComponent v-slot="{ item,      index }">
+      {{ item }}
+    </MyComponent>
+    <MyComponent>
+      <template #default="{       data }">
+        {{ data }}
+      </template>
+      <template #header="props    ">
+        {{ props.title }}
+      </template>
+    </MyComponent>
+    <!-- Case: __isInHtmlAttribute (string literals in v-slot) -->
+    <MyComponent v-slot="{ label =    'test' }">
+      {{ label }}
+    </MyComponent>
+
+    <!-- These should be OK (expression parsers) -->
+    <div v-if="condition&&anotherCondition">v-if</div>
+    <div v-show="isVisible   ">v-show</div>
+    <div :class="{ active:          isActive }">v-bind</div>
+    <button @click="handleClick($event          )">v-on</button>
+  </ul>
+</template>
+
+--- AFTER ----------
+<!-- Case: __isEmbeddedTypescriptGenericParameters -->
+<script setup lang="ts" generic="T extends Record<string, unknown>, U">
+  import { Route } from "router";
+  import { defineComponent } from "vue";
+
+  import B from "./b.vue";
+
+  // Case: __isVueBindings (defineProps/defineEmits)
+  const { foo, bar } = defineProps<{ foo: string; bar: number }>();
+  const emit = defineEmits<{ change: [value: T] }>();
+
+  // oxfmt-ignore
+  const x =                 1;
+</script>
+
+<template>
+  <ul>
+    <!-- Case: __isVueForBindingLeft (v-for) -->
+    <li v-for="item in items" :key="item.id">
+      {{ item.name }}
+    </li>
+    <li v-for="(item, index) in items" :key="index">{{ index }}: {{ item.name }}</li>
+    <li v-for="{ id, name } in items" :key="id">
+      {{ name }}
+    </li>
+    <li v-for="(value, key, index) in object" :key="key">{{ index }}: {{ key }} = {{ value }}</li>
+    <!-- Case: __isInHtmlAttribute (string literals in v-for) -->
+    <li v-for="{ name = 'default' } in items" :key="name">
+      {{ name }}
+    </li>
+
+    <!-- Case: __isVueBindings (v-slot) -->
+    <MyComponent v-slot="{ item, index }">
+      {{ item }}
+    </MyComponent>
+    <MyComponent>
+      <template #default="{ data }">
+        {{ data }}
+      </template>
+      <template #header="props">
+        {{ props.title }}
+      </template>
+    </MyComponent>
+    <!-- Case: __isInHtmlAttribute (string literals in v-slot) -->
+    <MyComponent v-slot="{ label = 'test' }">
+      {{ label }}
+    </MyComponent>
+
+    <!-- These should be OK (expression parsers) -->
+    <div v-if="condition && anotherCondition">v-if</div>
+    <div v-show="isVisible">v-show</div>
+    <div :class="{ active: isActive }">v-bind</div>
+    <button @click="handleClick($event)">v-on</button>
+  </ul>
+</template>
+
+--------------------"
+`;

--- a/apps/oxfmt/test/cli/js_in_xxx/fixtures/vue-directives.vue
+++ b/apps/oxfmt/test/cli/js_in_xxx/fixtures/vue-directives.vue
@@ -1,0 +1,60 @@
+<!-- Case: __isEmbeddedTypescriptGenericParameters -->
+<script setup lang="ts" generic="T extends Record<string  ,   unknown>, U">
+import B from "./b.vue";
+import { defineComponent } from "vue";
+import { Route } from "router";
+
+// Case: __isVueBindings (defineProps/defineEmits)
+const { foo,
+  bar } = defineProps<{ foo: string;    bar: number }>();
+const emit = defineEmits<{ change:
+  [value: T] }>();
+
+// oxfmt-ignore
+const x =                 1;
+</script>
+
+<template>
+  <ul>
+    <!-- Case: __isVueForBindingLeft (v-for) -->
+    <li v-for="item in    items" :key="item.id">
+      {{ item.name }}
+    </li>
+    <li v-for="(item,    index) in items" :key="index">
+      {{ index }}: {{ item.name }}
+    </li>
+    <li v-for="{ id, name     } in items" :key="id">
+      {{ name }}
+    </li>
+    <li v-for="(value, key,     index) in object" :key="key">
+      {{ index }}: {{ key }} = {{ value }}
+    </li>
+    <!-- Case: __isInHtmlAttribute (string literals in v-for) -->
+    <li v-for="{ name = 'default'   } in items" :key="name">
+      {{ name }}
+    </li>
+
+    <!-- Case: __isVueBindings (v-slot) -->
+    <MyComponent v-slot="{ item,      index }">
+      {{ item }}
+    </MyComponent>
+    <MyComponent>
+      <template #default="{       data }">
+        {{ data }}
+      </template>
+      <template #header="props    ">
+        {{ props.title }}
+      </template>
+    </MyComponent>
+    <!-- Case: __isInHtmlAttribute (string literals in v-slot) -->
+    <MyComponent v-slot="{ label =    'test' }">
+      {{ label }}
+    </MyComponent>
+
+    <!-- These should be OK (expression parsers) -->
+    <div v-if="condition&&anotherCondition">v-if</div>
+    <div v-show="isVisible   ">v-show</div>
+    <div :class="{ active:          isActive }">v-bind</div>
+    <button @click="handleClick($event          )">v-on</button>
+  </ul>
+</template>

--- a/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
+++ b/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
@@ -22,4 +22,13 @@ describe("js-in-xxx", () => {
     );
     expect(snapshot).toMatchSnapshot();
   });
+
+  it("should handle v-for, v-slot, generic attributes correctly", async () => {
+    const snapshot = await runWriteModeAndSnapshot(
+      fixturesDir,
+      ["vue-directives.vue"],
+      ["--config", "vue-full.json"],
+    );
+    expect(snapshot).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Initially, I didn't plan to support the expression part at this point.

However, it was discovered that `babel` parser is used in some parts of Vue expressions!

```vue
<li v-for="HERE in items"></li>
<li v-for="(HE, RE) in items"></li>
```

Therefore, if no action were taken, the placeholders inserted by Prettier would be used as is, breaking the code.

```vue
<li v-for="HERE in items"></li>
<!-- will be formatted -->
<li v-for="function _(HERE) {} in items"></li>
```

This PR reluctantly addresses those issues.

And this issue is unavoidable as long as we don't use Prettier's `estree` printer.
It will continue to be necessary even if `oxfmt` becomes capable of returning a `Doc`.

UPDATE: Even if we disregard the format result..., there are still the following TODOs just to avoid breaking the code.

- js-in-html: `onclick="..."` also uses `babel(-ts)`
- js-in-html: `__babelSourceType` for set `module` or not
- `__onHtmlBindingRoot`, `__isInHtmlAttribute`
- (maybe more)