### PR TITLE
fix(linter/valid-expect): allow string message in Vitest valid-expect

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
@@ -60,6 +60,9 @@ pub struct ValidExpectConfig {
     min_args: usize,
     /// Maximum number of arguments `expect` should be called with.
     max_args: usize,
+    /// When `true`, allow a string or template literal second argument as a custom message.
+    #[serde(skip)]
+    allow_string_message_arg: bool,
     /// When `true`, async assertions must be awaited in all contexts (not just return statements).
     always_await: bool,
 }
@@ -70,6 +73,7 @@ impl Default for ValidExpectConfig {
             async_matchers: vec![String::from("toResolve"), String::from("toReject")],
             min_args: 1,
             max_args: 1,
+            allow_string_message_arg: false,
             always_await: false,
         }
     }
@@ -103,7 +107,12 @@ impl ValidExpectConfig {
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
 
-        Self { async_matchers, min_args, max_args, always_await }
+        Self { async_matchers, min_args, max_args, allow_string_message_arg: false, always_await }
+    }
+
+    pub fn allow_string_message_arg(mut self) -> Self {
+        self.allow_string_message_arg = true;
+        self
     }
 
     pub fn run_once(&self, ctx: &LintContext) {
@@ -158,7 +167,13 @@ impl ValidExpectConfig {
             return;
         };
 
-        if call_expr.arguments.len() > self.max_args {
+        let allow_message_arg = self.allow_string_message_arg
+            && call_expr.arguments.len() == 2
+            && call_expr.arguments.get(1).and_then(|arg| arg.as_expression()).is_some_and(|expr| {
+                matches!(expr, Expression::StringLiteral(_) | Expression::TemplateLiteral(_))
+            });
+
+        if call_expr.arguments.len() > self.max_args && !allow_message_arg {
             let error = format!(
                 "Expect takes at most {} argument{} ",
                 self.max_args,

--- a/crates/oxc_linter/src/rules/vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/valid_expect.rs
@@ -6,8 +6,14 @@ use crate::{
     rules::shared::valid_expect::{DOCUMENTATION, ValidExpectConfig},
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ValidExpect(Box<ValidExpectConfig>);
+
+impl Default for ValidExpect {
+    fn default() -> Self {
+        Self(Box::new(ValidExpectConfig::default().allow_string_message_arg()))
+    }
+}
 
 declare_oxc_lint!(
     ValidExpect,
@@ -21,7 +27,7 @@ declare_oxc_lint!(
 
 impl Rule for ValidExpect {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(Self(Box::new(ValidExpectConfig::from_configuration(&value))))
+        Ok(Self(Box::new(ValidExpectConfig::from_configuration(&value).allow_string_message_arg())))
     }
 
     fn run_once(&self, ctx: &LintContext) {
@@ -140,6 +146,9 @@ fn test() {
         ),
         ("expect(1).toBe(2);", Some(serde_json::json!([{ "maxArgs": 2 }]))),
         ("expect(1, \"1 !== 2\").toBe(2);", Some(serde_json::json!([{ "maxArgs": 2 }]))),
+        ("expect(1, \"sum is incorrect\").toBe(1);", None),
+        ("test(\"valid-expect\", () => { expect(1 + 2, \"sum is incorrect\").toBe(3); });", None),
+        ("test(\"valid-expect\", () => { expect(1 + 2, `sum is ${label}`).toBe(3); });", None),
         (
             "test(\"valid-expect\", () => { expect(2).not.toBe(2); });",
             Some(serde_json::json!([{ "asyncMatchers": ["toRejectWith"] }])),
@@ -162,12 +171,12 @@ fn test() {
         ("expect().toBe(2);", Some(serde_json::json!([{ "minArgs": "undefined", "maxArgs": "undefined" }]))),
         ("expect().toBe(true);", None),
         ("expect().toEqual(\"something\");", None),
-        ("expect(\"something\", \"else\").toEqual(\"something\");", None),
         ("expect(\"something\", \"else\", \"entirely\").toEqual(\"something\");", Some(serde_json::json!([{ "maxArgs": 2 }]))),
         ("expect(\"something\", \"else\", \"entirely\").toEqual(\"something\");", Some(serde_json::json!([{ "maxArgs": 2, "minArgs": 2 }]))),
         ("expect(\"something\", \"else\", \"entirely\").toEqual(\"something\");", Some(serde_json::json!([{ "maxArgs": 2, "minArgs": 1 }]))),
         ("expect(\"something\").toEqual(\"something\");", Some(serde_json::json!([{ "minArgs": 2 }]))),
         ("expect(\"something\", \"else\").toEqual(\"something\");", Some(serde_json::json!([{ "maxArgs": 1, "minArgs": 3 }]))),
+        ("expect(1, message).toBe(1);", None),
         ("expect(\"something\");", None),
         ("expect();", None),
         ("expect(true).toBeDefined;", None),

--- a/crates/oxc_linter/src/snapshots/vitest_valid_expect.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_valid_expect.snap
@@ -23,13 +23,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
-   ╭─[valid_expect.tsx:1:1]
- 1 │ expect("something", "else").toEqual("something");
-   · ───────────────────────────
-   ╰────
-  help: Remove the extra arguments.
-
   ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 2 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else", "entirely").toEqual("something");
@@ -58,10 +51,17 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add the missing arguments.
 
-  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+  ⚠ eslint-plugin-vitest(valid-expect): Expect requires at least 3 arguments
    ╭─[valid_expect.tsx:1:1]
  1 │ expect("something", "else").toEqual("something");
    · ───────────────────────────
+   ╰────
+  help: Add the missing arguments.
+
+  ⚠ eslint-plugin-vitest(valid-expect): Expect takes at most 1 argument
+   ╭─[valid_expect.tsx:1:1]
+ 1 │ expect(1, message).toBe(1);
+   · ──────────────────
    ╰────
   help: Remove the extra arguments.
 


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/18851

Allows a 2nd expect argument when it is a string or template literal,
matching eslint-plugin-vitest behavior (https://github.com/vitest-dev/eslint-plugin-vitest/blob/472ba3d120e12eb7faa3d625c59679caa3ef2211/src/rules/valid-expect.ts#L315-L329).

Now this won't throw an error:

```ts
import { expect, test } from 'vitest'

test('adds 1 + 2 to equal 3', () => {
  expect(1 + 2, "sum is incorrect").toBe(4)
})
```

As this diverges from the jest rule, the PR is on top #21430 