### PR TITLE
fix(formatter): keep spread with callback on same line

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/call-expression/spread-with-callback.js
+++ b/crates/oxc_formatter/tests/fixtures/js/call-expression/spread-with-callback.js
@@ -1,0 +1,28 @@
+// Issue #18930 - spread with arrow callback
+target(...argument, () => {
+  // code
+});
+
+// Issue #18971 - spread with arrow callback returning value
+fn(...x, v => {
+  return v;
+});
+
+// Additional test cases
+foo(...args, (a, b) => {
+  console.log(a, b);
+});
+
+bar(...items, function() {
+  return 1;
+});
+
+// Multiple spreads
+baz(...a, ...b, () => {
+  return;
+});
+
+// Spread in the middle
+qux(first, ...rest, () => {
+  return;
+});

--- a/crates/oxc_formatter/tests/fixtures/js/call-expression/spread-with-callback.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/call-expression/spread-with-callback.js.snap
@@ -1,0 +1,99 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18930 - spread with arrow callback
+target(...argument, () => {
+  // code
+});
+
+// Issue #18971 - spread with arrow callback returning value
+fn(...x, v => {
+  return v;
+});
+
+// Additional test cases
+foo(...args, (a, b) => {
+  console.log(a, b);
+});
+
+bar(...items, function() {
+  return 1;
+});
+
+// Multiple spreads
+baz(...a, ...b, () => {
+  return;
+});
+
+// Spread in the middle
+qux(first, ...rest, () => {
+  return;
+});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18930 - spread with arrow callback
+target(...argument, () => {
+  // code
+});
+
+// Issue #18971 - spread with arrow callback returning value
+fn(...x, (v) => {
+  return v;
+});
+
+// Additional test cases
+foo(...args, (a, b) => {
+  console.log(a, b);
+});
+
+bar(...items, function () {
+  return 1;
+});
+
+// Multiple spreads
+baz(...a, ...b, () => {
+  return;
+});
+
+// Spread in the middle
+qux(first, ...rest, () => {
+  return;
+});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18930 - spread with arrow callback
+target(...argument, () => {
+  // code
+});
+
+// Issue #18971 - spread with arrow callback returning value
+fn(...x, (v) => {
+  return v;
+});
+
+// Additional test cases
+foo(...args, (a, b) => {
+  console.log(a, b);
+});
+
+bar(...items, function () {
+  return 1;
+});
+
+// Multiple spreads
+baz(...a, ...b, () => {
+  return;
+});
+
+// Spread in the middle
+qux(first, ...rest, () => {
+  return;
+});
+
+===================== End =====================


### PR DESCRIPTION
## Summary

When a function call has exactly 2 arguments where the first is a spread element and the second is a callback function, oxfmt was incorrectly breaking the arguments onto multiple lines, while Prettier keeps them on the same line.

**Before (wrong):**
```js
target(
  ...argument,
  () => {
    // code
  },
);
```

**After (correct, matches Prettier):**
```js
target(...argument, () => {
  // code
});
```

## Root Cause

In `arguments_grouped_layout`, `first.as_expression()` returns `None` for `SpreadElement` (since it's not an `Expression` variant), causing the function to return early without checking if the last argument could be grouped.

## Fix

The fix passes the optional expression directly to `should_group_last_argument_impl`, which already handles `None` correctly for the same-type checking. This simplifies the code while fixing the issue.

Fixes #18930
Fixes #18971

## Test plan

- [x] Added test fixture with various spread + callback patterns
- [x] All 154 formatter tests pass
- [x] Prettier conformance unchanged (99.07% JS, 98.17% TS)

🤖 Generated with [Claude Code](https://claude.ai/code)