### PR TITLE
refactor(linter/plugins): correct outdated comments

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -320,7 +320,7 @@ export type LanguageOptions = Readonly<typeof LANGUAGE_OPTIONS>;
 // However, we still want to discourage using these deprecated methods/getters in rules, because such rules
 // will not work in ESLint 10 in compatibility mode.
 //
-// TODO: When we write a rule tester, throw an error in the tester if the rule uses deprecated methods/getters.
+// TODO: Throw an error in `RuleTester` if the rule uses deprecated methods/getters.
 // We'll need to offer an option to opt out of these errors, for rules which delegate to another rule whose code
 // the author doesn't control.
 const FILE_CONTEXT = Object.freeze({

--- a/apps/oxlint/src-js/plugins/rule_meta.ts
+++ b/apps/oxlint/src-js/plugins/rule_meta.ts
@@ -45,7 +45,6 @@ export interface RuleMeta {
    * Default options for the rule.
    * If present, any user-provided options in their config will be merged on top of them recursively.
    */
-  // TODO: Use this to alter options passed to rules.
   defaultOptions?: Options;
   /**
    * Indicates whether the rule has been deprecated, and info about the deprecation and possible replacements.


### PR DESCRIPTION
Just update 1 outdated TODO comment, and delete another.