### PR TITLE
fix(linter): move primary span to loop in no-accumulating-spread

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -56,9 +56,9 @@ fn loop_spread_likely_object_diagnostic(
         .with_help("Consider using `Object.assign()` to mutate the accumulator instead.")
         .with_note("Using spreads within accumulators leads to `O(n^2)` time complexity.")
         .with_labels([
+            loop_span.label("For this loop"),
             accumulator_decl_span.label("From this accumulator"),
             spread_span.label("From this spread"),
-            loop_span.label("For this loop"),
         ])
 }
 fn loop_spread_likely_array_diagnostic(
@@ -70,9 +70,9 @@ fn loop_spread_likely_array_diagnostic(
         .with_help("Consider using `Array.prototype.push()` to mutate the accumulator instead.")
         .with_note("Using spreads within accumulators leads to `O(n^2)` time complexity.")
         .with_labels([
+            loop_span.label("For this loop"),
             accumulator_decl_span.label("From this accumulator"),
             spread_span.label("From this spread"),
-            loop_span.label("For this loop"),
         ])
 }
 


### PR DESCRIPTION
## Summary

- Fixed [#18988](https://github.com/oxc-project/oxc/issues/18988): the `oxc/no-accumulating-spread` rule's primary span (first label) now points to the loop statement instead of the accumulator declaration. This affects diagnostic positioning in editors (LSP) and JSON output, where the first label determines the reported location.

## Changes

Reordered labels in `loop_spread_likely_object_diagnostic` and `loop_spread_likely_array_diagnostic` so that `loop_span` comes first (becoming the primary span), followed by `accumulator_decl_span` and `spread_span`.

## Test plan

- All existing `no_accumulating_spread` tests pass without modification
- Snapshot output is unchanged (miette renders labels by source position regardless of order)
- The change affects `Info::new` in `reporter.rs` which uses `labels.next()` (first label) for diagnostic positioning