### PR TITLE
fix(linter/no-map-spread): improve actionability of error message

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -51,14 +51,16 @@ fn no_map_spread_diagnostic(
                 "Spreading to modify object properties in `map` calls is inefficient",
             )
             .with_labels([map_call.label("This map call spreads an object"), first])
-            .with_help("Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object")
-            .with_note("Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable."),
+            .with_help("Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object")
+            .with_note("Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable."),
             // Array
             Spread::Array(_) => OxcDiagnostic::warn(
                 "Spreading to modify array elements in `map` calls is inefficient",
             )
             .with_labels([map_call.label("This map call spreads an array"), first])
-            .with_help("Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array"),
+            .with_help("Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array")
+            .with_note("Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.")
+            ,
         };
 
     diagnostic.and_labels(others).and_labels(returned_label)

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -33,9 +33,9 @@ fn no_map_spread_diagnostic(
     assert!(!spans.is_empty());
     let mut spread_labels = spread.spread_spans().into_iter();
     let first_message = if spans.len() == 1 {
-        "It should be mutated in place"
+        "This spread creates an unnecessary copy"
     } else {
-        "They should be mutated in place"
+        "These spreads create unnecessary copies"
     };
     let first = spread_labels.next().unwrap().label(first_message);
     let others = spread_labels.map(LabeledSpan::from);
@@ -51,13 +51,13 @@ fn no_map_spread_diagnostic(
                 "Spreading to modify object properties in `map` calls is inefficient",
             )
             .with_labels([map_call.label("This map call spreads an object"), first])
-            .with_help("Consider using `Object.assign` instead"),
+            .with_help("Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object"),
             // Array
             Spread::Array(_) => OxcDiagnostic::warn(
                 "Spreading to modify array elements in `map` calls is inefficient",
             )
             .with_labels([map_call.label("This map call spreads an array"), first])
-            .with_help("Consider using `Array.prototype.concat` or `Array.prototype.push` instead"),
+            .with_help("Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array"),
         };
 
     diagnostic.and_labels(others).and_labels(returned_label)

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -51,7 +51,8 @@ fn no_map_spread_diagnostic(
                 "Spreading to modify object properties in `map` calls is inefficient",
             )
             .with_labels([map_call.label("This map call spreads an object"), first])
-            .with_help("Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object"),
+            .with_help("Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object")
+            .with_note("Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable."),
             // Array
             Spread::Array(_) => OxcDiagnostic::warn(
                 "Spreading to modify array elements in `map` calls is inefficient",

--- a/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
@@ -6,120 +6,120 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x }))
    ·           ─┬─         ──┬─
-   ·            │            ╰── It should be mutated in place
+   ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x, ...y }))
    ·           ─┬─         ──┬─  ────
-   ·            │            ╰── They should be mutated in place
+   ·            │            ╰── These spreads create unnecessary copies
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:23]
  1 │ let b = []; let a = b.map(x => ({ ...x }))
    ·                       ─┬─         ──┬─
-   ·                        │            ╰── It should be mutated in place
+   ·                        │            ╰── This spread creates an unnecessary copy
    ·                        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { return { ...x } })
    ·           ─┬─                 ──┬─
-   ·            │                    ╰── It should be mutated in place
+   ·            │                    ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => [ ...x ])
    ·           ─┬─        ──┬─
-   ·            │           ╰── It should be mutated in place
+   ·            │           ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.concat` or `Array.prototype.push` instead
+  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => [ ...x, ...y ])
    ·           ─┬─        ──┬─  ────
-   ·            │           ╰── They should be mutated in place
+   ·            │           ╰── These spreads create unnecessary copies
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.concat` or `Array.prototype.push` instead
+  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { return [ ...x ] })
    ·           ─┬─                 ──┬─
