### PR TITLE
fix(formatter): preserve parentheses around await with private field access

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -1029,6 +1029,7 @@ fn update_or_lower_expression_needs_parens(span: Span, parent: &AstNodes<'_>) ->
     match parent {
         AstNodes::TSNonNullExpression(_)
         | AstNodes::StaticMemberExpression(_)
+        | AstNodes::PrivateFieldExpression(_)
         | AstNodes::TaggedTemplateExpression(_) => return true,
         _ if is_class_extends(span, parent) || parent.is_call_like_callee_span(span) => {
             return true;

--- a/crates/oxc_formatter/tests/fixtures/js/await-expression/private-field-access.js
+++ b/crates/oxc_formatter/tests/fixtures/js/await-expression/private-field-access.js
@@ -1,0 +1,8 @@
+// Issue #18973 - await with private field access needs parentheses
+!(await a).#b;
+
+// Additional test cases
+(await a).#b;
+(await a).b;
+(await a)['b'];
+(await a)[0];

--- a/crates/oxc_formatter/tests/fixtures/js/await-expression/private-field-access.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/await-expression/private-field-access.js.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18973 - await with private field access needs parentheses
+!(await a).#b;
+
+// Additional test cases
+(await a).#b;
+(await a).b;
+(await a)['b'];
+(await a)[0];
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18973 - await with private field access needs parentheses
+!(await a).#b;
+
+// Additional test cases
+(await a).#b;
+(await a).b;
+(await a)["b"];
+(await a)[0];
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18973 - await with private field access needs parentheses
+!(await a).#b;
+
+// Additional test cases
+(await a).#b;
+(await a).b;
+(await a)["b"];
+(await a)[0];
+
+===================== End =====================


### PR DESCRIPTION
When an `await` expression is followed by private field access (`.#b`),
parentheses must be preserved to maintain correct semantics.

For example: `!(await a).#b` means "await a, then access #b, then negate".
Without parentheses, `!await a.#b` means "await (a.#b), then negate" - different.

The `update_or_lower_expression_needs_parens` function already handled
`StaticMemberExpression` (`.b`) and `ComputedMemberExpression` (`['b']`)
but was missing `PrivateFieldExpression` (`.#b`).

Fixes #18973