### PR TITLE
fix(formatter): preserve parentheses around nested sequence expressions

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -666,8 +666,7 @@ impl NeedsParentheses<'_> for AstNode<'_, SequenceExpression<'_>> {
             AstNodes::ReturnStatement(_)
             | AstNodes::ThrowStatement(_)
             // There's a precedence for writing `x++, y++`
-            | AstNodes::ForStatement(_)
-            | AstNodes::SequenceExpression(_) => false,
+            | AstNodes::ForStatement(_) => false,
             AstNodes::ExpressionStatement(stmt) => !stmt.is_arrow_function_body(),
             _ => true,
         }

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/nested-sequence.js
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/nested-sequence.js
@@ -1,0 +1,13 @@
+// Issue #18972 - nested sequence expressions should preserve parentheses
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter(x => x % 2 == 0))['0']));
+
+// Simpler test cases
+const simple = (1, (2, 3), 4);
+const nested = ((1, 2), (3, 4));

--- a/crates/oxc_formatter/tests/fixtures/js/sequence-expression/nested-sequence.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/sequence-expression/nested-sequence.js.snap
@@ -1,0 +1,50 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18972 - nested sequence expressions should preserve parentheses
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter(x => x % 2 == 0))['0']));
+
+// Simpler test cases
+const simple = (1, (2, 3), 4);
+const nested = ((1, 2), (3, 4));
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18972 - nested sequence expressions should preserve parentheses
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter((x) => x % 2 == 0))["0"]));
+
+// Simpler test cases
+const simple = (1, (2, 3), 4);
+const nested = ((1, 2), (3, 4));
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18972 - nested sequence expressions should preserve parentheses
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1, 2, 3, (1, 2, 3, 4), (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter((x) => x % 2 == 0))["0"]));
+
+// Simpler test cases
+const simple = (1, (2, 3), 4);
+const nested = ((1, 2), (3, 4));
+
+===================== End =====================


### PR DESCRIPTION
When a SequenceExpression is nested inside another SequenceExpression,
parentheses must be preserved to maintain the correct AST structure.

For example: `(1, (2, 3), 4)` has 3 elements, but without the inner
parentheses it would become `(1, 2, 3, 4)` with 4 elements - a semantic change.

Previously, `needs_parentheses` returned `false` for nested SequenceExpressions,
which caused the formatter to incorrectly remove the parentheses.

Now it returns `true` (matching Prettier's behavior) to preserve them.

Fixes #18972