-   ·            │                    ╰── It should be mutated in place
+   ·            │                    ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.concat` or `Array.prototype.push` instead
+  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map?.(x => ({ ...x }))
    ·   ─┬─           ──┬─
-   ·    │              ╰── It should be mutated in place
+   ·    │              ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.flatMap(x => ({ ...x }))
    ·           ───┬───         ──┬─
-   ·              │              ╰── It should be mutated in place
+   ·              │              ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x })); console.log(b)
    ·           ─┬─         ──┬─
-   ·            │            ╰── It should be mutated in place
+   ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:39]
  1 │ let b = []; console.log(b); let a = b.map(x => ({ ...x }));
    ·                                       ─┬─         ──┬─
-   ·                                        │            ╰── It should be mutated in place
+   ·                                        │            ╰── This spread creates an unnecessary copy
    ·                                        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { let x2 = { ...x }; return x2; })
    ·           ─┬─                   ──┬─           ─┬
    ·            │                      │             ╰── Map returns the spread here
-   ·            │                      ╰── It should be mutated in place
+   ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { let x2 = { ...x }; let x3 = x2; return x3; })
    ·           ─┬─                   ──┬─                        ─┬
    ·            │                      │                          ╰── Map returns the spread here
-   ·            │                      ╰── It should be mutated in place
+   ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -128,7 +128,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
  2 │             let y = { ...x };
    ·                       ──┬─
-   ·                         ╰── It should be mutated in place
+   ·                         ╰── This spread creates an unnecessary copy
  3 │             if (y.foo) {
    ╰────
    ╭─[no_map_spread.tsx:6:21]
@@ -138,166 +138,166 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ╰── Map returns the spread here
  7 │             }
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => someCond ? { ...x, foo: true } : { ...x, foo: false })
    ·           ─┬─                   ──┬─
-   ·            │                      ╰── It should be mutated in place
+   ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => someCond ? { ...x, foo: true } : { ...x, foo: false })
    ·           ─┬─                                         ──┬─
-   ·            │                                            ╰── It should be mutated in place
+   ·            │                                            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map( ({ x, y }) => ({ ...(cond ? x : y) }) )
    ·           ─┬─                   ────────┬────────
-   ·            │                            ╰── It should be mutated in place
+   ·            │                            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
  1 │ const b = a.map((x, i) => y ? { ...x, i } : x)
    ·             ─┬─                 ──┬─
-   ·              │                    ╰── It should be mutated in place
+   ·              │                    ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
  1 │ const b = a.map((x, i) => y ? x : { ...x, i })
    ·             ─┬─                     ──┬─
-   ·              │                        ╰── It should be mutated in place
+   ·              │                        ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => (0, { ...x }))
    ·           ─┬─            ──┬─
-   ·            │               ╰── It should be mutated in place
+   ·            │               ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(({ x, y }) => (x ?? { ...y }))
    ·           ─┬─                       ──┬─
-   ·            │                          ╰── It should be mutated in place
+   ·            │                          ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map((x => ({ ...x }))) as MyCustomMapper
    ·           ─┬─          ──┬─
-   ·            │             ╰── It should be mutated in place
+   ·            │             ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:7]
  1 │ foo().map(x => ({ ...x }))
    ·       ─┬─         ──┬─
-   ·        │            ╰── It should be mutated in place
+   ·        │            ╰── This spread creates an unnecessary copy
    ·        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:8]
  1 │ foo[1].map(x => ({ ...x }))
    ·        ─┬─         ──┬─
-   ·         │            ╰── It should be mutated in place
+   ·         │            ╰── This spread creates an unnecessary copy
    ·         ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ foo?.bar?.map(x => ({ ...x }))
    ·           ─┬─         ──┬─
-   ·            │            ╰── It should be mutated in place
+   ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:14]
  1 │ (foo ?? bar).map(x => ({ ...x }))
    ·              ─┬─         ──┬─
-   ·               │            ╰── It should be mutated in place
+   ·               │            ╰── This spread creates an unnecessary copy
    ·               ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:10]
  1 │ obj.#foo.map(x => ({ ...x }))
    ·          ─┬─         ──┬─
-   ·           │            ╰── It should be mutated in place
+   ·           │            ╰── This spread creates an unnecessary copy
    ·           ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...x.y }))
    ·   ─┬─         ───┬──
-   ·    │             ╰── It should be mutated in place
+   ·    │             ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...x[y] }))
    ·   ─┬─         ───┬───
-   ·    │             ╰── It should be mutated in place
+   ·    │             ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...(x ?? y) }))
    ·   ─┬─         ─────┬─────
-   ·    │               ╰── It should be mutated in place
+   ·    │               ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:28]
  1 │ function foo(a) { return a.map(x => ({ ...(x ?? y) })) }
    ·                            ─┬─         ─────┬─────
-   ·                             │               ╰── It should be mutated in place
+   ·                             │               ╰── This spread creates an unnecessary copy
    ·                             ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:20]
  1 │ const foo = a => a.map(x => ({ ...(x ?? y) }))
    ·                    ─┬─         ─────┬─────
-   ·                     │               ╰── It should be mutated in place
+   ·                     │               ╰── This spread creates an unnecessary copy
    ·                     ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign` instead
+  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object

