### PR TITLE
feat(linter/plugins): implement suggestions

### DIFF
--- a/apps/oxlint/test/fixtures/suggestions/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/suggestions/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "suggestions-plugin/suggestions": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/suggestions/files/index.js
+++ b/apps/oxlint/test/fixtures/suggestions/files/index.js
@@ -1,0 +1,15 @@
+debugger;
+
+let a = 1;
+let b = 2;
+let c = 3;
+let d = 4;
+let e = 5;
+let f = 6;
+let g = 7;
+let h = 8;
+let i = 9;
+let j = 10;
+let k = 11;
+
+debugger;

--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -1,0 +1,32 @@
+# Exit code
+0
+
+# stdout
+```
+Found 0 warnings and 0 errors.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```
+
+# File altered: files/index.js
+```
+
+
+let daddy = 1;
+let abacus = 2;
+let magic = 3;
+let damned = 4;
+let elephant = 5;
+let feck = 6;
+let numpty = 7;
+let dangermouse = 8;
+let granular = 9;
+let cowabunga = 10;
+let kaboom = 11;
+
+
+
+```

--- a/apps/oxlint/test/fixtures/suggestions/fix.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix.snap.md
@@ -1,0 +1,114 @@
+# Exit code
+1
+
+# stdout
+```
+  x suggestions-plugin(suggestions): Remove debugger statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | 
+   `----
+
+  x suggestions-plugin(suggestions): Replace "a" with "daddy"
+   ,-[files/index.js:3:5]
+ 2 | 
+ 3 | let a = 1;
+   :     ^
+ 4 | let b = 2;
+   `----
+
+  x suggestions-plugin(suggestions): Replace "b" with "abacus"
+   ,-[files/index.js:4:5]
+ 3 | let a = 1;
+ 4 | let b = 2;
+   :     ^
+ 5 | let c = 3;
+   `----
+
+  x suggestions-plugin(suggestions): Prefix "c" with "magi"
+   ,-[files/index.js:5:5]
+ 4 | let b = 2;
+ 5 | let c = 3;
+   :     ^
+ 6 | let d = 4;
+   `----
+
+  x suggestions-plugin(suggestions): Prefix "d" with "damne"
+   ,-[files/index.js:6:5]
+ 5 | let c = 3;
+ 6 | let d = 4;
+   :     ^
+ 7 | let e = 5;
+   `----
+
+  x suggestions-plugin(suggestions): Postfix "e" with "lephant"
+   ,-[files/index.js:7:5]
+ 6 | let d = 4;
+ 7 | let e = 5;
+   :     ^
+ 8 | let f = 6;
+   `----
+
+  x suggestions-plugin(suggestions): Postfix "f" with "eck"
+   ,-[files/index.js:8:5]
+ 7 | let e = 5;
+ 8 | let f = 6;
+   :     ^
+ 9 | let g = 7;
+   `----
+
+  x suggestions-plugin(suggestions): Replace "g" with "numpty"
+    ,-[files/index.js:9:5]
+  8 | let f = 6;
+  9 | let g = 7;
+    :     ^
+ 10 | let h = 8;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "h" with "dangermouse"
+    ,-[files/index.js:10:5]
+  9 | let g = 7;
+ 10 | let h = 8;
+    :     ^
+ 11 | let i = 9;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "i" with "granular"
+    ,-[files/index.js:11:5]
+ 10 | let h = 8;
+ 11 | let i = 9;
+    :     ^
+ 12 | let j = 10;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "j" with "cowabunga"
+    ,-[files/index.js:12:5]
+ 11 | let i = 9;
+ 12 | let j = 10;
+    :     ^
+ 13 | let k = 11;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "k" with "kaboom"
+    ,-[files/index.js:13:5]
+ 12 | let j = 10;
+ 13 | let k = 11;
+    :     ^
+ 14 | 
+    `----
+
+  x suggestions-plugin(suggestions): Remove debugger statement
+    ,-[files/index.js:15:1]
+ 14 | 
+ 15 | debugger;
+    : ^^^^^^^^^
+    `----
+
+Found 0 warnings and 13 errors.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/suggestions/options.json
+++ b/apps/oxlint/test/fixtures/suggestions/options.json
@@ -1,0 +1,4 @@
+{
+  "fix": true,
+  "fixSuggestions": true
+}

