### PR TITLE
fix(napi): disable mimalloc on Windows to fix worker_threads crash

### DIFF
--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -35,7 +35,7 @@ oxc_span = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -2,7 +2,12 @@
 
 #[cfg(all(
     feature = "allocator",
-    not(any(target_arch = "arm", target_os = "freebsd", target_family = "wasm"))
+    not(any(
+        target_arch = "arm",
+        target_os = "freebsd",
+        target_os = "windows",
+        target_family = "wasm"
+    ))
 ))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -32,7 +32,7 @@ rustc-hash = { workspace = true }
 napi = { workspace = true, features = ["async"] }
 napi-derive = { workspace = true }
 
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -17,7 +17,12 @@ pub use types::*;
 
 #[cfg(all(
     feature = "allocator",
-    not(any(target_arch = "arm", target_os = "freebsd", target_family = "wasm"))
+    not(any(
+        target_arch = "arm",
+        target_os = "freebsd",
+        target_os = "windows",
+        target_family = "wasm"
+    ))
 ))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -31,7 +31,7 @@ rustc-hash = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]

--- a/napi/transform/src/lib.rs
+++ b/napi/transform/src/lib.rs
@@ -1,6 +1,11 @@
 #[cfg(all(
     feature = "allocator",
-    not(any(target_arch = "arm", target_os = "freebsd", target_family = "wasm"))
+    not(any(
+        target_arch = "arm",
+        target_os = "freebsd",
+        target_os = "windows",
+        target_family = "wasm"
+    ))
 ))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;


### PR DESCRIPTION
## Summary

- Disable mimalloc as the global allocator on Windows for all NAPI packages (`oxc-parser`, `oxc-minify`, `oxc-transform`)
- On Windows, packages now use the system allocator instead

Fixes #15518

## Root Cause

mimalloc has known issues with DLL unloading on Windows when the DLL is loaded by the main thread but unloaded by a worker thread ([mimalloc issue #288](https://github.com/microsoft/mimalloc/issues/288)). The cleanup code has `_mi_is_main_thread()` checks that prevent proper memory cleanup when called from a non-main thread, causing `STATUS_ACCESS_VIOLATION` crashes.

## Platforms with mimalloc enabled

| Platform | mimalloc |
|----------|----------|
| macOS | ✅ |
| Linux x86_64 | ✅ |
| Linux aarch64 | ✅ |
| Windows | ❌ (disabled) |
| FreeBSD | ❌ |
| ARM 32-bit | ❌ |
| WASM | ❌ |

🤖 Generated with [Claude Code](https://claude.ai/code)