--- a/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
@@ -9,8 +9,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -19,8 +19,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │            ╰── These spreads create unnecessary copies
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:23]
@@ -29,8 +29,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │            ╰── This spread creates an unnecessary copy
    ·                        ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -39,8 +39,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                    ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -49,7 +49,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │           ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an array
    ╰────
-  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
+  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
+  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -58,7 +59,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │           ╰── These spreads create unnecessary copies
    ·            ╰── This map call spreads an array
    ╰────
-  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
+  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
+  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -67,7 +69,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                    ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an array
    ╰────
-  help: Use `Array.prototype.push()` or `.concat()` to add elements without copying the entire array
+  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
+  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -76,8 +79,8 @@ source: crates/oxc_linter/src/tester.rs
    ·    │              ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -86,8 +89,8 @@ source: crates/oxc_linter/src/tester.rs
    ·              │              ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -96,8 +99,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:39]
@@ -106,8 +109,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                        │            ╰── This spread creates an unnecessary copy
    ·                                        ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -117,8 +120,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -128,8 +131,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -148,8 +151,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ╰── Map returns the spread here
  7 │             }
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -158,8 +161,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                      ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -168,8 +171,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                                            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -178,8 +181,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
@@ -188,8 +191,8 @@ source: crates/oxc_linter/src/tester.rs
    ·              │                    ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
@@ -198,8 +201,8 @@ source: crates/oxc_linter/src/tester.rs
    ·              │                        ╰── This spread creates an unnecessary copy
    ·              ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -208,8 +211,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │               ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -218,8 +221,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                          ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -228,8 +231,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │             ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:7]
@@ -238,8 +241,8 @@ source: crates/oxc_linter/src/tester.rs
    ·        │            ╰── This spread creates an unnecessary copy
    ·        ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:8]
@@ -248,8 +251,8 @@ source: crates/oxc_linter/src/tester.rs
    ·         │            ╰── This spread creates an unnecessary copy
    ·         ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -258,8 +261,8 @@ source: crates/oxc_linter/src/tester.rs
    ·            │            ╰── This spread creates an unnecessary copy
    ·            ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:14]
@@ -268,8 +271,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               │            ╰── This spread creates an unnecessary copy
    ·               ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:10]
@@ -278,8 +281,8 @@ source: crates/oxc_linter/src/tester.rs
    ·           │            ╰── This spread creates an unnecessary copy
    ·           ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -288,8 +291,8 @@ source: crates/oxc_linter/src/tester.rs
    ·    │             ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -298,8 +301,8 @@ source: crates/oxc_linter/src/tester.rs
    ·    │             ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -308,8 +311,8 @@ source: crates/oxc_linter/src/tester.rs
    ·    │               ╰── This spread creates an unnecessary copy
    ·    ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:28]
@@ -318,8 +321,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                             │               ╰── This spread creates an unnecessary copy
    ·                             ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:20]
@@ -328,5 +331,5 @@ source: crates/oxc_linter/src/tester.rs
    ·                     │               ╰── This spread creates an unnecessary copy
    ·                     ╰── This map call spreads an object
    ╰────
-  help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
+  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.

--- a/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
@@ -1,138 +1,139 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x }))
    ·           ─┬─         ──┬─
-   ·            │            ╰── This spread creates an unnecessary copy
+   ·            │            ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x, ...y }))
    ·           ─┬─         ──┬─  ────
-   ·            │            ╰── These spreads create unnecessary copies
+   ·            │            ╰── These spreads allocate new values on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:23]
  1 │ let b = []; let a = b.map(x => ({ ...x }))
    ·                       ─┬─         ──┬─
-   ·                        │            ╰── This spread creates an unnecessary copy
+   ·                        │            ╰── This spread allocates a new value on each iteration
    ·                        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { return { ...x } })
    ·           ─┬─                 ──┬─
-   ·            │                    ╰── This spread creates an unnecessary copy
+   ·            │                    ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => [ ...x ])
    ·           ─┬─        ──┬─
-   ·            │           ╰── This spread creates an unnecessary copy
+   ·            │           ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
-  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
+  help: If in-place mutation is acceptable, use `push` (or `concat` when semantics match) instead of spreading
+  note: `push` mutates the array. `concat` returns a new array and is not equivalent for every iterable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => [ ...x, ...y ])
    ·           ─┬─        ──┬─  ────
-   ·            │           ╰── These spreads create unnecessary copies
+   ·            │           ╰── These spreads allocate new values on each iteration
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
-  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
+  help: If in-place mutation is acceptable, use `push` (or `concat` when semantics match) instead of spreading
+  note: `push` mutates the array. `concat` returns a new array and is not equivalent for every iterable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { return [ ...x ] })
    ·           ─┬─                 ──┬─
