### PR TITLE
test(linter/plugins): add ability to fix suggestions in JS plugins tests

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -19,6 +19,7 @@ const NODE_BIN_PATH = process.execPath;
  * - `files` as the only argument (so only lints the files in the fixture's `files` directory).
  *
  * Fixtures with an `options.json` file containing `"fix": true` are also run with `--fix` CLI option.
+ * Fixtures with an `options.json` file containing `"fixSuggestions": true` are also run with `--fix-suggestions` CLI option.
  * The files' contents after fixes are recorded in the snapshot.
  *
  * Fixtures with an `options.json` file containing `"oxlint": false` are skipped.
@@ -61,5 +62,15 @@ async function runFixture(fixture: Fixture, expect: ExpectStatic): Promise<void>
   if (options.fix) {
     const fixArgs = [args[0], "--fix", ...args.slice(1)];
     await testFixtureWithCommand({ ...testOptions, args: fixArgs, snapshotName: "fix" });
+  }
+
+  // Run Oxlint with `--fix-suggestions` option
+  if (options.fixSuggestions) {
+    const fixArgs = [args[0], "--fix-suggestions", ...args.slice(1)];
+    await testFixtureWithCommand({
+      ...testOptions,
+      args: fixArgs,
+      snapshotName: "fix-suggestions",
+    });
   }
 }

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -27,6 +27,8 @@ export interface Fixture {
     eslint: boolean;
     // Run Oxlint with fixes. Default: `false`.
     fix: boolean;
+    // Run Oxlint with fix-suggestions. Default: `false`.
+    fixSuggestions: boolean;
     // Run Oxlint single-threaded. Default: `false`.
     singleThread: boolean;
     // Run Oxlint/ESLint in a specific working directory.
@@ -40,6 +42,7 @@ const DEFAULT_OPTIONS: Fixture["options"] = {
   oxlint: true,
   eslint: false,
   fix: false,
+  fixSuggestions: false,
   singleThread: false,
   cwd: null,
 };
@@ -76,10 +79,11 @@ export function getFixtures(): Fixture[] {
       typeof options.oxlint !== "boolean" ||
       typeof options.eslint !== "boolean" ||
       typeof options.fix !== "boolean" ||
+      typeof options.fixSuggestions !== "boolean" ||
       typeof options.singleThread !== "boolean"
     ) {
       throw new TypeError(
-        "`oxlint`, `eslint`, `fix`, and `singleThread` properties in `options.json` must be booleans",
+        "`oxlint`, `eslint`, `fix`, `fixSuggestions`, and `singleThread` properties in `options.json` must be booleans",
       );
     }
     if (options.cwd !== null && typeof options.cwd !== "string") {


### PR DESCRIPTION
Add ability to run `oxlint` with `--fix-suggestions` flag in tests.