### PR TITLE
fix(oxfmt): workaround Node.js ThreadsafeFunction cleanup race condition

### DIFF
--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -55,4 +55,13 @@ void (async () => {
   // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
   // https://nodejs.org/api/process.html#processexitcode
   process.exitCode = exitCode!;
+
+  // Node.js < 25.4.0 has a race condition with ThreadsafeFunction cleanup that causes
+  // crashes on large codebases. Add a small delay to allow pending NAPI operations
+  // to complete before exit. Fixed in Node.js 25.4.0+.
+  // See: https://github.com/nodejs/node/issues/55706
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  if (major < 25 || (major === 25 && minor < 4)) {
+    setTimeout(() => process.exit(), 50);
+  }
 })();


### PR DESCRIPTION
Node.js < 25.4.0 has a race condition with ThreadsafeFunction cleanup during V8 shutdown that causes crashes on large codebases. This adds a 50ms delay before `process.exit()` to allow pending NAPI operations to complete.

The crash manifests as `Check failed: node->IsInUse()` or `Check failed: object_ != kGlobalHandleZapValue` in `napi_reference_unref`, occurring at ~39% rate on large codebases (12,000+ files) without the workaround.

The issue is fixed in Node.js 25.4.0+, so the workaround is only applied for earlier versions.

See: https://github.com/nodejs/node/issues/55706