-   ·            │                    ╰── This spread creates an unnecessary copy
+   ·            │                    ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an array
    ╰────
-  help: Consider using `Array.prototype.push()` or `.concat()` to add elements, this avoids copying the entire array
-  note: Note: `push` mutates the original arrays in the array. `concat` does not but has different semantics than spreading. Disable this rule if neither is acceptable.
+  help: If in-place mutation is acceptable, use `push` (or `concat` when semantics match) instead of spreading
+  note: `push` mutates the array. `concat` returns a new array and is not equivalent for every iterable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map?.(x => ({ ...x }))
    ·   ─┬─           ──┬─
-   ·    │              ╰── This spread creates an unnecessary copy
+   ·    │              ╰── This spread allocates a new value on each iteration
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.flatMap(x => ({ ...x }))
    ·           ───┬───         ──┬─
-   ·              │              ╰── This spread creates an unnecessary copy
+   ·              │              ╰── This spread allocates a new value on each iteration
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => ({ ...x })); console.log(b)
    ·           ─┬─         ──┬─
-   ·            │            ╰── This spread creates an unnecessary copy
+   ·            │            ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:39]
  1 │ let b = []; console.log(b); let a = b.map(x => ({ ...x }));
    ·                                       ─┬─         ──┬─
-   ·                                        │            ╰── This spread creates an unnecessary copy
+   ·                                        │            ╰── This spread allocates a new value on each iteration
    ·                                        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { let x2 = { ...x }; return x2; })
    ·           ─┬─                   ──┬─           ─┬
    ·            │                      │             ╰── Map returns the spread here
-   ·            │                      ╰── This spread creates an unnecessary copy
+   ·            │                      ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => { let x2 = { ...x }; let x3 = x2; return x3; })
    ·           ─┬─                   ──┬─                        ─┬
    ·            │                      │                          ╰── Map returns the spread here
-   ·            │                      ╰── This spread creates an unnecessary copy
+   ·            │                      ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -141,7 +142,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
  2 │             let y = { ...x };
    ·                       ──┬─
-   ·                         ╰── This spread creates an unnecessary copy
+   ·                         ╰── This spread allocates a new value on each iteration
  3 │             if (y.foo) {
    ╰────
    ╭─[no_map_spread.tsx:6:21]
@@ -151,185 +152,185 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ╰── Map returns the spread here
  7 │             }
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => someCond ? { ...x, foo: true } : { ...x, foo: false })
    ·           ─┬─                   ──┬─
-   ·            │                      ╰── This spread creates an unnecessary copy
+   ·            │                      ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => someCond ? { ...x, foo: true } : { ...x, foo: false })
    ·           ─┬─                                         ──┬─
-   ·            │                                            ╰── This spread creates an unnecessary copy
+   ·            │                                            ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map( ({ x, y }) => ({ ...(cond ? x : y) }) )
    ·           ─┬─                   ────────┬────────
-   ·            │                            ╰── This spread creates an unnecessary copy
+   ·            │                            ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
  1 │ const b = a.map((x, i) => y ? { ...x, i } : x)
    ·             ─┬─                 ──┬─
-   ·              │                    ╰── This spread creates an unnecessary copy
+   ·              │                    ╰── This spread allocates a new value on each iteration
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
  1 │ const b = a.map((x, i) => y ? x : { ...x, i })
    ·             ─┬─                     ──┬─
-   ·              │                        ╰── This spread creates an unnecessary copy
+   ·              │                        ╰── This spread allocates a new value on each iteration
    ·              ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(x => (0, { ...x }))
    ·           ─┬─            ──┬─
-   ·            │               ╰── This spread creates an unnecessary copy
+   ·            │               ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map(({ x, y }) => (x ?? { ...y }))
    ·           ─┬─                       ──┬─
-   ·            │                          ╰── This spread creates an unnecessary copy
+   ·            │                          ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ let a = b.map((x => ({ ...x }))) as MyCustomMapper
    ·           ─┬─          ──┬─
-   ·            │             ╰── This spread creates an unnecessary copy
+   ·            │             ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:7]
  1 │ foo().map(x => ({ ...x }))
    ·       ─┬─         ──┬─
-   ·        │            ╰── This spread creates an unnecessary copy
+   ·        │            ╰── This spread allocates a new value on each iteration
    ·        ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:8]
  1 │ foo[1].map(x => ({ ...x }))
    ·        ─┬─         ──┬─
-   ·         │            ╰── This spread creates an unnecessary copy
+   ·         │            ╰── This spread allocates a new value on each iteration
    ·         ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
  1 │ foo?.bar?.map(x => ({ ...x }))
    ·           ─┬─         ──┬─
