### PR TITLE
fix(linter/capitalized-comments): ignore prettier and oxfmt directives

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
@@ -23,6 +23,8 @@ const DIRECTIVES: &[&str] = &[
     "global ",
     "globals ",
     "exported",
+    "prettier-ignore",
+    "oxfmt-ignore",
 ];
 
 fn capitalized_comments_diagnostic(
@@ -455,6 +457,13 @@ fn test() {
         ("/* globals var1, var2 */", None),
         ("/* globals var1:true, var2 */", None),
         ("/* exported myVar */", None),
+        // Formatter directives should be ignored
+        ("// prettier-ignore", None),
+        ("/* prettier-ignore */", None),
+        ("// prettier-ignore-start", None),
+        ("// prettier-ignore-end", None),
+        ("// oxfmt-ignore", None),
+        ("/* oxfmt-ignore */", None),
         ("#!foo", None),
         ("#!foo", Some(serde_json::json!(["always"]))),
         ("#!Foo", Some(serde_json::json!(["never"]))),
@@ -533,6 +542,11 @@ fn test() {
         ("/* globals var1, var2 */", Some(serde_json::json!(["always"]))),
         ("/* globals var1:true, var2 */", Some(serde_json::json!(["always"]))),
         ("/* exported myVar */", Some(serde_json::json!(["always"]))),
+        // Formatter directives with "always"
+        ("// prettier-ignore", Some(serde_json::json!(["always"]))),
+        ("/* prettier-ignore */", Some(serde_json::json!(["always"]))),
+        ("// oxfmt-ignore", Some(serde_json::json!(["always"]))),
+        ("/* oxfmt-ignore */", Some(serde_json::json!(["always"]))),
         ("//lowercase", Some(serde_json::json!(["never"]))),
         ("// lowercase", Some(serde_json::json!(["never"]))),
         ("/*lowercase */", Some(serde_json::json!(["never"]))),


### PR DESCRIPTION
## Summary

- Add `prettier-ignore` and `oxfmt-ignore` to the list of directive prefixes that the `capitalized-comments` rule automatically ignores
- These are widely used formatter directives (e.g. `// prettier-ignore`) that should not trigger capitalization warnings
- Also covers `prettier-ignore-start` and `prettier-ignore-end` since the matching uses `starts_with`

Closes #17753