--- a/apps/oxlint/test/fixtures/suggestions/output.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/output.snap.md
@@ -1,0 +1,114 @@
+# Exit code
+1
+
+# stdout
+```
+  x suggestions-plugin(suggestions): Remove debugger statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+ 2 | 
+   `----
+
+  x suggestions-plugin(suggestions): Replace "a" with "daddy"
+   ,-[files/index.js:3:5]
+ 2 | 
+ 3 | let a = 1;
+   :     ^
+ 4 | let b = 2;
+   `----
+
+  x suggestions-plugin(suggestions): Replace "b" with "abacus"
+   ,-[files/index.js:4:5]
+ 3 | let a = 1;
+ 4 | let b = 2;
+   :     ^
+ 5 | let c = 3;
+   `----
+
+  x suggestions-plugin(suggestions): Prefix "c" with "magi"
+   ,-[files/index.js:5:5]
+ 4 | let b = 2;
+ 5 | let c = 3;
+   :     ^
+ 6 | let d = 4;
+   `----
+
+  x suggestions-plugin(suggestions): Prefix "d" with "damne"
+   ,-[files/index.js:6:5]
+ 5 | let c = 3;
+ 6 | let d = 4;
+   :     ^
+ 7 | let e = 5;
+   `----
+
+  x suggestions-plugin(suggestions): Postfix "e" with "lephant"
+   ,-[files/index.js:7:5]
+ 6 | let d = 4;
+ 7 | let e = 5;
+   :     ^
+ 8 | let f = 6;
+   `----
+
+  x suggestions-plugin(suggestions): Postfix "f" with "eck"
+   ,-[files/index.js:8:5]
+ 7 | let e = 5;
+ 8 | let f = 6;
+   :     ^
+ 9 | let g = 7;
+   `----
+
+  x suggestions-plugin(suggestions): Replace "g" with "numpty"
+    ,-[files/index.js:9:5]
+  8 | let f = 6;
+  9 | let g = 7;
+    :     ^
+ 10 | let h = 8;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "h" with "dangermouse"
+    ,-[files/index.js:10:5]
+  9 | let g = 7;
+ 10 | let h = 8;
+    :     ^
+ 11 | let i = 9;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "i" with "granular"
+    ,-[files/index.js:11:5]
+ 10 | let h = 8;
+ 11 | let i = 9;
+    :     ^
+ 12 | let j = 10;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "j" with "cowabunga"
+    ,-[files/index.js:12:5]
+ 11 | let i = 9;
+ 12 | let j = 10;
+    :     ^
+ 13 | let k = 11;
+    `----
+
+  x suggestions-plugin(suggestions): Replace "k" with "kaboom"
+    ,-[files/index.js:13:5]
+ 12 | let j = 10;
+ 13 | let k = 11;
+    :     ^
+ 14 | 
+    `----
+
+  x suggestions-plugin(suggestions): Remove debugger statement
+    ,-[files/index.js:15:1]
+ 14 | 
+ 15 | debugger;
+    : ^^^^^^^^^
+    `----
+
+Found 0 warnings and 13 errors.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/suggestions/plugin.ts
+++ b/apps/oxlint/test/fixtures/suggestions/plugin.ts
@@ -1,0 +1,238 @@
+import type { Node, Plugin, Rule, Suggestion } from "#oxlint/plugins";
+
+const rule: Rule = {
+  meta: {
+    hasSuggestions: true,
+  },
+  create(context) {
+    let debuggerCount = 0;
+    return {
+      DebuggerStatement(node) {
+        debuggerCount++;
+
+        let thisIsSuggestion;
+
+        const suggestion: Suggestion = {
+          desc: "Do it",
+          fix(fixer) {
+            thisIsSuggestion = this === suggestion;
+            if (debuggerCount === 1) return fixer.remove(node);
+            return fixer.removeRange([node.start, node.end]);
+          },
+        };
+
+        context.report({
+          message: "Remove debugger statement",
+          node,
+          suggest: [suggestion],
+        });
+
+        if (!thisIsSuggestion) {
+          context.report({ message: `this in fix function is not suggestion object`, node });
+        }
+      },
+      Identifier(node) {
+        switch (node.name) {
+          case "a":
+            return context.report({
+              message: 'Replace "a" with "daddy"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.replaceText(node, "daddy");
+                  },
+                },
+              ],
+            });
+
+          case "b":
+            return context.report({
+              message: 'Replace "b" with "abacus"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.replaceTextRange([node.start, node.end], "abacus");
+                  },
+                },
+              ],
+            });
+
+          case "c":
+            return context.report({
+              message: 'Prefix "c" with "magi"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.insertTextBefore(node, "magi");
+                  },
+                },
+              ],
+            });
+
+          case "d":
+            return context.report({
+              message: 'Prefix "d" with "damne"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.insertTextBeforeRange([node.start, node.end], "damne");
+                  },
+                },
+              ],
+            });
+
+          case "e":
+            return context.report({
+              message: 'Postfix "e" with "lephant"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.insertTextAfter(node, "lephant");
+                  },
+                },
+              ],
+            });
+
+          case "f":
+            return context.report({
+              message: 'Postfix "f" with "eck"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.insertTextAfterRange([node.start, node.end], "eck");
+                  },
+                },
+              ],
+            });
+
+          case "g":
+            return context.report({
+              message: 'Replace "g" with "numpty"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    // Fixes can be in any order
+                    return [
+                      fixer.insertTextAfter(node, "ty"),
+                      // Test that any object with `range` property works
+                      fixer.replaceText({ range: [node.start, node.end] } as Node, "mp"),
+                      fixer.insertTextBefore(node, "nu"),
+                    ];
+                  },
+                },
+              ],
+            });
+
+          case "h":
+            return context.report({
+              message: 'Replace "h" with "dangermouse"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    // Fixes can be in any order
+                    const { range } = node;
+                    return [
+                      fixer.replaceTextRange(range, "er"),
+                      fixer.insertTextAfterRange(range, "mouse"),
+                      fixer.insertTextBeforeRange(range, "dang"),
+                    ];
+                  },
+                },
+              ],
+            });
+
+          case "i":
+            return context.report({
+              message: 'Replace "i" with "granular"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  // `fix` can be a generator function
+                  *fix(fixer) {
+                    yield fixer.insertTextBefore(node, "gra");
+                    yield fixer.replaceText(node, "nu");
+                    // Test that any object with `range` property works
+                    yield fixer.insertTextAfter({ range: [node.start, node.end] } as Node, "lar");
+                  },
+                },
+              ],
+            });
+
+          case "j":
+            return context.report({
+              message: 'Replace "j" with "cowabunga"',
+              node,
+              suggest: [
+                {
+                  desc: "Do it",
+                  // `fix` can be a generator function
+                  *fix(fixer) {
+                    // Fixes can be in any order
+                    const { range } = node;
+                    yield fixer.insertTextAfterRange(range, "bunga");
+                    yield fixer.replaceTextRange(range, "a");
+                    yield fixer.insertTextBeforeRange(range, "cow");
+                  },
+                },
+              ],
+            });
+
+          case "k":
+            return context.report({
+              message: 'Replace "k" with "kaboom"',
+              node,
+              // `--fix-suggestions` will apply only the first suggestion
+              suggest: [
+                {
+                  desc: "Do it",
+                  fix(fixer) {
+                    return fixer.insertTextAfter(node, "aboom");
+                  },
+                },
+                {
+                  desc: "Do something else",
+                  fix(fixer) {
+                    return fixer.insertTextBefore(node, "prefix1");
+                  },
+                },
+                {
+                  desc: "Do another thing",
+                  fix(fixer) {
+                    return fixer.insertTextBefore(node, "prefix2");
+                  },
+                },
+              ],
+            });
+        }
+      },
+    };
+  },
+};
+
+const plugin: Plugin = {
+  meta: {
+    name: "suggestions-plugin",
+  },
+  rules: {
+    suggestions: rule,
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -139,7 +139,7 @@ pub struct ContextHost<'a> {
     ///
     /// Set via the `--fix`, `--fix-suggestions`, and `--fix-dangerously` CLI
     /// flags.
-    pub(super) fix: FixKind,
+    pub(crate) fix: FixKind,
     /// Path to the file being linted.
     pub(super) file_path: Box<Path>,
     /// Extension of the file being linted.

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -77,6 +77,7 @@ pub struct LintFileResult {
     pub start: u32,
     pub end: u32,
     pub fixes: Option<Vec<JsFix>>,
+    pub suggestions: Option<Vec<JsSuggestion>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -84,6 +85,13 @@ pub struct LintFileResult {
 pub struct JsFix {
     pub range: [u32; 2],
     pub text: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JsSuggestion {
+    pub message: String,
+    pub fixes: Vec<JsFix>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Implement support for suggestions.

Implementation exactly matches ESLint's.

The tests demonstrate that:

* `--fix-suggestions` applies suggestions.
* `--fix` does *not* apply suggestions.
* When a rule provides multiple suggestions, only the 1st is applied.

I've also confirmed that suggestions show up correctly in VSCode (once language server supports JS plugins).