-   ·            │            ╰── This spread creates an unnecessary copy
+   ·            │            ╰── This spread allocates a new value on each iteration
    ·            ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:14]
  1 │ (foo ?? bar).map(x => ({ ...x }))
    ·              ─┬─         ──┬─
-   ·               │            ╰── This spread creates an unnecessary copy
+   ·               │            ╰── This spread allocates a new value on each iteration
    ·               ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:10]
  1 │ obj.#foo.map(x => ({ ...x }))
    ·          ─┬─         ──┬─
-   ·           │            ╰── This spread creates an unnecessary copy
+   ·           │            ╰── This spread allocates a new value on each iteration
    ·           ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...x.y }))
    ·   ─┬─         ───┬──
-   ·    │             ╰── This spread creates an unnecessary copy
+   ·    │             ╰── This spread allocates a new value on each iteration
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...x[y] }))
    ·   ─┬─         ───┬───
-   ·    │             ╰── This spread creates an unnecessary copy
+   ·    │             ╰── This spread allocates a new value on each iteration
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
  1 │ a.map(x => ({ ...(x ?? y) }))
    ·   ─┬─         ─────┬─────
-   ·    │               ╰── This spread creates an unnecessary copy
+   ·    │               ╰── This spread allocates a new value on each iteration
    ·    ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:28]
  1 │ function foo(a) { return a.map(x => ({ ...(x ?? y) })) }
    ·                            ─┬─         ─────┬─────
-   ·                             │               ╰── This spread creates an unnecessary copy
+   ·                             │               ╰── This spread allocates a new value on each iteration
    ·                             ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:20]
  1 │ const foo = a => a.map(x => ({ ...(x ?? y) }))
    ·                    ─┬─         ─────┬─────
-   ·                     │               ╰── This spread creates an unnecessary copy
+   ·                     │               ╰── This spread allocates a new value on each iteration
    ·                     ╰── This map call spreads an object
    ╰────
-  help: Consider using `Object.assign(obj, { newProp })` to modify properties in place, this avoids copying the entire object
-  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if this is not acceptable.
+  help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
+  note: `Object.assign` mutates the first argument. Disable this rule if copy-on-write behavior is required.

--- a/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_map_spread.snap
@@ -10,6 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -19,6 +20,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:23]
@@ -28,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -37,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify array elements in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -73,6 +77,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -82,6 +87,7 @@ source: crates/oxc_linter/src/tester.rs
    ·              ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -91,6 +97,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:39]
@@ -100,6 +107,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                        ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -110,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -120,6 +129,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -139,6 +149,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │             }
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -148,6 +159,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -157,6 +169,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -166,6 +179,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
@@ -175,6 +189,7 @@ source: crates/oxc_linter/src/tester.rs
    ·              ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:13]
@@ -184,6 +199,7 @@ source: crates/oxc_linter/src/tester.rs
    ·              ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -193,6 +209,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -202,6 +219,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -211,6 +229,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:7]
@@ -220,6 +239,7 @@ source: crates/oxc_linter/src/tester.rs
    ·        ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:8]
@@ -229,6 +249,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:11]
@@ -238,6 +259,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:14]
@@ -247,6 +269,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:10]
@@ -256,6 +279,7 @@ source: crates/oxc_linter/src/tester.rs
    ·           ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -265,6 +289,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -274,6 +299,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:3]
@@ -283,6 +309,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:28]
@@ -292,6 +319,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.
 
   ⚠ oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient
    ╭─[no_map_spread.tsx:1:20]
@@ -301,3 +329,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ╰── This map call spreads an object
    ╰────
   help: Use `Object.assign(obj, { newProp })` to modify properties without copying the entire object
+  note: Note: `Object.assign` mutates the original objects in the array. Disable this rule if that is not acceptable.


### PR DESCRIPTION
## Summary

- Fixed [#18986](https://github.com/oxc-project/oxc/issues/18986): improved the `oxc/no-map-spread` rule's diagnostic messages to be more actionable.

## Changes

- Replaced vague spread label "It should be mutated in place" / "They should be mutated in place" with descriptive "This spread creates an unnecessary copy" / "These spreads create unnecessary copies"
- Enhanced help messages with concrete guidance:
  - Object: `Use Object.assign(obj, { newProp }) to modify properties without copying the entire object`
  - Array: `Use Array.prototype.push() or .concat() to add elements without copying the entire array`

## Test plan

- All existing tests pass
- Snapshot updated to reflect new messages