### PR TITLE
fix(deps): update bytes to 1.11.1 for RUSTSEC-2025-0008

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION
## Summary

- Updates `bytes` crate from 1.10.1 to 1.11.1 to fix security advisory RUSTSEC-2025-0008
- Fixes `cargo deny check` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)