### PR TITLE
fix(formatter): preserve trailing comma for single type parameter in .mts/.cts files

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-cts.cts
+++ b/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-cts.cts
@@ -1,0 +1,8 @@
+// Single type parameter in arrow function requires trailing comma in .cts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};

--- a/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-cts.cts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-cts.cts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Single type parameter in arrow function requires trailing comma in .cts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Single type parameter in arrow function requires trailing comma in .cts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Single type parameter in arrow function requires trailing comma in .cts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-mts.mts
+++ b/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-mts.mts
@@ -1,0 +1,8 @@
+// Single type parameter in arrow function requires trailing comma in .mts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};

--- a/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-mts.mts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/trailing-comma/issue-18924-mts.mts.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Single type parameter in arrow function requires trailing comma in .mts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Single type parameter in arrow function requires trailing comma in .mts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Single type parameter in arrow function requires trailing comma in .mts files
+const fn = <T,>() => {};
+
+// With constraint - no trailing comma needed
+const fn2 = <T extends string>() => {};
+
+// Multiple type parameters - no special handling needed
+const fn3 = <T, U>() => {};
+
+===================== End =====================


### PR DESCRIPTION
## Summary

- Preserve trailing comma for single generic type parameters in arrow functions in `.mts` and `.cts` files
- Previously only JSX files (`.jsx`, `.tsx`) had this behavior, but `.mts`/`.cts` files also require it for disambiguation
- Add test cases for both `.mts` and `.cts` files

Closes #18924

🤖 Generated with [Claude Code](https://claude.ai/code)