### PR TITLE
fix(formatter): add space before type annotation with leading comment

### DIFF
--- a/crates/oxc_formatter/src/print/parameters.rs
+++ b/crates/oxc_formatter/src/print/parameters.rs
@@ -114,7 +114,13 @@ impl<'a> FormatWrite<'a> for AstNode<'a, FormalParameter<'a>> {
                 if self.optional {
                     write!(f, "?");
                 }
-                write!(f, self.type_annotation());
+
+                if let Some(type_ann) = self.type_annotation() {
+                    if f.comments().has_comment_before(type_ann.span().start) {
+                        write!(f, space());
+                    }
+                    write!(f, type_ann);
+                }
             })
             .memoized();
 

--- a/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts
@@ -1,0 +1,15 @@
+// Issue #18970 - comment between parameter name and type annotation
+function f(x /* a */ : number) {}
+
+// Additional test cases
+function g(y /* comment */ : string, z /* another */ : boolean) {}
+
+// With different comment styles
+function h(a /* inline */ : number) {}
+
+// Multiple parameters with comments
+const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
+
+// Optional parameters with comments
+function optional(x? /* comment */ : number) {}
+function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}

--- a/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18970 - comment between parameter name and type annotation
+function f(x /* a */ : number) {}
+
+// Additional test cases
+function g(y /* comment */ : string, z /* another */ : boolean) {}
+
+// With different comment styles
+function h(a /* inline */ : number) {}
+
+// Multiple parameters with comments
+const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
+
+// Optional parameters with comments
+function optional(x? /* comment */ : number) {}
+function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18970 - comment between parameter name and type annotation
+function f(x /* a */ : number) {}
+
+// Additional test cases
+function g(y /* comment */ : string, z /* another */ : boolean) {}
+
+// With different comment styles
+function h(a /* inline */ : number) {}
+
+// Multiple parameters with comments
+const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
+
+// Optional parameters with comments
+function optional(x? /* comment */ : number) {}
+function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18970 - comment between parameter name and type annotation
+function f(x /* a */ : number) {}
+
+// Additional test cases
+function g(y /* comment */ : string, z /* another */ : boolean) {}
+
+// With different comment styles
+function h(a /* inline */ : number) {}
+
+// Multiple parameters with comments
+const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
+
+// Optional parameters with comments
+function optional(x? /* comment */ : number) {}
+function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}
+
+===================== End =====================


### PR DESCRIPTION
## Summary

When a comment appears between a function parameter name and its type annotation, oxfmt was missing the space before the comment.

**Before (wrong):**
```tsx
function f(x/* a */ : number) {}
```

**After (correct, matches Prettier):**
```tsx
function f(x /* a */ : number) {}
```

## Fix

Check if there are comments before the type annotation and add a space if so:

```rust
if let Some(type_ann) = self.type_annotation() {
    if f.comments().has_comment_before(type_ann.span().start) {
        write!(f, space());
    }
    write!(f, type_ann);
}
```

Fixes #18970

## Test plan

- [x] Added test fixture with various comment + type annotation patterns
- [x] Tests pass for both regular and optional parameters
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.ai/code)