### PR TITLE
chore(napi/parser): use dot reporter in CI to reduce log output

### DIFF
--- a/napi/parser/vitest.config.ts
+++ b/napi/parser/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       expand: false,
     },
     exclude,
+    reporters: process.env.CI ? ["dot"] : ["default"],
   },
   plugins: [
     // Enable Codspeed plugin in CI only


### PR DESCRIPTION
## Summary

- Use `dot` reporter in CI to avoid logging ~58,000 test names from `parse-raw.test.ts`
- `parse-raw.test.ts` runs test cases via `it.each()` from Test262 (~46k), TypeScript (~11k), and JSX (~40) fixtures

🤖 Generated with [Claude Code](https://claude.ai/code)