### PR TITLE
refactor(formatter): decouple JS/TS specifics to enable language-agnostic formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -687,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1261,6 +1261,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25376d12b2f6ae53f986f86e2a808a56af03d72284ae24fc35a2e290d09ee3c3"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1923,6 +1934,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
+ "oxc_formatter_core",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
@@ -1934,6 +1946,29 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-width",
+]
+
+[[package]]
+name = "oxc_formatter_core"
+version = "0.1.0"
+dependencies = [
+ "cow-utils",
+ "oxc_allocator",
+ "oxc_data_structures",
+ "oxc_span",
+ "rustc-hash",
+ "unicode-width",
+]
+
+[[package]]
+name = "oxc_formatter_json"
+version = "0.1.0"
+dependencies = [
+ "json5",
+ "oxc_allocator",
+ "oxc_formatter_core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2214,6 +2249,8 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_formatter",
+ "oxc_formatter_core",
+ "oxc_formatter_json",
  "oxc_parser",
  "oxc_span",
  "oxc_tasks_common",
@@ -2522,6 +2559,8 @@ dependencies = [
  "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_formatter",
+ "oxc_formatter_core",
+ "oxc_formatter_json",
  "oxc_language_server",
  "oxc_napi",
  "oxc_parser",
@@ -2955,7 +2994,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3050,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3339,7 +3378,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3875,7 +3914,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,8 @@ oxc_traverse = { version = "0.112.0", path = "crates/oxc_traverse" } # AST trave
 
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
+oxc_formatter_core = { path = "crates/oxc_formatter_core" } # Language-agnostic formatter core
+oxc_formatter_json = { path = "crates/oxc_formatter_json" } # Native JSON formatter
 oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
 oxc_linter = { path = "crates/oxc_linter" } # Linting engine
 oxc_macros = { path = "crates/oxc_macros" } # Proc macros
@@ -162,6 +164,7 @@ unicode-id-start = "1" # Unicode identifier validation
 
 #
 javascript-globals = "1.4.0" # JavaScript global definitions
+json5 = "0.4.1" # JSON5 parser
 json-strip-comments = "3.1.0" # Strip JSON comments
 oxc-browserslist = "2.2.0" # Browser compatibility queries
 oxc_index = { version = "4.1.0", features = ["nonmax", "serde"] } # Type-safe indices

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -31,6 +31,8 @@ oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
+oxc_formatter_core = { workspace = true }
+oxc_formatter_json = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_napi = { workspace = true }
 oxc_parser = { workspace = true }

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -9,6 +9,11 @@ use serde_json::Value;
 use tracing::instrument;
 
 use oxc_formatter::FormatOptions;
+use oxc_formatter_core::{
+    IndentStyle as CoreIndentStyle, IndentWidth as CoreIndentWidth, LineEnding as CoreLineEnding,
+    LineWidth as CoreLineWidth,
+};
+use oxc_formatter_json::JsonFormatOptions;
 use oxc_toml::Options as TomlFormatterOptions;
 
 use super::{
@@ -84,6 +89,13 @@ pub enum ResolvedOptions {
     },
     /// For TOML files.
     OxfmtToml { toml_options: TomlFormatterOptions, insert_final_newline: bool },
+    /// For JSON files formatted by native JSON formatter.
+    OxcFormatterJson {
+        json_format_options: Box<JsonFormatOptions>,
+        /// For parse-error fallback to external formatter.
+        external_options: Value,
+        insert_final_newline: bool,
+    },
     /// For non-JS files formatted by external formatter (Prettier).
     #[cfg(feature = "napi")]
     ExternalFormatter { external_options: Value, insert_final_newline: bool },
@@ -118,6 +130,11 @@ impl ResolvedOptions {
             FormatFileStrategy::OxfmtToml { .. } => {
                 ResolvedOptions::OxfmtToml { toml_options, insert_final_newline }
             }
+            FormatFileStrategy::OxcFormatterJson { .. } => ResolvedOptions::OxcFormatterJson {
+                json_format_options: Box::new(json_format_options_from(&format_options)),
+                external_options,
+                insert_final_newline,
+            },
             #[cfg(feature = "napi")]
             FormatFileStrategy::ExternalFormatter { .. } => {
                 ResolvedOptions::ExternalFormatter { external_options, insert_final_newline }
@@ -135,6 +152,25 @@ impl ResolvedOptions {
                 unreachable!("If `napi` feature is disabled, this should not be passed here")
             }
         }
+    }
+}
+
+fn json_format_options_from(options: &FormatOptions) -> JsonFormatOptions {
+    let indent_style =
+        if options.indent_style.is_tab() { CoreIndentStyle::Tab } else { CoreIndentStyle::Space };
+
+    let line_ending = match options.line_ending {
+        oxc_formatter::LineEnding::Lf => CoreLineEnding::Lf,
+        oxc_formatter::LineEnding::Crlf => CoreLineEnding::Crlf,
+        oxc_formatter::LineEnding::Cr => CoreLineEnding::Cr,
+    };
+
+    JsonFormatOptions {
+        indent_style,
+        indent_width: CoreIndentWidth::try_from(options.indent_width.value()).unwrap_or_default(),
+        line_ending,
+        line_width: CoreLineWidth::try_from(options.line_width.value()).unwrap_or_default(),
+        always_expand: false,
     }
 }
 

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -8,6 +8,7 @@ use tracing::instrument;
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_options};
+use oxc_formatter_json::{JsonFormatError, JsonFormatOptions, format_json};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
@@ -73,6 +74,37 @@ impl SourceFormatter {
                 FormatFileStrategy::OxfmtToml { .. },
                 ResolvedOptions::OxfmtToml { toml_options, insert_final_newline },
             ) => (Ok(Self::format_by_toml(source_text, toml_options)), insert_final_newline),
+            (
+                FormatFileStrategy::OxcFormatterJson { path },
+                ResolvedOptions::OxcFormatterJson {
+                    json_format_options,
+                    external_options,
+                    insert_final_newline,
+                },
+            ) => (
+                self.format_by_json_formatter(source_text, path, *json_format_options).or_else(
+                    |err| {
+                        if err.is_parse_error() {
+                            #[cfg(feature = "napi")]
+                            {
+                                return self.format_by_external_formatter(
+                                    source_text,
+                                    path,
+                                    "json",
+                                    external_options,
+                                );
+                            }
+                        }
+
+                        let _ = external_options;
+                        Err(OxcDiagnostic::error(format!(
+                            "Failed to format JSON file: {}\n{err}",
+                            path.display()
+                        )))
+                    },
+                ),
+                insert_final_newline,
+            ),
             #[cfg(feature = "napi")]
             (
                 FormatFileStrategy::ExternalFormatter { path, parser_name },
@@ -183,6 +215,16 @@ impl SourceFormatter {
     #[instrument(level = "debug", name = "oxfmt::format::oxc_toml", skip_all)]
     fn format_by_toml(source_text: &str, options: oxc_toml::Options) -> String {
         oxc_toml::format(source_text, options)
+    }
+
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_json", skip_all)]
+    fn format_by_json_formatter(
+        &self,
+        source_text: &str,
+        _path: &Path,
+        options: JsonFormatOptions,
+    ) -> Result<String, JsonFormatError> {
+        format_json(source_text, options)
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -82,7 +82,7 @@ impl SourceFormatter {
                     insert_final_newline,
                 },
             ) => (
-                self.format_by_json_formatter(source_text, path, *json_format_options).or_else(
+                Self::format_by_json_formatter(source_text, path, *json_format_options).or_else(
                     |err| {
                         if err.is_parse_error() {
                             #[cfg(feature = "napi")]
@@ -219,7 +219,6 @@ impl SourceFormatter {
 
     #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_json", skip_all)]
     fn format_by_json_formatter(
-        &self,
         source_text: &str,
         _path: &Path,
         options: JsonFormatOptions,

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -14,6 +14,10 @@ pub enum FormatFileStrategy {
     OxfmtToml {
         path: PathBuf,
     },
+    /// JSON files formatted by oxc native JSON formatter.
+    OxcFormatterJson {
+        path: PathBuf,
+    },
     ExternalFormatter {
         path: PathBuf,
         #[cfg_attr(not(feature = "napi"), expect(dead_code))]
@@ -59,6 +63,10 @@ impl TryFrom<PathBuf> for FormatFileStrategy {
         }
 
         let extension = path.extension().and_then(|ext| ext.to_str());
+        if is_native_json_extension(extension) {
+            return Ok(Self::OxcFormatterJson { path });
+        }
+
         if let Some(parser_name) = get_external_parser_name(file_name, extension) {
             return Ok(Self::ExternalFormatter { path, parser_name });
         }
@@ -70,13 +78,17 @@ impl TryFrom<PathBuf> for FormatFileStrategy {
 impl FormatFileStrategy {
     #[cfg(not(feature = "napi"))]
     pub fn can_format_without_external(&self) -> bool {
-        matches!(self, Self::OxcFormatter { .. } | Self::OxfmtToml { .. })
+        matches!(
+            self,
+            Self::OxcFormatter { .. } | Self::OxfmtToml { .. } | Self::OxcFormatterJson { .. }
+        )
     }
 
     pub fn path(&self) -> &Path {
         match self {
             Self::OxcFormatter { path, .. }
             | Self::OxfmtToml { path }
+            | Self::OxcFormatterJson { path }
             | Self::ExternalFormatter { path, .. }
             | Self::ExternalFormatterPackageJson { path, .. } => path,
         }
@@ -132,15 +144,10 @@ static TOML_FILENAMES: phf::Set<&'static str> = phf_set! {
 fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<&'static str> {
     // JSON and variants
     // NOTE: `package.json` is handled separately in `FormatFileStrategy::try_from()`
-    if file_name == "composer.json" || extension == Some("importmap") {
+    if extension == Some("importmap") {
         return Some("json-stringify");
     }
     if JSON_FILENAMES.contains(file_name) {
-        return Some("json");
-    }
-    if let Some(ext) = extension
-        && JSON_EXTENSIONS.contains(ext)
-    {
         return Some("json");
     }
     if let Some(ext) = extension
@@ -220,6 +227,10 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     }
 
     None
+}
+
+fn is_native_json_extension(extension: Option<&str>) -> bool {
+    extension.is_some_and(|ext| JSON_EXTENSIONS.contains(ext))
 }
 
 static JSON_EXTENSIONS: phf::Set<&'static str> = phf_set! {
@@ -368,10 +379,10 @@ mod tests {
     #[test]
     fn test_get_external_parser_name() {
         let test_cases = vec![
-            // JSON (NOTE: `package.json` is handled in TryFrom, not here)
+            // JSON external only (native `.json`/JSON_EXTENSIONS are handled in TryFrom)
             ("config.importmap", Some("json-stringify")),
-            ("data.json", Some("json")),
-            ("schema.avsc", Some("json")),
+            ("data.json", None),
+            ("schema.avsc", None),
             ("config.code-workspace", Some("jsonc")),
             ("settings.json5", Some("json5")),
             // HTML
@@ -429,7 +440,20 @@ mod tests {
         assert!(matches!(source, FormatFileStrategy::ExternalFormatterPackageJson { .. }));
 
         let source = FormatFileStrategy::try_from(PathBuf::from("composer.json")).unwrap();
-        assert!(matches!(source, FormatFileStrategy::ExternalFormatter { .. }));
+        assert!(matches!(source, FormatFileStrategy::OxcFormatterJson { .. }));
+    }
+
+    #[test]
+    fn test_native_json_files() {
+        let json_files = vec!["data.json", "schema.avsc", "config.geojson", "state.tfstate"];
+
+        for file_name in json_files {
+            let result = FormatFileStrategy::try_from(PathBuf::from(file_name));
+            assert!(
+                matches!(result, Ok(FormatFileStrategy::OxcFormatterJson { .. })),
+                "`{file_name}` should be detected as native JSON"
+            );
+        }
     }
 
     #[test]

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack", "code_buffer"] }
+oxc_formatter_core = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -9,6 +9,10 @@ use crate::{
     external_formatter::ExternalCallbacks, formatter::FormatElement, options::FormatOptions,
 };
 
+use oxc_formatter_core::{
+    FormatContext as CoreFormatContext, FormatContextExt as CoreFormatContextExt,
+};
+
 use super::{Comments, SourceText};
 
 /// Entry in the Tailwind context stack, tracking whether we're inside a Tailwind class context.
@@ -272,5 +276,34 @@ impl<'ast> FormatContext<'ast> {
     /// Get a mutable reference to the current Tailwind context, if any.
     pub fn tailwind_context_mut(&mut self) -> Option<&mut TailwindContextEntry> {
         self.tailwind_context_stack.last_mut()
+    }
+}
+
+impl<'ast> CoreFormatContext<'ast> for FormatContext<'ast> {
+    type Options = FormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn allocator(&self) -> &'ast Allocator {
+        self.allocator
+    }
+}
+
+impl<'ast> CoreFormatContextExt<'ast> for FormatContext<'ast> {
+    type Comments = Comments<'ast>;
+    type SourceText = SourceText<'ast>;
+
+    fn comments(&self) -> &Self::Comments {
+        &self.comments
+    }
+
+    fn comments_mut(&mut self) -> &mut Self::Comments {
+        &mut self.comments
+    }
+
+    fn source_text(&self) -> Self::SourceText {
+        self.source_text
     }
 }

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -28,6 +28,10 @@ use crate::{
 };
 #[cfg(feature = "detect_code_removal")]
 pub use detect_code_removal::detect_code_removal;
+pub use oxc_formatter_core as formatter_core;
+pub use oxc_formatter_core::{
+    Format as CoreFormat, FormatContext as CoreFormatContext, Formatter as CoreFormatter,
+};
 
 use self::formatter::prelude::tag::Label;
 

--- a/crates/oxc_formatter_core/Cargo.toml
+++ b/crates/oxc_formatter_core/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "oxc_formatter_core"
+version = "0.1.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description = "Language-agnostic formatter core primitives for oxc formatters."
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "stack"] }
+oxc_span = { workspace = true }
+
+cow-utils = { workspace = true }
+rustc-hash = { workspace = true }
+unicode-width = { workspace = true }

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -1,0 +1,28 @@
+use crate::format_element::FormatElement;
+
+pub trait Buffer {
+    fn write_element(&mut self, element: FormatElement);
+
+    fn elements(&self) -> &[FormatElement];
+}
+
+#[derive(Debug, Default)]
+pub struct VecBuffer {
+    elements: Vec<FormatElement>,
+}
+
+impl VecBuffer {
+    pub fn into_vec(self) -> Vec<FormatElement> {
+        self.elements
+    }
+}
+
+impl Buffer for VecBuffer {
+    fn write_element(&mut self, element: FormatElement) {
+        self.elements.push(element);
+    }
+
+    fn elements(&self) -> &[FormatElement] {
+        &self.elements
+    }
+}

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -1,0 +1,39 @@
+use crate::format_element::{FormatElement, LineMode};
+
+pub fn text(text: impl Into<String>) -> FormatElement {
+    FormatElement::text(text)
+}
+
+pub fn space() -> FormatElement {
+    FormatElement::Space
+}
+
+pub fn hard_line_break() -> FormatElement {
+    FormatElement::Line(LineMode::Hard)
+}
+
+pub fn indent(elements: Vec<FormatElement>) -> Vec<FormatElement> {
+    let mut result = Vec::with_capacity(elements.len() + 2);
+    result.push(FormatElement::IndentStart);
+    result.extend(elements);
+    result.push(FormatElement::IndentEnd);
+    result
+}
+
+pub fn join<I>(entries: I, separator: Vec<FormatElement>) -> Vec<FormatElement>
+where
+    I: IntoIterator<Item = Vec<FormatElement>>,
+{
+    let mut result = Vec::new();
+    let mut is_first = true;
+
+    for entry in entries {
+        if !is_first {
+            result.extend(separator.iter().cloned());
+        }
+        result.extend(entry);
+        is_first = false;
+    }
+
+    result
+}

--- a/crates/oxc_formatter_core/src/document.rs
+++ b/crates/oxc_formatter_core/src/document.rs
@@ -1,0 +1,55 @@
+use crate::{FormatContext, format_element::FormatElement, printer::Printer};
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Document {
+    elements: Vec<FormatElement>,
+}
+
+impl Document {
+    pub fn new(elements: Vec<FormatElement>) -> Self {
+        Self { elements }
+    }
+
+    pub fn elements(&self) -> &[FormatElement] {
+        &self.elements
+    }
+
+    pub fn into_elements(self) -> Vec<FormatElement> {
+        self.elements
+    }
+}
+
+#[derive(Debug)]
+pub struct Formatted<'a, Ctx>
+where
+    Ctx: FormatContext,
+{
+    document: Document,
+    context: &'a Ctx,
+}
+
+impl<'a, Ctx> Formatted<'a, Ctx>
+where
+    Ctx: FormatContext,
+{
+    pub fn new(document: Document, context: &'a Ctx) -> Self {
+        Self { document, context }
+    }
+
+    pub fn context(&self) -> &'a Ctx {
+        self.context
+    }
+
+    pub fn document(&self) -> &Document {
+        &self.document
+    }
+
+    pub fn into_document(self) -> Document {
+        self.document
+    }
+
+    pub fn print(self) -> String {
+        let printer = Printer::new(self.context.printer_options());
+        printer.print(self.document.elements())
+    }
+}

--- a/crates/oxc_formatter_core/src/format_element.rs
+++ b/crates/oxc_formatter_core/src/format_element.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FormatElement {
+    Text(String),
+    Space,
+    Line(LineMode),
+    IndentStart,
+    IndentEnd,
+}
+
+impl FormatElement {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text(text.into())
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LineMode {
+    Hard,
+}

--- a/crates/oxc_formatter_core/src/formatter/arguments.rs
+++ b/crates/oxc_formatter_core/src/formatter/arguments.rs
@@ -1,0 +1,137 @@
+use std::{ffi::c_void, marker::PhantomData};
+
+use super::{Buffer, Format, FormatContext, Formatter};
+
+/// Mono-morphed type to format an object. Used by the [crate::format!], [crate::format_args!], and
+/// [crate::write!] macros.
+///
+/// This struct is similar to a dynamic dispatch (using `dyn Format`) because it stores a pointer to the value.
+/// However, it doesn't store the pointer to `dyn Format`'s vtable, instead it statically resolves the function
+/// pointer of `Format::format` and stores it in `formatter`.
+#[derive(Clone, Copy)]
+pub struct Argument<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// The value to format stored as a raw pointer where `lifetime` stores the value's lifetime.
+    value: *const c_void,
+
+    /// Stores the lifetime of the value. To get the most out of our dear borrow checker.
+    lifetime: PhantomData<&'fmt ()>,
+
+    /// The function pointer to `value`'s `Format::format` method
+    formatter: fn(*const c_void, &mut Formatter<'_, 'ast, Ctx>),
+}
+
+impl<'fmt, 'ast, Ctx> Argument<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Called by the [biome_formatter::format_args] macro. Creates a mono-morphed value for formatting
+    /// an object.
+    #[doc(hidden)]
+    #[inline]
+    pub fn new<F: Format<'ast, Ctx>>(value: &'fmt F) -> Self {
+        #[inline(always)]
+        fn formatter<'ast, Ctx, F>(ptr: *const c_void, fmt: &mut Formatter<'_, 'ast, Ctx>)
+        where
+            Ctx: FormatContext<'ast>,
+            F: Format<'ast, Ctx>,
+        {
+            // SAFETY: Safe because the 'fmt lifetime is captured by the 'lifetime' field.
+            F::fmt(unsafe { &*ptr.cast::<F>() }, fmt);
+        }
+
+        Self {
+            value: std::ptr::from_ref::<F>(value).cast::<std::ffi::c_void>(),
+            lifetime: PhantomData,
+            formatter: formatter::<Ctx, F>,
+        }
+    }
+
+    /// Formats the value stored by this argument using the given formatter.
+    #[inline(always)]
+    pub(super) fn format(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        (self.formatter)(self.value, f);
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Argument<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        self.format(f);
+    }
+}
+
+/// Sequence of objects that should be formatted in the specified order.
+///
+/// The [`format_args!`] macro will safely create an instance of this structure.
+///
+/// You can use the `Arguments<a>` that [`format_args!]` return in `Format` context as seen below.
+/// It will call the `format` function for every of it's objects.
+///
+/// ```rust
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, format_args};
+///
+/// # fn main()  {
+/// let formatted = format!(SimpleFormatContext::default(), [
+///     format_args!(token("a"), space(), token("b"))
+/// ])?;
+///
+/// assert_eq!("a b", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Copy)]
+pub struct Arguments<'fmt, 'ast, Ctx>(pub &'fmt [Argument<'fmt, 'ast, Ctx>])
+where
+    Ctx: FormatContext<'ast>;
+
+impl<'fmt, 'ast, Ctx> Arguments<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn new(arguments: &'fmt [Argument<'fmt, 'ast, Ctx>]) -> Self {
+        Self(arguments)
+    }
+
+    /// Returns the arguments
+    #[inline]
+    pub fn items(&self) -> &'fmt [Argument<'fmt, 'ast, Ctx>] {
+        self.0
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Arguments<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[inline(always)]
+    fn fmt(&self, formatter: &mut Formatter<'_, 'ast, Ctx>) {
+        formatter.write_fmt(Arguments::new(self.0));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for Arguments<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Arguments[...]")
+    }
+}
+
+impl<'fmt, 'ast, Ctx> From<&'fmt Argument<'fmt, 'ast, Ctx>> for Arguments<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn from(argument: &'fmt Argument<'fmt, 'ast, Ctx>) -> Self {
+        Arguments::new(std::slice::from_ref(argument))
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/buffer.rs
+++ b/crates/oxc_formatter_core/src/formatter/buffer.rs
@@ -1,0 +1,709 @@
+#![expect(clippy::mutable_key_type)]
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use rustc_hash::FxHashMap;
+
+use oxc_allocator::{Allocator, TakeIn, Vec as ArenaVec};
+
+use super::{
+    Arguments, Format, FormatContext, FormatElement, FormatState,
+    format_element::Interned,
+    prelude::{LineMode, PrintMode, Tag, tag::Condition},
+};
+use crate::write;
+
+/// A trait for writing or formatting into `FormatElement`-accepting buffers or streams.
+pub trait Buffer<'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Writes a [crate::FormatElement] into this buffer, returning whether the write succeeded.
+    ///
+    /// # Errors
+    /// This function will return an instance of [crate::FormatError] on error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use biome_formatter::{Buffer, FormatElement, FormatState, SimpleFormatContext, VecBuffer};
+    ///
+    /// let mut state = FormatState::new(SimpleFormatContext::default());
+    /// let mut buffer = VecBuffer::new(&mut state);
+    ///
+    /// buffer.write_element(FormatElement::Token { text: "test"}).unwrap();
+    ///
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Token { text: "test" }]);
+    /// ```
+    ///
+    fn write_element(&mut self, element: FormatElement<'ast>);
+
+    /// Returns a slice containing all elements written into this buffer.
+    ///
+    /// Prefer using [BufferExtensions::start_recording] over accessing [Buffer::elements] directly.
+    #[doc(hidden)]
+    fn elements(&self) -> &[FormatElement<'ast>];
+
+    /// Glue for usage of the [`write!`] macro with implementors of this trait.
+    ///
+    /// This method should generally not be invoked manually, but rather through the [`write!`] macro itself.
+    ///
+    /// # Errors
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use biome_formatter::prelude::*;
+    /// use biome_formatter::{Buffer, FormatState, SimpleFormatContext, VecBuffer, format_args};
+    ///
+    /// let mut state = FormatState::new(SimpleFormatContext::default());
+    /// let mut buffer = VecBuffer::new(&mut state);
+    ///
+    /// buffer.write_fmt(format_args!(token("Hello World"))).unwrap();
+    ///
+    /// assert_eq!(buffer.into_vec(), vec![FormatElement::Token{ text: "Hello World" }]);
+    /// ```
+    fn write_fmt(mut self: &mut Self, arguments: Arguments<'_, 'ast, Ctx>) {
+        super::write(&mut self, arguments);
+    }
+
+    /// Returns the formatting state relevant for this formatting session.
+    fn state(&self) -> &FormatState<'ast, Ctx>;
+
+    /// Returns the mutable formatting state relevant for this formatting session.
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx>;
+}
+
+/// Implements the `[Buffer]` trait for all mutable references of objects implementing [Buffer].
+impl<'ast, Ctx, W> Buffer<'ast, Ctx> for &mut W
+where
+    Ctx: FormatContext<'ast>,
+    W: Buffer<'ast, Ctx> + ?Sized,
+{
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        (**self).write_element(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        (**self).elements()
+    }
+
+    fn write_fmt(&mut self, args: Arguments<'_, 'ast, Ctx>) {
+        (**self).write_fmt(args);
+    }
+
+    fn state(&self) -> &FormatState<'ast, Ctx> {
+        (**self).state()
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx> {
+        (**self).state_mut()
+    }
+}
+
+/// Vector backed [`Buffer`] implementation.
+///
+/// The buffer writes all elements into the internal elements buffer.
+pub struct VecBuffer<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    state: &'buf mut FormatState<'ast, Ctx>,
+    elements: ArenaVec<'ast, FormatElement<'ast>>,
+}
+
+impl<'buf, 'ast, Ctx> VecBuffer<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    pub fn new(state: &'buf mut FormatState<'ast, Ctx>) -> Self {
+        Self::new_with_vec(state, ArenaVec::new_in(state.context().allocator()))
+    }
+
+    pub fn new_with_vec(
+        state: &'buf mut FormatState<'ast, Ctx>,
+        elements: ArenaVec<'ast, FormatElement<'ast>>,
+    ) -> Self {
+        Self { state, elements }
+    }
+
+    /// Creates a buffer with the specified capacity
+    pub fn with_capacity(capacity: usize, state: &'buf mut FormatState<'ast, Ctx>) -> Self {
+        let elements = ArenaVec::with_capacity_in(capacity, state.context().allocator());
+        Self { state, elements }
+    }
+
+    /// Consumes the buffer and returns the written [`FormatElement]`s as a vector.
+    pub fn into_vec(self) -> ArenaVec<'ast, FormatElement<'ast>> {
+        self.elements
+    }
+
+    /// Takes the elements without consuming self
+    pub fn take_vec(&mut self) -> ArenaVec<'ast, FormatElement<'ast>> {
+        self.elements.take_in(self.state.context().allocator())
+    }
+}
+
+impl<'ast, Ctx> Deref for VecBuffer<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    type Target = [FormatElement<'ast>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.elements
+    }
+}
+
+impl<'ast, Ctx> DerefMut for VecBuffer<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.elements
+    }
+}
+
+impl<'ast, Ctx> Buffer<'ast, Ctx> for VecBuffer<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        self.elements.push(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        self
+    }
+
+    fn state(&self) -> &FormatState<'ast, Ctx> {
+        self.state
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx> {
+        self.state
+    }
+}
+
+/// This struct wraps an existing buffer and emits a preamble text when the first text is written.
+///
+/// This can be useful if you, for example, want to write some content if what gets written next isn't empty.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{FormatState, Formatted, PreambleBuffer, SimpleFormatContext, VecBuffer, write};
+/// use biome_formatter::prelude::*;
+///
+/// struct Preamble;
+///
+/// impl Format<SimpleFormatContext> for Preamble {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
+///         write!(f, [token("# heading"), hard_line_break()])
+///     }
+/// }
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+///
+/// {
+///     let mut with_preamble = PreambleBuffer::new(&mut buffer, Preamble);
+///
+///     write!(&mut with_preamble, [token("this text will be on a new line")])?;
+/// }
+///
+/// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
+/// assert_eq!("# heading\nthis text will be on a new line", formatted.print()?.as_code());
+///
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The pre-amble does not get written if no content is written to the buffer.
+///
+/// ```
+/// use biome_formatter::{FormatState, Formatted, PreambleBuffer, SimpleFormatContext, VecBuffer, write};
+/// use biome_formatter::prelude::*;
+///
+/// struct Preamble;
+///
+/// impl Format<SimpleFormatContext> for Preamble {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
+///         write!(f, [token("# heading"), hard_line_break()])
+///     }
+/// }
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+/// {
+///     let mut with_preamble = PreambleBuffer::new(&mut buffer, Preamble);
+/// }
+///
+/// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
+/// assert_eq!("", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+pub struct PreambleBuffer<'a, 'buf, Ctx, Preamble>
+where
+    Ctx: FormatContext<'a>,
+{
+    /// The wrapped buffer
+    inner: &'buf mut dyn Buffer<'a, Ctx>,
+
+    /// The pre-amble to write once the first content gets written to this buffer.
+    preamble: Preamble,
+
+    /// Whether some content (including the pre-amble) has been written at this point.
+    empty: bool,
+}
+
+impl<'ast, 'buf, Ctx, Preamble> PreambleBuffer<'ast, 'buf, Ctx, Preamble>
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[expect(unused)]
+    pub fn new(inner: &'buf mut dyn Buffer<'ast, Ctx>, preamble: Preamble) -> Self {
+        Self { inner, preamble, empty: true }
+    }
+
+    /// Returns `true` if the preamble has been written, `false` otherwise.
+    #[expect(unused)]
+    pub fn did_write_preamble(&self) -> bool {
+        !self.empty
+    }
+}
+
+impl<'ast, Ctx, Preamble> Buffer<'ast, Ctx> for PreambleBuffer<'ast, '_, Ctx, Preamble>
+where
+    Ctx: FormatContext<'ast>,
+    Preamble: Format<'ast, Ctx>,
+{
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        if self.empty {
+            write!(self.inner, [&self.preamble]);
+            self.empty = false;
+        }
+
+        self.inner.write_element(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        self.inner.elements()
+    }
+
+    fn state(&self) -> &FormatState<'ast, Ctx> {
+        self.inner.state()
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx> {
+        self.inner.state_mut()
+    }
+}
+
+/// Buffer that allows you inspecting elements as they get written to the formatter.
+pub struct Inspect<'ast, 'inner, Ctx, Inspector>
+where
+    Ctx: FormatContext<'ast>,
+{
+    inner: &'inner mut dyn Buffer<'ast, Ctx>,
+    inspector: Inspector,
+}
+
+impl<'ast, 'inner, Ctx, Inspector> Inspect<'ast, 'inner, Ctx, Inspector>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn new(inner: &'inner mut dyn Buffer<'ast, Ctx>, inspector: Inspector) -> Self {
+        Self { inner, inspector }
+    }
+}
+
+impl<'a, Ctx, Inspector> Buffer<'a, Ctx> for Inspect<'a, '_, Ctx, Inspector>
+where
+    Ctx: FormatContext<'a>,
+    Inspector: FnMut(&FormatElement),
+{
+    fn write_element(&mut self, element: FormatElement<'a>) {
+        (self.inspector)(&element);
+        self.inner.write_element(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'a>] {
+        self.inner.elements()
+    }
+
+    fn state(&self) -> &FormatState<'a, Ctx> {
+        self.inner.state()
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'a, Ctx> {
+        self.inner.state_mut()
+    }
+}
+
+/// A Buffer that removes any soft line breaks.
+///
+/// * Removes [`lines`](FormatElement::Line) with the mode [`Soft`](LineMode::Soft).
+/// * Replaces [`lines`](FormatElement::Line) with the mode [`Soft`](LineMode::SoftOrSpace) with a [`Space`](FormatElement::Space)
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, write};
+///
+/// # fn main()  {
+/// use biome_formatter::{RemoveSoftLinesBuffer, SimpleFormatContext, VecBuffer};
+/// use biome_formatter::prelude::format_with;
+/// let formatted = format!(
+///     SimpleFormatContext::default(),
+///     [format_with(|f| {
+///         let mut buffer = RemoveSoftLinesBuffer::new(f);
+///
+///         write!(
+///             buffer,
+///             [
+///                 token("The next soft line or space gets replaced by a space"),
+///                 soft_line_break_or_space(),
+///                 token("and the line here"),
+///                 soft_line_break(),
+///                 token("is removed entirely.")
+///             ]
+///         )
+///     })]
+/// )?;
+///
+/// assert_eq!(
+///     formatted.document().as_ref(),
+///     &[
+///         FormatElement::Token { text: "The next soft line or space gets replaced by a space" },
+///         FormatElement::Space,
+///         FormatElement::Token { text: "and the line here" },
+///         FormatElement::Token { text: "is removed entirely." }
+///     ]
+/// );
+///
+/// # Ok(())
+/// # }
+/// ```
+pub struct RemoveSoftLinesBuffer<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    inner: &'buf mut dyn Buffer<'ast, Ctx>,
+
+    /// Caches the interned elements after the soft line breaks have been removed.
+    ///
+    /// The `key` is the [Interned] element as it has been passed to [Self::write_element] or the child of another
+    /// [Interned] element. The `value` is the matching document of the key where all soft line breaks have been removed.
+    ///
+    /// It's fine to not snapshot the cache. The worst that can happen is that it holds on interned elements
+    /// that are now unused. But there's little harm in that and the cache is cleaned when dropping the buffer.
+    interned_cache: FxHashMap<Interned<'ast>, Interned<'ast>>,
+
+    /// Store the conditional content stack to help determine if the current element is within expanded conditional content.
+    conditional_content_stack: Vec<Condition>,
+}
+
+impl<'buf, 'ast, Ctx> RemoveSoftLinesBuffer<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Creates a new buffer that removes the soft line breaks before writing them into `buffer`.
+    pub fn new(inner: &'buf mut dyn Buffer<'ast, Ctx>) -> Self {
+        Self { inner, interned_cache: FxHashMap::default(), conditional_content_stack: Vec::new() }
+    }
+
+    /// Removes the soft line breaks from an interned element.
+    fn clean_interned(&mut self, interned: Interned<'ast>) -> Interned<'ast> {
+        clean_interned(
+            interned,
+            &mut self.interned_cache,
+            &mut self.conditional_content_stack,
+            self.inner.state().context().allocator(),
+        )
+    }
+
+    /// Marker for whether a `StartConditionalContent(mode: Expanded)` has been
+    /// written but not yet closed.
+    fn is_in_expanded_conditional_content(&self) -> bool {
+        self.conditional_content_stack
+            .iter()
+            .last()
+            .is_some_and(|condition| condition.mode == PrintMode::Expanded)
+    }
+}
+
+// Extracted to function to avoid monomorphization
+fn clean_interned<'ast>(
+    interned: Interned<'ast>,
+    interned_cache: &mut FxHashMap<Interned<'ast>, Interned<'ast>>,
+    condition_content_stack: &mut Vec<Condition>,
+    allocator: &'ast Allocator,
+) -> Interned<'ast> {
+    if let Some(cleaned) = interned_cache.get(&interned) {
+        cleaned.clone()
+    } else {
+        // Find the first soft line break element, interned element, or conditional expanded
+        // content that must be changed.
+        let result = interned.iter().enumerate().find_map(|(index, element)| match element {
+            FormatElement::Line(LineMode::Soft | LineMode::SoftOrSpace)
+            | FormatElement::Tag(Tag::StartConditionalContent(_) | Tag::EndConditionalContent)
+            | FormatElement::BestFitting(_) => {
+                let cleaned = ArenaVec::from_iter_in(interned[..index].iter().cloned(), allocator);
+                Some((cleaned, &interned[index..]))
+            }
+            FormatElement::Interned(inner) => {
+                let cleaned_inner = clean_interned(
+                    inner.clone(),
+                    interned_cache,
+                    condition_content_stack,
+                    allocator,
+                );
+
+                if &cleaned_inner == inner {
+                    None
+                } else {
+                    let mut cleaned = ArenaVec::with_capacity_in(interned.len(), allocator);
+                    cleaned.extend(interned[..index].iter().cloned());
+                    cleaned.push(FormatElement::Interned(cleaned_inner));
+                    Some((cleaned, &interned[index + 1..]))
+                }
+            }
+            _ => None,
+        });
+
+        let result = match result {
+            // Copy the whole interned buffer so that becomes possible to change the necessary elements.
+            Some((mut cleaned, rest)) => {
+                let mut element_stack = rest.iter().rev().collect::<Vec<_>>();
+                while let Some(element) = element_stack.pop() {
+                    match element {
+                        FormatElement::Tag(Tag::StartConditionalContent(condition)) => {
+                            condition_content_stack.push(condition.clone());
+                        }
+                        FormatElement::Tag(Tag::EndConditionalContent) => {
+                            condition_content_stack.pop();
+                        }
+                        // All content within an expanded conditional gets dropped. If there's a
+                        // matching flat variant, that will still get kept.
+                        _ if condition_content_stack
+                            .iter()
+                            .last()
+                            .is_some_and(|condition| condition.mode == PrintMode::Expanded) => {}
+
+                        FormatElement::Line(LineMode::Soft) => {}
+                        FormatElement::Line(LineMode::SoftOrSpace) => {
+                            cleaned.push(FormatElement::Space);
+                        }
+
+                        FormatElement::Interned(interned) => {
+                            cleaned.push(FormatElement::Interned(clean_interned(
+                                interned.clone(),
+                                interned_cache,
+                                condition_content_stack,
+                                allocator,
+                            )));
+                        }
+                        // Since this buffer aims to simulate infinite print width, we don't need to retain the best fitting.
+                        // Just extract the flattest variant and then handle elements within it.
+                        FormatElement::BestFitting(best_fitting) => {
+                            let most_flat = best_fitting.most_flat();
+                            most_flat.iter().rev().for_each(|element| element_stack.push(element));
+                        }
+                        element => cleaned.push(element.clone()),
+                    }
+                }
+
+                Interned::new(cleaned)
+            }
+            // No change necessary, return existing interned element
+            None => interned.clone(),
+        };
+
+        interned_cache.insert(interned, result.clone());
+        result
+    }
+}
+
+impl<'ast, Ctx> Buffer<'ast, Ctx> for RemoveSoftLinesBuffer<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        let mut element_stack = Vec::from_iter([element]);
+        while let Some(element) = element_stack.pop() {
+            match element {
+                FormatElement::Tag(Tag::StartConditionalContent(condition)) => {
+                    self.conditional_content_stack.push(condition.clone());
+                }
+                FormatElement::Tag(Tag::EndConditionalContent) => {
+                    self.conditional_content_stack.pop();
+                }
+                // All content within an expanded conditional gets dropped. If there's a
+                // matching flat variant, that will still get kept.
+                _ if self.is_in_expanded_conditional_content() => {}
+
+                FormatElement::Line(LineMode::Soft) => {}
+                FormatElement::Line(LineMode::SoftOrSpace) => {
+                    self.inner.write_element(FormatElement::Space);
+                }
+                FormatElement::Interned(interned) => {
+                    let cleaned = self.clean_interned(interned);
+                    self.inner.write_element(FormatElement::Interned(cleaned));
+                }
+                // Since this buffer aims to simulate infinite print width, we don't need to retain the best fitting.
+                // Just extract the flattest variant and then handle elements within it.
+                FormatElement::BestFitting(best_fitting) => {
+                    let most_flat = best_fitting.most_flat();
+                    element_stack.extend(most_flat.iter().rev().cloned());
+                }
+                element => self.inner.write_element(element),
+            }
+        }
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        self.inner.elements()
+    }
+
+    fn state(&self) -> &FormatState<'ast, Ctx> {
+        self.inner.state()
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx> {
+        self.inner.state_mut()
+    }
+}
+
+pub trait BufferExtensions<'ast, Ctx>: Buffer<'ast, Ctx> + Sized
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Returns a new buffer that calls the passed inspector for every element that gets written to the output
+    #[must_use]
+    #[expect(unused)]
+    fn inspect<'inner, F>(&'inner mut self, inspector: F) -> Inspect<'ast, 'inner, Ctx, F>
+    where
+        F: FnMut(&FormatElement),
+    {
+        Inspect::new(self, inspector)
+    }
+
+    /// Starts a recording that gives you access to all elements that have been written between the start
+    /// and end of the recording
+    ///
+    /// #Examples
+    ///
+    /// ```
+    /// use std::ops::Deref;
+    /// use biome_formatter::prelude::*;
+    /// use biome_formatter::{write, format, SimpleFormatContext};
+    ///
+    /// # fn main()  {
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+    ///     let mut recording = f.start_recording();
+    ///
+    ///     write!(recording, [token("A")])?;
+    ///     write!(recording, [token("B")])?;
+    ///
+    ///     write!(recording, [format_with(|f| write!(f, [token("C"), token("D")]))])?;
+    ///
+    ///     let recorded = recording.stop();
+    ///     assert_eq!(
+    ///         recorded.deref(),
+    ///         &[
+    ///             FormatElement::Token{ text: "A" },
+    ///             FormatElement::Token{ text: "B" },
+    ///             FormatElement::Token{ text: "C" },
+    ///             FormatElement::Token{ text: "D" }
+    ///         ]
+    ///     );
+    ///
+    ///     Ok(())
+    /// })])?;
+    ///
+    /// assert_eq!(formatted.print()?.as_code(), "ABCD");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    fn start_recording(&mut self) -> Recording<'_, Self, Ctx> {
+        Recording::new(self)
+    }
+
+    /// Writes a sequence of elements into this buffer.
+    fn write_elements<I>(&mut self, elements: I)
+    where
+        I: IntoIterator<Item = FormatElement<'ast>>,
+    {
+        for element in elements {
+            self.write_element(element);
+        }
+    }
+}
+
+impl<'ast, Ctx, T> BufferExtensions<'ast, Ctx> for T
+where
+    Ctx: FormatContext<'ast>,
+    T: Buffer<'ast, Ctx>,
+{
+}
+
+#[derive(Debug)]
+pub struct Recording<'buf, Buffer, Ctx> {
+    start: usize,
+    buffer: &'buf mut Buffer,
+    _marker: std::marker::PhantomData<Ctx>,
+}
+
+impl<'ast, 'buf, B, Ctx> Recording<'buf, B, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    B: Buffer<'ast, Ctx>,
+{
+    fn new(buffer: &'buf mut B) -> Self {
+        Self { start: buffer.elements().len(), buffer, _marker: std::marker::PhantomData }
+    }
+
+    #[inline(always)]
+    pub fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, Ctx>) {
+        self.buffer.write_fmt(arguments);
+    }
+
+    #[inline(always)]
+    #[expect(unused)]
+    pub fn write_element(&mut self, element: FormatElement<'ast>) {
+        self.buffer.write_element(element);
+    }
+
+    pub fn stop(self) -> Recorded<'buf, 'ast> {
+        let buffer: &'buf B = self.buffer;
+        let elements = buffer.elements();
+
+        let recorded = if self.start > elements.len() {
+            // May happen if buffer was rewound.
+            &[]
+        } else {
+            &elements[self.start..]
+        };
+
+        Recorded(recorded)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Recorded<'buf, 'ast>(&'buf [FormatElement<'ast>]);
+
+impl<'ast> Deref for Recorded<'_, 'ast> {
+    type Target = [FormatElement<'ast>];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/builders.rs
+++ b/crates/oxc_formatter_core/src/formatter/builders.rs
@@ -1795,9 +1795,9 @@ where
     should_expand: bool,
 }
 
-impl<Ctx> Group<'_, '_, Ctx>
+impl<'ast, Ctx> Group<'_, 'ast, Ctx>
 where
-    for<'ast> Ctx: FormatContext<'ast>,
+    Ctx: FormatContext<'ast>,
 {
     pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
         self.group_id = group_id;

--- a/crates/oxc_formatter_core/src/formatter/builders.rs
+++ b/crates/oxc_formatter_core/src/formatter/builders.rs
@@ -1,0 +1,2743 @@
+use std::{cell::Cell, num::NonZeroU8};
+
+use Tag::{
+    EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
+    EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign, StartConditionalContent,
+    StartDedent, StartEntry, StartFill, StartGroup, StartIndent, StartIndentIfGroupBreaks,
+    StartLabelled, StartLineSuffix,
+};
+use oxc_allocator::Vec as ArenaVec;
+use oxc_span::{GetSpan, Span};
+
+use super::{
+    Argument, Arguments, Buffer, FormatContext, GroupId, VecBuffer,
+    format_element::{
+        self, TextWidth,
+        tag::{Condition, Tag},
+    },
+    prelude::{
+        tag::{DedentMode, GroupMode, LabelId},
+        *,
+    },
+    separated::FormatSeparatedIter,
+};
+use crate::formatter::context::SourceTextExt;
+use crate::options::IndentWidthProvider;
+use crate::{TrailingSeparator, write};
+
+/// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
+///
+/// It's omitted if the enclosing `Group` fits on a single line.
+/// A soft line break is identical to a hard line break when not enclosed inside of a `Group`.
+///
+/// # Examples
+///
+/// Soft line breaks are omitted if the enclosing `Group` fits on a single line
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![token("a,"), soft_line_break(), token("b")])
+/// ])?;
+///
+/// assert_eq!(
+///     "a,b",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+/// See [soft_line_break_or_space] if you want to insert a space between the elements if the enclosing
+/// `Group` fits on a single line.
+///
+/// Soft line breaks are emitted if the enclosing `Group` doesn't fit on a single line
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("a long word,"),
+///         soft_line_break(),
+///         token("so that the group doesn't fit on a single line"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a long word,\nso that the group doesn't fit on a single line",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn soft_line_break() -> Line {
+    Line::new(LineMode::Soft)
+}
+
+/// A forced line break that are always printed. A hard line break forces any enclosing `Group`
+/// to be printed over multiple lines.
+///
+/// # Examples
+///
+/// It forces a line break, even if the enclosing `Group` would otherwise fit on a single line.
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("a,"),
+///         hard_line_break(),
+///         token("b"),
+///         hard_line_break()
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a,\nb\n",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn hard_line_break() -> Line {
+    Line::new(LineMode::Hard)
+}
+
+/// A forced empty line. An empty line inserts enough line breaks in the output for
+/// the previous and next element to be separated by an empty line.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// fn test() {
+/// let elements = format!(
+///     SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("a,"),
+///         empty_line(),
+///         token("b"),
+///         empty_line()
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a,\n\nb\n\n",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn empty_line() -> Line {
+    Line::new(LineMode::Empty)
+}
+
+/// A line break if the enclosing `Group` doesn't fit on a single line, a space otherwise.
+///
+/// # Examples
+///
+/// The line breaks are emitted as spaces if the enclosing `Group` fits on a single line:
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("a,"),
+///         soft_line_break_or_space(),
+///         token("b"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a, b",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The printer breaks the lines if the enclosing `Group` doesn't fit on a single line:
+/// ```
+/// use biome_formatter::{format_args, format, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("a long word,"),
+///         soft_line_break_or_space(),
+///         token("so that the group doesn't fit on a single line"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a long word,\nso that the group doesn't fit on a single line",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn soft_line_break_or_space() -> Line {
+    Line::new(LineMode::SoftOrSpace)
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Line {
+    mode: LineMode,
+}
+
+impl Line {
+    const fn new(mode: LineMode) -> Self {
+        Self { mode }
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Line
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Line(self.mode));
+    }
+}
+
+impl std::fmt::Debug for Line {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Line").field(&self.mode).finish()
+    }
+}
+
+/// Creates a [`FormatElement::Token`] that gets written as is to the output.
+///
+/// # SAFELY
+///
+/// This function is safe to use only if the provided text contains no line breaks, tab characters,
+/// or other non-ASCII characters.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [token("Hello World")])?;
+///
+/// assert_eq!(
+///     "Hello World",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Printing a string literal as a literal requires that the string literal is properly escaped and
+/// enclosed in quotes (depending on the target language).
+///
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
+/// let elements = format!(SimpleFormatContext::default(), [token("\"Hello\\tWorld\"")])?;
+///
+/// assert_eq!(r#""Hello\tWorld""#, elements.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn token(text: &'static str) -> Token {
+    debug_assert_token_ascii_only_and_no_linebreaks(text);
+    Token { text }
+}
+
+fn debug_assert_token_ascii_only_and_no_linebreaks(text: &str) {
+    debug_assert!(
+        text.as_bytes().iter().all(|&c| c.is_ascii() && !matches!(c, b'\r' | b'\n' | b'\t')),
+        "`FormatElement::Token` can only contain ASCII characters without line breaks or tab characters. Found invalid content: '{text}'"
+    );
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct Token {
+    text: &'static str,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Token
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Token { text: self.text });
+    }
+}
+
+impl std::fmt::Debug for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "Token({})", self.text)
+    }
+}
+
+/// Creates a text from a dynamic string and a range of the input source
+pub fn text(text: &str) -> Text<'_> {
+    debug_assert_no_cr_line_break(text);
+    Text { text, width: None }
+}
+
+/// Creates a text from a dynamic string that contains no whitespace characters
+pub fn text_without_whitespace(text: &str) -> Text<'_> {
+    debug_assert!(
+        text.as_bytes().iter().all(|&b| !b.is_ascii_whitespace()),
+        "The content '{text}' contains whitespace characters but text must not contain any whitespace characters."
+    );
+    Text { text, width: Some(TextWidth::from_non_whitespace_str(text)) }
+}
+
+#[derive(Eq, PartialEq)]
+pub struct Text<'a> {
+    text: &'a str,
+    width: Option<TextWidth>,
+}
+
+impl<'a, Ctx> Format<'a, Ctx> for Text<'a>
+where
+    Ctx: FormatContext<'a>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+        f.write_element(FormatElement::Text {
+            text: self.text,
+            width: self
+                .width
+                .unwrap_or_else(|| TextWidth::from_text(self.text, f.options().indent_width())),
+        });
+    }
+}
+
+impl std::fmt::Debug for Text<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "Text({})", self.text)
+    }
+}
+
+/// Debug assert that the given text contains no `\r` line terminator characters.
+//
+// `#[inline(always)]` because this is a no-op in release mode
+#[inline(always)]
+#[expect(clippy::inline_always)]
+#[track_caller]
+fn debug_assert_no_cr_line_break(text: &str) {
+    debug_assert!(
+        !text.contains('\r'),
+        "The content `{text}` contains an unsupported `\\r` line terminator character but text must only use line feeds `\\n` as line separator. Use `\\n` instead of `\\r` and `\\r\\n` to insert a line break in strings."
+    );
+}
+
+/// Pushes some content to the end of the current line
+///
+/// ## Examples
+///
+/// ```
+/// use biome_formatter::{format};
+/// use biome_formatter::prelude::*;
+///
+/// fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     token("a"),
+///     line_suffix(&token("c")),
+///     token("b")
+/// ])?;
+///
+/// assert_eq!(
+///     "abc",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn line_suffix<'a, 'ast, Ctx, Content>(inner: &'a Content) -> LineSuffix<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    LineSuffix { content: Argument::new(inner) }
+}
+
+#[derive(Copy, Clone)]
+pub struct LineSuffix<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'a, 'ast, Ctx>,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for LineSuffix<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartLineSuffix));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndLineSuffix));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for LineSuffix<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("LineSuffix").field(&"{{content}}").finish()
+    }
+}
+
+/// Inserts a boundary for line suffixes that forces the printer to print all pending line suffixes.
+/// Helpful if a line suffix shouldn't pass a certain point.
+///
+/// ## Examples
+///
+/// Forces the line suffix "c" to be printed before the token `d`.
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn  main()  {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     token("a"),
+///     line_suffix(&token("c")),
+///     token("b"),
+///     line_suffix_boundary(),
+///     token("d")
+/// ])?;
+///
+/// assert_eq!(
+///     "abc\nd",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+pub const fn line_suffix_boundary() -> LineSuffixBoundary {
+    LineSuffixBoundary
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct LineSuffixBoundary;
+
+impl<'ast, Ctx> Format<'ast, Ctx> for LineSuffixBoundary
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::LineSuffixBoundary);
+    }
+}
+
+/// Marks some content with a label.
+///
+/// This does not directly influence how this content will be printed, but some
+/// parts of the formatter may inspect the [labelled element](Tag::StartLabelled)
+/// using [FormatElements::has_label].
+///
+/// ## Examples
+///
+/// ```rust
+/// # use biome_formatter::prelude::*;
+/// # use biome_formatter::{format, write, LineWidth};
+///
+/// #[derive(Debug, Copy, Clone)]
+/// enum MyLabels {
+///     Main
+/// }
+///
+/// impl tag::Label for MyLabels {
+///     fn id(&self) -> u64 {
+///         *self as u64
+///     }
+///
+///     fn debug_name(&self) -> &'static str {
+///         match self {
+///             Self::Main => "Main"
+///         }
+///     }
+/// }
+///
+/// # fn test() {
+/// let formatted = format!(
+///     SimpleFormatContext::default(),
+///     [format_with(|f| {
+///         let mut recording = f.start_recording();
+///         write!(recording, [
+///             labelled(
+///                 LabelId::of(MyLabels::Main),
+///                 &token("'I have a label'")
+///             )
+///         ])?;
+///
+///         let recorded = recording.stop();
+///
+///         let is_labelled = recorded.first().is_some_and(|element| element.has_label(LabelId::of(MyLabels::Main)));
+///
+///         if is_labelled {
+///             write!(f, [token(" has label `Main`")])
+///         } else {
+///             write!(f, [token(" doesn't have label `Main`")])
+///         }
+///     })]
+/// )?;
+///
+/// assert_eq!("'I have a label' has label `Main`", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Alternatives
+///
+/// Use `Memoized.inspect(f)?.has_label(LabelId::of(MyLabels::Main)` if you need to know if some content breaks that should
+/// only be written later.
+#[inline]
+pub fn labelled<'a, 'ast, Ctx, Content>(
+    label_id: LabelId,
+    content: &'a Content,
+) -> FormatLabelled<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    FormatLabelled { label_id, content: Argument::new(content) }
+}
+
+#[derive(Copy, Clone)]
+pub struct FormatLabelled<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    label_id: LabelId,
+    content: Argument<'a, 'ast, Ctx>,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for FormatLabelled<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartLabelled(self.label_id)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndLabelled));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for FormatLabelled<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Label").field(&self.label_id).field(&"{{content}}").finish()
+    }
+}
+
+/// Inserts a single space. Allows to separate different tokens.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// // the tab must be encoded as \\t to not literally print a tab character ("Hello{tab}World" vs "Hello\tWorld")
+/// let elements = format!(SimpleFormatContext::default(), [token("a"), space(), token("b")])?;
+///
+/// assert_eq!("a b", elements.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn space() -> Space {
+    Space
+}
+
+/// Inserts a single space.
+/// The main difference with space is that
+/// it always adds a space even when it's the last element of a group.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("nineteen_characters"),
+///         soft_line_break(),
+///         token("1"),
+///         hard_space(),
+///     ])
+/// ])?;
+/// assert_eq!(
+///     "nineteen_characters\n1",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+/// # Examples
+///
+/// Without HardSpace
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("nineteen_characters"),
+///         soft_line_break(),
+///         token("1"),
+///         space(),
+///     ])
+/// ])?;
+/// assert_eq!(
+///     "nineteen_characters1",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub const fn hard_space() -> HardSpace {
+    HardSpace
+}
+
+/// Optionally inserts a single space if the given condition is true.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::format;
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [token("a"), maybe_space(true), token("b")])?;
+/// let nospace = format!(SimpleFormatContext::default(), [token("a"), maybe_space(false), token("b")])?;
+///
+/// assert_eq!("a b", elements.print()?.as_code());
+/// assert_eq!("ab", nospace.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn maybe_space(should_insert: bool) -> Option<Space> {
+    if should_insert { Some(Space) } else { None }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Space;
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Space
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Space);
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct HardSpace;
+
+impl<'ast, Ctx> Format<'ast, Ctx> for HardSpace
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::HardSpace);
+    }
+}
+/// It adds a level of indentation to the given content
+///
+/// It doesn't add any line breaks at the edges of the content, meaning that
+/// the line breaks have to be manually added.
+///
+/// This helper should be used only in rare cases, instead you should rely more on
+/// [block_indent] and [soft_block_indent]
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let block = format!(SimpleFormatContext::default(), [
+///     token("switch {"),
+///     block_indent(&format_args![
+///         token("default:"),
+///         indent(&format_args![
+///             // this is where we want to use a
+///             hard_line_break(),
+///             token("break;"),
+///         ])
+///     ]),
+///     token("}"),
+/// ])?;
+///
+/// assert_eq!(
+///     "switch {\n\tdefault:\n\t\tbreak;\n}",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// When the indent_style is tab, [indent] convert the preceding alignments to indents
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, format_args};
+///
+/// # fn test() {
+/// let block = format!(
+///     SimpleFormatContext::default(),
+///     [
+///         token("root"),
+///         indent(&format_args![align(
+///             2,
+///             &format_args![indent(&format_args![
+///                 hard_line_break(),
+///                 token("should be 3 tabs"),
+///             ])]
+///         )])
+///     ]
+/// )?;
+///
+/// assert_eq!(
+///     "root\n\t\t\tshould be 3 tabs",
+///     block.print()?.as_code()
+/// );
+/// #    Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn indent<'a, 'ast, Ctx, Content>(content: &'a Content) -> Indent<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    Indent { content: Argument::new(content) }
+}
+
+#[derive(Copy, Clone)]
+pub struct Indent<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'a, 'ast, Ctx>,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Indent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartIndent));
+
+        let elements_length = f.elements().len();
+
+        Arguments::from(&self.content).fmt(f);
+
+        debug_assert_ne!(
+            elements_length,
+            f.elements().len(),
+            "Indent's content must produce at least one element"
+        );
+
+        f.write_element(FormatElement::Tag(EndIndent));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for Indent<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Indent").field(&"{{content}}").finish()
+    }
+}
+
+/// It reduces the indention for the given content depending on the closest [indent] or [align] parent element.
+/// * [align] Undoes the spaces added by [align]
+/// * [indent] Reduces the indention level by one
+///
+/// This is a No-op if the indention level is zero.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let block = format!(SimpleFormatContext::default(), [
+///     token("root"),
+///     align(2, &format_args![
+///         hard_line_break(),
+///         token("aligned"),
+///         dedent(&format_args![
+///             hard_line_break(),
+///             token("not aligned"),
+///         ]),
+///         dedent(&indent(&format_args![
+///             hard_line_break(),
+///             token("Indented, not aligned")
+///         ]))
+///     ]),
+///     dedent(&format_args![
+///         hard_line_break(),
+///         token("Dedent on root level is a no-op.")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "root\n  aligned\nnot aligned\n\tIndented, not aligned\nDedent on root level is a no-op.",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, format_args, IndentStyle, IndentWidth, SimpleFormatOptions};
+///
+/// # fn test() {
+///     let context = SimpleFormatContext::new(SimpleFormatOptions {
+///         indent_width: IndentWidth::try_from(8).unwrap(),
+///         indent_style: IndentStyle::Space,
+///         ..SimpleFormatOptions::default()
+///     });
+///     let elements = format!(
+///         context,
+///         [
+///             token("root"),
+///             indent(&format_args![
+///                 hard_line_break(),
+///                 token("Indented"),
+///                 align(
+///                     2,
+///                     &format_args![
+///                         hard_line_break(),
+///                         token("Indented and aligned"),
+///                         dedent(&format_args![
+///                             hard_line_break(),
+///                             token("Indented, not aligned"),
+///                         ]),
+///                     ]
+///                 ),
+///             ]),
+///             align(
+///                 2,
+///                 &format_args![
+///                     hard_line_break(),
+///                     token("Aligned"),
+///                     indent(&format_args![
+///                         hard_line_break(),
+///                         token("Aligned, and indented"),
+///                         dedent(&format_args![
+///                             hard_line_break(),
+///                             token("aligned, not indented"),
+///                         ]),
+///                     ])
+///                 ]
+///             ),
+///             dedent(&format_args![hard_line_break(), token("root level")])
+///         ]
+///     )?;
+///     assert_eq!(
+///      "root\n        Indented\n          Indented and aligned\n        Indented, not aligned\n  Aligned\n          Aligned, and indented\n  aligned, not indented\nroot level",
+///      elements.print()?.as_code()
+///  );
+/// #    Ok(())
+/// # }
+/// ```
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, format_args};
+///
+/// # fn test() {
+/// let block = format!(
+///     SimpleFormatContext::default(),
+///     [
+///         token("root"),
+///         indent(&format_args![align(
+///             2,
+///             &format_args![align(
+///                 2,
+///                 &format_args![indent(&format_args![
+///                     hard_line_break(),
+///                     token("should be 4 tabs"),
+///                     dedent(&format_args![
+///                         hard_line_break(),
+///                         token("should be 1 tab and 4 spaces"),
+///                     ]),
+///                 ])]
+///             ),]
+///         )])
+///     ]
+/// )?;
+/// assert_eq!(
+///     "root\n\t\t\t\tshould be 4 tabs\n\t    should be 1 tab and 4 spaces",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn dedent<'ast, Ctx, Content>(content: &Content) -> Dedent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    Dedent { content: Argument::new(content), mode: DedentMode::Level }
+}
+
+#[derive(Copy, Clone)]
+pub struct Dedent<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'a, 'ast, Ctx>,
+    mode: DedentMode,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Dedent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartDedent(self.mode)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndDedent(self.mode)));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for Dedent<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Dedent").field(&"{{content}}").finish()
+    }
+}
+
+/// It resets the indent document so that the content will be printed at the start of the line.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let block = format!(SimpleFormatContext::default(), [
+///     token("root"),
+///     indent(&format_args![
+///         hard_line_break(),
+///         token("indent level 1"),
+///         indent(&format_args![
+///             hard_line_break(),
+///             token("indent level 2"),
+///             align(2, &format_args![
+///                 hard_line_break(),
+///                 token("two space align"),
+///                 dedent_to_root(&format_args![
+///                     hard_line_break(),
+///                     token("starts at the beginning of the line")
+///                 ]),
+///             ]),
+///             hard_line_break(),
+///             token("end indent level 2"),
+///         ])
+///  ]),
+/// ])?;
+///
+/// assert_eq!(
+///     "root\n\tindent level 1\n\t\tindent level 2\n\t\t  two space align\nstarts at the beginning of the line\n\t\tend indent level 2",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Prettier
+///
+/// This resembles the behaviour of Prettier's `align(Number.NEGATIVE_INFINITY, content)` IR element.
+#[inline]
+pub fn dedent_to_root<'ast, Ctx, Content>(content: &Content) -> Dedent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    Dedent { content: Argument::new(content), mode: DedentMode::Root }
+}
+
+/// Aligns its content by indenting the content by `count` spaces.
+///
+/// [align] is a variant of `[indent]` that indents its content by a specified number of spaces rather than
+/// using the configured indent character (tab or a specified number of spaces).
+///
+/// You should use [align] when you want to indent a content by a specific number of spaces.
+/// Using [indent] is preferred in all other situations as it respects the users preferred indent character.
+///
+/// # Examples
+///
+/// ## Tab indention
+///
+/// ```
+/// use std::num::NonZeroU8;
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let block = format!(SimpleFormatContext::default(), [
+///     token("a"),
+///     hard_line_break(),
+///     token("?"),
+///     space(),
+///     align(2, &format_args![
+///         token("function () {"),
+///         hard_line_break(),
+///         token("}"),
+///     ]),
+///     hard_line_break(),
+///     token(":"),
+///     space(),
+///     align(2, &format_args![
+///         token("function () {"),
+///         block_indent(&token("console.log('test');")),
+///         token("}"),
+///     ]),
+///     token(";")
+/// ])?;
+///
+/// assert_eq!(
+///     "a\n? function () {\n  }\n: function () {\n\t\tconsole.log('test');\n  };",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// You can see that:
+///
+/// * the printer indents the function's `}` by two spaces because it is inside of an `align`.
+/// * the block `console.log` gets indented by two tabs.
+///   This is because `align` increases the indention level by one (same as `indent`)
+///   if you nest an `indent` inside an `align`.
+///   Meaning that, `align > ... > indent` results in the same indention as `indent > ... > indent`.
+///
+/// ## Spaces indention
+///
+/// ```
+/// use std::num::NonZeroU8;
+/// use biome_formatter::{format, format_args, IndentStyle, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     indent_style: IndentStyle::Space,
+///     indent_width: 4.try_into().unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let block = format!(context, [
+///     token("a"),
+///     hard_line_break(),
+///     token("?"),
+///     space(),
+///     align(2, &format_args![
+///         token("function () {"),
+///         hard_line_break(),
+///         token("}"),
+///     ]),
+///     hard_line_break(),
+///     token(":"),
+///     space(),
+///     align(2, &format_args![
+///         token("function () {"),
+///         block_indent(&token("console.log('test');")),
+///         token("}"),
+///     ]),
+///     token(";")
+/// ])?;
+///
+/// assert_eq!(
+///     "a\n? function () {\n  }\n: function () {\n      console.log('test');\n  };",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The printing of `align` differs if using spaces as indention sequence *and* it contains an `indent`.
+/// You can see the difference when comparing the indention of the `console.log(...)` expression to the previous example:
+///
+/// * tab indention: Printer indents the expression with two tabs because the `align` increases the indention level.
+/// * space indention: Printer indents the expression by 4 spaces (one indention level) **and** 2 spaces for the align.
+pub fn align<'ast, Ctx, Content>(count: u8, content: &Content) -> Align<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    Align {
+        count: NonZeroU8::new(count).expect("Alignment count must be a non-zero number."),
+        content: Argument::new(content),
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Align<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    count: NonZeroU8,
+    content: Argument<'a, 'ast, Ctx>,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Align<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartAlign(tag::Align(self.count))));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndAlign));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for Align<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Align")
+            .field("count", &self.count)
+            .field("content", &"{{content}}")
+            .finish()
+    }
+}
+
+/// Inserts a hard line break before and after the content and increases the indention level for the content by one.
+///
+/// Block indents indent a block of code, such as in a function body, and therefore insert a line
+/// break before and after the content.
+///
+/// Doesn't create an indention if the passed in content is [FormatElement.is_empty].
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let block = format![
+///     SimpleFormatContext::default(),
+///     [
+///         token("{"),
+///         block_indent(&format_args![
+///             token("let a = 10;"),
+///             hard_line_break(),
+///             token("let c = a + 5;"),
+///         ]),
+///         token("}"),
+///     ]
+/// ]?;
+///
+/// assert_eq!(
+///     "{\n\tlet a = 10;\n\tlet c = a + 5;\n}",
+///     block.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn block_indent<'ast, Ctx>(content: &impl Format<'ast, Ctx>) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    BlockIndent { content: Argument::new(content), mode: IndentMode::Block }
+}
+
+/// Indents the content by inserting a line break before and after the content and increasing
+/// the indention level for the content by one if the enclosing group doesn't fit on a single line.
+/// Doesn't change the formatting if the enclosing group fits on a single line.
+///
+/// # Examples
+///
+/// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't fit on a single line
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("'First string',"),
+///             soft_line_break_or_space(),
+///             token("'second string',"),
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[\n\t'First string',\n\t'second string',\n]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Doesn't change the formatting if the enclosing `Group` fits on a single line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("5,"),
+///             soft_line_break_or_space(),
+///             token("10"),
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[5, 10]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn soft_block_indent<'ast, Ctx>(content: &impl Format<'ast, Ctx>) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    BlockIndent { content: Argument::new(content), mode: IndentMode::Soft }
+}
+
+/// Conditionally adds spaces around the content if its enclosing group fits
+/// within a single line and the caller suggests that the space should be added.
+/// Otherwise indents the content and separates it by line breaks.
+///
+/// # Examples
+///
+/// Adds line breaks and indents the content if the enclosing group doesn't fit on the line.
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("{"),
+///         soft_block_indent_with_maybe_space(&format_args![
+///             token("aPropertyThatExceeds"),
+///             token(":"),
+///             space(),
+///             token("'line width'"),
+///         ], false),
+///         token("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{\n\taPropertyThatExceeds: 'line width'\n}",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Adds spaces around the content if the caller requests it and the group fits on the line.
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("{"),
+///         soft_block_indent_with_maybe_space(&format_args![
+///             token("a"),
+///             token(":"),
+///             space(),
+///             token("5"),
+///         ], true),
+///         token("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{ a: 5 }",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Does not add spaces around the content if the caller denies it and the group fits on the line.
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("{"),
+///         soft_block_indent_with_maybe_space(&format_args![
+///             token("a"),
+///             token(":"),
+///             space(),
+///             token("5"),
+///         ], false),
+///         token("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{a: 5}",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+pub fn soft_block_indent_with_maybe_space<'ast, Ctx>(
+    content: &impl Format<'ast, Ctx>,
+    should_add_space: bool,
+) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    if should_add_space { soft_space_or_block_indent(content) } else { soft_block_indent(content) }
+}
+
+/// If the enclosing `Group` doesn't fit on a single line, inserts a line break and indent.
+/// Otherwise, just inserts a space.
+///
+/// Line indents are used to break a single line of code, and therefore only insert a line
+/// break before the content and not after the content.
+///
+/// # Examples
+///
+/// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't
+/// fit on a single line. Otherwise, just inserts a space.
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("name"),
+///         space(),
+///         token("="),
+///         soft_line_indent_or_space(&format_args![
+///             token("firstName"),
+///             space(),
+///             token("+"),
+///             space(),
+///             token("lastName"),
+///         ]),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "name =\n\tfirstName + lastName",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Only adds a space if the enclosing `Group` fits on a single line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("a"),
+///         space(),
+///         token("="),
+///         soft_line_indent_or_space(&token("10")),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a = 10",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn soft_line_indent_or_space<'ast, Ctx>(
+    content: &impl Format<'ast, Ctx>,
+) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    BlockIndent { content: Argument::new(content), mode: IndentMode::SoftLineOrSpace }
+}
+
+/// It functions similarly to soft_line_indent_or_space, but instead of a regular space, it inserts a hard space.
+///
+/// # Examples
+///
+/// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't
+/// fit on a single line. Otherwise, just inserts a space.
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("name"),
+///         space(),
+///         token("="),
+///         soft_line_indent_or_hard_space(&format_args![
+///             token("firstName"),
+///             space(),
+///             token("+"),
+///             space(),
+///             token("lastName"),
+///         ]),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "name =\n\tfirstName + lastName",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Only adds a space if the enclosing `Group` fits on a single line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("a"),
+///         space(),
+///         token("="),
+///         soft_line_indent_or_hard_space(&token("10")),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "a = 10",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// It enforces a space after the "=" assignment operators
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(8).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("value"),
+///         soft_line_break_or_space(),
+///         token("="),
+///         soft_line_indent_or_hard_space(&format_args![
+///             token("10"),
+///         ]),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "value\n=\n\t10",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+#[expect(unused)]
+pub fn soft_line_indent_or_hard_space<'ast, Ctx>(
+    content: &impl Format<'ast, Ctx>,
+) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    BlockIndent { content: Argument::new(content), mode: IndentMode::HardSpace }
+}
+
+#[derive(Copy, Clone)]
+pub struct BlockIndent<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'fmt, 'ast, Ctx>,
+    mode: IndentMode,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum IndentMode {
+    Soft,
+    Block,
+    SoftSpace,
+    HardSpace,
+    SoftLineOrSpace,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartIndent));
+
+        match self.mode {
+            IndentMode::Soft => write!(f, soft_line_break()),
+            IndentMode::Block => write!(f, hard_line_break()),
+            IndentMode::SoftLineOrSpace | IndentMode::SoftSpace => {
+                write!(f, soft_line_break_or_space());
+            }
+            IndentMode::HardSpace => write!(f, [hard_space(), soft_line_break()]),
+        }
+
+        let elements_length = f.elements().len();
+
+        Arguments::from(&self.content).fmt(f);
+
+        debug_assert_ne!(
+            elements_length,
+            f.elements().len(),
+            "BlockIndent's content must produce at least one element"
+        );
+
+        f.write_element(FormatElement::Tag(EndIndent));
+
+        match self.mode {
+            IndentMode::Soft => write!(f, [soft_line_break()]),
+            IndentMode::Block => write!(f, [hard_line_break()]),
+            IndentMode::SoftSpace => write!(f, [soft_line_break_or_space()]),
+            IndentMode::SoftLineOrSpace | IndentMode::HardSpace => (),
+        }
+    }
+}
+
+impl<Ctx> std::fmt::Debug for BlockIndent<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self.mode {
+            IndentMode::Soft => "SoftBlockIndent",
+            IndentMode::Block => "HardBlockIndent",
+            IndentMode::SoftLineOrSpace => "SoftLineIndentOrSpace",
+            IndentMode::SoftSpace => "SoftSpaceBlockIndent",
+            IndentMode::HardSpace => "HardSpaceBlockIndent",
+        };
+
+        f.debug_tuple(name).field(&"{{content}}").finish()
+    }
+}
+
+/// Adds spaces around the content if its enclosing group fits on a line, otherwise indents the content and separates it by line breaks.
+///
+/// # Examples
+///
+/// Adds line breaks and indents the content if the enclosing group doesn't fit on the line.
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(10).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("{"),
+///         soft_space_or_block_indent(&format_args![
+///             token("aPropertyThatExceeds"),
+///             token(":"),
+///             space(),
+///             token("'line width'"),
+///         ]),
+///         token("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{\n\taPropertyThatExceeds: 'line width'\n}",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Adds spaces around the content if the group fits on the line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("{"),
+///         soft_space_or_block_indent(&format_args![
+///             token("a"),
+///             token(":"),
+///             space(),
+///             token("5"),
+///         ]),
+///         token("}")
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "{ a: 5 }",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+pub fn soft_space_or_block_indent<'ast, Ctx>(
+    content: &impl Format<'ast, Ctx>,
+) -> BlockIndent<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    BlockIndent { content: Argument::new(content), mode: IndentMode::SoftSpace }
+}
+
+/// Creates a logical `Group` around the content that should either consistently be printed on a single line
+/// or broken across multiple lines.
+///
+/// The printer will try to print the content of the `Group` on a single line, ignoring all soft line breaks and
+/// emitting spaces for soft line breaks or spaces. The printer tracks back if it isn't successful either
+/// because it encountered a hard line break, or because printing the `Group` on a single line exceeds
+/// the configured line width, and thus it must print all its content on multiple lines,
+/// emitting line breaks for all line break kinds.
+///
+/// # Examples
+///
+/// `Group` that fits on a single line
+///
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("1,"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[1, 2, 3]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The printer breaks the `Group` over multiple lines if its content doesn't fit on a single line
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("'Good morning! How are you today?',"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn group<'ast, Ctx>(content: &impl Format<'ast, Ctx>) -> Group<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    Group { content: Argument::new(content), group_id: None, should_expand: false }
+}
+
+#[derive(Copy, Clone)]
+pub struct Group<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'fmt, 'ast, Ctx>,
+    #[expect(clippy::struct_field_names)] // Keep the name the same as it is in the original source
+    group_id: Option<GroupId>,
+    should_expand: bool,
+}
+
+impl<Ctx> Group<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
+        self.group_id = group_id;
+        self
+    }
+
+    /// Changes the [PrintMode] of the group from [`Flat`](PrintMode::Flat) to [`Expanded`](PrintMode::Expanded).
+    /// The result is that any soft-line break gets printed as a regular line break.
+    ///
+    /// This is useful for content rendered inside of a [FormatElement::BestFitting] that prints each variant
+    /// in [PrintMode::Flat] to change some content to be printed in [`Expanded`](PrintMode::Expanded) regardless.
+    /// See the documentation of the [`best_fitting`] macro for an example.
+    pub fn should_expand(mut self, should_expand: bool) -> Self {
+        self.should_expand = should_expand;
+        self
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for Group<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        let mode = if self.should_expand { GroupMode::Expand } else { GroupMode::Flat };
+
+        f.write_element(FormatElement::Tag(StartGroup(
+            tag::Group::new().with_id(self.group_id).with_mode(mode),
+        )));
+
+        Arguments::from(&self.content).fmt(f);
+
+        f.write_element(FormatElement::Tag(EndGroup));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for Group<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GroupElements")
+            .field("group_id", &self.group_id)
+            .field("should_expand", &self.should_expand)
+            .field("content", &"{{content}}")
+            .finish()
+    }
+}
+
+/// IR element that forces the parent group to print in expanded mode.
+///
+/// Has no effect if used outside of a group or element that introduce implicit groups (fill element).
+///
+/// ## Examples
+///
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("'Good morning! How are you today?',"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             expand_parent(), // Forces the parent to expand
+///             soft_line_break_or_space(),
+///             token("3"),
+///         ]),
+///         token("]"),
+///     ])
+/// ]);
+///
+/// assert_eq!(
+///     "[\n\t'Good morning! How are you today?',\n\t2,\n\t3\n]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Prettier
+/// Equivalent to Prettier's `break_parent` IR element
+pub const fn expand_parent() -> ExpandParent {
+    ExpandParent
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ExpandParent;
+
+impl<'ast, Ctx> Format<'ast, Ctx> for ExpandParent
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::ExpandParent);
+    }
+}
+
+/// Adds a conditional content that is emitted only if it isn't inside an enclosing `Group` that
+/// is printed on a single line. The element allows, for example, to insert a trailing comma after the last
+/// array element only if the array doesn't fit on a single line.
+///
+/// The element has no special meaning if used outside of a `Group`. In that case, the content is always emitted.
+///
+/// If you're looking for a way to only print something if the `Group` fits on a single line see [self::if_group_fits_on_line].
+///
+/// # Examples
+///
+/// Omits the trailing comma for the last array element if the `Group` fits on a single line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let elements = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("1,"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///             if_group_breaks(&token(","))
+///         ]),
+///         token("]"),
+///     ])
+/// ]);
+///
+/// assert_eq!(
+///     "[1, 2, 3]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Prints the trailing comma for the last array element if the `Group` doesn't fit on a single line
+/// ```
+/// use biome_formatter::{format_args, format, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::printer::PrintWidth;
+///
+/// fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let elements = format!(context, [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("'A somewhat longer string to force a line break',"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///             if_group_breaks(&token(","))
+///         ]),
+///         token("]"),
+///     ])
+/// ]);
+///
+/// assert_eq!(
+///     "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3,\n]",
+///     elements.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn if_group_breaks<'ast, Ctx, Content>(content: &Content) -> IfGroupBreaks<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    IfGroupBreaks { content: Argument::new(content), group_id: None, mode: PrintMode::Expanded }
+}
+
+/// Adds a conditional content specific for `Group`s that fit on a single line. The content isn't
+/// emitted for `Group`s spanning multiple lines.
+///
+/// See [if_group_breaks] if you're looking for a way to print content only for groups spanning multiple lines.
+///
+/// # Examples
+///
+/// Adds the trailing comma for the last array element if the `Group` fits on a single line
+/// ```
+/// use biome_formatter::{format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let formatted = format!(SimpleFormatContext::default(), [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("1,"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///             if_group_fits_on_line(&token(","))
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[1, 2, 3,]",
+///     formatted.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Omits the trailing comma for the last array element if the `Group` doesn't fit on a single line
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let formatted = format!(context, [
+///     group(&format_args![
+///         token("["),
+///         soft_block_indent(&format_args![
+///             token("'A somewhat longer string to force a line break',"),
+///             soft_line_break_or_space(),
+///             token("2,"),
+///             soft_line_break_or_space(),
+///             token("3"),
+///             if_group_fits_on_line(&token(","))
+///         ]),
+///         token("]"),
+///     ])
+/// ])?;
+///
+/// assert_eq!(
+///     "[\n\t'A somewhat longer string to force a line break',\n\t2,\n\t3\n]",
+///     formatted.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn if_group_fits_on_line<'ast, Ctx, Content>(
+    flat_content: &Content,
+) -> IfGroupBreaks<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    IfGroupBreaks { mode: PrintMode::Flat, group_id: None, content: Argument::new(flat_content) }
+}
+
+#[derive(Copy, Clone)]
+pub struct IfGroupBreaks<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'a, 'ast, Ctx>,
+    group_id: Option<GroupId>,
+    mode: PrintMode,
+}
+
+impl<'ast, Ctx> IfGroupBreaks<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Inserts some content that the printer only prints if the group with the specified `group_id`
+    /// is printed in multiline mode. The referred group must appear before this element in the document
+    /// but doesn't have to one of its ancestors.
+    ///
+    /// # Examples
+    ///
+    /// Prints the trailing comma if the array group doesn't fit. The `group_id` is necessary
+    /// because `fill` creates an implicit group around each item and tries to print the item in flat mode.
+    /// The item `[4]` in this example fits on a single line but the trailing comma should still be printed
+    ///
+    /// ```
+    /// use biome_formatter::{format, format_args, write, LineWidth, SimpleFormatOptions};
+    /// use biome_formatter::prelude::*;
+    ///
+    /// # fn test() {
+    /// let context = SimpleFormatContext::new(SimpleFormatOptions {
+    ///     line_width: LineWidth::try_from(20).unwrap(),
+    ///     ..SimpleFormatOptions::default()
+    /// });
+    ///
+    /// let formatted = format!(context, [format_with(|f| {
+    ///     let group_id = f.group_id("array");
+    ///
+    ///     write!(f, [
+    ///         group(
+    ///             &format_args![
+    ///                 token("["),
+    ///                 soft_block_indent(&format_with(|f| {
+    ///                     f.fill()
+    ///                         .entry(&soft_line_break_or_space(), &token("1,"))
+    ///                         .entry(&soft_line_break_or_space(), &token("234568789,"))
+    ///                         .entry(&soft_line_break_or_space(), &token("3456789,"))
+    ///                         .entry(&soft_line_break_or_space(), &format_args!(
+    ///                             token("["),
+    ///                             soft_block_indent(&token("4")),
+    ///                             token("]"),
+    ///                             if_group_breaks(&token(",")).with_group_id(Some(group_id))
+    ///                         ))
+    ///                     .finish()
+    ///                 })),
+    ///                 token("]")
+    ///             ],
+    ///         ).with_group_id(Some(group_id))
+    ///     ])
+    /// })])?;
+    ///
+    /// assert_eq!(
+    ///     "[\n\t1, 234568789,\n\t3456789, [4],\n]",
+    ///     formatted.print()?.as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
+        self.group_id = group_id;
+        self
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for IfGroupBreaks<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartConditionalContent(
+            Condition::new(self.mode).with_group_id(self.group_id),
+        )));
+        self.content.fmt(f);
+        f.write_element(FormatElement::Tag(EndConditionalContent));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for IfGroupBreaks<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self.mode {
+            PrintMode::Flat => "IfGroupFitsOnLine",
+            PrintMode::Expanded => "IfGroupBreaks",
+        };
+
+        f.debug_struct(name)
+            .field("group_id", &self.group_id)
+            .field("content", &"{{content}}")
+            .finish()
+    }
+}
+
+/// Increases the indent level by one if the group with the specified id breaks.
+///
+/// This IR has the same semantics as using [if_group_breaks] and [if_group_fits_on_line] together.
+///
+/// ```
+/// # use biome_formatter::prelude::*;
+/// # use biome_formatter::write;
+/// # let format = format_with(|f: &mut Formatter<SimpleFormatContext>| {
+/// let id = f.group_id("head");
+///
+/// write!(f, [
+///     group(&token("Head")).with_group_id(Some(id)),
+///     if_group_breaks(&indent(&token("indented"))).with_group_id(Some(id)),
+///     if_group_fits_on_line(&token("indented")).with_group_id(Some(id))
+/// ])
+///
+/// # });
+/// ```
+///
+/// If you want to indent some content if the enclosing group breaks, use [`indent`].
+///
+/// Use [if_group_breaks] or [if_group_fits_on_line] if the fitting and breaking content differs more than just the
+/// indention level.
+///
+/// # Examples
+///
+/// Indent the body of an arrow function if the group wrapping the signature breaks:
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions, write};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let content = format_with(|f| {
+///     let group_id = f.group_id("header");
+///
+///     write!(f, [
+///         group(&token("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
+///         indent_if_group_breaks(&format_args![hard_line_break(), token("a => b")], group_id)
+///     ])
+/// });
+///
+/// let context = SimpleFormatContext::new(SimpleFormatOptions {
+///     line_width: LineWidth::try_from(20).unwrap(),
+///     ..SimpleFormatOptions::default()
+/// });
+///
+/// let formatted = format!(context, [content])?;
+///
+/// assert_eq!(
+///     "(aLongHeaderThatBreaksForSomeReason) =>\n\ta => b",
+///     formatted.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// It doesn't add an indent if the group wrapping the signature doesn't break:
+/// ```
+/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions, write};
+/// use biome_formatter::prelude::*;
+///
+/// # fn test() {
+/// let content = format_with(|f| {
+///     let group_id = f.group_id("header");
+///
+///     write!(f, [
+///         group(&token("(aLongHeaderThatBreaksForSomeReason) =>")).with_group_id(Some(group_id)),
+///         indent_if_group_breaks(&format_args![hard_line_break(), token("a => b")], group_id)
+///     ])
+/// });
+///
+/// let formatted = format!(SimpleFormatContext::default(), [content])?;
+///
+/// assert_eq!(
+///     "(aLongHeaderThatBreaksForSomeReason) =>\na => b",
+///     formatted.print()?.as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn indent_if_group_breaks<'a, 'ast, Ctx, Content>(
+    content: &'a Content,
+    group_id: GroupId,
+) -> IndentIfGroupBreaks<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+    Content: Format<'ast, Ctx>,
+{
+    IndentIfGroupBreaks { group_id, content: Argument::new(content) }
+}
+
+#[derive(Copy, Clone)]
+pub struct IndentIfGroupBreaks<'a, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    content: Argument<'a, 'ast, Ctx>,
+    group_id: GroupId,
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for IndentIfGroupBreaks<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        f.write_element(FormatElement::Tag(StartIndentIfGroupBreaks(self.group_id)));
+        Arguments::from(&self.content).fmt(f);
+        f.write_element(FormatElement::Tag(EndIndentIfGroupBreaks(self.group_id)));
+    }
+}
+
+impl<Ctx> std::fmt::Debug for IndentIfGroupBreaks<'_, '_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndentIfGroupBreaks")
+            .field("group_id", &self.group_id)
+            .field("content", &"{{content}}")
+            .finish()
+    }
+}
+
+/// Utility for formatting some content with an inline lambda function.
+#[derive(Copy, Clone)]
+pub struct FormatWith<T> {
+    formatter: T,
+}
+
+impl<'ast, Ctx, T> Format<'ast, Ctx> for FormatWith<T>
+where
+    Ctx: FormatContext<'ast>,
+    T: Fn(&mut Formatter<'_, 'ast, Ctx>),
+{
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        (self.formatter)(f);
+    }
+}
+
+impl<T> std::fmt::Debug for FormatWith<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FormatWith").field(&"{{formatter}}").finish()
+    }
+}
+
+/// Creates an object implementing `Format` that calls the passed closure to perform the formatting.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{SimpleFormatContext, format, write};
+/// use biome_rowan::TextSize;
+///
+/// struct MyFormat {
+///     items: Vec<&'static str>,
+/// }
+///
+/// impl Format<SimpleFormatContext> for MyFormat {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
+///         write!(f, [
+///             token("("),
+///             block_indent(&format_with(|f| {
+///                 let separator = space();
+///                 let mut join = f.join_with(&separator);
+///
+///                 for item in &self.items {
+///                     join.entry(&format_with(|f| write!(f, [text(item, TextSize::default())])));
+///                 }
+///                 join.finish()
+///             })),
+///             token(")")
+///         ])
+///     }
+/// }
+///
+/// # fn test() {
+/// let formatted = format!(SimpleFormatContext::default(), [MyFormat { items: vec!["a", "b", "c"]}])?;
+///
+/// assert_eq!("(\n\ta b c\n)", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+pub const fn format_with<'ast, Ctx, T>(formatter: T) -> FormatWith<T>
+where
+    Ctx: FormatContext<'ast>,
+    T: Fn(&mut Formatter<'_, 'ast, Ctx>),
+{
+    FormatWith { formatter }
+}
+
+/// Creates an inline `Format` object that can only be formatted once.
+///
+/// This can be useful in situation where the borrow checker doesn't allow you to use [`format_with`]
+/// because the code formatting the content consumes the value and cloning the value is too expensive.
+/// An example of this is if you want to nest a `FormatElement` or non-cloneable `Iterator` inside of a
+/// `block_indent` as shown can see in the examples section.
+///
+/// # Panics
+///
+/// Panics if the object gets formatted more than once.
+///
+/// # Example
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{SimpleFormatContext, format, write, Buffer};
+///
+/// struct MyFormat;
+///
+/// fn generate_values() -> impl Iterator<Item=Token> {
+///     vec![token("1"), token("2"), token("3"), token("4")].into_iter()
+/// }
+///
+/// impl Format<SimpleFormatContext> for MyFormat {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
+///         let mut values = generate_values();
+///
+///         let first = values.next();
+///
+///         // Formats the first item outside of the block and all other items inside of the block,
+///         // separated by line breaks
+///         write!(f, [
+///             first,
+///             block_indent(&format_once(|f| {
+///                 // Using format_with isn't possible here because the iterator gets consumed here
+///                 f.join_with(&hard_line_break()).entries(values).finish()
+///             })),
+///         ])
+///     }
+/// }
+///
+/// # fn test() {
+/// let formatted = format!(SimpleFormatContext::default(), [MyFormat])?;
+///
+/// assert_eq!("1\n\t2\n\t3\n\t4\n", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Formatting the same value twice results in a panic.
+///
+/// ```panics
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{SimpleFormatContext, format, write, Buffer};
+/// use biome_rowan::TextSize;
+///
+/// let mut count = 0;
+///
+/// let value = format_once(|f| {
+///     write!(f, [dynamic_token(&std::format!("Formatted {count}."), TextSize::default())])
+/// });
+///
+/// format!(SimpleFormatContext::default(), [value]).expect("Formatting once works fine");
+///
+/// // Formatting the value more than once panics
+/// format!(SimpleFormatContext::default(), [value]);
+/// ```
+pub const fn format_once<'ast, Ctx, T>(formatter: T) -> FormatOnce<T>
+where
+    Ctx: FormatContext<'ast>,
+    T: FnOnce(&mut Formatter<'_, 'ast, Ctx>),
+{
+    FormatOnce { formatter: Cell::new(Some(formatter)) }
+}
+
+pub struct FormatOnce<T> {
+    formatter: Cell<Option<T>>,
+}
+
+impl<'ast, Ctx, T> Format<'ast, Ctx> for FormatOnce<T>
+where
+    Ctx: FormatContext<'ast>,
+    T: FnOnce(&mut Formatter<'_, 'ast, Ctx>),
+{
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        let formatter = self.formatter.take().expect("Tried to format a `format_once` at least twice. This is not allowed. You may want to use `format_with` or `format.memoized` instead.");
+
+        (formatter)(f);
+    }
+}
+
+impl<T> std::fmt::Debug for FormatOnce<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("FormatOnce").field(&"{{formatter}}").finish()
+    }
+}
+
+/// Builder to join together a sequence of content.
+/// See [Formatter::join]
+#[must_use = "must eventually call `finish()` on Format builders"]
+pub struct JoinBuilder<'fmt, 'buf, 'ast, Ctx, Separator>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>,
+    with: Option<Separator>,
+    has_elements: bool,
+}
+
+impl<'fmt, 'buf, 'ast, Ctx, Separator> JoinBuilder<'fmt, 'buf, 'ast, Ctx, Separator>
+where
+    Ctx: FormatContext<'ast>,
+    Separator: Format<'ast, Ctx>,
+{
+    /// Creates a new instance that joins the elements without a separator
+    pub(super) fn new(fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>) -> Self {
+        Self { fmt, has_elements: false, with: None }
+    }
+
+    /// Creates a new instance that prints the passed separator between every two entries.
+    pub(super) fn with_separator(
+        fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>,
+        with: Separator,
+    ) -> Self {
+        Self { fmt, has_elements: false, with: Some(with) }
+    }
+
+    /// Adds a new entry to the join output.
+    pub fn entry(&mut self, entry: &dyn Format<'ast, Ctx>) -> &mut Self {
+        if let Some(with) = &self.with
+            && self.has_elements
+        {
+            with.fmt(self.fmt);
+        }
+        self.has_elements = true;
+
+        entry.fmt(self.fmt);
+
+        self
+    }
+
+    /// Adds the contents of an iterator of entries to the join output.
+    pub fn entries<F, I>(&mut self, entries: I) -> &mut Self
+    where
+        F: Format<'ast, Ctx>,
+        I: IntoIterator<Item = F>,
+    {
+        for entry in entries {
+            self.entry(&entry);
+        }
+
+        self
+    }
+
+    pub fn entries_with_trailing_separator<F, I>(
+        &mut self,
+        entries: I,
+        separator: &'static str,
+        trailing_separator: TrailingSeparator,
+    ) -> &mut Self
+    where
+        F: Format<'ast, Ctx> + GetSpan,
+        I: IntoIterator<Item = F>,
+    {
+        let iter = FormatSeparatedIter::new(entries.into_iter(), separator)
+            .with_trailing_separator(trailing_separator);
+
+        for entry in iter {
+            self.entry(&entry);
+        }
+
+        self
+    }
+}
+
+/// Builder to join together nodes that ensures that nodes separated by empty lines continue
+/// to be separated by empty lines in the formatted output.
+#[must_use = "must eventually call `finish()` on Format builders"]
+pub struct JoinNodesBuilder<'fmt, 'buf, 'ast, Ctx, Separator>
+where
+    Ctx: super::context::FormatContextExt<'ast>,
+{
+    /// The separator to insert between nodes. Either a soft or hard line break
+    separator: Separator,
+    fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>,
+    has_elements: bool,
+}
+
+impl<'fmt, 'buf, 'ast, Ctx, Separator> JoinNodesBuilder<'fmt, 'buf, 'ast, Ctx, Separator>
+where
+    Ctx: super::context::FormatContextExt<'ast>,
+    Separator: Format<'ast, Ctx>,
+{
+    pub(super) fn new(separator: Separator, fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>) -> Self {
+        Self { separator, fmt, has_elements: false }
+    }
+
+    /// Adds a new node with the specified formatted content to the output, respecting any new lines
+    /// that appear before the node in the input source.
+    pub fn entry(&mut self, span: Span, content: &dyn Format<'ast, Ctx>) {
+        if self.has_elements {
+            if self.has_lines_before(span) {
+                write!(self.fmt, empty_line());
+            } else {
+                self.separator.fmt(self.fmt);
+            }
+        }
+        self.has_elements = true;
+        write!(self.fmt, content);
+    }
+
+    /// Writes an entry without adding a separating line break or empty line.
+    pub fn entry_no_separator(&mut self, content: &dyn Format<'ast, Ctx>) {
+        self.has_elements = true;
+        write!(self.fmt, content);
+    }
+
+    /// Adds an iterator of entries to the output. Each entry is a `(node, content)` tuple.
+    pub fn entries<'a, F, I>(&mut self, entries: I) -> &mut Self
+    where
+        F: Format<'ast, Ctx> + GetSpan + 'a,
+        I: IntoIterator<Item = F>,
+    {
+        for content in entries {
+            self.entry(content.span(), &content);
+        }
+        self
+    }
+
+    pub fn entries_with_trailing_separator<'a, F, I>(
+        &mut self,
+        entries: I,
+        separator: &'static str,
+        trailing_separator: TrailingSeparator,
+    ) -> &mut Self
+    where
+        F: Format<'ast, Ctx> + GetSpan + 'a,
+        I: IntoIterator<Item = F>,
+    {
+        let iter = FormatSeparatedIter::new(entries.into_iter(), separator)
+            .with_trailing_separator(trailing_separator);
+
+        for content in iter {
+            self.entry(content.span(), &content);
+        }
+        self
+    }
+
+    /// Get the number of line breaks between two consecutive SyntaxNodes in the tree
+    pub fn has_lines_before(&self, span: Span) -> bool {
+        self.fmt.source_text().get_lines_before(span, self.fmt.comments()) > 1
+    }
+}
+
+/// Builder to fill as many elements as possible on a single line.
+#[must_use = "must eventually call `finish()` on Format builders"]
+pub struct FillBuilder<'fmt, 'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>,
+    empty: bool,
+}
+
+impl<'fmt, 'buf, 'ast, Ctx> FillBuilder<'fmt, 'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    pub(crate) fn new(fmt: &'fmt mut Formatter<'buf, 'ast, Ctx>) -> Self {
+        fmt.write_element(FormatElement::Tag(StartFill));
+
+        Self { fmt, empty: true }
+    }
+
+    /// Adds an iterator of entries to the fill output. Uses the passed `separator` to separate any two items.
+    pub fn entries<F, I>(&mut self, separator: &dyn Format<'ast, Ctx>, entries: I) -> &mut Self
+    where
+        F: Format<'ast, Ctx>,
+        I: IntoIterator<Item = F>,
+    {
+        for entry in entries {
+            self.entry(separator, &entry);
+        }
+
+        self
+    }
+
+    /// Adds a new entry to the fill output. The `separator` isn't written if this is the first element in the list.
+    pub fn entry(
+        &mut self,
+        separator: &dyn Format<'ast, Ctx>,
+        entry: &dyn Format<'ast, Ctx>,
+    ) -> &mut Self {
+        if self.empty {
+            self.empty = false;
+        } else {
+            self.fmt.write_element(FormatElement::Tag(StartEntry));
+            separator.fmt(self.fmt);
+            self.fmt.write_element(FormatElement::Tag(EndEntry));
+        }
+
+        self.fmt.write_element(FormatElement::Tag(StartEntry));
+        entry.fmt(self.fmt);
+        self.fmt.write_element(FormatElement::Tag(EndEntry));
+
+        self
+    }
+
+    /// Finishes the output and returns any error encountered
+    pub fn finish(&mut self) {
+        self.fmt.write_element(FormatElement::Tag(EndFill));
+    }
+}
+
+/// The first variant is the most flat, and the last is the most expanded variant.
+/// See [`best_fitting!`] macro for a more in-detail documentation
+#[derive(Clone)]
+pub struct BestFitting<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    variants: Arguments<'fmt, 'ast, Ctx>,
+}
+
+impl<'fmt, 'ast, Ctx> BestFitting<'fmt, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Creates a new best fitting IR with the given variants. The method itself isn't unsafe
+    /// but it is to discourage people from using it because the printer will panic if
+    /// the slice doesn't contain at least the least and most expanded variants.
+    ///
+    /// You're looking for a way to create a `BestFitting` object, use the `best_fitting![least_expanded, most_expanded]` macro.
+    ///
+    /// This is intended to be only used in the `best_fitting!` macro. As we can't place tail
+    /// expressions in a block for temporary lifetime extension since Rust 2024, we can't use an
+    /// `unsafe` block in the macro. Thus, this function can't be marked as unsafe, but it shouldn't
+    /// be used from outside.
+    ///
+    /// ## Safety
+    /// The slice must contain at least two variants.
+    #[doc(hidden)]
+    pub fn from_arguments_unchecked(variants: Arguments<'fmt, 'ast, Ctx>) -> Self {
+        assert!(
+            variants.0.len() >= 2,
+            "Requires at least the least expanded and most expanded variants"
+        );
+
+        Self { variants }
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for BestFitting<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        let mut buffer = VecBuffer::new(f.state_mut());
+        let variants = self.variants.items();
+
+        let mut formatted_variants = Vec::with_capacity(variants.len());
+
+        for variant in variants {
+            buffer.write_element(FormatElement::Tag(StartEntry));
+            buffer.write_fmt(Arguments::from(variant));
+            buffer.write_element(FormatElement::Tag(EndEntry));
+
+            formatted_variants.push(buffer.take_vec().into_bump_slice());
+        }
+
+        let formatted_variants =
+            ArenaVec::from_iter_in(formatted_variants, f.context().allocator());
+
+        // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,
+        // safe to call into the unsafe `from_vec_unchecked` function
+        let element = unsafe {
+            FormatElement::BestFitting(format_element::BestFittingElement::from_vec_unchecked(
+                formatted_variants,
+            ))
+        };
+
+        f.write_element(element);
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/comments.rs
+++ b/crates/oxc_formatter_core/src/formatter/comments.rs
@@ -1,0 +1,472 @@
+//! On-demand comment processing architecture for the formatter.
+//!
+//! This module implements a fundamentally different approach to comment handling compared to
+//! traditional formatters like Prettier. Instead of pre-processing and attaching comments to
+//! AST nodes, we process comments on-demand during formatting using a cursor-based system.
+//!
+//! ## Core Architecture: On-Demand vs Pre-processes
+//!
+//! ### Why Not Pre-processes (like Prettier)?
+//! Prettier's approach pre-processes all comments and attaches them to AST nodes before formatting:
+//!
+//! **Performance Issues:**
+//! - **HashMap overhead**: Inserting comments into hash maps significantly hurts performance
+//! - **AST visitor cost**: Requires an additional full AST traversal to process comments
+//! - **Memory allocation**: Every node potentially stores comment arrays
+//!
+//! **Association Complexity:**
+//! - **Hard to associate comments with nodes**: Determining which node "owns" a comment requires intricate heuristics
+//! - **Edge case handling**: Many special cases require complex pre-processing logic
+//!
+//! ### Our On-Demand Approach
+//! We process comments lazily during formatting using position-based queries:
+//!
+//! **Performance Benefits:**
+//! - **No hash map overhead**: We directly use the parser's comment array, no additional data structures
+//! - **Single AST pass**: No additional traversal needed for comment processing
+//! - **Zero memory allocation**: No comment storage on AST nodes, just reference the parser's data
+//! - **Lazy evaluation**: Only process comments that actually need formatting
+//!
+//! **Simpler Association:**
+//! - **Position-based logic**: Comments found by source position, not ownership rules
+//! - **Flexible categorization**: Comment roles determined dynamically during formatting
+//!
+//! ### Trade-offs of On-Demand
+//! **Complexity Cost:**
+//! - **More utility methods needed**: Requires many comment-checking utilities (as seen in this module)
+//! - **Distributed logic**: Comment handling spread across formatter instead of centralized
+//! - **Extra checking work**: Each node must query and check for relevant comments
+//!
+//! ## How We Print Comments
+//!
+//! ### Leading Comments
+//! **When**: Before formatting an AST node
+//! **How**: Query `comments_before(node.span.start)` to find all unprinted comments that end at or before the node
+//! **Logic**: Print each comment with appropriate spacing, then mark as printed
+//! ```javascript
+//! // Leading comment 1
+//! /* Leading comment 2 */
+//! function example() {}
+//! ```
+//!
+//! ### Trailing Comments
+//! **When**: After formatting an AST node
+//! **How**: Use complex logic in `get_trailing_comments()` to determine which comments belong to this node vs following nodes
+//! **Logic**: Consider comment position, type, and context to avoid "stealing" comments from following nodes
+//! ```javascript
+//! const a = 1, // Trailing comment for 'a'
+//!       b = 2; // This could be trailing for 'a' or 'b' - complex ownership logic needed
+//! ```
+//!
+//! ### Dangling Comments
+//! **When**: Inside container nodes (objects, arrays, blocks) that are empty or have no children to attach comments to
+//! **How**: Query `comments_between()` to find comments within the container span when the container is empty
+//! **Logic**: Format with appropriate indentation within the empty container
+//! ```javascript
+//! {
+//!   // Dangling comment in empty object
+//! }
+//!
+//! [
+//!   // Dangling comment in empty array
+//! ]
+//! ```
+//!
+//! ## Avoiding Comment Re-printing
+//!
+//! ### The `printed_count` Cursor System
+//! The key to avoiding duplicate comments is our cursor-based tracking:
+//!
+//! 1. **All comments are sorted by position** in the original array
+//! 2. **`printed_count` acts as a cursor** dividing processed from unprocessed comments
+//! 3. **Query methods only search unprinted comments** (`comments[printed_count..]`)
+//! 4. **After printing, we advance the cursor** to mark comments as processed
+//!
+//! ```md
+//! Comments: [A, B, C, D, E, F]
+//!           └─processed─┘ └─unprocessed─┘
+//!           printed_count = 3
+//! ```
+//!
+//! ### Why This Works
+//! - **Sequential processing**: Comments are always processed in source order
+//! - **No double-processing**: Once printed, comments are never considered again
+//! - **Efficient queries**: We only search the remaining unprocessed comments
+//! - **Simple state management**: Single counter tracks entire system state
+//!
+//! ## References
+//! - [Prettier handles special comments](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/language-js/comments/handle-comments.js)
+//! - [Prettier pre-processes comments](https://github.com/prettier/prettier/blob/7584432401a47a26943dd7a9ca9a8e032ead7285/src/main/comments/attach.js)
+use oxc_ast::{Comment, CommentContent};
+use oxc_span::{GetSpan, Span};
+
+use crate::formatter::SourceText;
+
+#[derive(Debug, Clone)]
+pub struct Comments<'a> {
+    source_text: SourceText<'a>,
+    inner: &'a [Comment],
+    /// **Critical state field**: Tracks how many comments have been processed.
+    ///
+    /// This acts as a cursor dividing the comments array into two sections:
+    /// - `comments[0..printed_count]`: Already formatted (must not be processed again)
+    /// - `comments[printed_count..]`: Available for processing
+    ///
+    /// This field MUST be incremented each time a comment is formatted to maintain
+    /// system integrity. All comment query methods rely on this for correctness.
+    printed_count: usize,
+    /// The index of the type cast comment that has been printed already.
+    /// Used to prevent duplicate processing of special TypeScript type cast comments.
+    last_handled_type_cast_comment: usize,
+    type_cast_node_span: Span,
+    /// Optional limit for the unprinted_comments view.
+    ///
+    /// When set, [`Self::unprinted_comments()`] will only return comments up to this index,
+    /// effectively hiding comments beyond this point from the formatter.
+    pub view_limit: Option<usize>,
+}
+
+impl<'a> Comments<'a> {
+    pub fn new(source_text: SourceText<'a>, comments: &'a [Comment]) -> Self {
+        Comments {
+            source_text,
+            inner: comments,
+            printed_count: 0,
+            last_handled_type_cast_comment: 0,
+            type_cast_node_span: Span::default(),
+            view_limit: None,
+        }
+    }
+
+    /// Returns comments that have not been printed yet.
+    #[inline]
+    pub fn unprinted_comments(&self) -> &'a [Comment] {
+        let end = self.view_limit.unwrap_or(self.inner.len());
+        &self.inner[self.printed_count..end]
+    }
+
+    /// Returns comments that have already been printed.
+    #[inline]
+    pub fn printed_comments(&self) -> &'a [Comment] {
+        &self.inner[..self.printed_count]
+    }
+
+    /// Returns an iterator over comments that end before or at the given position.
+    pub fn comments_before_iter(&self, pos: u32) -> impl Iterator<Item = &Comment> {
+        self.unprinted_comments().iter().take_while(move |c| c.span.end <= pos)
+    }
+
+    /// Returns all comments that end before or at the given position.
+    pub fn comments_before(&self, pos: u32) -> &'a [Comment] {
+        let index = self.comments_before_iter(pos).count();
+        &self.unprinted_comments()[..index]
+    }
+
+    /// Returns all block comments that end before or at the given position.
+    pub fn block_comments_before(&self, pos: u32) -> &'a [Comment] {
+        let index = self.comments_before_iter(pos).take_while(|c| c.is_block()).count();
+        &self.unprinted_comments()[..index]
+    }
+
+    /// Returns all block comments that end before or at the given position.
+    pub fn line_comments_before(&self, pos: u32) -> &'a [Comment] {
+        let index = self.comments_before_iter(pos).take_while(|c| c.is_line()).count();
+        &self.unprinted_comments()[..index]
+    }
+
+    /// Returns comments that are on their own line and end before or at the given position.
+    pub fn own_line_comments_before(&self, pos: u32) -> &'a [Comment] {
+        let index = self.comments_before_iter(pos).take_while(|c| c.preceded_by_newline()).count();
+        &self.unprinted_comments()[..index]
+    }
+
+    /// Returns end-of-line comments that are after the given position (excluding printed ones).
+    pub fn end_of_line_comments_after(&self, mut pos: u32) -> &'a [Comment] {
+        let comments = self.comments_after(pos);
+        for (index, comment) in comments.iter().enumerate() {
+            if self.source_text.all_bytes_match(pos, comment.span.start, |b| {
+                matches!(b, b'\t' | b' ' | b'=' | b':')
+            }) {
+                if comment.is_line() || comment.followed_by_newline() {
+                    return &comments[..=index];
+                }
+                pos = comment.span.end;
+            } else {
+                break;
+            }
+        }
+        &[]
+    }
+
+    /// Returns comments that start after the given position (excluding printed ones).
+    pub fn comments_after(&self, pos: u32) -> &'a [Comment] {
+        let comments = self.unprinted_comments();
+        let start_index = comments.iter().take_while(|c| c.span.end < pos).count();
+        &comments[start_index..]
+    }
+
+    /// Returns comments that fall between the given start and end positions.
+    pub fn comments_in_range(&self, start: u32, end: u32) -> &'a [Comment] {
+        let comments = self.comments_after(start);
+        let end_index = comments.iter().take_while(|c| c.span.end <= end).count();
+        &comments[..end_index]
+    }
+
+    /// Returns comments that occur before the first instance of a specific character.
+    pub(crate) fn comments_before_character(&self, mut start: u32, character: u8) -> &'a [Comment] {
+        let comments = self.comments_after(start);
+
+        for (index, comment) in comments.iter().enumerate() {
+            if self.source_text.bytes_contain(start, comment.span.start, character) {
+                return &comments[..index];
+            }
+            start = comment.span.end;
+        }
+
+        comments
+    }
+
+    /// Checks if there are any comments between the given positions.
+    pub fn has_comment_in_range(&self, start: u32, end: u32) -> bool {
+        self.comments_before_iter(end).any(|comment| comment.span.end > start)
+    }
+
+    /// Checks if there are any comments within the given span.
+    #[inline]
+    pub fn has_comment_in_span(&self, span: Span) -> bool {
+        self.has_comment_in_range(span.start, span.end)
+    }
+
+    /// Checks if there are any comments before the given position.
+    #[inline]
+    pub fn has_comment_before(&self, start: u32) -> bool {
+        self.comments_before_iter(start).next().is_some()
+    }
+
+    /// Checks if there are any leading own-line comments before the given position.
+    pub fn has_leading_own_line_comment(&self, start: u32) -> bool {
+        self.comments_before_iter(start).any(|comment| comment.followed_by_newline())
+    }
+
+    pub fn has_end_of_line_comment_after(&self, pos: u32) -> bool {
+        !self.end_of_line_comments_after(pos).is_empty()
+    }
+
+    /// **Critical method**: Advances the printed cursor by one.
+    ///
+    /// This MUST be called after formatting each comment to maintain system integrity.
+    /// Failure to call this method will result in:
+    /// - Comments being processed multiple times
+    /// - Incorrect comment categorization in subsequent queries
+    /// - Malformed formatter output
+    ///
+    /// This is automatically called by the trivia formatting functions, but must be
+    /// called manually if comments are formatted through other means.
+    #[inline]
+    pub fn increment_printed_count(&mut self) {
+        self.printed_count += 1;
+    }
+
+    /// **Critical method**: Advances the printed cursor by the specified amount.
+    ///
+    /// Used when multiple comments are processed in batch. Each unit of `count`
+    /// represents one comment that has been formatted and should be marked as processed.
+    ///
+    /// Like [`Comments::increment_printed_count`], this is essential for maintaining the
+    /// integrity of the comment tracking system.
+    #[inline]
+    pub fn increase_printed_count_by(&mut self, count: usize) {
+        self.printed_count += count;
+    }
+
+    /// Gets trailing comments for a node based on its context.
+    /// Returns comments that should be printed as trailing comments for `preceding_node`.
+    ///
+    /// `following_span_start` is the start position of the following sibling node, or 0 if none.
+    pub fn get_trailing_comments(
+        &self,
+        enclosing_span: Span,
+        preceding_span: Span,
+        following_span_start: u32,
+    ) -> &'a [Comment] {
+        let comments = self.unprinted_comments();
+        if comments.is_empty() {
+            return &[];
+        }
+
+        let source_text = self.source_text;
+
+        // All of the comments before this node are printed already.
+        debug_assert!(
+            comments.first().is_none_or(|comment| comment.span.end > preceding_span.start)
+        );
+
+        if following_span_start == 0 {
+            // Find dangling comments at the end of the enclosing node
+            let comments = self.comments_before(enclosing_span.end);
+            let mut start = preceding_span.end;
+            for (idx, comment) in comments.iter().enumerate() {
+                // Comments inside the preceding node, which should be printed without checking
+                if start > comment.span.start {
+                    continue;
+                }
+
+                if !source_text.all_bytes_match(start, comment.span.start, |b| {
+                    b.is_ascii_whitespace() || matches!(b, b')' | b',' | b';')
+                }) {
+                    return &comments[..idx];
+                }
+
+                start = comment.span.end;
+            }
+
+            return comments;
+        }
+
+        let mut comment_index = 0;
+        let mut type_cast_comment = None;
+
+        while let Some(comment) = comments.get(comment_index) {
+            // Stop if the comment:
+            // 1. is over the following node
+            // 2. is after the enclosing node, which means the comment should be printed in the parent node.
+            if comment.span.end > following_span_start || comment.span.end > enclosing_span.end {
+                break;
+            }
+
+            if following_span_start > enclosing_span.end && comment.span.end <= enclosing_span.end {
+                // Do nothing; this comment is inside the enclosing node, and the following node is outside the enclosing node.
+                // So it must be a trailing comment, continue checking the next comment.
+            } else if self.is_type_cast_comment(comment) {
+                // `A || /* @type {Number} */ (B)`:
+                //      ^^^^^^^^^^^^^^^^^^^^^^^^
+                // Type cast comments should always be treated as leading comment to the following node
+                type_cast_comment = Some(comment);
+                break;
+            } else if comment.preceded_by_newline() {
+                // Own-line comments should be treated as leading comments to the following node
+                break;
+            } else if comment.followed_by_newline() {
+                // End-of-line comments are always trailing comments to the preceding node.
+                return &comments[..=comment_index];
+            }
+
+            comment_index += 1;
+        }
+
+        // Find the first comment (from the end) that has non-whitespace/non-paren content after it
+        let mut gap_end = type_cast_comment.map_or(following_span_start, |c| c.span.start);
+
+        for (idx, comment) in comments[..comment_index].iter().enumerate().rev() {
+            if source_text.all_bytes_match(comment.span.end, gap_end, |b| {
+                b.is_ascii_whitespace() || b == b'('
+            }) {
+                gap_end = comment.span.start;
+            } else {
+                // If there is a non-whitespace character, we stop here
+                return &comments[..=idx];
+            }
+        }
+
+        &[]
+    }
+
+    /// Checks if the node has a suppression comment.
+    pub fn is_suppressed(&self, start: u32) -> bool {
+        self.comments_before(start).iter().any(|comment| self.is_suppression_comment(comment))
+    }
+
+    /// Checks if a comment is a suppression comment (`oxfmt-ignore`).
+    ///
+    /// `prettier-ignore` is also supported for compatibility.
+    pub fn is_suppression_comment(&self, comment: &Comment) -> bool {
+        let text = self.source_text.text_for(&comment.content_span()).trim();
+        matches!(text, "oxfmt-ignore" | "prettier-ignore")
+    }
+
+    /// Checks if a comment is a type cast comment containing `@type` or `@satisfies`.
+    pub fn is_type_cast_comment(&self, comment: &Comment) -> bool {
+        const TYPE_PATTERN: &[u8] = b"@type";
+        const SATISFIES_PATTERN: &[u8] = b"@satisfies";
+
+        /// Checks if a pattern matches at the given position.
+        fn matches_pattern_at(bytes: &[u8], pos: usize, pattern: &[u8]) -> bool {
+            bytes[pos..].starts_with(pattern)
+                && bytes
+                    .get(pos + pattern.len())
+                    .is_some_and(|&byte| byte.is_ascii_whitespace() || byte == b'{')
+        }
+
+        if !matches!(comment.content, CommentContent::Jsdoc) {
+            return false;
+        }
+
+        let bytes = self.source_text.text_for(&comment.span).as_bytes();
+        for (i, &byte) in bytes.iter().enumerate() {
+            if byte == b'@'
+                && (matches_pattern_at(bytes, i, TYPE_PATTERN)
+                    || matches_pattern_at(bytes, i, SATISFIES_PATTERN))
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Finds the index of a type cast comment before the given span.
+    ///
+    /// Searches for a JSDoc comment containing @type or @satisfies that is followed
+    /// by an opening parenthesis, which indicates a type cast pattern.
+    pub fn get_type_cast_comment_index(&self, span: Span) -> Option<usize> {
+        self.unprinted_comments().iter().take_while(|c| c.span.end <= span.start).position(
+            |comment| {
+                self.source_text.next_non_whitespace_byte_is(comment.span.end, b'(')
+                    && self.is_type_cast_comment(comment)
+            },
+        )
+    }
+
+    /// Marks the given span as a type cast node.
+    pub fn mark_as_type_cast_node(&mut self, node: &impl GetSpan) {
+        self.type_cast_node_span = node.span();
+        self.last_handled_type_cast_comment = self.printed_count;
+    }
+
+    /// Checks if the most recently printed type cast comment has been handled.
+    pub fn is_handled_type_cast_comment(&self) -> bool {
+        self.printed_count == self.last_handled_type_cast_comment
+    }
+
+    #[inline]
+    pub fn is_type_cast_node(&self, node: &impl GetSpan) -> bool {
+        self.type_cast_node_span == node.span()
+    }
+
+    /// Temporarily limits the unprinted comments view to only those before the given position.
+    /// Returns the previous view limit to allow restoration.
+    pub fn limit_comments_up_to(&mut self, end_pos: u32) -> Option<usize> {
+        // Save the original limit for restoration
+        let original_limit = self.view_limit;
+
+        // Find the index of the first comment that starts at or after end_pos
+        // Using binary search would be more efficient for large comment arrays
+        let limit_index = self.inner[self.printed_count..]
+            .iter()
+            .position(|c| c.span.start >= end_pos)
+            .map_or(self.inner.len(), |idx| self.printed_count + idx);
+
+        // Only update if we're actually limiting the view
+        if limit_index < self.inner.len() {
+            self.view_limit = Some(limit_index);
+        }
+
+        original_limit
+    }
+
+    /// Restores the view limit to a previously saved value.
+    /// This is typically used after temporarily limiting the view with `limit_comments_up_to`.
+    #[inline]
+    pub fn restore_view_limit(&mut self, limit: Option<usize>) {
+        self.view_limit = limit;
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/context.rs
+++ b/crates/oxc_formatter_core/src/formatter/context.rs
@@ -1,0 +1,102 @@
+use oxc_allocator::Allocator;
+use oxc_span::Span;
+
+use crate::{
+    formatter::printer::{AsPrinterOptions, PrinterOptions},
+    options::{IndentStyle, IndentWidth, IndentWidthProvider, LineEnding, LineWidth},
+};
+
+/// Formatting context for a formatting session.
+pub trait FormatContext<'ast> {
+    type Options: AsPrinterOptions + IndentWidthProvider;
+
+    /// Returns the formatting options for this context.
+    fn options(&self) -> &Self::Options;
+
+    /// Returns the allocator used for this formatting session.
+    fn allocator(&self) -> &'ast Allocator;
+}
+
+/// Optional extension trait for contexts that expose comment and source text helpers.
+pub trait FormatContextExt<'ast>: FormatContext<'ast> {
+    type Comments;
+    type SourceText: Copy + SourceTextExt<Self::Comments>;
+
+    fn comments(&self) -> &Self::Comments;
+    fn comments_mut(&mut self) -> &mut Self::Comments;
+    fn source_text(&self) -> Self::SourceText;
+}
+
+pub trait SourceTextExt<Comments> {
+    fn get_lines_before(&self, span: Span, comments: &Comments) -> usize;
+}
+
+#[derive(Debug, Clone)]
+pub struct SimpleFormatOptions {
+    pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
+    pub line_ending: LineEnding,
+    pub line_width: LineWidth,
+}
+
+impl Default for SimpleFormatOptions {
+    fn default() -> Self {
+        Self {
+            indent_style: IndentStyle::default(),
+            indent_width: IndentWidth::default(),
+            line_ending: LineEnding::default(),
+            line_width: LineWidth::default(),
+        }
+    }
+}
+
+impl AsPrinterOptions for SimpleFormatOptions {
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::default()
+            .with_indent_style(self.indent_style)
+            .with_indent_width(self.indent_width)
+            .with_print_width(self.line_width.into())
+            .with_line_ending(self.line_ending)
+    }
+}
+
+impl IndentWidthProvider for SimpleFormatOptions {
+    fn indent_width(&self) -> IndentWidth {
+        self.indent_width
+    }
+}
+
+#[derive(Clone)]
+pub struct SimpleFormatContext<'ast> {
+    allocator: &'ast Allocator,
+    options: SimpleFormatOptions,
+}
+
+impl<'ast> SimpleFormatContext<'ast> {
+    pub fn new(allocator: &'ast Allocator) -> Self {
+        Self { allocator, options: SimpleFormatOptions::default() }
+    }
+
+    pub fn with_options(allocator: &'ast Allocator, options: SimpleFormatOptions) -> Self {
+        Self { allocator, options }
+    }
+}
+
+impl<'ast> FormatContext<'ast> for SimpleFormatContext<'ast> {
+    type Options = SimpleFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn allocator(&self) -> &'ast Allocator {
+        self.allocator
+    }
+}
+
+impl Default for SimpleFormatContext<'static> {
+    fn default() -> Self {
+        let allocator = Box::leak(Box::new(Allocator::default()));
+        Self::new(allocator)
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/diagnostics.rs
+++ b/crates/oxc_formatter_core/src/formatter/diagnostics.rs
@@ -1,0 +1,244 @@
+// use biome_console::fmt::Formatter;
+// use biome_console::markup;
+// use biome_diagnostics::{Category, Diagnostic, DiagnosticTags, Location, Severity, category};
+// use biome_rowan::{SyntaxError, TextRange};
+use std::error::Error;
+
+use super::{TextRange, prelude::TagKind};
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+/// Series of errors encountered during formatting
+pub enum FormatError {
+    /// In case a node can't be formatted because it either misses a require child element or
+    /// a child is present that should not (e.g. a trailing comma after a rest element).
+    SyntaxError,
+    /// In case range formatting failed because the provided range was larger
+    /// than the formatted syntax tree
+    RangeError { input: TextRange, tree: TextRange },
+
+    /// In case printing the document failed because it has an invalid structure.
+    InvalidDocument(InvalidDocumentError),
+
+    /// Formatting failed because some content encountered a situation where a layout
+    /// choice by an enclosing [crate::Format] resulted in a poor layout for a child [crate::Format].
+    ///
+    /// It's up to an enclosing [crate::Format] to handle the error and pick another layout.
+    /// This error should not be raised if there's no outer [crate::Format] handling the poor layout error,
+    /// avoiding that formatting of the whole document fails.
+    PoorLayout,
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FormatError::SyntaxError => {
+                fmt.write_str("Can't format code because it contains syntax errors")
+            }
+            FormatError::RangeError { input, tree } => {
+                std::write!(fmt, "Formatting range {input:?} is larger than syntax tree {tree:?}")
+            }
+            FormatError::InvalidDocument(error) => std::write!(
+                fmt,
+                "Invalid document: {error}\n\n This is an internal Biome error. Please report if necessary."
+            ),
+            FormatError::PoorLayout => fmt.write_str(
+                "Poor layout: The formatter wasn't able to pick a good layout for your document. This is an internal Biome error. Please report if necessary.",
+            ),
+        }
+    }
+}
+
+impl Error for FormatError {}
+
+// impl From<SyntaxError> for FormatError {
+// fn from(error: SyntaxError) -> Self {
+// FormatError::from(&error)
+// }
+// }
+
+// impl From<&SyntaxError> for FormatError {
+// fn from(syntax_error: &SyntaxError) -> Self {
+// match syntax_error {
+// SyntaxError::MissingRequiredChild
+// | SyntaxError::UnexpectedBogusNode
+// | SyntaxError::UnexpectedMetavariable => FormatError::SyntaxError,
+// }
+// }
+// }
+
+impl From<PrintError> for FormatError {
+    fn from(error: PrintError) -> Self {
+        FormatError::from(&error)
+    }
+}
+
+impl From<&PrintError> for FormatError {
+    fn from(error: &PrintError) -> Self {
+        match error {
+            PrintError::InvalidDocument(reason) => FormatError::InvalidDocument(*reason),
+        }
+    }
+}
+
+// impl Diagnostic for FormatError {
+// fn location(&self) -> Location<'_> {
+// Location::builder().build()
+// }
+
+// fn severity(&self) -> Severity {
+// Severity::Error
+// }
+
+// fn tags(&self) -> DiagnosticTags {
+// match self {
+// FormatError::SyntaxError => DiagnosticTags::empty(),
+// FormatError::RangeError { .. } => DiagnosticTags::empty(),
+// FormatError::InvalidDocument(_) => DiagnosticTags::INTERNAL,
+// FormatError::PoorLayout => DiagnosticTags::INTERNAL,
+// }
+// }
+
+// fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+// std::fmt::Display::fmt(self, fmt)
+// }
+
+// fn category(&self) -> Option<&'static Category> {
+// Some(category!("format"))
+// }
+
+// fn message(
+// &self,
+// fmt: &mut biome_diagnostics::console::fmt::Formatter<'_>,
+// ) -> std::io::Result<()> {
+// match self {
+// FormatError::SyntaxError => fmt.write_str("Syntax error."),
+// FormatError::RangeError { input, tree } => {
+// std::write!(fmt, "Formatting range {input:?} is larger than syntax tree {tree:?}")
+// }
+// FormatError::InvalidDocument(error) => std::write!(fmt, "Invalid document: {error}"),
+// FormatError::PoorLayout => {
+// fmt.write_str(
+// "Poor layout: The formatter wasn't able to pick a good layout for your document."
+// )
+// }
+// }
+// }
+// }
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum InvalidDocumentError {
+    /// Mismatching start/end kinds
+    ///
+    /// ```plain
+    /// StartIndent
+    /// ...
+    /// EndGroup
+    /// ```
+    StartEndTagMismatch { start_kind: TagKind, end_kind: TagKind },
+
+    /// End tag without a corresponding start tag.
+    ///
+    /// ```plain
+    /// Text
+    /// EndGroup
+    /// ```
+    StartTagMissing { kind: TagKind },
+
+    /// Expected a specific start tag but instead is:
+    /// * at the end of the document
+    /// * at another start tag
+    /// * at an end tag
+    ExpectedStart { expected_start: TagKind, actual: ActualStart },
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ActualStart {
+    /// The actual element is not a tag.
+    Content,
+
+    /// The actual element was a start tag of another kind.
+    Start(TagKind),
+
+    /// The actual element is an end tag instead of a start tag.
+    End(TagKind),
+
+    /// Reached the end of the document
+    EndOfDocument,
+}
+
+impl std::fmt::Display for InvalidDocumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InvalidDocumentError::StartEndTagMismatch { start_kind, end_kind } => {
+                std::write!(f, "Expected end tag of kind {start_kind:?} but found {end_kind:?}.")
+            }
+            InvalidDocumentError::StartTagMissing { kind } => {
+                std::write!(f, "End tag of kind {kind:?} without matching start tag.")
+            }
+            InvalidDocumentError::ExpectedStart { expected_start, actual } => match actual {
+                ActualStart::EndOfDocument => {
+                    std::write!(
+                        f,
+                        "Expected start tag of kind {expected_start:?} but at the end of document."
+                    )
+                }
+                ActualStart::Start(start) => {
+                    std::write!(
+                        f,
+                        "Expected start tag of kind {expected_start:?} but found start tag of kind {start:?}."
+                    )
+                }
+                ActualStart::End(end) => {
+                    std::write!(
+                        f,
+                        "Expected start tag of kind {expected_start:?} but found end tag of kind {end:?}."
+                    )
+                }
+                ActualStart::Content => {
+                    std::write!(
+                        f,
+                        "Expected start tag of kind {expected_start:?} but found non-tag element."
+                    )
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PrintError {
+    InvalidDocument(InvalidDocumentError),
+}
+
+impl Error for PrintError {}
+
+impl std::fmt::Display for PrintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrintError::InvalidDocument(inner) => {
+                std::write!(f, "Invalid document: {inner}")
+            }
+        }
+    }
+}
+
+// impl Diagnostic for PrintError {
+// fn category(&self) -> Option<&'static Category> {
+// Some(category!("format"))
+// }
+
+// fn severity(&self) -> Severity {
+// Severity::Error
+// }
+
+// fn message(&self, fmt: &mut Formatter<'_>) -> std::io::Result<()> {
+// match self {
+// PrintError::InvalidDocument(inner) => {
+// let inner = format!("{inner}");
+// fmt.write_markup(markup! {
+// "Invalid document: "{{inner}}
+// })
+// }
+// }
+// }
+// }

--- a/crates/oxc_formatter_core/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter_core/src/formatter/format_element/document.rs
@@ -1,0 +1,722 @@
+#![expect(clippy::mutable_key_type)]
+use cow_utils::CowUtils;
+use std::ops::Deref;
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use rustc_hash::FxHashMap;
+
+use super::super::prelude::*;
+use super::tag::Tag;
+use crate::formatter::prelude::tag::{DedentMode, GroupMode};
+use crate::options::IndentWidthProvider;
+use crate::{Format, formatter::Formatter, formatter::SimpleFormatContext};
+
+use crate::{format, write};
+
+/// A formatted document.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Document<'a> {
+    elements: &'a [FormatElement<'a>],
+    sorted_tailwind_classes: Vec<String>,
+}
+
+impl<'a> Document<'a> {
+    /// Creates a new document from the given elements.
+    pub fn new(
+        elements: ArenaVec<'a, FormatElement<'a>>,
+        sorted_tailwind_classes: Vec<String>,
+    ) -> Self {
+        Self { elements: elements.into_bump_slice(), sorted_tailwind_classes }
+    }
+
+    /// Consumes the document and returns its elements and sorted Tailwind CSS classes.
+    pub fn into_elements_and_tailwind_classes(self) -> (&'a [FormatElement<'a>], Vec<String>) {
+        (self.elements, self.sorted_tailwind_classes)
+    }
+
+    /// Replaces the document's format elements with new ones.
+    ///
+    /// If you have modified the elements and want to update the document,
+    /// use this method to set the new elements.
+    pub fn replace_elements(&mut self, elements: ArenaVec<'a, FormatElement<'a>>) {
+        self.elements = elements.into_bump_slice();
+    }
+}
+
+impl Document<'_> {
+    /// Sets [`expand`](tag::Group::expand) to [`GroupMode::Propagated`] if the group contains any of:
+    /// * a group with [`expand`](tag::Group::expand) set to [GroupMode::Propagated] or [GroupMode::Expand].
+    /// * a non-soft [line break](FormatElement::Line) with mode [LineMode::Hard], [LineMode::Empty], or [LineMode::Literal].
+    /// * a [FormatElement::ExpandParent]
+    ///
+    /// [`BestFitting`] elements act as expand boundaries, meaning that the fact that a
+    /// [`BestFitting`]'s content expands is not propagated past the [`BestFitting`] element.
+    ///
+    /// [`BestFitting`]: FormatElement::BestFitting
+    pub(crate) fn propagate_expand(&self) {
+        #[derive(Debug)]
+        enum Enclosing<'a> {
+            Group(&'a tag::Group),
+            BestFitting,
+        }
+
+        fn expand_parent(enclosing: &[Enclosing]) {
+            if let Some(Enclosing::Group(group)) = enclosing.last() {
+                group.propagate_expand();
+            }
+        }
+
+        fn propagate_expands<'a>(
+            elements: &'a [FormatElement<'a>],
+            enclosing: &mut Vec<Enclosing<'a>>,
+            checked_interned: &mut FxHashMap<&'a Interned<'a>, bool>,
+        ) -> bool {
+            let mut expands = false;
+            for element in elements {
+                let element_expands = match element {
+                    FormatElement::Tag(Tag::StartGroup(group)) => {
+                        enclosing.push(Enclosing::Group(group));
+                        false
+                    }
+                    FormatElement::Tag(Tag::EndGroup) => match enclosing.pop() {
+                        Some(Enclosing::Group(group)) => !group.mode().is_flat(),
+                        _ => false,
+                    },
+                    FormatElement::Interned(interned) => {
+                        if let Some(interned_expands) = checked_interned.get(interned) {
+                            *interned_expands
+                        } else {
+                            let interned_expands =
+                                propagate_expands(interned, enclosing, checked_interned);
+                            checked_interned.insert(interned, interned_expands);
+                            interned_expands
+                        }
+                    }
+                    FormatElement::BestFitting(best_fitting) => {
+                        enclosing.push(Enclosing::BestFitting);
+
+                        for variant in best_fitting.variants() {
+                            propagate_expands(variant, enclosing, checked_interned);
+                        }
+
+                        enclosing.pop();
+                        // BestFitting acts as a boundary, meaning there is no need to continue
+                        // processing this element and we can move onto the next. However, we
+                        // _don't_ set `expands = false`, because that ends up negating the
+                        // expansion when processing `Interned` elements.
+                        //
+                        // Only interned lists are affected, because they cache the expansion value
+                        // based on the value of `expands` at the end of iterating the children. If
+                        // a `best_fitting` element occurs after the last expanding element, and we
+                        // end up setting `expands = false` here, then the interned element ends up
+                        // thinking that its content doesn't expand, even though it might. Example:
+                        //   group(1,
+                        //     interned 1 [
+                        //       expand_parent,
+                        //       best_fitting,
+                        //     ]
+                        //   )
+                        //   group(2,
+                        //     [ref interned 1]
+                        //   )
+                        // Here, `group(1)` gets expanded directly by the `expand_parent` element.
+                        // This happens immediately, and then `expands = true` is set. The interned
+                        // element continues processing, and encounters the `best_fitting`. If
+                        // we set `expands = false` there, then the interned element's result ends
+                        // up being `false`, even though it does actually expand. Then, when
+                        // `group(2)` checks for expansion, it looks at the ref to `interned 1`,
+                        // which thinks it doesn't expand, and so `group(2)` stays flat.
+                        //
+                        // By _not_ setting `expands = false`, even though `best_fitting` is a
+                        // boundary for expansion, we ensure that any references to the interned
+                        // element will get the correct value for whether the contained content
+                        // actually expands, regardless of the order of elements within it.
+                        //
+                        // Instead, just returning false here enforces that `best_fitting` doesn't
+                        // think it expands _itself_, but allows other sibling elements to still
+                        // propagate their expansion.
+                        false
+                    }
+                    // `FormatElement::Token` cannot contain line breaks
+                    FormatElement::Text { text: _, width } => width.is_multiline(),
+                    FormatElement::ExpandParent
+                    | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
+                    _ => false,
+                };
+
+                if element_expands {
+                    expands = true;
+                    expand_parent(enclosing);
+                }
+            }
+
+            expands
+        }
+
+        let mut enclosing: Vec<Enclosing> = Vec::new();
+        let mut interned = FxHashMap::default();
+        propagate_expands(self, &mut enclosing, &mut interned);
+    }
+}
+
+impl<'a> Deref for Document<'a> {
+    type Target = [FormatElement<'a>];
+
+    fn deref(&self) -> &Self::Target {
+        self.elements
+    }
+}
+
+impl std::fmt::Display for Document<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let allocator = Allocator::default();
+        let context = SimpleFormatContext::new(&allocator);
+        let formatted = format!(context, [FormatElementSlice(self.elements)]);
+
+        f.write_str(formatted.print().expect("Expected a valid document").as_code())
+    }
+}
+
+struct FormatElementSlice<'a>(&'a [FormatElement<'a>]);
+
+impl<'a, Ctx> Format<'a, Ctx> for FormatElementSlice<'a>
+where
+    Ctx: super::super::context::FormatContext<'a>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+        use Tag::{
+            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
+            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
+            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+        };
+
+        write!(f, [ContentArrayStart]);
+
+        let mut tag_stack = Vec::new();
+        let mut first_element = true;
+        let mut in_text = false;
+
+        let mut iter = self.0.iter().peekable();
+
+        while let Some(element) = iter.next() {
+            if !first_element && !in_text && !element.is_end_tag() {
+                // Write a separator between every two elements
+                write!(f, [token(","), soft_line_break_or_space()]);
+            }
+
+            first_element = false;
+
+            match element {
+                element @ (FormatElement::Space
+                | FormatElement::HardSpace
+                | FormatElement::Token { .. }
+                | FormatElement::Text { .. }) => {
+                    if !in_text {
+                        write!(f, [token("\"")]);
+                    }
+
+                    in_text = true;
+
+                    match element {
+                        FormatElement::Space | FormatElement::HardSpace => {
+                            write!(f, [token(" ")]);
+                        }
+                        element if element.is_text() => {
+                            // escape quotes
+                            let new_element = match element {
+                                // except for static text because source_position is unknown
+                                FormatElement::Token { .. } => element.clone(),
+                                FormatElement::Text { text, width: _ } => {
+                                    let text = text.cow_replace('"', "\\\"");
+                                    FormatElement::Text {
+                                        text: f.context().allocator().alloc_str(&text),
+                                        width: TextWidth::from_text(
+                                            &text,
+                                            f.options().indent_width(),
+                                        ),
+                                    }
+                                }
+                                _ => unreachable!(),
+                            };
+                            f.write_element(new_element);
+                        }
+                        _ => unreachable!(),
+                    }
+
+                    let is_next_text = iter.peek().is_some_and(|e| e.is_text() || e.is_space());
+
+                    if !is_next_text {
+                        write!(f, [token("\"")]);
+                        in_text = false;
+                    }
+                }
+
+                FormatElement::Line(mode) => match mode {
+                    LineMode::SoftOrSpace => {
+                        write!(f, [token("soft_line_break_or_space")]);
+                    }
+                    LineMode::Soft => {
+                        write!(f, [token("soft_line_break")]);
+                    }
+                    LineMode::Hard => {
+                        write!(f, [token("hard_line_break")]);
+                    }
+                    LineMode::Empty => {
+                        write!(f, [token("empty_line")]);
+                    }
+                },
+                FormatElement::ExpandParent => {
+                    write!(f, [token("expand_parent")]);
+                }
+
+                FormatElement::LineSuffixBoundary => {
+                    write!(f, [token("line_suffix_boundary")]);
+                }
+
+                FormatElement::BestFitting(best_fitting) => {
+                    write!(f, [token("best_fitting([")]);
+                    f.write_elements([
+                        FormatElement::Tag(StartIndent),
+                        FormatElement::Line(LineMode::Hard),
+                    ]);
+
+                    for variant in best_fitting.variants() {
+                        write!(f, [FormatElementSlice(variant), hard_line_break()]);
+                    }
+
+                    f.write_elements([
+                        FormatElement::Tag(EndIndent),
+                        FormatElement::Line(LineMode::Hard),
+                    ]);
+
+                    write!(f, [token("])")]);
+                }
+
+                FormatElement::Interned(interned) => {
+                    let interned_elements = f.state_mut().printed_interned_elements();
+                    match interned_elements.get(interned).copied() {
+                        None => {
+                            let index = interned_elements.len();
+                            interned_elements.insert(interned.clone(), index);
+
+                            write!(
+                                f,
+                                [
+                                    text(
+                                        f.context()
+                                            .allocator()
+                                            .alloc_str(&std::format!("<interned {index}>"))
+                                    ),
+                                    space(),
+                                    FormatElementSlice(&**interned),
+                                ]
+                            );
+                        }
+                        Some(reference) => {
+                            write!(
+                                f,
+                                [text(
+                                    f.context()
+                                        .allocator()
+                                        .alloc_str(&std::format!("<ref interned *{reference}>"))
+                                )]
+                            );
+                        }
+                    }
+                }
+
+                FormatElement::Tag(tag) => {
+                    if tag.is_start() {
+                        first_element = true;
+                        tag_stack.push(tag.kind());
+                    }
+                    // Handle documents with mismatching start/end or superfluous end tags
+                    else {
+                        match tag_stack.pop() {
+                            None => {
+                                // Only write the end tag without any indent to ensure the output document is valid.
+                                write!(
+                                    f,
+                                    [
+                                        token("<END_TAG_WITHOUT_START<"),
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("{:?}", tag.kind()))
+                                        ),
+                                        token(">>"),
+                                    ]
+                                );
+                                first_element = false;
+                                continue;
+                            }
+                            Some(start_kind) if start_kind != tag.kind() => {
+                                write!(
+                                    f,
+                                    [
+                                        ContentArrayEnd,
+                                        token(")"),
+                                        soft_line_break_or_space(),
+                                        token("ERROR<START_END_TAG_MISMATCH<start: "),
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("{start_kind:?}"))
+                                        ),
+                                        token(", end: "),
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("{:?}", tag.kind()))
+                                        ),
+                                        token(">>")
+                                    ]
+                                );
+                                first_element = false;
+                                continue;
+                            }
+                            _ => {
+                                // all ok
+                            }
+                        }
+                    }
+
+                    match tag {
+                        StartIndent => {
+                            write!(f, [token("indent(")]);
+                        }
+
+                        StartDedent(mode) => {
+                            let label = match mode {
+                                DedentMode::Level => "dedent",
+                                DedentMode::Root => "dedentRoot",
+                            };
+
+                            write!(f, [token(label), token("(")]);
+                        }
+
+                        StartAlign(tag::Align(count)) => {
+                            write!(
+                                f,
+                                [
+                                    token("align("),
+                                    text(f.context().allocator().alloc_str(&count.to_string()),),
+                                    token(","),
+                                    space(),
+                                ]
+                            );
+                        }
+
+                        StartLineSuffix => {
+                            write!(f, [token("line_suffix(")]);
+                        }
+
+                        StartGroup(group) => {
+                            write!(f, [token("group(")]);
+
+                            if let Some(group_id) = group.id() {
+                                write!(
+                                    f,
+                                    [
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("\"{group_id:?}\""))
+                                        ),
+                                        token(","),
+                                        space(),
+                                    ]
+                                );
+                            }
+
+                            match group.mode() {
+                                GroupMode::Flat => {}
+                                GroupMode::Expand => {
+                                    write!(f, [token("expand: true,"), space()]);
+                                }
+                                GroupMode::Propagated => {
+                                    write!(f, [token("expand: propagated,"), space()]);
+                                }
+                            }
+                        }
+
+                        StartIndentIfGroupBreaks(id) => {
+                            write!(
+                                f,
+                                [
+                                    token("indent_if_group_breaks("),
+                                    text(
+                                        f.context()
+                                            .allocator()
+                                            .alloc_str(&std::format!("\"{id:?}\"")),
+                                    ),
+                                    token(","),
+                                    space(),
+                                ]
+                            );
+                        }
+
+                        StartConditionalContent(condition) => {
+                            match condition.mode {
+                                PrintMode::Flat => {
+                                    write!(f, [token("if_group_fits_on_line(")]);
+                                }
+                                PrintMode::Expanded => {
+                                    write!(f, [token("if_group_breaks(")]);
+                                }
+                            }
+
+                            if let Some(group_id) = condition.group_id {
+                                write!(
+                                    f,
+                                    [
+                                        text(
+                                            f.context()
+                                                .allocator()
+                                                .alloc_str(&std::format!("\"{group_id:?}\"")),
+                                        ),
+                                        token(","),
+                                        space(),
+                                    ]
+                                );
+                            }
+                        }
+
+                        StartLabelled(label_id) => {
+                            write!(
+                                f,
+                                [
+                                    token("label("),
+                                    text(
+                                        f.context()
+                                            .allocator()
+                                            .alloc_str(&std::format!("\"{label_id:?}\"")),
+                                    ),
+                                    token(","),
+                                    space(),
+                                ]
+                            );
+                        }
+
+                        StartFill => {
+                            write!(f, [token("fill(")]);
+                        }
+
+                        StartEntry => {
+                            // handled after the match for all start tags
+                        }
+                        EndEntry => write!(f, [ContentArrayEnd]),
+
+                        EndFill
+                        | EndLabelled
+                        | EndConditionalContent
+                        | EndIndentIfGroupBreaks(_)
+                        | EndAlign
+                        | EndIndent
+                        | EndGroup
+                        | EndLineSuffix
+                        | EndDedent(_) => {
+                            write!(f, [ContentArrayEnd, token(")")]);
+                        }
+                    }
+
+                    if tag.is_start() {
+                        write!(f, [ContentArrayStart]);
+                    }
+                }
+                FormatElement::TailwindClass(index) => {
+                    write!(
+                        f,
+                        [
+                            token("<TAILWIND_CLASS<"),
+                            text(f.context().allocator().alloc_str(&std::format!("{index}"))),
+                            token(">>"),
+                        ]
+                    );
+                }
+            }
+        }
+
+        while let Some(top) = tag_stack.pop() {
+            write!(
+                f,
+                [
+                    ContentArrayEnd,
+                    token(")"),
+                    soft_line_break_or_space(),
+                    text(
+                        f.context()
+                            .allocator()
+                            .alloc_str(&std::format!("<START_WITHOUT_END<{top:?}>>"))
+                    ),
+                ]
+            );
+        }
+
+        write!(f, [ContentArrayEnd]);
+    }
+}
+
+struct ContentArrayStart;
+
+impl<'a, Ctx> Format<'a, Ctx> for ContentArrayStart
+where
+    Ctx: super::super::context::FormatContext<'a>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+        use Tag::{StartGroup, StartIndent};
+
+        write!(f, [token("[")]);
+
+        f.write_elements([
+            FormatElement::Tag(StartGroup(tag::Group::new())),
+            FormatElement::Tag(StartIndent),
+            FormatElement::Line(LineMode::Soft),
+        ]);
+    }
+}
+
+struct ContentArrayEnd;
+
+impl<'a, Ctx> Format<'a, Ctx> for ContentArrayEnd
+where
+    Ctx: super::super::context::FormatContext<'a>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+        use Tag::{EndGroup, EndIndent};
+        f.write_elements([
+            FormatElement::Tag(EndIndent),
+            FormatElement::Line(LineMode::Soft),
+            FormatElement::Tag(EndGroup),
+        ]);
+
+        write!(f, [token("]")]);
+    }
+}
+
+impl FormatElements for [FormatElement<'_>] {
+    fn will_break(&self) -> bool {
+        use Tag::{EndLineSuffix, StartLineSuffix};
+        let mut ignore_depth = 0usize;
+
+        for element in self {
+            match element {
+                // Line suffix
+                // Ignore if any of its content breaks
+                FormatElement::Tag(StartLineSuffix) => {
+                    ignore_depth += 1;
+                }
+                FormatElement::Tag(EndLineSuffix) => {
+                    ignore_depth -= 1;
+                }
+                FormatElement::Interned(interned) if ignore_depth == 0 => {
+                    if interned.will_break() {
+                        return true;
+                    }
+                }
+                FormatElement::Line(line) if line.will_break() => {
+                    return true;
+                }
+                element if ignore_depth == 0 && element.will_break() => {
+                    return true;
+                }
+                _ => {}
+            }
+        }
+
+        debug_assert_eq!(ignore_depth, 0, "Unclosed start container");
+
+        false
+    }
+
+    fn may_directly_break(&self) -> bool {
+        use Tag::{EndLineSuffix, StartLineSuffix};
+        let mut ignore_depth = 0usize;
+
+        for element in self {
+            match element {
+                // Line suffix
+                // Ignore if any of its content breaks
+                FormatElement::Tag(StartLineSuffix) => {
+                    ignore_depth += 1;
+                }
+                FormatElement::Tag(EndLineSuffix) => {
+                    ignore_depth -= 1;
+                }
+                FormatElement::Interned(interned) if ignore_depth == 0 => {
+                    if interned.may_directly_break() {
+                        return true;
+                    }
+                }
+
+                element if ignore_depth == 0 && element.may_directly_break() => {
+                    return true;
+                }
+                _ => {}
+            }
+        }
+
+        debug_assert_eq!(ignore_depth, 0, "Unclosed start container");
+
+        false
+    }
+
+    fn has_label(&self, expected: LabelId) -> bool {
+        self.first().is_some_and(|element| element.has_label(expected))
+    }
+
+    fn start_tag(&self, kind: TagKind) -> Option<&Tag> {
+        fn traverse_slice<'a>(
+            slice: &'a [FormatElement],
+            kind: TagKind,
+            depth: &mut usize,
+        ) -> Option<&'a Tag> {
+            for element in slice.iter().rev() {
+                match element {
+                    FormatElement::Tag(tag) if tag.kind() == kind => {
+                        if tag.is_start() {
+                            if *depth == 0 {
+                                // Invalid document
+                                return None;
+                            } else if *depth == 1 {
+                                return Some(tag);
+                            }
+                            *depth -= 1;
+                        } else {
+                            *depth += 1;
+                        }
+                    }
+                    FormatElement::Interned(interned) => {
+                        match traverse_slice(interned, kind, depth) {
+                            Some(start) => {
+                                return Some(start);
+                            }
+                            // Reached end or invalid document
+                            None if *depth == 0 => {
+                                return None;
+                            }
+                            _ => {
+                                // continue with other elements
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            None
+        }
+
+        // Assert that the document ends at a tag with the specified kind;
+        let _ = self.end_tag(kind);
+
+        let mut depth = 0usize;
+
+        traverse_slice(self, kind, &mut depth)
+    }
+
+    fn end_tag(&self, kind: TagKind) -> Option<&Tag> {
+        self.last().and_then(|element| element.end_tag(kind))
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/formatter/format_element/mod.rs
@@ -1,0 +1,605 @@
+pub mod document;
+pub mod tag;
+
+// #[cfg(target_pointer_width = "64")]
+// use biome_rowan::static_assert;
+use std::hash::{Hash, Hasher};
+use std::ptr;
+use std::{borrow::Cow, ops::Deref};
+
+use unicode_width::UnicodeWidthStr;
+
+use oxc_allocator::Vec as ArenaVec;
+
+use crate::IndentWidth;
+
+use super::{
+    TagKind,
+    format_element::tag::{LabelId, Tag},
+};
+
+#[cfg(debug_assertions)]
+const _: () = {
+    if cfg!(target_pointer_width = "64") {
+        assert!(
+            size_of::<FormatElement>() == 40,
+            "`FormatElement` size exceeds 40 bytes, expected 40 bytes in 64-bit platforms"
+        );
+    } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
+        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
+        //
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
+        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
+        assert!(
+            size_of::<FormatElement>() == 24,
+            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 32-bit platforms"
+        );
+    }
+};
+
+#[cfg(not(debug_assertions))]
+const _: () = {
+    if cfg!(target_pointer_width = "64") {
+        assert!(
+            size_of::<FormatElement>() == 24,
+            "`FormatElement` size exceeds 24 bytes, expected 24 bytes in 64-bit platforms"
+        );
+    } else if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
+        // Some 32-bit platforms have 8-byte alignment for `u64` and `f64`, while others have 4-byte alignment.
+        //
+        // Skip these assertions on 32-bit platforms where `u64` / `f64` have 4-byte alignment, because
+        // some layout calculations may be incorrect. https://github.com/oxc-project/oxc/pull/13716
+        assert!(
+            size_of::<FormatElement>() == 16,
+            "`FormatElement` size exceeds 16 bytes, expected 16 bytes in 32-bit platforms"
+        );
+    }
+};
+
+/// Language agnostic IR for formatting source code.
+///
+/// Use the helper functions like [crate::builders::space], [crate::builders::soft_line_break] etc. defined in this file to create elements.
+#[derive(Clone, Eq, PartialEq)]
+pub enum FormatElement<'a> {
+    /// A space token, see [crate::builders::space] for documentation.
+    Space,
+    HardSpace,
+    /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break], and [crate::builders::soft_line_break_or_space] for documentation.
+    Line(LineMode),
+
+    /// Forces the parent group to print in expanded mode.
+    ExpandParent,
+
+    /// A ASCII only Token that contains no line breaks or tab characters.
+    Token {
+        text: &'static str,
+    },
+
+    /// An arbitrary text that can contain tabs, newlines, and unicode characters.
+    Text {
+        text: &'a str,
+        width: TextWidth,
+    },
+
+    /// Prevents that line suffixes move past this boundary. Forces the printer to print any pending
+    /// line suffixes, potentially by inserting a hard line break.
+    LineSuffixBoundary,
+
+    /// An interned format element. Useful when the same content must be emitted multiple times to avoid
+    /// deep cloning the IR when using the `best_fitting!` macro or `if_group_fits_on_line` and `if_group_breaks`.
+    Interned(Interned<'a>),
+
+    /// A list of different variants representing the same content. The printer picks the best fitting content.
+    /// Line breaks inside of a best fitting don't propagate to parent groups.
+    BestFitting(BestFittingElement<'a>),
+
+    /// A [Tag] that marks the start/end of some content to which some special formatting is applied.
+    Tag(Tag),
+
+    /// A Tailwind CSS class sorting marker.
+    /// The usize is an index into the collected tailwind classes array.
+    /// During printing, this will be replaced with the sorted class name.
+    TailwindClass(usize),
+}
+
+impl std::fmt::Debug for FormatElement<'_> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            FormatElement::Space | FormatElement::HardSpace => fmt.write_str("Space"),
+            FormatElement::Line(mode) => fmt.debug_tuple("Line").field(mode).finish(),
+            FormatElement::ExpandParent => fmt.write_str("ExpandParent"),
+            FormatElement::Token { text } => fmt.debug_tuple("Token").field(text).finish(),
+            FormatElement::Text { text, .. } => fmt.debug_tuple("Text").field(text).finish(),
+            FormatElement::LineSuffixBoundary => fmt.write_str("LineSuffixBoundary"),
+            FormatElement::BestFitting(best_fitting) => {
+                fmt.debug_tuple("BestFitting").field(&best_fitting).finish()
+            }
+            FormatElement::Interned(interned) => fmt.debug_list().entries(&**interned).finish(),
+            FormatElement::Tag(tag) => fmt.debug_tuple("Tag").field(tag).finish(),
+            FormatElement::TailwindClass(index) => {
+                fmt.debug_tuple("TailwindClass").field(index).finish()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum LineMode {
+    /// See [crate::builders::soft_line_break_or_space] for documentation.
+    SoftOrSpace,
+    /// See [crate::builders::soft_line_break] for documentation.
+    Soft,
+    /// See [crate::builders::hard_line_break] for documentation.
+    Hard,
+    /// See [crate::builders::empty_line] for documentation.
+    Empty,
+}
+
+impl LineMode {
+    pub const fn is_hard(self) -> bool {
+        matches!(self, LineMode::Hard)
+    }
+
+    pub const fn will_break(self) -> bool {
+        matches!(self, LineMode::Hard | LineMode::Empty)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PrintMode {
+    /// Omits any soft line breaks
+    Flat,
+    /// Prints soft line breaks as line breaks
+    Expanded,
+}
+
+impl PrintMode {
+    pub const fn is_flat(self) -> bool {
+        matches!(self, PrintMode::Flat)
+    }
+
+    pub const fn is_expanded(self) -> bool {
+        matches!(self, PrintMode::Expanded)
+    }
+}
+
+#[derive(Clone)]
+pub struct Interned<'a>(&'a [FormatElement<'a>]);
+
+impl<'a> Interned<'a> {
+    pub(super) fn new(content: ArenaVec<'a, FormatElement<'a>>) -> Self {
+        Self(content.into_bump_slice())
+    }
+}
+
+impl PartialEq for Interned<'_> {
+    fn eq(&self, other: &Interned<'_>) -> bool {
+        ptr::eq(self.0, other.0)
+    }
+}
+
+impl Eq for Interned<'_> {}
+
+impl Hash for Interned<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ptr().addr().hash(state);
+    }
+}
+
+impl std::fmt::Debug for Interned<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a> Deref for Interned<'a> {
+    type Target = [FormatElement<'a>];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+const LINE_SEPARATOR: char = '\u{2028}';
+
+const PARAGRAPH_SEPARATOR: char = '\u{2029}';
+
+#[expect(unused)]
+pub const LINE_TERMINATORS: [char; 3] = ['\r', LINE_SEPARATOR, PARAGRAPH_SEPARATOR];
+
+/// Replace the line terminators matching the provided list with "\n"
+/// since its the only line break type supported by the printer
+pub fn normalize_newlines<const N: usize>(text: &str, terminators: [char; N]) -> Cow<'_, str> {
+    let mut result = String::new();
+    let mut last_end = 0;
+
+    for (start, part) in text.match_indices(terminators) {
+        result.push_str(&text[last_end..start]);
+        result.push('\n');
+
+        last_end = start + part.len();
+        // If the current character is \r and the
+        // next is \n, skip over the entire sequence
+        if part == "\r" && text[last_end..].starts_with('\n') {
+            last_end += 1;
+        }
+    }
+
+    // If the result is empty no line terminators were matched,
+    // return the entire input text without allocating a new String
+    if result.is_empty() {
+        Cow::Borrowed(text)
+    } else {
+        result.push_str(&text[last_end..text.len()]);
+        Cow::Owned(result)
+    }
+}
+
+impl FormatElement<'_> {
+    /// Returns `true` if self is a [FormatElement::Tag]
+    pub const fn is_tag(&self) -> bool {
+        matches!(self, FormatElement::Tag(_))
+    }
+
+    /// Returns `true` if self is a [FormatElement::Tag] and [Tag::is_start] is `true`.
+    pub const fn is_start_tag(&self) -> bool {
+        match self {
+            FormatElement::Tag(tag) => tag.is_start(),
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if self is a [FormatElement::Tag] and [Tag::is_end] is `true`.
+    pub const fn is_end_tag(&self) -> bool {
+        match self {
+            FormatElement::Tag(tag) => tag.is_end(),
+            _ => false,
+        }
+    }
+
+    pub const fn is_text(&self) -> bool {
+        matches!(self, FormatElement::Text { .. } | FormatElement::Token { .. })
+    }
+
+    pub const fn is_space(&self) -> bool {
+        matches!(self, FormatElement::Space)
+    }
+
+    pub const fn is_line(&self) -> bool {
+        matches!(self, FormatElement::Line(_))
+    }
+}
+
+impl FormatElements for FormatElement<'_> {
+    fn will_break(&self) -> bool {
+        match self {
+            FormatElement::ExpandParent => true,
+            FormatElement::Tag(Tag::StartGroup(group)) => !group.mode().is_flat(),
+            FormatElement::Line(line_mode) => line_mode.will_break(),
+            FormatElement::Text { text: _, width } => width.is_multiline(),
+            FormatElement::Interned(interned) => interned.will_break(),
+            // Traverse into the most flat version because the content is guaranteed to expand when even
+            // the most flat version contains some content that forces a break.
+            FormatElement::BestFitting(best_fitting) => best_fitting.most_flat().will_break(),
+            // `FormatElement::Token` cannot contain line breaks
+            FormatElement::Token { .. }
+            | FormatElement::LineSuffixBoundary
+            | FormatElement::Space
+            | FormatElement::Tag(_)
+            | FormatElement::HardSpace
+            | FormatElement::TailwindClass(_) => false,
+        }
+    }
+
+    fn may_directly_break(&self) -> bool {
+        matches!(self, FormatElement::Line(_))
+    }
+
+    fn has_label(&self, label_id: LabelId) -> bool {
+        match self {
+            FormatElement::Tag(Tag::StartLabelled(actual)) => *actual == label_id,
+            FormatElement::Interned(interned) => interned.deref().has_label(label_id),
+            _ => false,
+        }
+    }
+
+    fn start_tag(&self, _: TagKind) -> Option<&Tag> {
+        None
+    }
+
+    fn end_tag(&self, kind: TagKind) -> Option<&Tag> {
+        match self {
+            FormatElement::Tag(tag) if tag.kind() == kind && tag.is_end() => Some(tag),
+            _ => None,
+        }
+    }
+}
+
+/// Provides the printer with different representations for the same element so that the printer
+/// can pick the best fitting variant.
+///
+/// Best fitting is defined as the variant that takes the most horizontal space but fits on the line.
+#[derive(Clone, Eq, PartialEq)]
+pub struct BestFittingElement<'a> {
+    /// The different variants for this element.
+    /// The first element is the one that takes up the most space horizontally (the most flat),
+    /// The last element takes up the least space horizontally (but most horizontal space).
+    variants: &'a [&'a [FormatElement<'a>]],
+}
+
+impl<'a> BestFittingElement<'a> {
+    /// Creates a new best fitting IR with the given variants. The method itself isn't unsafe
+    /// but it is to discourage people from using it because the printer will panic if
+    /// the slice doesn't contain at least the least and most expanded variants.
+    ///
+    /// You're looking for a way to create a `BestFitting` object, use the `best_fitting![least_expanded, most_expanded]` macro.
+    ///
+    /// ## Safety
+    /// The slice must contain at least two variants.
+    #[doc(hidden)]
+    pub unsafe fn from_vec_unchecked(variants: ArenaVec<'a, &'a [FormatElement<'a>]>) -> Self {
+        debug_assert!(
+            variants.len() >= 2,
+            "Requires at least the least expanded and most expanded variants"
+        );
+
+        Self { variants: variants.into_bump_slice() }
+    }
+
+    /// Returns the most expanded variant
+    pub fn most_expanded(&self) -> &[FormatElement<'a>] {
+        self.variants.last().expect(
+            "Most contain at least two elements, as guaranteed by the best fitting builder.",
+        )
+    }
+
+    /// Splits the variants into the most expanded and the remaining flat variants
+    pub fn split_to_most_expanded_and_flat_variants(
+        &self,
+    ) -> (&&[FormatElement<'a>], &[&[FormatElement<'a>]]) {
+        // SAFETY: We have already asserted that there are at least two variants for creating this struct.
+        unsafe { self.variants.split_last().unwrap_unchecked() }
+    }
+
+    pub fn variants(&self) -> &[&'a [FormatElement<'a>]] {
+        self.variants
+    }
+
+    /// Returns the least expanded variant
+    pub fn most_flat(&self) -> &[FormatElement<'a>] {
+        self.variants.first().expect(
+            "Most contain at least two elements, as guaranteed by the best fitting builder.",
+        )
+    }
+}
+
+impl std::fmt::Debug for BestFittingElement<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.variants).finish()
+    }
+}
+
+pub trait FormatElements {
+    /// Returns true if this [FormatElement] is guaranteed to break across multiple lines by the printer.
+    /// This is the case if this format element recursively contains a:
+    /// * [crate::builders::empty_line] or [crate::builders::hard_line_break]
+    /// * A token containing '\n'
+    ///
+    /// Use this with caution, this is only a heuristic and the printer may print the element over multiple
+    /// lines if this element is part of a group and the group doesn't fit on a single line.
+    fn will_break(&self) -> bool;
+
+    /// Returns true if this [FormatElement] has the potential to break across multiple lines when printed.
+    /// This is the case _only_ if this format element recursively contains a [FormatElement::Line].
+    ///
+    /// It's possible for [FormatElements::will_break] to return true while this function returns false,
+    /// such as when the group contains a [crate::builders::expand_parent] or some text within the group
+    /// contains a newline. Neither of those cases directly contain a [FormatElement::Line], and so they
+    /// do not _directly_ break.
+    fn may_directly_break(&self) -> bool;
+
+    /// Returns true if the element has the given label.
+    fn has_label(&self, label: LabelId) -> bool;
+
+    /// Returns the start tag of `kind` if:
+    /// * the last element is an end tag of `kind`.
+    /// * there's a matching start tag in this document (may not be true if this slice is an interned element and the `start` is in the document storing the interned element).
+    #[expect(unused)]
+    fn start_tag(&self, kind: TagKind) -> Option<&Tag>;
+
+    /// Returns the end tag if:
+    /// * the last element is an end tag of `kind`
+    fn end_tag(&self, kind: TagKind) -> Option<&Tag>;
+}
+
+/// New-type wrapper for a text Unicode width. Mainly to prevent access to the inner value.
+///
+/// ## Representation
+///
+/// Uses a single `u32` to efficiently store both the width value and a multiline flag:
+///
+/// - Bit 31: Multiline flag (1 = multiline, 0 = single line)
+/// - Bits 0-30: Width value (stored directly)
+///
+/// This encoding allows `TextWidth` to fit in 4 bytes while supporting both a width value
+/// and a boolean flag. The maximum representable width is 2^31 - 1 (0x7FFFFFFF).
+///
+/// The maximum value is sufficient in practice as texts that long would exceed any
+/// reasonable line width configuration (typically < 500 columns).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct TextWidth(u32);
+
+impl TextWidth {
+    /// Bit mask for the multiline flag (highest bit)
+    const MULTILINE_MASK: u32 = 1 << 31;
+
+    /// Bit mask for extracting the width value (all bits except the highest)
+    const WIDTH_MASK: u32 = Self::MULTILINE_MASK - 1;
+
+    /// Encodes width and multiline flag into a single u32.
+    const fn encode(width: u32, multiline: bool) -> u32 {
+        debug_assert!(width <= Self::WIDTH_MASK, "width exceeds maximum representable value");
+
+        // Set multiline flag if needed
+        if multiline { width | Self::MULTILINE_MASK } else { width }
+    }
+
+    /// Creates a single-line text width.
+    pub const fn single(width: u32) -> Self {
+        Self(Self::encode(width, false))
+    }
+
+    /// Creates a multi-line text width.
+    pub const fn multiline(width: u32) -> Self {
+        Self(Self::encode(width, true))
+    }
+
+    /// Returns the width value.
+    pub const fn value(self) -> u32 {
+        self.0 & Self::WIDTH_MASK
+    }
+
+    /// Calculates width from text, handling tabs, newlines, and Unicode.
+    ///
+    /// NOTE: Uses `UnicodeWidthStr::width()` for accurate emoji sequence handling.
+    /// Counting by `char` can lead to incorrect widths for complex Unicode sequences.
+    /// e.g. "🗑️" (U+1F5D1 U+FE0F) is a single emoji with width 2, but counting chars gives width 1.
+    #[expect(clippy::cast_possible_truncation)]
+    pub fn from_text(text: &str, indent_width: IndentWidth) -> TextWidth {
+        // Fast path for empty text
+        if text.is_empty() {
+            return Self::single(0);
+        }
+
+        let mut width = 0u32;
+        let mut segment_start = 0;
+        for (i, c) in text.char_indices() {
+            match c {
+                '\t' => {
+                    width += text[segment_start..i].width() as u32;
+                    width += u32::from(indent_width.value());
+                    segment_start = i + 1; // Skip the tab character
+                }
+                '\n' => {
+                    width += text[segment_start..i].width() as u32;
+                    return Self::multiline(width);
+                }
+                _ => {}
+            }
+        }
+        width += text[segment_start..].width() as u32;
+
+        Self::single(width)
+    }
+
+    /// Creates width from a string known to not contain whitespace.
+    /// More efficient than `from_text` when whitespace is guaranteed absent.
+    pub fn from_non_whitespace_str(name: &str) -> TextWidth {
+        #[expect(clippy::cast_possible_truncation)]
+        Self::single(name.width() as u32)
+    }
+
+    /// Returns true if the text contains newlines.
+    pub(crate) const fn is_multiline(self) -> bool {
+        (self.0 & Self::MULTILINE_MASK) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn indent_width(value: u8) -> IndentWidth {
+        IndentWidth::try_from(value).expect("valid indent width")
+    }
+
+    #[test]
+    fn single_width_round_trips_zero() {
+        let width = TextWidth::single(0);
+        debug_assert_eq!(width.value(), 0);
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn multiline_sets_flag_without_touching_width() {
+        let width = TextWidth::multiline(3);
+        debug_assert_eq!(width.value(), 3);
+        debug_assert!(width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_uses_indent_width_for_tabs() {
+        let width = TextWidth::from_text("\t", indent_width(4));
+        debug_assert_eq!(width.value(), 4);
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_marks_multiline_on_newline() {
+        let width = TextWidth::from_text("ab\nc", indent_width(2));
+        debug_assert_eq!(width.value(), 2);
+        debug_assert!(width.is_multiline());
+    }
+
+    #[test]
+    fn from_non_whitespace_and_len_match() {
+        let name = "hello";
+        #[expect(clippy::cast_possible_truncation)]
+        let name_len = name.len() as u32;
+        debug_assert_eq!(TextWidth::from_non_whitespace_str(name).value(), name_len);
+    }
+
+    #[test]
+    fn is_single_line_inverse_of_is_multiline() {
+        let single = TextWidth::single(10);
+        debug_assert!(!single.is_multiline());
+
+        let multi = TextWidth::multiline(10);
+        debug_assert!(multi.is_multiline());
+    }
+
+    #[test]
+    fn from_text_handles_unicode() {
+        // Emoji width
+        let width = TextWidth::from_text("👍", indent_width(2));
+        debug_assert_eq!(width.value(), 2); // Most emojis are width 2
+        debug_assert!(!width.is_multiline());
+
+        // Chinese characters
+        let width = TextWidth::from_text("你好", indent_width(2));
+        debug_assert_eq!(width.value(), 4); // Each CJK char is width 2
+        debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn from_text_handles_emoji_sequences() {
+        use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+        // Emoji with variation selector: 🗑️ = U+1F5D1 + U+FE0F
+        let emoji = "🗑️";
+
+        // Counting by char gives wrong width
+        let wrong: usize = emoji.chars().filter_map(UnicodeWidthChar::width).sum();
+        debug_assert_eq!(wrong, 1);
+        // Need to count by str for correct width
+        debug_assert_eq!(emoji.width(), 2);
+        // Verify `TextWidth` also gets it right
+        let width = TextWidth::from_text(emoji, indent_width(2));
+        debug_assert_eq!(width.value(), 2);
+
+        // Emoji with text
+        let width = TextWidth::from_text("🗑️ DELETE", indent_width(2));
+        debug_assert_eq!(width.value(), 9); // 2 (emoji) + 1 (space) + 6 (DELETE)
+
+        // Another emoji with variation selector: ⚠️ = U+26A0 + U+FE0F
+        let width = TextWidth::from_text("⚠️", indent_width(2));
+        debug_assert_eq!(width.value(), 2);
+    }
+
+    #[test]
+    fn from_text_empty_returns_zero() {
+        let width = TextWidth::from_text("", indent_width(2));
+        debug_assert_eq!(width.value(), 0);
+        debug_assert!(!width.is_multiline());
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/format_element/tag.rs
+++ b/crates/oxc_formatter_core/src/formatter/format_element/tag.rs
@@ -1,0 +1,274 @@
+use std::{cell::Cell, num::NonZeroU8};
+
+use super::super::{GroupId, format_element::PrintMode};
+
+/// A Tag marking the start and end of some content to which some special formatting should be applied.
+///
+/// Tags always come in pairs of a start and an end tag and the styling defined by this tag
+/// will be applied to all elements in between the start/end tags.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Tag {
+    /// Indents the content one level deeper, see [crate::builders::indent] for documentation and examples.
+    StartIndent,
+    EndIndent,
+
+    /// Variant of [TagKind::Indent] that indents content by a number of spaces. For example, `Align(2)`
+    /// indents any content following a line break by an additional two spaces.
+    ///
+    /// Nesting (Aligns)[TagKind::Align] has the effect that all except the most inner align are handled as (Indent)[TagKind::Indent].
+    StartAlign(Align),
+    EndAlign,
+
+    /// Reduces the indention of the specified content either by one level or to the root, depending on the mode.
+    /// Reverse operation of `Indent` and can be used to *undo* an `Align` for nested content.
+    StartDedent(DedentMode),
+    EndDedent(DedentMode),
+
+    /// Creates a logical group where its content is either consistently printed:
+    /// * on a single line: Omitting `LineMode::Soft` line breaks and printing spaces for `LineMode::SoftOrSpace`
+    /// * on multiple lines: Printing all line breaks
+    ///
+    /// See [crate::builders::group] for documentation and examples.
+    StartGroup(Group),
+    EndGroup,
+
+    /// Allows to specify content that gets printed depending on whatever the enclosing group
+    /// is printed on a single line or multiple lines. See [crate::builders::if_group_breaks] for examples.
+    StartConditionalContent(Condition),
+    EndConditionalContent,
+
+    /// Optimized version of [Tag::StartConditionalContent] for the case where some content
+    /// should be indented if the specified group breaks.
+    StartIndentIfGroupBreaks(GroupId),
+    EndIndentIfGroupBreaks(GroupId),
+
+    /// Concatenates multiple elements together with a given separator printed in either
+    /// flat or expanded mode to fill the print width. Expect that the content is a list of alternating
+    /// [element, separator] See [crate::Formatter::fill].
+    StartFill,
+    EndFill,
+
+    /// Entry inside of a [Tag::StartFill]
+    StartEntry,
+    EndEntry,
+
+    /// Delay the printing of its content until the next line break
+    StartLineSuffix,
+    EndLineSuffix,
+
+    /// Special semantic element marking the content with a label.
+    /// This does not directly influence how the content will be printed.
+    ///
+    /// See [crate::builders::labelled] for documentation.
+    StartLabelled(LabelId),
+    EndLabelled,
+}
+
+impl Tag {
+    /// Returns `true` if `self` is any start tag.
+    pub const fn is_start(&self) -> bool {
+        matches!(
+            self,
+            Tag::StartIndent
+                | Tag::StartAlign(_)
+                | Tag::StartDedent(_)
+                | Tag::StartGroup { .. }
+                | Tag::StartConditionalContent(_)
+                | Tag::StartIndentIfGroupBreaks(_)
+                | Tag::StartFill
+                | Tag::StartEntry
+                | Tag::StartLineSuffix
+                | Tag::StartLabelled(_)
+        )
+    }
+
+    /// Returns `true` if `self` is any end tag.
+    pub const fn is_end(&self) -> bool {
+        !self.is_start()
+    }
+
+    pub const fn kind(&self) -> TagKind {
+        use Tag::{
+            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
+            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
+            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+        };
+
+        match self {
+            StartIndent | EndIndent => TagKind::Indent,
+            StartAlign(_) | EndAlign => TagKind::Align,
+            StartDedent(_) | EndDedent(_) => TagKind::Dedent,
+            StartGroup(_) | EndGroup => TagKind::Group,
+            StartConditionalContent(_) | EndConditionalContent => TagKind::ConditionalContent,
+            StartIndentIfGroupBreaks(_) | EndIndentIfGroupBreaks(_) => TagKind::IndentIfGroupBreaks,
+            StartFill | EndFill => TagKind::Fill,
+            StartEntry | EndEntry => TagKind::Entry,
+            StartLineSuffix | EndLineSuffix => TagKind::LineSuffix,
+            StartLabelled(_) | EndLabelled => TagKind::Labelled,
+        }
+    }
+}
+
+/// The kind of a [Tag].
+///
+/// Each start end tag pair has its own [tag kind](TagKind).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum TagKind {
+    Indent,
+    Align,
+    Dedent,
+    Group,
+    ConditionalContent,
+    IndentIfGroupBreaks,
+    Fill,
+    Entry,
+    LineSuffix,
+    Labelled,
+    TailwindClass,
+}
+
+#[derive(Debug, Copy, Default, Clone, Eq, PartialEq)]
+pub enum GroupMode {
+    /// Print group in flat mode.
+    #[default]
+    Flat,
+
+    /// The group should be printed in expanded mode
+    Expand,
+
+    /// Expand mode has been propagated from an enclosing group to this group.
+    Propagated,
+}
+
+impl GroupMode {
+    pub const fn is_flat(self) -> bool {
+        matches!(self, GroupMode::Flat)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Group {
+    id: Option<GroupId>,
+    mode: Cell<GroupMode>,
+}
+
+impl Group {
+    pub fn new() -> Self {
+        Self { id: None, mode: Cell::new(GroupMode::Flat) }
+    }
+
+    pub fn with_id(mut self, id: Option<GroupId>) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub fn with_mode(mut self, mode: GroupMode) -> Self {
+        self.mode = Cell::new(mode);
+        self
+    }
+
+    pub fn mode(&self) -> GroupMode {
+        self.mode.get()
+    }
+
+    pub fn propagate_expand(&self) {
+        if self.mode.get() == GroupMode::Flat {
+            self.mode.set(GroupMode::Propagated);
+        }
+    }
+
+    pub fn id(&self) -> Option<GroupId> {
+        self.id
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum DedentMode {
+    /// Reduces the indent by a level (if the current indent is > 0)
+    Level,
+
+    /// Reduces the indent to the root
+    Root,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Condition {
+    /// * Flat -> Omitted if the enclosing group is a multiline group, printed for groups fitting on a single line
+    /// * Multiline -> Omitted if the enclosing group fits on a single line, printed if the group breaks over multiple lines.
+    pub(crate) mode: PrintMode,
+
+    /// The id of the group for which it should check if it breaks or not. The group must appear in the document
+    /// before the conditional group (but doesn't have to be in the ancestor chain).
+    pub(crate) group_id: Option<GroupId>,
+}
+
+impl Condition {
+    pub fn new(mode: PrintMode) -> Self {
+        Self { mode, group_id: None }
+    }
+
+    pub fn with_group_id(mut self, id: Option<GroupId>) -> Self {
+        self.group_id = id;
+        self
+    }
+
+    pub fn mode(&self) -> PrintMode {
+        self.mode
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Align(pub(crate) NonZeroU8);
+
+impl Align {
+    pub fn count(&self) -> NonZeroU8 {
+        self.0
+    }
+}
+
+#[derive(Debug, Eq, Copy, Clone)]
+pub struct LabelId {
+    value: u64,
+    #[cfg(debug_assertions)]
+    name: &'static str,
+}
+
+impl PartialEq for LabelId {
+    fn eq(&self, other: &Self) -> bool {
+        let is_equal = self.value == other.value;
+
+        #[cfg(debug_assertions)]
+        {
+            if is_equal {
+                assert_eq!(
+                    self.name, other.name,
+                    "Two `LabelId`s with different names have the same `value`. Are you mixing labels of two different `LabelDefinition` or are the values returned by the `LabelDefinition` not unique?"
+                );
+            }
+        }
+
+        is_equal
+    }
+}
+
+impl LabelId {
+    #[expect(clippy::needless_pass_by_value)] // The `Label` trait is unnecessary, would refactor it later.
+    pub fn of<T: Label>(label: T) -> Self {
+        Self {
+            value: label.id(),
+            #[cfg(debug_assertions)]
+            name: label.debug_name(),
+        }
+    }
+}
+
+/// Defines the valid labels of a language. You want to have at most one implementation per formatter
+/// project.
+pub trait Label {
+    /// Returns the `u64` uniquely identifying this specific label.
+    fn id(&self) -> u64;
+
+    /// Returns the name of the label that is shown in debug builds.
+    fn debug_name(&self) -> &'static str;
+}

--- a/crates/oxc_formatter_core/src/formatter/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter/formatter.rs
@@ -1,0 +1,297 @@
+#![allow(clippy::module_inception)]
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+
+use super::{
+    Arguments, Buffer, FormatContext, FormatState, GroupId, VecBuffer,
+    builders::{FillBuilder, JoinBuilder, JoinNodesBuilder, Line},
+    context::FormatContextExt,
+    prelude::*,
+};
+
+/// Handles the formatting of a CST and stores the context how the CST should be formatted (user preferences).
+///
+/// The formatter is passed to the [Format] implementation of every node in the CST so that they
+/// can use it to format their children.
+pub struct Formatter<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    pub(super) buffer: &'buf mut dyn Buffer<'ast, Ctx>,
+}
+
+impl<'buf, 'ast, Ctx> Formatter<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Creates a new context that uses the given formatter context
+    pub fn new(buffer: &'buf mut (dyn Buffer<'ast, Ctx> + 'buf)) -> Self {
+        Self { buffer }
+    }
+
+    pub fn allocator(&self) -> &'ast Allocator {
+        self.context().allocator()
+    }
+
+    /// Returns the format options
+    #[inline]
+    pub fn options(&self) -> &Ctx::Options {
+        self.context().options()
+    }
+
+    /// Returns the Context specifying how to format the current CST
+    #[inline]
+    pub fn context(&self) -> &Ctx {
+        self.state().context()
+    }
+
+    /// Returns a mutable reference to the context.
+    #[inline]
+    pub fn context_mut(&mut self) -> &mut Ctx {
+        self.state_mut().context_mut()
+    }
+
+    /// Creates a new group id that is unique to this document. The passed debug name is used in the
+    /// [std::fmt::Debug] of the document if this is a debug build.
+    /// The name is unused for production builds and has no meaning on the equality of two group ids.
+    #[inline]
+    pub fn group_id(&self, debug_name: &'static str) -> GroupId {
+        self.state().group_id(debug_name)
+    }
+
+    /// Joins multiple [Format] together without any separator
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use biome_formatter::format;
+    /// use biome_formatter::prelude::*;
+    ///
+    /// # fn main()  {
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+    ///     f.join()
+    ///         .entry(&token("a"))
+    ///         .entry(&space())
+    ///         .entry(&token("+"))
+    ///         .entry(&space())
+    ///         .entry(&token("b"))
+    ///         .finish()
+    /// })])?;
+    ///
+    /// assert_eq!(
+    ///     "a + b",
+    ///     formatted.print()?.as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn join<'fmt>(&'fmt mut self) -> JoinBuilder<'fmt, 'buf, 'ast, Ctx, ()> {
+        JoinBuilder::new(self)
+    }
+
+    /// Joins the objects by placing the specified separator between every two items.
+    ///
+    /// ## Examples
+    ///
+    /// Joining different tokens by separating them with a comma and a space.
+    ///
+    /// ```
+    /// use biome_formatter::{format, format_args};
+    /// use biome_formatter::prelude::*;
+    ///
+    /// # fn main()  {
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+    ///     f.join_with(&format_args!(token(","), space()))
+    ///         .entry(&token("1"))
+    ///         .entry(&token("2"))
+    ///         .entry(&token("3"))
+    ///         .entry(&token("4"))
+    ///         .finish()
+    /// })])?;
+    ///
+    /// assert_eq!(
+    ///     "1, 2, 3, 4",
+    ///     formatted.print()?.as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn join_with<'fmt, Joiner>(
+        &'fmt mut self,
+        joiner: Joiner,
+    ) -> JoinBuilder<'fmt, 'buf, 'ast, Ctx, Joiner>
+    where
+        Joiner: Format<'ast, Ctx>,
+    {
+        JoinBuilder::with_separator(self, joiner)
+    }
+
+    /// Concatenates a list of [crate::Format] objects with spaces and line breaks to fit
+    /// them on as few lines as possible. Each element introduces a conceptual group. The printer
+    /// first tries to print the item in flat mode but then prints it in expanded mode if it doesn't fit.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use biome_formatter::prelude::*;
+    /// use biome_formatter::{format, format_args};
+    ///
+    /// # fn main()  {
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+    ///     f.fill()
+    ///         .entry(&soft_line_break_or_space(), &token("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+    ///         .entry(&soft_line_break_or_space(), &token("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+    ///         .entry(&soft_line_break_or_space(), &token("cccccccccccccccccccccccccccccc"))
+    ///         .entry(&soft_line_break_or_space(), &token("dddddddddddddddddddddddddddddd"))
+    ///         .finish()
+    /// })])?;
+    ///
+    /// assert_eq!(
+    ///     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\ncccccccccccccccccccccccccccccc dddddddddddddddddddddddddddddd",
+    ///     formatted.print()?.as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust
+    /// use biome_formatter::prelude::*;
+    /// use biome_formatter::{format, format_args};
+    ///
+    /// # fn main()  {
+    /// let entries = vec![
+    ///     token("<b>Important: </b>"),
+    ///     token("Please do not commit memory bugs such as segfaults, buffer overflows, etc. otherwise you "),
+    ///     token("<em>will</em>"),
+    ///     token(" be reprimanded")
+    /// ];
+    ///
+    /// let formatted = format!(SimpleFormatContext::default(), [format_with(|f| {
+    ///     f.fill().entries(&soft_line_break(), entries.iter()).finish()
+    /// })])?;
+    ///
+    /// assert_eq!(
+    ///     &std::format!("<b>Important: </b>\nPlease do not commit memory bugs such as segfaults, buffer overflows, etc. otherwise you \n<em>will</em> be reprimanded"),
+    ///     formatted.print()?.as_code()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn fill<'fmt>(&'fmt mut self) -> FillBuilder<'fmt, 'buf, 'ast, Ctx> {
+        FillBuilder::new(self)
+    }
+
+    /// Formats `content` into an interned element without writing it to the formatter's buffer.
+    pub fn intern(&mut self, content: &dyn Format<'ast, Ctx>) -> Option<FormatElement<'ast>> {
+        let mut buffer = VecBuffer::new(self.state_mut());
+        crate::write!(&mut buffer, [content]);
+        let elements = buffer.into_vec();
+
+        self.intern_vec(elements)
+    }
+
+    #[expect(clippy::unused_self)] // Keep `self` the same as the original source
+    pub fn intern_vec(
+        &self,
+        mut elements: ArenaVec<'ast, FormatElement<'ast>>,
+    ) -> Option<FormatElement<'ast>> {
+        match elements.len() {
+            0 => None,
+            // Doesn't get cheaper than calling clone, use the element directly
+            // SAFETY: Safe because of the `len == 1` check in the match arm.
+            1 => Some(elements.pop().unwrap()),
+            _ => Some(FormatElement::Interned(Interned::new(elements))),
+        }
+    }
+}
+
+impl<'buf, 'ast, Ctx> Formatter<'buf, 'ast, Ctx>
+where
+    Ctx: FormatContextExt<'ast>,
+{
+    /// Specialized version of [crate::Formatter::join_with] for joining SyntaxNodes separated by a space, soft
+    /// line break or empty line depending on the input file.
+    ///
+    /// This function inspects the input source and separates consecutive elements with either
+    /// a [crate::builders::soft_line_break_or_space] or [crate::builders::empty_line] depending on how many line breaks were
+    /// separating the elements in the original file.
+    pub fn join_nodes_with_soft_line<'fmt>(
+        &'fmt mut self,
+    ) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Ctx, Line> {
+        JoinNodesBuilder::new(soft_line_break_or_space(), self)
+    }
+
+    /// Specialized version of [crate::Formatter::join_with] for joining SyntaxNodes separated by one or more
+    /// line breaks depending on the input file.
+    ///
+    /// This function inspects the input source and separates consecutive elements with either
+    /// a [crate::builders::hard_line_break] or [crate::builders::empty_line] depending on how many line breaks were separating the
+    /// elements in the original file.
+    pub fn join_nodes_with_hardline<'fmt>(
+        &'fmt mut self,
+    ) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Ctx, Line> {
+        JoinNodesBuilder::new(hard_line_break(), self)
+    }
+
+    /// Specialized version of [crate::Formatter::join_with] for joining SyntaxNodes separated by a simple space.
+    ///
+    /// This function *disregards* the input source and always separates consecutive elements with a plain
+    /// [crate::builders::space], forcing a flat layout regardless of any line breaks or spaces were separating
+    /// the elements in the original file.
+    ///
+    /// This function should likely only be used in a `best_fitting!` context, where one variant attempts to
+    /// force a list of nodes onto a single line without any possible breaks, then falls back to a broken
+    /// out variant if the content does not fit.
+    pub fn join_nodes_with_space<'fmt>(
+        &'fmt mut self,
+    ) -> JoinNodesBuilder<'fmt, 'buf, 'ast, Ctx, Space> {
+        JoinNodesBuilder::new(space(), self)
+    }
+
+    /// Returns the source text wrapper.
+    #[inline]
+    pub fn source_text(&self) -> Ctx::SourceText {
+        self.context().source_text()
+    }
+
+    /// Returns the comments from the context.
+    #[inline]
+    pub fn comments(&self) -> &Ctx::Comments {
+        self.context().comments()
+    }
+
+    /// Returns a mutable reference to the comments.
+    #[inline]
+    pub fn comments_mut(&mut self) -> &mut Ctx::Comments {
+        self.context_mut().comments_mut()
+    }
+}
+
+impl<'ast, Ctx> Buffer<'ast, Ctx> for Formatter<'_, 'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[inline(always)]
+    fn write_element(&mut self, element: FormatElement<'ast>) {
+        self.buffer.write_element(element);
+    }
+
+    fn elements(&self) -> &[FormatElement<'ast>] {
+        self.buffer.elements()
+    }
+
+    #[inline(always)]
+    fn write_fmt(&mut self, arguments: Arguments<'_, 'ast, Ctx>) {
+        for argument in arguments.items() {
+            argument.format(self);
+        }
+    }
+
+    fn state(&self) -> &FormatState<'ast, Ctx> {
+        self.buffer.state()
+    }
+
+    fn state_mut(&mut self) -> &mut FormatState<'ast, Ctx> {
+        self.buffer.state_mut()
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/group_id.rs
+++ b/crates/oxc_formatter_core/src/formatter/group_id.rs
@@ -1,0 +1,90 @@
+use std::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+#[cfg(debug_assertions)]
+mod debug {
+    use super::*;
+
+    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+    pub struct GroupId {
+        pub(super) value: NonZeroU32,
+        name: &'static str,
+    }
+
+    impl GroupId {
+        pub(super) fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
+            Self { value, name: debug_name }
+        }
+    }
+
+    impl std::fmt::Debug for GroupId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "#{}-{}", self.name, self.value)
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+mod release {
+    use super::*;
+
+    /// Unique identification for a group.
+    ///
+    /// See [crate::Formatter::group_id] on how to get a unique id.
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+    pub struct GroupId {
+        pub(super) value: NonZeroU32,
+    }
+
+    impl GroupId {
+        /// Creates a new unique group id with the given debug name (only stored in debug builds)
+        #[cfg_attr(debug_assertions, expect(unused))]
+        pub(super) fn new(value: NonZeroU32, _: &'static str) -> Self {
+            Self { value }
+        }
+    }
+
+    impl std::fmt::Debug for GroupId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "#{}", self.value)
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+pub type GroupId = release::GroupId;
+#[cfg(debug_assertions)]
+pub type GroupId = debug::GroupId;
+
+impl From<GroupId> for u32 {
+    fn from(id: GroupId) -> Self {
+        id.value.get()
+    }
+}
+
+/// Builder to construct unique group ids that are unique if created with the same builder.
+pub(super) struct UniqueGroupIdBuilder {
+    next_id: AtomicU32,
+}
+
+impl UniqueGroupIdBuilder {
+    /// Creates a new unique group id with the given debug name.
+    pub fn group_id(&self, debug_name: &'static str) -> GroupId {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let id = NonZeroU32::new(id).unwrap_or_else(|| panic!("Group ID counter overflowed"));
+
+        GroupId::new(id, debug_name)
+    }
+}
+
+impl Default for UniqueGroupIdBuilder {
+    fn default() -> Self {
+        UniqueGroupIdBuilder {
+            // Start with 1 because `GroupId` wraps a `NonZeroU32` to reduce memory usage.
+            next_id: AtomicU32::new(1),
+        }
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/macros.rs
+++ b/crates/oxc_formatter_core/src/formatter/macros.rs
@@ -1,0 +1,339 @@
+/// Constructs the parameters for other formatting macros.
+///
+/// This macro functions by taking a list of objects implementing [crate::Format]. It canonicalize the
+/// arguments into a single type.
+///
+/// This macro produces a value of type [crate::Arguments]. This value can be passed to
+/// the macros within [crate]. All other formatting macros ([`format!`](crate::format!),
+/// [`write!`](crate::write!)) are proxied through this one. This macro avoids heap allocations.
+///
+/// You can use the [`Arguments`] value that `format_args!` returns in  `Format` contexts
+/// as seen below.
+///
+/// ```rust
+/// use biome_formatter::{SimpleFormatContext, format, format_args};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main()  {
+/// let formatted = format!(SimpleFormatContext::default(), [
+///     format_args!(token("Hello World"))
+/// ])?;
+///
+/// assert_eq!("Hello World", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`Format`]: crate::Format
+/// [`Arguments`]: crate::Arguments
+#[macro_export]
+macro_rules! format_args {
+    ($($value:expr),+ $(,)?) => {
+        $crate::formatter::Arguments::new(&[
+            $(
+                $crate::formatter::Argument::new(&$value)
+            ),+
+        ])
+    }
+}
+
+/// Writes formatted data into a buffer.
+///
+/// This macro accepts a 'buffer' and a list of format arguments. Each argument will be formatted
+/// and the result will be passed to the buffer. The writer may be any value with a `write_fmt` method;
+/// generally this comes from an implementation of the [crate::Buffer] trait.
+///
+/// # Examples
+///
+/// ```rust
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{Buffer, FormatState, SimpleFormatContext, VecBuffer, write};
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+/// write!(&mut buffer, [token("Hello"), space()])?;
+/// write!(&mut buffer, [token("World")])?;
+///
+/// assert_eq!(
+///     buffer.into_vec(),
+///     vec![
+///         FormatElement::Token { text: "Hello" },
+///         FormatElement::Space,
+///         FormatElement::Token { text: "World" },
+///     ]
+///  );
+/// #  Ok(())
+/// # }
+/// ```
+#[macro_export]
+macro_rules! write {
+    ($dst:expr, [$($arg:expr),+ $(,)?]) => {{
+        let result = $dst.write_fmt($crate::format_args!($($arg),+));
+        result
+    }};
+    ($dst:expr, $arg:expr) => {{
+        let result = $dst.write_fmt($crate::format_args!($arg));
+        result
+    }}
+}
+
+/// Writes formatted data into the given buffer and prints all written elements for a quick and dirty debugging.
+///
+/// An example:
+///
+/// ```rust
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{FormatState, VecBuffer};
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+///
+/// dbg_write!(buffer, [token("Hello")])?;
+/// // ^-- prints: [src/main.rs:7][0] = StaticToken("Hello")
+///
+/// assert_eq!(buffer.into_vec(), vec![FormatElement::Token { text: "Hello" }]);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Note that the macro is intended as debugging tool and therefore you should avoid having
+/// uses of it in version control for long periods (other than in tests and similar). Format output
+/// from production code is better done with `[write!]`
+#[macro_export]
+macro_rules! dbg_write {
+    ($dst:expr, [$($arg:expr),+ $(,)?]) => {{
+        use $crate::BufferExtensions;
+        let mut count = 0;
+        let mut inspect = $dst.inspect(|element: &FormatElement| {
+            std::eprintln!(
+                "[{}:{}][{}] = {element:#?}",
+                std::file!(), std::line!(), count
+            );
+            count += 1;
+        });
+        let result = inspect.write_fmt($crate::format_args!($($arg),+));
+        result
+    }}
+}
+
+/// Creates the Format IR for a value.
+///
+/// The first argument `format!` receives is the [FormatContext] that specify how elements must be formatted.
+/// Additional parameters passed get formatted by using their [crate::Format] implementation.
+///
+///
+/// ## Examples
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::format;
+///
+/// let formatted = format!(SimpleFormatContext::default(), [token("("), token("a"), token(")")]).unwrap();
+///
+/// assert_eq!(
+///     formatted.into_document(),
+///     Document::from(vec![
+///         FormatElement::Token { text: "(" },
+///         FormatElement::Token { text: "a" },
+///         FormatElement::Token { text: ")" },
+///     ])
+/// );
+/// ```
+#[macro_export]
+macro_rules! format {
+    ($context:expr, [$($arg:expr),+ $(,)?]) => {{
+        ($crate::formatter::format($context, $crate::format_args!($($arg),+)))
+    }}
+}
+
+/// Provides multiple different alternatives and the printer picks the first one that fits.
+///
+/// Use this as last resort because it requires that the printer must try all variants in the worst case.
+/// The passed variants must be in the following order:
+/// * First: The variant that takes up most space horizontally
+/// * Last: The variant that takes up the least space horizontally by splitting the content over multiple lines.
+///
+/// ## Examples
+///
+/// ```
+/// use biome_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main()  {
+/// let formatted = format!(
+///     SimpleFormatContext::default(),
+///     [
+///         token("aVeryLongIdentifier"),
+///         best_fitting!(
+///             // Everything fits on a single line
+///             format_args!(
+///                 token("("),
+///                 group(&format_args![
+///                     token("["),
+///                         soft_block_indent(&format_args![
+///                         token("1,"),
+///                         soft_line_break_or_space(),
+///                         token("2,"),
+///                         soft_line_break_or_space(),
+///                         token("3"),
+///                     ]),
+///                     token("]")
+///                 ]),
+///                 token(")")
+///             ),
+///
+///             // Breaks after `[`, but prints all elements on a single line
+///             format_args!(
+///                 token("("),
+///                 token("["),
+///                 block_indent(&token("1, 2, 3")),
+///                 token("]"),
+///                 token(")"),
+///             ),
+///
+///             // Breaks after `[` and prints each element on a single line
+///             format_args!(
+///                 token("("),
+///                 block_indent(&format_args![
+///                     token("["),
+///                     block_indent(&format_args![
+///                         token("1,"),
+///                         hard_line_break(),
+///                         token("2,"),
+///                         hard_line_break(),
+///                         token("3"),
+///                     ]),
+///                     token("]"),
+///                 ]),
+///                 token(")")
+///             )
+///         )
+///     ]
+/// )?;
+///
+/// let document = formatted.into_document();
+///
+/// // Takes the first variant if everything fits on a single line
+/// assert_eq!(
+///     "aVeryLongIdentifier([1, 2, 3])",
+///     Formatted::new(document.clone(), SimpleFormatContext::default())
+///         .print()?
+///         .as_code()
+/// );
+///
+/// // It takes the second if the first variant doesn't fit on a single line. The second variant
+/// // has some additional line breaks to make sure inner groups don't break
+/// assert_eq!(
+///     "aVeryLongIdentifier([\n\t1, 2, 3\n])",
+///     Formatted::new(document.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 21.try_into().unwrap(), ..SimpleFormatOptions::default() }))
+///         .print()?
+///         .as_code()
+/// );
+///
+/// // Prints the last option as last resort
+/// assert_eq!(
+///     "aVeryLongIdentifier(\n\t[\n\t\t1,\n\t\t2,\n\t\t3\n\t]\n)",
+///     Formatted::new(document.clone(), SimpleFormatContext::new(SimpleFormatOptions { line_width: 20.try_into().unwrap(), ..SimpleFormatOptions::default() }))
+///         .print()?
+///         .as_code()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ### Enclosing group with `should_expand: true`
+///
+/// ```
+/// use biome_formatter::{Formatted, LineWidth, format, format_args, SimpleFormatOptions};
+/// use biome_formatter::prelude::*;
+///
+/// # fn main()  {
+/// let formatted = format!(
+///     SimpleFormatContext::default(),
+///     [
+///         best_fitting!(
+///             // Prints the method call on the line but breaks the array.
+///             format_args!(
+///                 token("expect(a).toMatch("),
+///                 group(&format_args![
+///                     token("["),
+///                     soft_block_indent(&format_args![
+///                         token("1,"),
+///                         soft_line_break_or_space(),
+///                         token("2,"),
+///                         soft_line_break_or_space(),
+///                         token("3"),
+///                     ]),
+///                     token("]")
+///                 ]).should_expand(true),
+///                 token(")")
+///             ),
+///
+///             // Breaks after `(`
+///            format_args!(
+///                 token("expect(a).toMatch("),
+///                 group(&soft_block_indent(
+///                     &group(&format_args![
+///                         token("["),
+///                         soft_block_indent(&format_args![
+///                             token("1,"),
+///                             soft_line_break_or_space(),
+///                             token("2,"),
+///                             soft_line_break_or_space(),
+///                             token("3"),
+///                         ]),
+///                         token("]")
+///                     ]).should_expand(true),
+///                 )).should_expand(true),
+///                 token(")")
+///             ),
+///         )
+///     ]
+/// )?;
+///
+/// let document = formatted.into_document();
+///
+/// assert_eq!(
+///     "expect(a).toMatch([\n\t1,\n\t2,\n\t3\n])",
+///     Formatted::new(document.clone(), SimpleFormatContext::default())
+///         .print()?
+///         .as_code()
+/// );
+///
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The first variant fits because all its content up to the first line break fit on the line without exceeding
+/// the configured print width.
+///
+/// ## Complexity
+/// Be mindful of using this IR element as it has a considerable performance penalty:
+/// * There are multiple representation for the same content. This results in increased memory usage
+///   and traversal time in the printer.
+/// * The worst case complexity is that the printer tires each variant. This can result in quadratic
+///   complexity if used in nested structures.
+///
+/// ## Behavior
+/// This IR is similar to Prettier's `conditionalGroup`. The printer measures each variant, except the [`MostExpanded`], in [`Flat`] mode
+/// to find the first variant that fits and prints this variant in [`Flat`] mode. If no variant fits, then
+/// the printer falls back to printing the [`MostExpanded`] variant in `[`Expanded`] mode.
+///
+/// The definition of *fits* differs to groups in that the printer only tests if it is possible to print
+/// the content up to the first non-soft line break without exceeding the configured print width.
+/// This definition differs from groups as that non-soft line breaks make group expand.
+///
+/// [crate::BestFitting] acts as a "break" boundary, meaning that it is considered to fit
+///
+///
+/// [`Flat`]: crate::format_element::PrintMode::Flat
+/// [`Expanded`]: crate::format_element::PrintMode::Expanded
+/// [`MostExpanded`]: crate::format_element::BestFittingElement::most_expanded
+#[macro_export]
+macro_rules! best_fitting {
+    ($least_expanded:expr, $($tail:expr),+ $(,)?) => {
+        BestFitting::from_arguments_unchecked($crate::format_args!($least_expanded, $($tail),+))
+    };
+}

--- a/crates/oxc_formatter_core/src/formatter/mod.rs
+++ b/crates/oxc_formatter_core/src/formatter/mod.rs
@@ -1,0 +1,351 @@
+//! Infrastructure for code formatting
+//!
+//! This module defines [FormatElement], an IR to format code documents and provides a mean to print
+//! such a document to a string. Objects that know how to format themselves implement the [Format] trait.
+//!
+//! ## Formatting Traits
+//!
+//! * [Format]: Implemented by objects that can be formatted.
+//!
+//! ## Formatting Macros
+//!
+//! This crate defines two macros to construct the IR. These are inspired by Rust's `fmt` macros
+//! * [`format!`]: Formats a formattable object
+//! * [`format_args!`]: Concatenates a sequence of Format objects.
+//! * [`write!`]: Writes a sequence of formattable objects into an output buffer.
+
+// FIXME
+#![allow(rustdoc::broken_intra_doc_links)]
+
+mod arguments;
+pub mod buffer;
+pub mod builders;
+mod context;
+pub mod diagnostics;
+pub mod format_element;
+pub mod format_extensions;
+pub mod formatter;
+pub mod group_id;
+pub mod macros;
+pub mod prelude;
+pub mod printer;
+pub mod separated;
+mod state;
+mod text_range;
+pub mod token;
+
+use std::fmt::Debug;
+
+use self::printer::AsPrinterOptions;
+
+pub use buffer::{Buffer, BufferExtensions, VecBuffer};
+pub use format_element::FormatElement;
+pub use group_id::GroupId;
+
+use self::printer::Printer;
+pub use self::{
+    arguments::{Argument, Arguments},
+    context::{
+        FormatContext, FormatContextExt, SimpleFormatContext, SimpleFormatOptions, SourceTextExt,
+    },
+    diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError},
+    formatter::Formatter,
+    state::FormatState,
+    text_range::TextRange,
+};
+use self::{format_element::document::Document, group_id::UniqueGroupIdBuilder, prelude::TagKind};
+
+#[derive(Debug)]
+pub struct Formatted<'a, Ctx>
+where
+    Ctx: FormatContext<'a>,
+{
+    document: Document<'a>,
+    context: Ctx,
+}
+
+impl<'a, Ctx> Formatted<'a, Ctx>
+where
+    Ctx: FormatContext<'a>,
+{
+    pub fn new(document: Document<'a>, context: Ctx) -> Self {
+        Self { document, context }
+    }
+
+    /// Returns the context used during formatting.
+    pub fn context(&self) -> &Ctx {
+        &self.context
+    }
+
+    /// Returns the formatted document.
+    pub fn document(&self) -> &Document<'a> {
+        &self.document
+    }
+
+    pub fn document_mut(&mut self) -> &mut Document<'a> {
+        &mut self.document
+    }
+
+    /// Consumes `self` and returns the formatted document.
+    pub fn into_document(self) -> Document<'a> {
+        self.document
+    }
+}
+
+impl<'a, Ctx> Formatted<'a, Ctx>
+where
+    Ctx: FormatContext<'a>,
+{
+    pub fn print(self) -> PrintResult<Printed> {
+        let print_options = self.context.options().as_print_options();
+        let (elements, sorted_tailwind_classes) =
+            self.document.into_elements_and_tailwind_classes();
+        let printed = Printer::new(print_options, &sorted_tailwind_classes).print(elements)?;
+        Ok(printed)
+    }
+
+    pub fn print_with_indent(self, indent: u16) -> PrintResult<Printed> {
+        let print_options = self.context.options().as_print_options();
+        let (elements, sorted_tailwind_classes) =
+            self.document.into_elements_and_tailwind_classes();
+        let printed = Printer::new(print_options, &sorted_tailwind_classes)
+            .print_with_indent(elements, indent)?;
+        Ok(printed)
+    }
+}
+pub type PrintResult<T> = Result<T, PrintError>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Printed {
+    code: String,
+    range: Option<TextRange>,
+}
+
+impl Printed {
+    pub fn new(code: String, range: Option<TextRange>) -> Self {
+        Self { code, range }
+    }
+
+    /// Construct an empty formatter result
+    pub fn new_empty() -> Self {
+        Self { code: String::new(), range: None }
+    }
+
+    /// Range of the input source file covered by this formatted code,
+    /// or None if the entire file is covered in this instance
+    pub fn range(&self) -> Option<TextRange> {
+        self.range
+    }
+
+    /// Access the resulting code, borrowing the result
+    pub fn as_code(&self) -> &str {
+        &self.code
+    }
+
+    /// Access the resulting code, consuming the result
+    pub fn into_code(self) -> String {
+        self.code
+    }
+}
+
+// Public return type of the formatter
+pub type FormatResult<F> = Result<F, FormatError>;
+
+/// Formatting trait for types that can create a formatted representation. The `biome_formatter` equivalent
+/// to [std::fmt::Display].
+///
+/// ## Example
+/// Implementing `Format` for a custom struct
+///
+/// ```
+/// use biome_formatter::{format, write, IndentStyle, LineWidth};
+/// use biome_formatter::prelude::*;
+/// use biome_rowan::TextSize;
+///
+/// struct Paragraph(String);
+///
+/// impl Format<SimpleFormatContext> for Paragraph {
+///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>)  {
+///         write!(f, [
+///             hard_line_break(),
+///             text(&self.0, TextSize::from(0)),
+///             hard_line_break(),
+///         ])
+///     }
+/// }
+///
+/// # fn main()  {
+/// let paragraph = Paragraph(String::from("test"));
+/// let formatted = format!(SimpleFormatContext::default(), [paragraph])?;
+///
+/// assert_eq!("test\n", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+pub trait Format<'ast, Ctx, T = ()>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Formats the object using the given formatter.
+    /// # Errors
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>);
+
+    /// Formats the object using the given formatter with additional options.
+    /// # Errors
+    fn fmt_with_options(&self, _options: T, _f: &mut Formatter<'_, 'ast, Ctx>) {
+        unreachable!("Please implement it first.")
+    }
+}
+
+impl<'ast, Ctx, T> Format<'ast, Ctx> for &T
+where
+    Ctx: FormatContext<'ast>,
+    T: ?Sized + Format<'ast, Ctx>,
+{
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        Format::fmt(&**self, f);
+    }
+}
+
+impl<'ast, Ctx, T> Format<'ast, Ctx> for &mut T
+where
+    Ctx: FormatContext<'ast>,
+    T: ?Sized + Format<'ast, Ctx>,
+{
+    #[inline(always)]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        Format::fmt(&**self, f);
+    }
+}
+
+impl<'ast, Ctx, T> Format<'ast, Ctx> for Option<T>
+where
+    Ctx: FormatContext<'ast>,
+    T: Format<'ast, Ctx>,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        if let Some(value) = self {
+            value.fmt(f);
+        }
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for ()
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[inline]
+    fn fmt(&self, _: &mut Formatter<'_, 'ast, Ctx>) {
+        // Intentionally left empty
+    }
+}
+
+impl<'ast, Ctx> Format<'ast, Ctx> for str
+where
+    Ctx: FormatContext<'ast>,
+{
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, Ctx>) {
+        let text = f.context().allocator().alloc_str(self);
+        Format::fmt(&builders::text(text), f);
+    }
+}
+
+/// The `write` function takes a target buffer and an `Arguments` struct that can be precompiled with the `format_args!` macro.
+///
+/// The arguments will be formatted in-order into the output buffer provided.
+///
+/// # Examples
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{VecBuffer, format_args, FormatState, write, Formatted};
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+///
+/// write!(&mut buffer, [format_args!(token("Hello World"))])?;
+///
+/// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
+///
+/// assert_eq!("Hello World", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Please note that using [`write!`] might be preferable. Example:
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{VecBuffer, format_args, FormatState, write, Formatted};
+///
+/// # fn main()  {
+/// let mut state = FormatState::new(SimpleFormatContext::default());
+/// let mut buffer = VecBuffer::new(&mut state);
+///
+/// write!(&mut buffer, [token("Hello World")])?;
+///
+/// let formatted = Formatted::new(Document::from(buffer.into_vec()), SimpleFormatContext::default());
+///
+/// assert_eq!("Hello World", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+#[inline(always)]
+pub fn write<'ast, Ctx>(output: &mut dyn Buffer<'ast, Ctx>, args: Arguments<'_, 'ast, Ctx>)
+where
+    Ctx: FormatContext<'ast>,
+{
+    Formatter::new(output).write_fmt(args);
+}
+
+/// The `format` function takes an [`Arguments`] struct and returns the resulting formatting IR.
+///
+/// The [`Arguments`] instance can be created with the [`format_args!`].
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format, format_args};
+///
+/// # fn main()  {
+/// let formatted = format!(SimpleFormatContext::default(), [&format_args!(token("test"))])?;
+/// assert_eq!("test", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Please note that using [`format!`] might be preferable. Example:
+///
+/// ```
+/// use biome_formatter::prelude::*;
+/// use biome_formatter::{format};
+///
+/// # fn main()  {
+/// let formatted = format!(SimpleFormatContext::default(), [token("test")])?;
+/// assert_eq!("test", formatted.print()?.as_code());
+/// # Ok(())
+/// # }
+/// ```
+pub fn format<'ast, Ctx>(context: Ctx, arguments: Arguments<'_, 'ast, Ctx>) -> Formatted<'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    let mut state = FormatState::new(context);
+    let mut buffer = VecBuffer::new(&mut state);
+
+    buffer.write_fmt(arguments);
+
+    let elements = buffer.into_vec();
+    let document = Document::new(elements, Vec::new());
+
+    document.propagate_expand();
+
+    Formatted::new(document, state.into_context())
+}

--- a/crates/oxc_formatter_core/src/formatter/prelude.rs
+++ b/crates/oxc_formatter_core/src/formatter/prelude.rs
@@ -1,0 +1,10 @@
+pub use super::{Buffer as _, BufferExtensions, Format, Format as _, FormatContext};
+pub use super::{
+    builders::*,
+    format_element::{
+        tag::{LabelId, Tag, TagKind},
+        *,
+    },
+    format_extensions::{MemoizeFormat, Memoized},
+    formatter::Formatter,
+};

--- a/crates/oxc_formatter_core/src/formatter/printer/call_stack.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/call_stack.rs
@@ -1,0 +1,323 @@
+use std::{fmt::Debug, num::NonZeroU8};
+
+use super::super::{
+    InvalidDocumentError, PrintError, PrintResult,
+    format_element::{PrintMode, tag::TagKind},
+    printer::{
+        Indention,
+        stack::{Stack, StackedStack},
+    },
+};
+use crate::options::IndentStyle;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(super) enum StackFrameKind {
+    Root,
+    Tag(TagKind),
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub(super) struct StackFrame {
+    kind: StackFrameKind,
+    args: PrintElementArgs,
+}
+
+/// Stores arguments passed to `print_element` call, holding the state specific to printing an element.
+/// E.g. the `indent` depends on the token the Printer's currently processing. That's why
+/// it must be stored outside of the [PrinterState] that stores the state common to all elements.
+///
+/// The state is passed by value, which is why it's important that it isn't storing any heavy
+/// data structures. Such structures should be stored on the [PrinterState] instead.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(super) struct PrintElementArgs {
+    mode: PrintMode,
+}
+
+impl PrintElementArgs {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) fn mode(self) -> PrintMode {
+        self.mode
+    }
+
+    pub fn with_print_mode(mut self, mode: PrintMode) -> Self {
+        self.mode = mode;
+        self
+    }
+}
+
+impl Default for PrintElementArgs {
+    fn default() -> Self {
+        Self { mode: PrintMode::Expanded }
+    }
+}
+
+/// Call stack that stores the [PrintElementCallArgs].
+///
+/// New [PrintElementCallArgs] are pushed onto the stack for every [`start`](Tag::is_start) [`Tag`](FormatElement::Tag)
+/// and popped when reaching the corresponding [`end`](Tag::is_end) [`Tag`](FormatElement::Tag).
+pub(super) trait CallStack {
+    type Stack: Stack<StackFrame> + Debug;
+
+    fn stack(&self) -> &Self::Stack;
+
+    fn stack_mut(&mut self) -> &mut Self::Stack;
+
+    /// Pops the call arguments at the top and asserts that they correspond to a start tag of `kind`.
+    ///
+    /// Returns `Ok` with the arguments if the kind of the top stack frame matches `kind`, otherwise
+    /// returns `Err`.
+    fn pop(&mut self, kind: TagKind) -> PrintResult<PrintElementArgs> {
+        let last = self.stack_mut().pop();
+
+        match last {
+            Some(StackFrame { kind: StackFrameKind::Tag(actual_kind), args })
+                if actual_kind == kind =>
+            {
+                Ok(args)
+            }
+            // Start / End kind don't match
+            Some(StackFrame { kind: StackFrameKind::Tag(expected_kind), .. }) => {
+                Err(PrintError::InvalidDocument(Self::invalid_document_error(
+                    kind,
+                    Some(expected_kind),
+                )))
+            }
+            // Tried to pop the outer most stack frame, which is not valid
+            Some(frame @ StackFrame { kind: StackFrameKind::Root, .. }) => {
+                // Put it back in to guarantee that the stack is never empty
+                self.stack_mut().push(frame);
+                Err(PrintError::InvalidDocument(Self::invalid_document_error(kind, None)))
+            }
+
+            // This should be unreachable but having it for completeness. Happens if the stack is empty.
+            None => Err(PrintError::InvalidDocument(Self::invalid_document_error(kind, None))),
+        }
+    }
+
+    #[cold]
+    fn invalid_document_error(
+        end_kind: TagKind,
+        start_kind: Option<TagKind>,
+    ) -> InvalidDocumentError {
+        match start_kind {
+            None => InvalidDocumentError::StartTagMissing { kind: end_kind },
+            Some(start_kind) => InvalidDocumentError::StartEndTagMismatch { start_kind, end_kind },
+        }
+    }
+
+    /// Returns the [PrintElementArgs] for the current stack frame.
+    fn top(&self) -> PrintElementArgs {
+        self.stack().top().expect("Expected `stack` to never be empty.").args
+    }
+
+    /// Returns the [TagKind] of the current stack frame or [None] if this is the root stack frame.
+    fn top_kind(&self) -> Option<TagKind> {
+        match self.stack().top().expect("Expected `stack` to never be empty.").kind {
+            StackFrameKind::Root => None,
+            StackFrameKind::Tag(kind) => Some(kind),
+        }
+    }
+
+    /// Creates a new stack frame for a [FormatElement::Tag] of `kind` with `args` as the call arguments.
+    fn push(&mut self, kind: TagKind, args: PrintElementArgs) {
+        self.stack_mut().push(StackFrame { kind: StackFrameKind::Tag(kind), args });
+    }
+}
+
+/// Call stack used for printing the [FormatElement]s
+#[derive(Debug, Clone)]
+pub(super) struct PrintCallStack(Vec<StackFrame>);
+
+impl PrintCallStack {
+    pub(super) fn new(args: PrintElementArgs) -> Self {
+        Self(vec![StackFrame { kind: StackFrameKind::Root, args }])
+    }
+}
+
+impl CallStack for PrintCallStack {
+    type Stack = Vec<StackFrame>;
+
+    fn stack(&self) -> &Self::Stack {
+        &self.0
+    }
+
+    fn stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.0
+    }
+}
+
+/// Call stack used for measuring if some content fits on the line.
+///
+/// The stack is a view on top of the [PrintCallStack] because the stack frames are still necessary for printing.
+#[must_use]
+pub(super) struct FitsCallStack<'print> {
+    stack: StackedStack<'print, StackFrame>,
+}
+
+impl<'print> FitsCallStack<'print> {
+    pub(super) fn new(print: &'print PrintCallStack, saved: Vec<StackFrame>) -> Self {
+        let stack = StackedStack::with_vec(&print.0, saved);
+
+        Self { stack }
+    }
+
+    pub(super) fn finish(self) -> Vec<StackFrame> {
+        self.stack.into_vec()
+    }
+}
+
+impl<'a> CallStack for FitsCallStack<'a> {
+    type Stack = StackedStack<'a, StackFrame>;
+
+    fn stack(&self) -> &Self::Stack {
+        &self.stack
+    }
+
+    fn stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.stack
+    }
+}
+
+/// Suffix stack that stores the indention.
+///
+/// When ElementKind is [suffix], push the current indention onto the SuffixStack.
+pub(super) trait SuffixStack {
+    type SuffixStack: Stack<Indention> + Debug;
+    fn suffix_stack_mut(&mut self) -> &mut Self::SuffixStack;
+    fn push_suffix(&mut self, indention: Indention) {
+        self.suffix_stack_mut().push(indention);
+    }
+}
+
+/// Indent stack that stores the history of indention.
+///
+/// When the element kind is [indent] or [align], push the current indentation onto the stack of indentations.
+/// When the element kind is [dedent], pop the last item from the indentations stack and push it onto the temp_indentations stack.
+/// When the element kind is [end_dedent], pop the last item from the temp_indentations stack and push it onto the indentations stack.
+pub(super) trait IndentStack {
+    type Stack: Stack<Indention> + Debug;
+    type HistoryStack: Stack<Indention> + Debug;
+
+    fn current_stack(&self) -> &Self::Stack;
+
+    fn current_stack_mut(&mut self) -> &mut Self::Stack;
+    fn history_stack_mut(&mut self) -> &mut Self::HistoryStack;
+
+    fn start_dedent(&mut self) {
+        if let Some(indent) = self.current_stack_mut().pop() {
+            self.history_stack_mut().push(indent);
+        }
+    }
+    fn end_dedent(&mut self) {
+        if let Some(indent) = self.history_stack_mut().pop() {
+            self.current_stack_mut().push(indent);
+        }
+    }
+    fn pop(&mut self) {
+        self.current_stack_mut().pop();
+    }
+    fn indention(&self) -> Indention {
+        self.current_stack().top().copied().unwrap_or_default()
+    }
+    fn reset_indent(&mut self) {
+        self.current_stack_mut().push(Indention::default());
+    }
+    fn indent(&mut self, indent_style: IndentStyle) {
+        let next_indent = self.indention().increment_level(indent_style);
+        self.current_stack_mut().push(next_indent);
+    }
+    fn align(&mut self, count: NonZeroU8) {
+        let next_indent = self.indention().set_align(count);
+        self.current_stack_mut().push(next_indent);
+    }
+}
+
+/// Indent stack used for storing indetion history when printing the [FormatElement]s
+#[derive(Debug, Clone)]
+pub(super) struct PrintIndentStack {
+    indentions: Vec<Indention>,
+    history_indentions: Vec<Indention>,
+    suffix_indentions: Vec<Indention>,
+}
+
+impl PrintIndentStack {
+    pub(super) fn new(indention: Indention) -> Self {
+        Self {
+            indentions: vec![indention],
+            history_indentions: Vec::new(),
+            suffix_indentions: Vec::new(),
+        }
+    }
+
+    pub fn flush_suffixes(&mut self) {
+        self.indentions.extend(self.suffix_indentions.drain(..).rev());
+    }
+}
+impl IndentStack for PrintIndentStack {
+    type HistoryStack = Vec<Indention>;
+    type Stack = Vec<Indention>;
+
+    fn current_stack(&self) -> &Self::Stack {
+        &self.indentions
+    }
+
+    fn current_stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.indentions
+    }
+
+    fn history_stack_mut(&mut self) -> &mut Self::HistoryStack {
+        &mut self.history_indentions
+    }
+}
+impl SuffixStack for PrintIndentStack {
+    type SuffixStack = Vec<Indention>;
+
+    fn suffix_stack_mut(&mut self) -> &mut Self::SuffixStack {
+        &mut self.suffix_indentions
+    }
+}
+/// Indent stack used for storing the history of indention when measuring fits on the line.
+///
+/// The stack is a view on top of the [PrintIndentStack] because the stack frames are still necessary when printing.
+pub(super) struct FitsIndentStack<'print> {
+    indentions: StackedStack<'print, Indention>,
+    history_indentions: StackedStack<'print, Indention>,
+}
+
+impl<'print> FitsIndentStack<'print> {
+    pub(super) fn new(
+        print: &'print PrintIndentStack,
+        saved_indent_stack: Vec<Indention>,
+        saved_history_indent_stack: Vec<Indention>,
+    ) -> Self {
+        let indentions = StackedStack::with_vec(&print.indentions, saved_indent_stack);
+        let history_indentions =
+            StackedStack::with_vec(&print.history_indentions, saved_history_indent_stack);
+
+        Self { indentions, history_indentions }
+    }
+
+    pub(super) fn finish(self) -> (Vec<Indention>, Vec<Indention>) {
+        (self.indentions.into_vec(), self.history_indentions.into_vec())
+    }
+}
+
+impl<'a> IndentStack for FitsIndentStack<'a> {
+    type HistoryStack = StackedStack<'a, Indention>;
+    type Stack = StackedStack<'a, Indention>;
+
+    fn current_stack(&self) -> &Self::Stack {
+        &self.indentions
+    }
+
+    fn current_stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.indentions
+    }
+
+    fn history_stack_mut(&mut self) -> &mut Self::HistoryStack {
+        &mut self.history_indentions
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/printer/line_suffixes.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/line_suffixes.rs
@@ -1,0 +1,39 @@
+use super::{super::FormatElement, call_stack::PrintElementArgs};
+
+/// Stores the queued line suffixes.
+#[derive(Debug, Default)]
+pub(super) struct LineSuffixes<'a> {
+    suffixes: Vec<LineSuffixEntry<'a>>,
+}
+
+impl<'a> LineSuffixes<'a> {
+    /// Extends the line suffixes with `elements`, storing their call stack arguments with them.
+    pub(super) fn extend<I>(&mut self, args: PrintElementArgs, elements: I)
+    where
+        I: IntoIterator<Item = &'a FormatElement<'a>>,
+    {
+        self.suffixes.extend(elements.into_iter().map(LineSuffixEntry::Suffix));
+        self.suffixes.push(LineSuffixEntry::Args(args));
+    }
+
+    /// Takes all the pending line suffixes.
+    pub(super) fn take_pending<'l>(
+        &'l mut self,
+    ) -> impl DoubleEndedIterator<Item = LineSuffixEntry<'a>> + 'l + ExactSizeIterator {
+        self.suffixes.drain(..)
+    }
+
+    /// Returns `true` if there are any line suffixes and `false` otherwise.
+    pub(super) fn has_pending(&self) -> bool {
+        !self.suffixes.is_empty()
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(super) enum LineSuffixEntry<'a> {
+    /// A line suffix to print
+    Suffix(&'a FormatElement<'a>),
+
+    /// Potentially changed call arguments that should be used to format any following items.
+    Args(PrintElementArgs),
+}

--- a/crates/oxc_formatter_core/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/mod.rs
@@ -1,0 +1,1789 @@
+mod call_stack;
+mod line_suffixes;
+mod printer_options;
+mod queue;
+mod stack;
+
+use std::num::NonZeroU8;
+
+use oxc_data_structures::code_buffer::{self, CodeBuffer};
+pub use printer_options::*;
+use unicode_width::UnicodeWidthChar;
+
+use self::call_stack::PrintIndentStack;
+use super::{
+    ActualStart, FormatElement, GroupId, InvalidDocumentError, PrintError, PrintResult, Printed,
+    format_element::{BestFittingElement, LineMode, PrintMode, tag::Condition},
+    prelude::{
+        Tag::EndFill,
+        TextWidth,
+        tag::{DedentMode, Tag, TagKind},
+    },
+    printer::{
+        call_stack::{
+            CallStack, FitsCallStack, FitsIndentStack, IndentStack, PrintCallStack,
+            PrintElementArgs, StackFrame, SuffixStack,
+        },
+        line_suffixes::{LineSuffixEntry, LineSuffixes},
+        queue::{
+            AllPredicate, FitsEndPredicate, FitsQueue, PrintQueue, Queue, SingleEntryPredicate,
+        },
+    },
+};
+use crate::options::IndentStyle;
+
+/// Prints the format elements into a string
+#[derive(Debug, Default)]
+pub struct Printer<'a> {
+    options: PrinterOptions,
+    state: PrinterState<'a>,
+}
+
+impl<'a> Printer<'a> {
+    pub fn new(options: PrinterOptions, sorted_tailwind_classes: &'a [String]) -> Self {
+        let (indent_char, indent_width) = match options.indent_style() {
+            IndentStyle::Tab => (code_buffer::IndentChar::Tab, 1),
+            IndentStyle::Space => {
+                (code_buffer::IndentChar::Space, options.indent_width().value() as usize)
+            }
+        };
+        let buffer = CodeBuffer::with_indent(indent_char, indent_width);
+        Self { options, state: PrinterState::new(buffer, sorted_tailwind_classes) }
+    }
+
+    /// Prints the passed in element as well as all its content
+    pub fn print(self, document: &'a [FormatElement<'a>]) -> PrintResult<Printed> {
+        self.print_with_indent(document, 0)
+    }
+
+    /// Prints the passed in element as well as all its content,
+    /// starting at the specified indentation level
+    pub fn print_with_indent(
+        mut self,
+        document: &'a [FormatElement<'a>],
+        indent: u16,
+    ) -> PrintResult<Printed> {
+        let mut stack = PrintCallStack::new(PrintElementArgs::new());
+        let mut queue: PrintQueue<'a> = PrintQueue::new(document);
+        let mut indent_stack = PrintIndentStack::new(Indention::Level(indent));
+
+        while let Some(element) = queue.pop() {
+            self.print_element(&mut stack, &mut indent_stack, &mut queue, element)?;
+
+            if queue.is_empty() {
+                self.flush_line_suffixes(&mut queue, &mut stack, &mut indent_stack, None);
+            }
+        }
+
+        Ok(Printed::new(self.state.buffer.into_string(), None))
+    }
+
+    /// Prints a single element and push the following elements to queue
+    fn print_element(
+        &mut self,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+        queue: &mut PrintQueue<'a>,
+        element: &'a FormatElement,
+    ) -> PrintResult<()> {
+        use Tag::{
+            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
+            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
+            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+        };
+
+        let args = stack.top();
+        match element {
+            FormatElement::Space | FormatElement::HardSpace => {
+                if self.state.line_width > 0 {
+                    self.state.pending_space = true;
+                }
+            }
+
+            FormatElement::Token { text } => self.print_text(Text::Token(text)),
+            FormatElement::Text { text, width } => {
+                self.print_text(Text::Text { text, width: *width });
+            }
+            FormatElement::Line(line_mode) => {
+                if args.mode().is_flat() {
+                    match line_mode {
+                        LineMode::Soft | LineMode::SoftOrSpace => {
+                            if line_mode == &LineMode::SoftOrSpace && self.state.line_width > 0 {
+                                self.state.pending_space = true;
+                            }
+                            return Ok(());
+                        }
+                        LineMode::Hard | LineMode::Empty => {
+                            self.state.measured_group_fits = false;
+                        }
+                    }
+                }
+
+                if self.state.line_suffixes.has_pending() {
+                    self.flush_line_suffixes(queue, stack, indent_stack, Some(element));
+                    return Ok(());
+                }
+
+                // Only print a newline if the current line isn't already empty
+                if self.state.line_width > 0 {
+                    self.print_char('\n');
+                    self.state.has_empty_line = false;
+                }
+
+                // Print a second line break if this is an empty line
+                if line_mode == &LineMode::Empty && !self.state.has_empty_line {
+                    self.print_char('\n');
+                    self.state.has_empty_line = true;
+                }
+
+                self.state.pending_space = false;
+                self.state.pending_indent = indent_stack.indention();
+            }
+
+            FormatElement::ExpandParent => {
+                // Handled in `Document::propagate_expands()
+            }
+
+            FormatElement::LineSuffixBoundary => {
+                const HARD_BREAK: &FormatElement = &FormatElement::Line(LineMode::Hard);
+                self.flush_line_suffixes(queue, stack, indent_stack, Some(HARD_BREAK));
+            }
+
+            FormatElement::BestFitting(best_fitting) => {
+                self.print_best_fitting(best_fitting, queue, stack, indent_stack)?;
+            }
+
+            FormatElement::Interned(content) => {
+                queue.extend_back(content);
+            }
+
+            FormatElement::Tag(StartGroup(group)) => {
+                let group_mode = if group.mode().is_flat() {
+                    match args.mode() {
+                        PrintMode::Flat if self.state.measured_group_fits => {
+                            // A parent group has already verified that this group fits on a single line
+                            // Thus, just continue in flat mode
+                            PrintMode::Flat
+                        }
+                        // The printer is either in expanded mode or it's necessary to re-measure if the group fits
+                        // because the printer printed a line break
+                        _ => {
+                            self.state.measured_group_fits = true;
+
+                            if let Some(id) = group.id() {
+                                self.state.group_modes.insert_print_mode(id, PrintMode::Flat);
+                            }
+
+                            // Measure to see if the group fits up on a single line. If that's the case,
+                            // print the group in "flat" mode, otherwise continue in expanded mode
+                            stack.push(TagKind::Group, args.with_print_mode(PrintMode::Flat));
+                            let fits = self.fits(queue, stack, indent_stack)?;
+                            stack.pop(TagKind::Group)?;
+
+                            if fits { PrintMode::Flat } else { PrintMode::Expanded }
+                        }
+                    }
+                } else {
+                    PrintMode::Expanded
+                };
+
+                stack.push(TagKind::Group, args.with_print_mode(group_mode));
+
+                if let Some(id) = group.id() {
+                    self.state.group_modes.insert_print_mode(id, group_mode);
+                }
+            }
+
+            FormatElement::Tag(StartFill) => {
+                self.print_fill_entries(queue, stack, indent_stack)?;
+            }
+
+            FormatElement::Tag(StartIndent) => {
+                indent_stack.indent(self.options.indent_style());
+                stack.push(TagKind::Indent, args);
+            }
+
+            FormatElement::Tag(StartDedent(mode)) => {
+                match mode {
+                    DedentMode::Level => indent_stack.start_dedent(),
+                    DedentMode::Root => indent_stack.reset_indent(),
+                }
+                stack.push(TagKind::Dedent, args);
+            }
+
+            FormatElement::Tag(StartAlign(align)) => {
+                indent_stack.align(align.count());
+                stack.push(TagKind::Align, args);
+            }
+
+            FormatElement::Tag(StartConditionalContent(Condition { mode, group_id })) => {
+                let group_mode = match group_id {
+                    None => args.mode(),
+                    Some(id) => self.state.group_modes.unwrap_print_mode(*id, element),
+                };
+
+                if group_mode == *mode {
+                    stack.push(TagKind::ConditionalContent, args);
+                } else {
+                    queue.skip_content(TagKind::ConditionalContent);
+                }
+            }
+
+            FormatElement::Tag(StartIndentIfGroupBreaks(group_id)) => {
+                let group_mode = self.state.group_modes.unwrap_print_mode(*group_id, element);
+
+                if group_mode == PrintMode::Expanded {
+                    indent_stack.indent(self.options.indent_style);
+                }
+
+                stack.push(TagKind::IndentIfGroupBreaks, args);
+            }
+
+            FormatElement::Tag(StartLineSuffix) => {
+                indent_stack.push_suffix(indent_stack.indention());
+                self.state.line_suffixes.extend(args, queue.iter_content(TagKind::LineSuffix));
+            }
+            FormatElement::Tag(tag @ (StartLabelled(_) | StartEntry)) => {
+                stack.push(tag.kind(), args);
+            }
+            FormatElement::Tag(
+                tag @ (EndLabelled | EndEntry | EndGroup | EndConditionalContent | EndFill),
+            ) => {
+                stack.pop(tag.kind())?;
+            }
+            FormatElement::Tag(tag @ EndIndentIfGroupBreaks(group_id)) => {
+                if self.state.group_modes.unwrap_print_mode(*group_id, element)
+                    == PrintMode::Expanded
+                {
+                    indent_stack.pop();
+                }
+                stack.pop(tag.kind())?;
+            }
+            FormatElement::Tag(tag @ (EndIndent | EndAlign | EndLineSuffix)) => {
+                stack.pop(tag.kind())?;
+                indent_stack.pop();
+            }
+            FormatElement::Tag(tag @ EndDedent(mode)) => {
+                match mode {
+                    DedentMode::Level => indent_stack.end_dedent(),
+                    DedentMode::Root => indent_stack.pop(),
+                }
+                stack.pop(tag.kind())?;
+            }
+            FormatElement::TailwindClass(index) => {
+                if let Some(text) = self.state.sorted_tailwind_classes.get(*index) {
+                    let width = TextWidth::from_text(text, self.options.indent_width);
+                    self.print_text(Text::Text { text, width });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fits(
+        &mut self,
+        queue: &PrintQueue<'a>,
+        stack: &PrintCallStack,
+        indent_stack: &PrintIndentStack,
+    ) -> PrintResult<bool> {
+        let mut measure = FitsMeasurer::new(queue, stack, indent_stack, self);
+        let result = measure.fits(&mut AllPredicate);
+        measure.finish();
+        result
+    }
+
+    fn flush_line_suffixes(
+        &mut self,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+        line_break: Option<&'a FormatElement>,
+    ) {
+        let suffixes = self.state.line_suffixes.take_pending();
+
+        if suffixes.len() > 0 {
+            // Print this line break element again once all the line suffixes have been flushed
+            if let Some(line_break) = line_break {
+                queue.push(line_break);
+            }
+            indent_stack.flush_suffixes();
+            for entry in suffixes.rev() {
+                match entry {
+                    LineSuffixEntry::Suffix(suffix) => {
+                        queue.push(suffix);
+                    }
+                    LineSuffixEntry::Args(args) => {
+                        const LINE_SUFFIX_END: &FormatElement =
+                            &FormatElement::Tag(Tag::EndLineSuffix);
+                        stack.push(TagKind::LineSuffix, args);
+                        queue.push(LINE_SUFFIX_END);
+                    }
+                }
+            }
+        }
+    }
+
+    fn print_best_fitting(
+        &mut self,
+        best_fitting: &'a BestFittingElement,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+    ) -> PrintResult<()> {
+        let args = stack.top();
+
+        if args.mode().is_flat() && self.state.measured_group_fits {
+            queue.extend_back(best_fitting.most_flat());
+            self.print_entry(queue, stack, indent_stack, args)
+        } else {
+            self.state.measured_group_fits = true;
+
+            let (most_expanded, remaining_variants) =
+                best_fitting.split_to_most_expanded_and_flat_variants();
+
+            for variant in remaining_variants {
+                // Test if this variant fits and if so, use it. Otherwise try the next
+                // variant.
+
+                // Try to fit only the first variant on a single line
+                if !matches!(variant.first(), Some(&FormatElement::Tag(Tag::StartEntry))) {
+                    return invalid_start_tag(TagKind::Entry, variant.first());
+                }
+
+                let entry_args = args.with_print_mode(PrintMode::Flat);
+
+                // Skip the first element because we want to override the args for the entry and the
+                // args must be popped from the stack as soon as it sees the matching end entry.
+                let content = &variant[1..];
+
+                queue.extend_back(content);
+                stack.push(TagKind::Entry, entry_args);
+                let variant_fits = self.fits(queue, stack, indent_stack)?;
+                stack.pop(TagKind::Entry)?;
+
+                // Remove the content slice because printing needs the variant WITH the start entry
+                let popped_slice = queue.pop_slice();
+                debug_assert_eq!(popped_slice, Some(content));
+
+                if variant_fits {
+                    queue.extend_back(variant);
+                    return self.print_entry(queue, stack, indent_stack, entry_args);
+                }
+            }
+
+            // No variant fits, take the last (most expanded) as fallback
+            queue.extend_back(most_expanded);
+            self.print_entry(queue, stack, indent_stack, args.with_print_mode(PrintMode::Expanded))
+        }
+    }
+
+    /// Tries to fit as much content as possible on a single line.
+    ///
+    /// `Fill` is a sequence of *item*, *separator*, *item*, *separator*, *item*, ... entries.
+    /// The goal is to fit as many items (with their separators) on a single line as possible and
+    /// first expand the *separator* if the content exceeds the print width and only fallback to expanding
+    /// the *item*s if the *item* or the *item* and the expanded *separator* don't fit on the line.
+    ///
+    /// The implementation handles the following 5 cases:
+    ///
+    /// * The *item*, *separator*, and the *next item* fit on the same line.
+    ///   Print the *item* and *separator* in flat mode.
+    /// * The *item* and *separator* fit on the line but there's not enough space for the *next item*.
+    ///   Print the *item* in flat mode and the *separator* in expanded mode.
+    /// * The *item* fits on the line but the *separator* does not in flat mode.
+    ///   Print the *item* in flat mode and the *separator* in expanded mode.
+    /// * The *item* fits on the line but the *separator* does not in flat **NOR** expanded mode.
+    ///   Print the *item* and *separator* in expanded mode.
+    /// * The *item* does not fit on the line.
+    ///   Print the *item* and *separator* in expanded mode.
+    fn print_fill_entries(
+        &mut self,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+    ) -> PrintResult<()> {
+        let args = stack.top();
+
+        // It's already known that the content fit, print all items in flat mode.
+        if self.state.measured_group_fits && args.mode().is_flat() {
+            stack.push(TagKind::Fill, args.with_print_mode(PrintMode::Flat));
+            return Ok(());
+        }
+
+        stack.push(TagKind::Fill, args);
+
+        while matches!(queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+            let mut measurer = FitsMeasurer::new_flat(queue, stack, indent_stack, self);
+
+            // The number of item/separator pairs that fit on the same line.
+            let mut flat_pairs = 0usize;
+            let mut item_fits = measurer.fill_item_fits()?;
+
+            let last_pair_layout = if item_fits {
+                // Measure the remaining pairs until the first item or separator that does not fit (or the end of the fill element).
+                // Optimisation to avoid re-measuring the next-item twice:
+                // * Once when measuring if the *item*, *separator*, *next-item* fit
+                // * A second time when measuring if *next-item*, *separator*, *next-next-item* fit.
+                loop {
+                    // Item that fits without a following separator.
+                    if !matches!(measurer.queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+                        break FillPairLayout::Flat;
+                    }
+
+                    let separator_fits = measurer.fill_separator_fits(PrintMode::Flat)?;
+
+                    // Item fits but the flat separator does not.
+                    if !separator_fits {
+                        break FillPairLayout::ItemMaybeFlat;
+                    }
+
+                    // Last item/separator pair that both fit
+                    if !matches!(measurer.queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+                        break FillPairLayout::Flat;
+                    }
+
+                    item_fits = measurer.fill_item_fits()?;
+
+                    if item_fits {
+                        flat_pairs += 1;
+                    } else {
+                        // Item and separator both fit, but the next element doesn't.
+                        // Print the separator in expanded mode and then re-measure if the item now
+                        // fits in the next iteration of the outer loop.
+                        break FillPairLayout::ItemFlatSeparatorExpanded;
+                    }
+                }
+            } else {
+                // Neither item nor separator fit, print both in expanded mode.
+                FillPairLayout::Expanded
+            };
+
+            measurer.finish();
+
+            // Print all pairs that fit in flat mode.
+            for _ in 0..flat_pairs {
+                self.print_fill_item(
+                    queue,
+                    stack,
+                    indent_stack,
+                    args.with_print_mode(PrintMode::Flat),
+                )?;
+                self.print_fill_separator(
+                    queue,
+                    stack,
+                    indent_stack,
+                    args.with_print_mode(PrintMode::Flat),
+                )?;
+            }
+
+            let item_mode = match last_pair_layout {
+                FillPairLayout::Flat | FillPairLayout::ItemFlatSeparatorExpanded => PrintMode::Flat,
+                FillPairLayout::Expanded => PrintMode::Expanded,
+                FillPairLayout::ItemMaybeFlat => {
+                    let mut measurer = FitsMeasurer::new_flat(queue, stack, indent_stack, self);
+                    // SAFETY: That the item fits is guaranteed by `ItemMaybeFlat`.
+                    // Re-measuring is required to get the measurer in the correct state for measuring the separator.
+                    assert!(measurer.fill_item_fits()?);
+                    let separator_fits = measurer.fill_separator_fits(PrintMode::Expanded)?;
+                    measurer.finish();
+
+                    if separator_fits { PrintMode::Flat } else { PrintMode::Expanded }
+                }
+            };
+
+            self.print_fill_item(queue, stack, indent_stack, args.with_print_mode(item_mode))?;
+
+            if matches!(queue.top(), Some(FormatElement::Tag(Tag::StartEntry))) {
+                let separator_mode = match last_pair_layout {
+                    FillPairLayout::Flat => PrintMode::Flat,
+                    FillPairLayout::ItemFlatSeparatorExpanded
+                    | FillPairLayout::Expanded
+                    | FillPairLayout::ItemMaybeFlat => PrintMode::Expanded,
+                };
+
+                // Push a new stack frame with print mode `Flat` for the case where the separator gets printed in expanded mode
+                // but does contain a group to ensure that the group will measure "fits" with the "flat" versions of the next item/separator.
+                stack.push(TagKind::Fill, args.with_print_mode(PrintMode::Flat));
+                self.print_fill_separator(
+                    queue,
+                    stack,
+                    indent_stack,
+                    args.with_print_mode(separator_mode),
+                )?;
+                stack.pop(TagKind::Fill)?;
+            }
+        }
+
+        if queue.top() == Some(&FormatElement::Tag(EndFill)) {
+            Ok(())
+        } else {
+            invalid_end_tag(TagKind::Fill, stack.top_kind())
+        }
+    }
+
+    /// Semantic alias for [Self::print_entry] for fill items.
+    fn print_fill_item(
+        &mut self,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+        args: PrintElementArgs,
+    ) -> PrintResult<()> {
+        self.print_entry(queue, stack, indent_stack, args)
+    }
+
+    /// Semantic alias for [Self::print_entry] for fill separators.
+    fn print_fill_separator(
+        &mut self,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+        args: PrintElementArgs,
+    ) -> PrintResult<()> {
+        self.print_entry(queue, stack, indent_stack, args)
+    }
+
+    /// Fully print an element (print the element itself and all its descendants)
+    ///
+    /// Unlike [print_element], this function ensures the entire element has
+    /// been printed when it returns and the queue is back to its original state
+    fn print_entry(
+        &mut self,
+        queue: &mut PrintQueue<'a>,
+        stack: &mut PrintCallStack,
+        indent_stack: &mut PrintIndentStack,
+        args: PrintElementArgs,
+    ) -> PrintResult<()> {
+        let start_entry = queue.top();
+
+        if !matches!(start_entry, Some(&FormatElement::Tag(Tag::StartEntry))) {
+            return invalid_start_tag(TagKind::Entry, start_entry);
+        }
+
+        let mut depth = 0;
+
+        while let Some(element) = queue.pop() {
+            match element {
+                FormatElement::Tag(Tag::StartEntry) => {
+                    // Handle the start of the first element by pushing the args on the stack.
+                    if depth == 0 {
+                        depth = 1;
+                        stack.push(TagKind::Entry, args);
+                        continue;
+                    }
+
+                    depth += 1;
+                }
+                FormatElement::Tag(Tag::EndEntry) => {
+                    depth -= 1;
+                    // Reached the end entry, pop the entry from the stack and return.
+                    if depth == 0 {
+                        stack.pop(TagKind::Entry)?;
+                        return Ok(());
+                    }
+                }
+                _ => {
+                    // Fall through
+                }
+            }
+
+            self.print_element(stack, indent_stack, queue, element)?;
+        }
+
+        invalid_end_tag(TagKind::Entry, stack.top_kind())
+    }
+
+    fn print_text(&mut self, text: Text) {
+        if !self.state.pending_indent.is_empty() {
+            let indent = std::mem::take(&mut self.state.pending_indent);
+
+            let level = indent.level() as usize;
+            self.state.buffer.print_indent(level);
+            self.state.line_width += level * self.options.indent_width().value() as usize;
+
+            let align_count = indent.align() as usize;
+            for _ in 0..align_count {
+                // SAFETY: `' '` is an valid ASCII character
+                unsafe {
+                    self.state.buffer.print_byte_unchecked(b' ');
+                }
+            }
+            self.state.line_width += align_count;
+        }
+
+        // Print pending spaces
+        if self.state.pending_space {
+            // SAFETY: `' '` is an valid ASCII character
+            unsafe {
+                self.state.buffer.print_byte_unchecked(b' ');
+            }
+            self.state.pending_space = false;
+            self.state.line_width += 1;
+        }
+
+        match text {
+            Text::Token(text) => {
+                // SAFETY: `text` is a ASCII-only string
+                unsafe {
+                    self.state.buffer.print_bytes_unchecked(text.as_bytes());
+                }
+                self.state.line_width += text.len();
+            }
+            Text::Text { text, width } => {
+                if width.is_multiline() {
+                    let line_break_position = text.find('\n').unwrap_or(text.len());
+                    let (first_line, remaining) = text.split_at(line_break_position);
+                    self.state.buffer.print_str(first_line);
+                    self.state.line_width += width.value() as usize;
+                    // Print the remaining lines
+                    for char in remaining.chars() {
+                        self.print_char(char);
+                    }
+                } else {
+                    self.state.buffer.print_str(text);
+                    self.state.line_width += width.value() as usize;
+                }
+            }
+        }
+
+        self.state.has_empty_line = false;
+    }
+
+    fn print_char(&mut self, char: char) {
+        if char == '\n' {
+            // SAFETY: `line_ending` is one of `\n`, `\r\n` or `\r`, all valid ASCII sequences
+            unsafe {
+                self.state.buffer.print_bytes_unchecked(self.options.line_ending.as_bytes());
+            }
+
+            self.state.line_width = 0;
+        } else {
+            let char_width = if char == '\t' {
+                // SAFETY: `'\t'` is an valid ASCII character
+                unsafe {
+                    self.state.buffer.print_byte_unchecked(b'\t');
+                }
+                self.options.indent_width().value() as usize
+            } else {
+                self.state.buffer.print_char(char);
+                char.width().unwrap_or(0)
+            };
+
+            self.state.line_width += char_width;
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum FillPairLayout {
+    /// The item, separator, and next item fit. Print the first item and the separator in flat mode.
+    Flat,
+
+    /// The item and separator fit but the next element does not. Print the item in flat mode and
+    /// the separator in expanded mode.
+    ItemFlatSeparatorExpanded,
+
+    /// The item does not fit. Print the item and any potential separator in expanded mode.
+    Expanded,
+
+    /// The item fits but the separator does not in flat mode. If the separator fits in expanded mode then
+    /// print the item in flat and the separator in expanded mode, otherwise print both in expanded mode.
+    ItemMaybeFlat,
+}
+
+/// Printer state that is global to all elements.
+/// Stores the result of the print operation (buffer and mappings) and at what
+/// position the printer currently is.
+#[derive(Default, Debug)]
+struct PrinterState<'a> {
+    buffer: CodeBuffer,
+    pending_indent: Indention,
+    pending_space: bool,
+    measured_group_fits: bool,
+    line_width: usize,
+    has_empty_line: bool,
+    line_suffixes: LineSuffixes<'a>,
+    group_modes: GroupModes,
+    // Re-used queue to measure if a group fits. Optimisation to avoid re-allocating a new
+    // vec everytime a group gets measured
+    fits_stack: Vec<StackFrame>,
+    fits_indent_stack: Vec<Indention>,
+    fits_stack_tem_indent: Vec<Indention>,
+    fits_queue: Vec<&'a [FormatElement<'a>]>,
+    /// Sorted Tailwind CSS classes for lookup during printing
+    sorted_tailwind_classes: &'a [String],
+}
+
+impl<'a> PrinterState<'a> {
+    pub fn new(buffer: CodeBuffer, sorted_tailwind_classes: &'a [String]) -> Self {
+        Self {
+            buffer,
+            sorted_tailwind_classes,
+            // Initialize `measured_group_fits` to true to indicate that groups are initially assumed to fit.
+            measured_group_fits: true,
+            ..Default::default()
+        }
+    }
+}
+/// Tracks the mode in which groups with ids are printed. Stores the groups at `group.id()` index.
+/// This is based on the assumption that the group ids for a single document are dense.
+#[derive(Debug, Default)]
+struct GroupModes(Vec<Option<PrintMode>>);
+
+impl GroupModes {
+    fn insert_print_mode(&mut self, group_id: GroupId, mode: PrintMode) {
+        let index = u32::from(group_id) as usize;
+
+        if self.0.len() <= index {
+            self.0.resize(index + 1, None);
+        }
+
+        self.0[index] = Some(mode);
+    }
+
+    fn get_print_mode(&self, group_id: GroupId) -> Option<PrintMode> {
+        let index = u32::from(group_id) as usize;
+        self.0.get(index).and_then(|option| option.as_ref().copied())
+    }
+
+    fn unwrap_print_mode(&self, group_id: GroupId, next_element: &FormatElement) -> PrintMode {
+        self.get_print_mode(group_id).unwrap_or_else(|| {
+            panic!("Expected group with id {group_id:?} to exist but it wasn't present in the document. Ensure that a group with such a document appears in the document before the element {next_element:?}.")
+        })
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Indention {
+    /// Indent the content by `count` levels by using the indention sequence specified by the printer options.
+    Level(u16),
+
+    /// Indent the content by n-`level`s using the indention sequence specified by the printer options and `align` spaces.
+    Align { level: u16, align: NonZeroU8, align_count: u16 },
+}
+
+impl Indention {
+    const fn is_empty(self) -> bool {
+        matches!(self, Indention::Level(0))
+    }
+
+    /// Creates a new indention level with a zero-indent.
+    const fn new() -> Self {
+        Indention::Level(0)
+    }
+
+    /// Returns the indention level
+    fn level(self) -> u16 {
+        match self {
+            Indention::Level(count) => count,
+            Indention::Align { level: indent, .. } => indent,
+        }
+    }
+
+    /// Returns the number of trailing align spaces or 0 if none
+    fn align(self) -> u8 {
+        match self {
+            Indention::Level(_) => 0,
+            Indention::Align { align, .. } => align.into(),
+        }
+    }
+
+    /// Increments the level by one.
+    ///
+    /// The behaviour depends on the [`indent_style`][IndentStyle] if this is an [Indent::Align]:
+    /// * **Tabs**: `align` is converted into an indent. This results in `level` increasing by two: once for the align, once for the level increment
+    /// * **Spaces**: Increments the `level` by one and keeps the `align` unchanged.
+    ///
+    /// Keeps any  the current value is [Indent::Align] and increments the level by one.
+    fn increment_level(self, indent_style: IndentStyle) -> Self {
+        match self {
+            Indention::Level(count) => Indention::Level(count + 1),
+            // Increase the indent AND convert the align to an indent
+            Indention::Align { level, align_count, .. } if indent_style.is_tab() => {
+                Indention::Level(level + align_count + 1)
+            }
+            Indention::Align { level: indent, align, align_count } => {
+                Indention::Align { level: indent + 1, align, align_count }
+            }
+        }
+    }
+
+    /// Adds an `align` of `count` spaces to the current indention.
+    ///
+    /// It increments the `level` value if the current value is [Indent::IndentAlign].
+    fn set_align(self, count: NonZeroU8) -> Self {
+        match self {
+            Indention::Level(indent_count) => {
+                Indention::Align { level: indent_count, align: count, align_count: 1 }
+            }
+
+            // Convert the existing align to an indent
+            Indention::Align { level: indent, align, align_count } => Indention::Align {
+                level: indent,
+                align: align.saturating_add(count.get()),
+                align_count: align_count + 1,
+            },
+        }
+    }
+}
+
+impl Default for Indention {
+    fn default() -> Self {
+        Indention::new()
+    }
+}
+
+#[must_use = "FitsMeasurer must be finished."]
+struct FitsMeasurer<'a, 'print> {
+    state: FitsState<'print>,
+    queue: FitsQueue<'a, 'print>,
+    stack: FitsCallStack<'print>,
+    indent_stack: FitsIndentStack<'print>,
+    printer: &'print mut Printer<'a>,
+    must_be_flat: bool,
+}
+
+impl<'a, 'print> FitsMeasurer<'a, 'print> {
+    fn new_flat(
+        print_queue: &'print PrintQueue<'a>,
+        print_stack: &'print PrintCallStack,
+        print_indent_stack: &'print PrintIndentStack,
+        printer: &'print mut Printer<'a>,
+    ) -> Self {
+        let mut measurer = Self::new(print_queue, print_stack, print_indent_stack, printer);
+        measurer.must_be_flat = true;
+        measurer
+    }
+
+    fn new(
+        print_queue: &'print PrintQueue<'a>,
+        print_stack: &'print PrintCallStack,
+        print_indent_stack: &'print PrintIndentStack,
+        printer: &'print mut Printer<'a>,
+    ) -> Self {
+        let saved_stack = std::mem::take(&mut printer.state.fits_stack);
+        let saved_queue = std::mem::take(&mut printer.state.fits_queue);
+        let saved_indent_stack = std::mem::take(&mut printer.state.fits_indent_stack);
+        let saved_stack_tem_indent = std::mem::take(&mut printer.state.fits_stack_tem_indent);
+        debug_assert!(saved_stack.is_empty());
+        debug_assert!(saved_queue.is_empty());
+        debug_assert!(saved_indent_stack.is_empty());
+        debug_assert!(saved_stack_tem_indent.is_empty());
+
+        let fits_queue = FitsQueue::new(print_queue, saved_queue);
+        let fits_stack = FitsCallStack::new(print_stack, saved_stack);
+
+        let fits_indent_stack =
+            FitsIndentStack::new(print_indent_stack, saved_indent_stack, saved_stack_tem_indent);
+
+        let fits_state = FitsState {
+            pending_indent: printer.state.pending_indent,
+            pending_space: printer.state.pending_space,
+            line_width: printer.state.line_width,
+            has_line_suffix: printer.state.line_suffixes.has_pending(),
+            sorted_tailwind_classes: printer.state.sorted_tailwind_classes,
+        };
+
+        Self {
+            state: fits_state,
+            queue: fits_queue,
+            stack: fits_stack,
+            indent_stack: fits_indent_stack,
+            must_be_flat: false,
+            printer,
+        }
+    }
+
+    /// Tests if it's possible to print the content of the queue up to the first hard line break
+    /// or the end of the document on a single line without exceeding the line width.
+    fn fits<P>(&mut self, predicate: &mut P) -> PrintResult<bool>
+    where
+        P: FitsEndPredicate,
+    {
+        while let Some(element) = self.queue.pop() {
+            match self.fits_element(element)? {
+                Fits::Yes => return Ok(true),
+                Fits::No => return Ok(false),
+                Fits::Maybe => {
+                    if predicate.is_end(element)? {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Tests if the content of a `Fill` item fits in [PrintMode::Flat].
+    ///
+    /// Returns `Err` if the top element of the queue is not a [Tag::StartEntry]
+    /// or if the document has any mismatching start/end tags.
+    fn fill_item_fits(&mut self) -> PrintResult<bool> {
+        self.fill_entry_fits(PrintMode::Flat)
+    }
+
+    /// Tests if the content of a `Fill` separator fits with `mode`.
+    ///
+    /// Returns `Err` if the top element of the queue is not a [Tag::StartEntry]
+    /// or if the document has any mismatching start/end tags.
+    fn fill_separator_fits(&mut self, mode: PrintMode) -> PrintResult<bool> {
+        self.fill_entry_fits(mode)
+    }
+
+    /// Tests if the elements between the [Tag::StartEntry] and [Tag::EndEntry]
+    /// of a fill item or separator fits with `mode`.
+    ///
+    /// Returns `Err` if the queue isn't positioned at a [Tag::StartEntry] or if
+    /// the matching [Tag::EndEntry] is missing.
+    fn fill_entry_fits(&mut self, mode: PrintMode) -> PrintResult<bool> {
+        let start_entry = self.queue.top();
+
+        if !matches!(start_entry, Some(&FormatElement::Tag(Tag::StartEntry))) {
+            return invalid_start_tag(TagKind::Entry, start_entry);
+        }
+
+        self.stack.push(TagKind::Fill, self.stack.top().with_print_mode(mode));
+        let mut predicate = SingleEntryPredicate::default();
+        let fits = self.fits(&mut predicate)?;
+
+        if predicate.is_done() {
+            self.stack.pop(TagKind::Fill)?;
+        }
+
+        Ok(fits)
+    }
+
+    /// Tests if the passed element fits on the current line or not.
+    fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
+        use Tag::{
+            EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,
+            EndIndentIfGroupBreaks, EndLabelled, EndLineSuffix, StartAlign,
+            StartConditionalContent, StartDedent, StartEntry, StartFill, StartGroup, StartIndent,
+            StartIndentIfGroupBreaks, StartLabelled, StartLineSuffix,
+        };
+
+        let args = self.stack.top();
+
+        match element {
+            FormatElement::Space => {
+                if self.state.line_width > 0 {
+                    self.state.pending_space = true;
+                }
+            }
+            FormatElement::HardSpace => {
+                self.state.line_width += 1;
+                if self.state.line_width > usize::from(self.options().print_width) {
+                    return Ok(Fits::No);
+                }
+            }
+            FormatElement::Line(line_mode) => {
+                if args.mode().is_flat() {
+                    match line_mode {
+                        LineMode::SoftOrSpace => {
+                            self.state.pending_space = true;
+                        }
+                        LineMode::Soft => {}
+                        LineMode::Hard | LineMode::Empty => {
+                            // Even in flat mode, content that _directly_ contains a hard or empty
+                            // line is considered to fit when a hard break is reached, since that
+                            // break is always going to exist, regardless of the print mode.
+                            // This is particularly important for `Fill` entries, where _ungrouped_
+                            // content that contains hard breaks shouldn't force the surrounding
+                            // elements to also expand. Example:
+                            //   [
+                            //     -1, -2, 3
+                            //     // leading comment
+                            //     -4, -5, -6
+                            //   ]
+                            // Here, `-4` contains a hardline because of the leading comment, but that
+                            // doesn't cause the element (`-4`) nor the separator (`,`) to print in
+                            // expanded mode, allowing the rest of the elements to fill in. If this
+                            // _did_ respect `must_be_flat` and returned `Fits::No` instead, the result
+                            // would put the `-4` on its own line, which is not preferable (at least,
+                            // it doesn't match Prettier):
+                            //   [
+                            //     -1, -2, 3
+                            //     // leading comment
+                            //     -4,
+                            //     -5, -6
+                            //   ]
+                            // The perception here is that most comments inline for fills are used to
+                            // separate _groups_ rather than to single out an individual element.
+                            //
+                            // The alternative case is when the fill entry is grouped, in which case
+                            // this fit returns `Yes`, but the parent group is already known to
+                            // expand _because_ of this hard line, and so the fill entry and separator
+                            // are automatically printed in expanded mode anyway, and this fit check
+                            // has no bearing on that (so it doesn't need to care about flat or not):
+                            //   <div>
+                            //     <span a b>
+                            //       <Foo />
+                            //     </span>{" "}
+                            //     ({variable})
+                            //   </div>
+                            // Here the `<span>...</span>` _is_ grouped and contains a hardline, so it
+                            // is known to break and _not_ fit already because the check is performed
+                            // on the group. But within the group itself, the content with hardlines
+                            // (the `\n<Foo />\n`) _does_ fit, for the same logic in the first case.
+                            return Ok(Fits::Yes);
+                        }
+                    }
+                } else {
+                    // Reachable if the restQueue contains an element with mode expanded because Expanded
+                    // is what the mode's initialized to by default
+                    // This means, the printer is outside of the current element at this point and any
+                    // line break should be printed as regular line break -> Fits
+                    return Ok(Fits::Yes);
+                }
+            }
+
+            FormatElement::Token { text } => {
+                return Ok(self.fits_text(Text::Token(text)));
+            }
+            FormatElement::Text { text, width } => {
+                return Ok(self.fits_text(Text::Text { text, width: *width }));
+            }
+
+            FormatElement::LineSuffixBoundary => {
+                if self.state.has_line_suffix {
+                    return Ok(Fits::No);
+                }
+            }
+
+            FormatElement::ExpandParent => {
+                if self.must_be_flat {
+                    return Ok(Fits::No);
+                }
+            }
+
+            FormatElement::BestFitting(best_fitting) => {
+                let slice = match args.mode() {
+                    PrintMode::Flat => best_fitting.most_flat(),
+                    PrintMode::Expanded => best_fitting.most_expanded(),
+                };
+
+                if !matches!(slice.first(), Some(FormatElement::Tag(Tag::StartEntry))) {
+                    return invalid_start_tag(TagKind::Entry, slice.first());
+                }
+
+                self.queue.extend_back(slice);
+            }
+
+            FormatElement::Interned(content) => self.queue.extend_back(content),
+
+            FormatElement::Tag(StartIndent) => {
+                self.indent_stack.indent(self.options().indent_style());
+                self.stack.push(TagKind::Indent, args);
+            }
+
+            FormatElement::Tag(StartDedent(mode)) => {
+                match mode {
+                    DedentMode::Level => self.indent_stack.start_dedent(),
+                    DedentMode::Root => self.indent_stack.reset_indent(),
+                }
+                self.stack.push(TagKind::Dedent, args);
+            }
+
+            FormatElement::Tag(StartAlign(align)) => {
+                self.indent_stack.align(align.count());
+                self.stack.push(TagKind::Align, args);
+            }
+
+            FormatElement::Tag(StartGroup(group)) => {
+                if self.must_be_flat && !group.mode().is_flat() {
+                    return Ok(Fits::No);
+                }
+
+                let group_mode =
+                    if group.mode().is_flat() { args.mode() } else { PrintMode::Expanded };
+
+                self.stack.push(TagKind::Group, args.with_print_mode(group_mode));
+
+                if let Some(id) = group.id() {
+                    self.group_modes_mut().insert_print_mode(id, group_mode);
+                }
+            }
+
+            FormatElement::Tag(StartConditionalContent(condition)) => {
+                let group_mode = match condition.group_id {
+                    None => args.mode(),
+                    Some(group_id) => {
+                        self.group_modes().get_print_mode(group_id).unwrap_or_else(|| args.mode())
+                    }
+                };
+
+                if group_mode == condition.mode {
+                    self.stack.push(TagKind::ConditionalContent, args);
+                } else {
+                    self.queue.skip_content(TagKind::ConditionalContent);
+                }
+            }
+
+            FormatElement::Tag(StartIndentIfGroupBreaks(id)) => {
+                let group_mode =
+                    self.group_modes().get_print_mode(*id).unwrap_or_else(|| args.mode());
+
+                match group_mode {
+                    PrintMode::Flat => {
+                        self.stack.push(TagKind::IndentIfGroupBreaks, args);
+                    }
+                    PrintMode::Expanded => {
+                        self.indent_stack.indent(self.options().indent_style());
+                        self.stack.push(TagKind::IndentIfGroupBreaks, args);
+                    }
+                }
+            }
+
+            FormatElement::Tag(StartLineSuffix) => {
+                self.queue.skip_content(TagKind::LineSuffix);
+                self.state.has_line_suffix = true;
+            }
+
+            FormatElement::Tag(EndLineSuffix) => {
+                return invalid_end_tag(TagKind::LineSuffix, self.stack.top_kind());
+            }
+
+            FormatElement::Tag(tag @ (StartFill | StartLabelled(_) | StartEntry)) => {
+                self.stack.push(tag.kind(), args);
+            }
+            FormatElement::Tag(
+                tag @ (EndLabelled | EndEntry | EndGroup | EndConditionalContent | EndFill),
+            ) => {
+                self.stack.pop(tag.kind())?;
+            }
+            FormatElement::Tag(tag @ EndIndentIfGroupBreaks(group_id)) => {
+                let group_mode =
+                    self.group_modes().get_print_mode(*group_id).unwrap_or_else(|| args.mode());
+                if group_mode == PrintMode::Expanded {
+                    self.indent_stack.pop();
+                }
+                self.stack.pop(tag.kind())?;
+            }
+            FormatElement::Tag(tag @ (EndIndent | EndAlign)) => {
+                self.stack.pop(tag.kind())?;
+                self.indent_stack.pop();
+            }
+            FormatElement::Tag(tag @ EndDedent(mode)) => {
+                if matches!(mode, DedentMode::Level) {
+                    self.indent_stack.end_dedent();
+                }
+                self.stack.pop(tag.kind())?;
+            }
+            FormatElement::TailwindClass(index) => {
+                if let Some(text) = self.state.sorted_tailwind_classes.get(*index) {
+                    let width = TextWidth::from_text(text, self.options().indent_width);
+                    return Ok(self.fits_text(Text::Text { text, width }));
+                }
+            }
+        }
+
+        Ok(Fits::Maybe)
+    }
+
+    fn fits_text(&mut self, text: Text) -> Fits {
+        let indent = std::mem::take(&mut self.state.pending_indent);
+        self.state.line_width += indent.level() as usize
+            * self.options().indent_width().value() as usize
+            + indent.align() as usize;
+
+        if self.state.pending_space {
+            self.state.line_width += 1;
+        }
+
+        match text {
+            Text::Token(text) => {
+                self.state.line_width += text.len();
+            }
+            Text::Text { text: _, width } => {
+                if width.is_multiline() {
+                    return if self.must_be_flat
+                        || self.state.line_width + width.value() as usize
+                            > usize::from(self.options().print_width)
+                    {
+                        Fits::No
+                    } else {
+                        Fits::Yes
+                    };
+                }
+
+                self.state.line_width += width.value() as usize;
+            }
+        }
+
+        if self.state.line_width > usize::from(self.options().print_width) {
+            return Fits::No;
+        }
+
+        self.state.pending_space = false;
+
+        Fits::Maybe
+    }
+
+    fn finish(self) {
+        let mut queue = self.queue.finish();
+        queue.clear();
+        self.printer.state.fits_queue = queue;
+
+        let mut stack = self.stack.finish();
+        stack.clear();
+        self.printer.state.fits_stack = stack;
+
+        let (mut indent_stack, mut history_stack) = self.indent_stack.finish();
+        indent_stack.clear();
+        self.printer.state.fits_indent_stack = indent_stack;
+        history_stack.clear();
+        self.printer.state.fits_stack_tem_indent = history_stack;
+    }
+
+    fn options(&self) -> &PrinterOptions {
+        &self.printer.options
+    }
+
+    fn group_modes(&self) -> &GroupModes {
+        &self.printer.state.group_modes
+    }
+
+    fn group_modes_mut(&mut self) -> &mut GroupModes {
+        &mut self.printer.state.group_modes
+    }
+}
+
+#[cold]
+fn invalid_end_tag<R>(end_tag: TagKind, start_tag: Option<TagKind>) -> PrintResult<R> {
+    Err(PrintError::InvalidDocument(match start_tag {
+        None => InvalidDocumentError::StartTagMissing { kind: end_tag },
+        Some(kind) => {
+            InvalidDocumentError::StartEndTagMismatch { start_kind: end_tag, end_kind: kind }
+        }
+    }))
+}
+
+#[cold]
+fn invalid_start_tag<R>(expected: TagKind, actual: Option<&FormatElement>) -> PrintResult<R> {
+    let start = match actual {
+        None => ActualStart::EndOfDocument,
+        Some(FormatElement::Tag(tag)) => {
+            if tag.is_start() {
+                ActualStart::Start(tag.kind())
+            } else {
+                ActualStart::End(tag.kind())
+            }
+        }
+        Some(_) => ActualStart::Content,
+    };
+
+    Err(PrintError::InvalidDocument(InvalidDocumentError::ExpectedStart {
+        actual: start,
+        expected_start: expected,
+    }))
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum Fits {
+    // Element fits
+    Yes,
+    // Element doesn't fit
+    No,
+    // Element may fit, depends on the elements following it
+    Maybe,
+}
+
+impl From<bool> for Fits {
+    fn from(value: bool) -> Self {
+        if value { Fits::Yes } else { Fits::No }
+    }
+}
+
+/// State used when measuring if a group fits on a single line
+#[derive(Debug)]
+struct FitsState<'print> {
+    pending_indent: Indention,
+    pending_space: bool,
+    has_line_suffix: bool,
+    line_width: usize,
+    sorted_tailwind_classes: &'print [String],
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Text<'a> {
+    /// ASCII only text that contains no line breaks or tab characters.
+    Token(&'a str),
+    /// Arbitrary text. May contain `\n` line breaks, tab characters, or unicode characters.
+    Text { text: &'a str, width: TextWidth },
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+
+    use crate::formatter::prelude::document::Document;
+    use crate::formatter::printer::{PrintWidth, Printer, PrinterOptions};
+    use crate::formatter::{FormatState, Printed, SimpleFormatContext, VecBuffer};
+    use crate::{IndentStyle, LineEnding};
+    use crate::{format_args, formatter::prelude::*, write};
+
+    fn format<'a>(
+        allocator: &'a Allocator,
+        root: &dyn Format<'a, SimpleFormatContext<'a>>,
+    ) -> Printed {
+        format_with_options(
+            allocator,
+            root,
+            PrinterOptions {
+                indent_style: IndentStyle::Space,
+                indent_width: 2.try_into().unwrap(),
+                line_ending: LineEnding::Lf,
+                ..PrinterOptions::default()
+            },
+        )
+    }
+
+    fn format_with_options<'a>(
+        allocator: &'a Allocator,
+        root: &dyn Format<'a, SimpleFormatContext<'a>>,
+        options: PrinterOptions,
+    ) -> Printed {
+        let formatted = crate::format!(SimpleFormatContext::new(allocator), [root]);
+
+        Printer::new(options, &[]).print(formatted.document()).expect("Document to be valid")
+    }
+
+    #[test]
+    fn it_prints_a_group_on_a_single_line_if_it_fits() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &FormatArrayElements {
+                items: vec![&token("\"a\""), &token("\"b\""), &token("\"c\""), &token("\"d\"")],
+                _context: std::marker::PhantomData,
+            },
+        );
+
+        assert_eq!(r#"["a", "b", "c", "d"]"#, result.as_code());
+    }
+
+    #[test]
+    fn it_tracks_the_indent_for_each_token() {
+        let allocator = Allocator::default();
+        let formatted = format(
+            &allocator,
+            &format_args!(
+                token("a"),
+                soft_block_indent(&format_args!(
+                    token("b"),
+                    soft_block_indent(&format_args!(
+                        token("c"),
+                        soft_block_indent(
+                            &format_args!(token("d"), soft_line_break(), token("d"),)
+                        ),
+                        token("c"),
+                    )),
+                    token("b"),
+                )),
+                token("a")
+            ),
+        );
+
+        assert_eq!(
+            r"a
+  b
+    c
+      d
+      d
+    c
+  b
+a",
+            formatted.as_code()
+        );
+    }
+
+    #[test]
+    fn it_converts_line_endings() {
+        let allocator = Allocator::default();
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Tab,
+            line_ending: LineEnding::Crlf,
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options(
+            &allocator,
+            &format_args!(
+                token("function main() {"),
+                block_indent(&text("let x = `This is a multiline\nstring`;")),
+                token("}"),
+                hard_line_break()
+            ),
+            options,
+        );
+
+        assert_eq!(
+            "function main() {\r\n\tlet x = `This is a multiline\r\nstring`;\r\n}\r\n",
+            result.as_code()
+        );
+    }
+
+    #[test]
+    fn it_converts_line_endings_to_cr() {
+        let allocator = Allocator::default();
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Tab,
+            line_ending: LineEnding::Cr,
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options(
+            &allocator,
+            &format_args!(
+                token("function main() {"),
+                block_indent(&text("let x = `This is a multiline\nstring`;")),
+                token("}"),
+                hard_line_break()
+            ),
+            options,
+        );
+
+        assert_eq!(
+            "function main() {\r\tlet x = `This is a multiline\rstring`;\r}\r",
+            result.as_code()
+        );
+    }
+
+    #[test]
+    fn it_breaks_a_group_if_a_string_contains_a_newline() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &FormatArrayElements {
+                items: vec![&text("`This is a string spanning\ntwo lines`"), &token("\"b\"")],
+                _context: std::marker::PhantomData,
+            },
+        );
+
+        assert_eq!(
+            r#"[
+  `This is a string spanning
+two lines`,
+  "b",
+]"#,
+            result.as_code()
+        );
+    }
+    #[test]
+    fn it_breaks_a_group_if_it_contains_a_hard_line_break() {
+        let allocator = Allocator::default();
+        let result =
+            format(&allocator, &group(&format_args!(token("a"), block_indent(&token("b")))));
+
+        assert_eq!("a\n  b\n", result.as_code());
+    }
+
+    #[test]
+    fn it_breaks_parent_groups_if_they_dont_fit_on_a_single_line() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &FormatArrayElements {
+                items: vec![
+                    &token("\"a\""),
+                    &token("\"b\""),
+                    &token("\"c\""),
+                    &token("\"d\""),
+                    &FormatArrayElements {
+                        items: vec![
+                            &token("\"0123456789\""),
+                            &token("\"0123456789\""),
+                            &token("\"0123456789\""),
+                            &token("\"0123456789\""),
+                            &token("\"0123456789\""),
+                            &token("\"0123456789\""),
+                        ],
+                        _context: std::marker::PhantomData,
+                    },
+                ],
+                _context: std::marker::PhantomData,
+            },
+        );
+
+        assert_eq!(
+            r#"[
+  "a",
+  "b",
+  "c",
+  "d",
+  ["0123456789", "0123456789", "0123456789", "0123456789", "0123456789", "0123456789"],
+]"#,
+            result.as_code()
+        );
+    }
+
+    #[test]
+    fn it_use_the_indent_character_specified_in_the_options() {
+        let allocator = Allocator::default();
+        let options = PrinterOptions {
+            indent_style: IndentStyle::Tab,
+            indent_width: 2.try_into().unwrap(),
+            print_width: PrintWidth::new(19),
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options(
+            &allocator,
+            &FormatArrayElements {
+                items: vec![&token("'a'"), &token("'b'"), &token("'c'"), &token("'d'")],
+                _context: std::marker::PhantomData,
+            },
+            options,
+        );
+
+        assert_eq!("[\n\t'a',\n\t\'b',\n\t\'c',\n\t'd',\n]", result.as_code());
+    }
+
+    #[test]
+    fn it_prints_consecutive_hard_lines_as_one() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &format_args!(
+                token("a"),
+                hard_line_break(),
+                hard_line_break(),
+                hard_line_break(),
+                token("b"),
+            ),
+        );
+
+        assert_eq!("a\nb", result.as_code());
+    }
+
+    #[test]
+    fn it_prints_consecutive_empty_lines_as_one() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &format_args!(token("a"), empty_line(), empty_line(), empty_line(), token("b"),),
+        );
+
+        assert_eq!("a\n\nb", result.as_code());
+    }
+
+    #[test]
+    fn it_prints_consecutive_mixed_lines_as_one() {
+        let allocator = Allocator::default();
+        let result = format(
+            &allocator,
+            &format_args!(
+                token("a"),
+                empty_line(),
+                hard_line_break(),
+                empty_line(),
+                hard_line_break(),
+                token("b"),
+            ),
+        );
+
+        assert_eq!("a\n\nb", result.as_code());
+    }
+
+    #[test]
+    fn test_fill_breaks() {
+        let allocator = Allocator::default();
+        let mut state = FormatState::new(FormatContext::dummy(&allocator));
+        let mut buffer = VecBuffer::new(&mut state);
+        let mut formatter = Formatter::new(&mut buffer);
+
+        formatter
+            .fill()
+            // These all fit on the same line together
+            .entry(&soft_line_break_or_space(), &format_args!(token("1"), token(",")))
+            .entry(&soft_line_break_or_space(), &format_args!(token("2"), token(",")))
+            .entry(&soft_line_break_or_space(), &format_args!(token("3"), token(",")))
+            // This one fits on a line by itself,
+            .entry(&soft_line_break_or_space(), &format_args!(token("723493294"), token(",")))
+            // fits without breaking
+            .entry(
+                &soft_line_break_or_space(),
+                &group(&format_args!(token("["), soft_block_indent(&token("5")), token("],"))),
+            )
+            // this one must be printed in expanded mode to fit
+            .entry(
+                &soft_line_break_or_space(),
+                &group(&format_args!(
+                    token("["),
+                    soft_block_indent(&token("123456789")),
+                    token("]"),
+                )),
+            )
+            .finish();
+
+        let document = Document::new(buffer.into_vec(), Vec::default());
+
+        let printed = Printer::new(
+            PrinterOptions::default()
+                .with_indent_style(IndentStyle::Tab)
+                .with_print_width(PrintWidth::new(10)),
+            &[],
+        )
+        .print(&document)
+        .unwrap();
+
+        assert_eq!(printed.as_code(), "1, 2, 3,\n723493294,\n[5],\n[\n\t123456789\n]");
+    }
+
+    #[test]
+    fn line_suffix_printed_at_end() {
+        let allocator = Allocator::default();
+        let printed = format(
+            &allocator,
+            &format_args!(
+                group(&format_args!(
+                    token("["),
+                    soft_block_indent(&format_with(|f| {
+                        f.fill()
+                            .entry(
+                                &soft_line_break_or_space(),
+                                &format_args!(token("1"), token(",")),
+                            )
+                            .entry(
+                                &soft_line_break_or_space(),
+                                &format_args!(token("2"), token(",")),
+                            )
+                            .entry(
+                                &soft_line_break_or_space(),
+                                &format_args!(token("3"), if_group_breaks(&token(","))),
+                            )
+                            .finish();
+                    })),
+                    token("]")
+                )),
+                token(";"),
+                &line_suffix(&format_args!(space(), token("// trailing"), space()))
+            ),
+        );
+
+        assert_eq!(printed.as_code(), "[1, 2, 3]; // trailing");
+    }
+    #[test]
+    fn conditional_with_group_id_in_fits() {
+        let allocator = Allocator::default();
+        let content = format_with(|f| {
+            let group_id = f.group_id("test");
+            write!(
+                f,
+                [
+                    group(&format_args!(
+                        token("The referenced group breaks."),
+                        hard_line_break()
+                    ))
+                    .with_group_id(Some(group_id)),
+                    group(&format_args!(
+                        token("This group breaks because:"),
+                        soft_line_break_or_space(),
+                        if_group_fits_on_line(&token("This content fits but should not be printed.")).with_group_id(Some(group_id)),
+                        if_group_breaks(&token("It measures with the 'if_group_breaks' variant because the referenced group breaks and that's just way too much text.")).with_group_id(Some(group_id)),
+                    ))
+                ]
+            );
+        });
+
+        let printed = format(&allocator, &content);
+
+        assert_eq!(
+            printed.as_code(),
+            "The referenced group breaks.\nThis group breaks because:\nIt measures with the 'if_group_breaks' variant because the referenced group breaks and that's just way too much text."
+        );
+    }
+
+    #[test]
+    fn out_of_order_group_ids() {
+        let allocator = Allocator::default();
+        let content = format_with(|f| {
+            let id_1 = f.group_id("id-1");
+            let id_2 = f.group_id("id-2");
+
+            write!(
+                f,
+                [group(&token("Group with id-2")).with_group_id(Some(id_2)), hard_line_break()]
+            );
+
+            write!(f,
+            [
+                group(&token("Group with id-1 does not fit on the line because it exceeds the line width of 100 characters by..........")).with_group_id(Some(id_1)),
+                hard_line_break()
+            ]);
+
+            write!(
+                f,
+                [
+                    if_group_fits_on_line(&token("Group 2 fits")).with_group_id(Some(id_2)),
+                    hard_line_break(),
+                    if_group_breaks(&token("Group 1 breaks")).with_group_id(Some(id_1))
+                ]
+            );
+        });
+
+        let printed = format(&allocator, &content);
+
+        assert_eq!(
+            printed.as_code(),
+            r"Group with id-2
+Group with id-1 does not fit on the line because it exceeds the line width of 100 characters by..........
+Group 2 fits
+Group 1 breaks"
+        );
+    }
+
+    #[test]
+    fn break_group_if_partial_string_exceeds_print_width() {
+        let allocator = Allocator::default();
+        let options =
+            PrinterOptions { print_width: PrintWidth::new(10), ..PrinterOptions::default() };
+
+        let result = format_with_options(
+            &allocator,
+            &format_args!(group(&format_args!(
+                token("("),
+                soft_line_break(),
+                text("This is a string\n containing a newline"),
+                soft_line_break(),
+                token(")")
+            ))),
+            options,
+        );
+
+        assert_eq!("(\nThis is a string\n containing a newline\n)", result.as_code());
+    }
+
+    struct FormatArrayElements<'a, Ctx>
+    where
+        Ctx: super::super::context::FormatContext<'a>,
+    {
+        items: Vec<&'a dyn Format<'a, Ctx>>,
+        _context: std::marker::PhantomData<Ctx>,
+    }
+
+    impl<'a, Ctx> Format<'a, Ctx> for FormatArrayElements<'a, Ctx>
+    where
+        Ctx: super::super::context::FormatContext<'a>,
+    {
+        fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+            write!(
+                f,
+                [group(&format_args!(
+                    token("["),
+                    soft_block_indent(&format_args!(
+                        format_with(|f| {
+                            f.join_with(format_args!(token(","), soft_line_break_or_space()))
+                                .entries(&self.items);
+                        }),
+                        if_group_breaks(&token(",")),
+                    )),
+                    token("]")
+                ))]
+            );
+        }
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/printer/printer_options/mod.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/printer_options/mod.rs
@@ -1,0 +1,99 @@
+use crate::options::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+
+/// Options that affect how the [crate::Printer] prints the format tokens
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrinterOptions {
+    /// Width of an indent in characters.
+    /// if indent_style is set to IndentStyle::Tab, treat tab visualization width as this value.
+    pub indent_width: IndentWidth,
+
+    /// What's the max width of a line. Defaults to 80
+    pub print_width: PrintWidth,
+
+    /// The type of line ending to apply to the printed input
+    pub line_ending: LineEnding,
+
+    /// Whether the printer should use tabs or spaces to indent code and if spaces, by how many.
+    pub indent_style: IndentStyle,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PrintWidth(u32);
+
+impl PrintWidth {
+    pub fn new(width: u32) -> Self {
+        Self(width)
+    }
+}
+
+impl Default for PrintWidth {
+    fn default() -> Self {
+        LineWidth::default().into()
+    }
+}
+
+impl From<LineWidth> for PrintWidth {
+    fn from(width: LineWidth) -> Self {
+        Self(u32::from(u16::from(width)))
+    }
+}
+
+impl From<PrintWidth> for usize {
+    fn from(width: PrintWidth) -> Self {
+        width.0 as usize
+    }
+}
+
+pub trait AsPrinterOptions {
+    fn as_print_options(&self) -> PrinterOptions;
+}
+
+impl PrinterOptions {
+    pub fn with_print_width(mut self, width: PrintWidth) -> Self {
+        self.print_width = width;
+        self
+    }
+
+    pub fn with_indent_style(mut self, style: IndentStyle) -> Self {
+        self.indent_style = style;
+
+        self
+    }
+
+    pub fn with_indent_width(mut self, width: IndentWidth) -> Self {
+        self.indent_width = width;
+
+        self
+    }
+
+    pub fn with_line_ending(mut self, line_ending: LineEnding) -> Self {
+        self.line_ending = line_ending;
+
+        self
+    }
+
+    pub(crate) fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    /// Width of an indent in characters.
+    pub(super) const fn indent_width(&self) -> IndentWidth {
+        self.indent_width
+    }
+
+    #[expect(dead_code)]
+    pub(super) const fn line_ending(&self) -> LineEnding {
+        self.line_ending
+    }
+}
+
+impl Default for PrinterOptions {
+    fn default() -> Self {
+        PrinterOptions {
+            indent_width: IndentWidth::default(),
+            print_width: PrintWidth::default(),
+            indent_style: IndentStyle::default(),
+            line_ending: LineEnding::Lf,
+        }
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/printer/queue.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/queue.rs
@@ -1,0 +1,324 @@
+use std::{fmt::Debug, iter::FusedIterator, marker::PhantomData};
+
+use super::{
+    super::{format_element::tag::TagKind, prelude::Tag},
+    FormatElement, PrintResult, invalid_end_tag, invalid_start_tag,
+    stack::{Stack, StackedStack},
+};
+
+/// Queue of [FormatElement]s.
+pub(super) trait Queue<'a> {
+    type Stack: Stack<&'a [FormatElement<'a>]>;
+
+    fn stack(&self) -> &Self::Stack;
+
+    fn stack_mut(&mut self) -> &mut Self::Stack;
+
+    fn next_index(&self) -> usize;
+
+    fn set_next_index(&mut self, index: usize);
+
+    /// Pops the element at the end of the queue.
+    fn pop(&mut self) -> Option<&'a FormatElement<'a>> {
+        match self.stack().top() {
+            Some(top_slice) => {
+                // Safe because queue ensures that slices inside `slices` are never empty.
+                let next_index = self.next_index();
+                let element = &top_slice[next_index];
+
+                if next_index + 1 == top_slice.len() {
+                    self.stack_mut().pop().unwrap();
+                    self.set_next_index(0);
+                } else {
+                    self.set_next_index(next_index + 1);
+                }
+
+                Some(element)
+            }
+            None => None,
+        }
+    }
+
+    /// Returns the next element, not traversing into [FormatElement::Interned].
+    fn top_with_interned(&self) -> Option<&'a FormatElement<'a>> {
+        self.stack().top().map(|top_slice| &top_slice[self.next_index()])
+    }
+
+    /// Returns the next element, recursively resolving the first element of [FormatElement::Interned].
+    fn top(&self) -> Option<&'a FormatElement<'a>> {
+        let mut top = self.top_with_interned();
+
+        while let Some(FormatElement::Interned(interned)) = top {
+            top = interned.first();
+        }
+
+        top
+    }
+
+    /// Queues a single element to process before the other elements in this queue.
+    fn push(&mut self, element: &'a FormatElement) {
+        self.extend_back(std::slice::from_ref(element));
+    }
+
+    /// Queues a slice of elements to process before the other elements in this queue.
+    fn extend_back(&mut self, elements: &'a [FormatElement]) {
+        match elements {
+            [] => {
+                // Don't push empty slices
+            }
+            slice => {
+                let next_index = self.next_index();
+                let stack = self.stack_mut();
+                if let Some(top) = stack.pop() {
+                    stack.push(&top[next_index..]);
+                }
+
+                stack.push(slice);
+                self.set_next_index(0);
+            }
+        }
+    }
+
+    /// Removes top slice.
+    fn pop_slice(&mut self) -> Option<&'a [FormatElement<'a>]> {
+        self.set_next_index(0);
+        self.stack_mut().pop()
+    }
+
+    /// Skips all content until it finds the corresponding end tag with the given kind.
+    fn skip_content(&mut self, kind: TagKind)
+    where
+        Self: Sized,
+    {
+        let iter = self.iter_content(kind);
+
+        for _ in iter {
+            // consume whole iterator until end
+        }
+    }
+
+    /// Iterates over all elements until it finds the matching end tag of the specified kind.
+    fn iter_content<'q>(&'q mut self, kind: TagKind) -> QueueContentIterator<'a, 'q, Self>
+    where
+        Self: Sized,
+    {
+        QueueContentIterator::new(self, kind)
+    }
+}
+
+/// Queue with the elements to print.
+#[derive(Debug, Default, Clone)]
+pub(super) struct PrintQueue<'a> {
+    slices: Vec<&'a [FormatElement<'a>]>,
+    next_index: usize,
+}
+
+impl<'a> PrintQueue<'a> {
+    pub(super) fn new(slice: &'a [FormatElement<'a>]) -> Self {
+        let slices = match slice {
+            [] => Vec::default(),
+            slice => vec![slice],
+        };
+
+        Self { slices, next_index: 0 }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.slices.is_empty()
+    }
+}
+
+impl<'a> Queue<'a> for PrintQueue<'a> {
+    type Stack = Vec<&'a [FormatElement<'a>]>;
+
+    fn stack(&self) -> &Self::Stack {
+        &self.slices
+    }
+
+    fn stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.slices
+    }
+
+    fn next_index(&self) -> usize {
+        self.next_index
+    }
+
+    fn set_next_index(&mut self, index: usize) {
+        self.next_index = index;
+    }
+}
+
+/// Queue for measuring if an element fits on the line.
+///
+/// The queue is a view on top of the [PrintQueue] because no elements should be removed
+/// from the [PrintQueue] while measuring.
+#[must_use]
+#[derive(Debug)]
+pub(super) struct FitsQueue<'a, 'print> {
+    stack: StackedStack<'print, &'a [FormatElement<'a>]>,
+    next_index: usize,
+}
+
+impl<'a, 'print> FitsQueue<'a, 'print> {
+    pub(super) fn new(
+        print_queue: &'print PrintQueue<'a>,
+        saved: Vec<&'a [FormatElement]>,
+    ) -> Self {
+        let stack = StackedStack::with_vec(&print_queue.slices, saved);
+
+        Self { stack, next_index: print_queue.next_index }
+    }
+
+    pub(super) fn finish(self) -> Vec<&'a [FormatElement<'a>]> {
+        self.stack.into_vec()
+    }
+}
+
+impl<'a, 'print> Queue<'a> for FitsQueue<'a, 'print> {
+    type Stack = StackedStack<'print, &'a [FormatElement<'a>]>;
+
+    fn stack(&self) -> &Self::Stack {
+        &self.stack
+    }
+
+    fn stack_mut(&mut self) -> &mut Self::Stack {
+        &mut self.stack
+    }
+
+    fn next_index(&self) -> usize {
+        self.next_index
+    }
+
+    fn set_next_index(&mut self, index: usize) {
+        self.next_index = index;
+    }
+}
+
+pub(super) struct QueueContentIterator<'a, 'q, Q: Queue<'a>> {
+    queue: &'q mut Q,
+    kind: TagKind,
+    depth: usize,
+    lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a, 'q, Q> QueueContentIterator<'a, 'q, Q>
+where
+    Q: Queue<'a>,
+{
+    fn new(queue: &'q mut Q, kind: TagKind) -> Self {
+        Self { queue, kind, depth: 1, lifetime: PhantomData }
+    }
+}
+
+impl<'a, Q> Iterator for QueueContentIterator<'a, '_, Q>
+where
+    Q: Queue<'a>,
+{
+    type Item = &'a FormatElement<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.depth == 0 {
+            None
+        } else {
+            let mut top = self.queue.pop();
+
+            while let Some(FormatElement::Interned(interned)) = top {
+                self.queue.extend_back(interned);
+                top = self.queue.pop();
+            }
+
+            match top.expect("Missing end signal.") {
+                element @ FormatElement::Tag(tag) if tag.kind() == self.kind => {
+                    if tag.is_start() {
+                        self.depth += 1;
+                    } else {
+                        self.depth -= 1;
+
+                        if self.depth == 0 {
+                            return None;
+                        }
+                    }
+
+                    Some(element)
+                }
+                element => Some(element),
+            }
+        }
+    }
+}
+
+impl<'a, Q> FusedIterator for QueueContentIterator<'a, '_, Q> where Q: Queue<'a> {}
+
+/// A predicate determining when to end measuring if some content fits on the line.
+///
+/// Called for every [`element`](FormatElement) in the [FitsQueue] when measuring if a content
+/// fits on the line. The measuring of the content ends after the first element [`element`](FormatElement) for which this
+/// predicate returns `true` (similar to a take while iterator except that it takes while the predicate returns `false`).
+pub(super) trait FitsEndPredicate {
+    fn is_end(&mut self, element: &FormatElement) -> PrintResult<bool>;
+}
+
+/// Filter that includes all elements until it reaches the end of the document.
+pub(super) struct AllPredicate;
+
+impl FitsEndPredicate for AllPredicate {
+    fn is_end(&mut self, _element: &FormatElement) -> PrintResult<bool> {
+        Ok(false)
+    }
+}
+
+/// Filter that takes all elements between two matching [Tag::StartEntry] and [Tag::EndEntry] tags.
+#[derive(Debug)]
+pub(super) enum SingleEntryPredicate {
+    Entry { depth: usize },
+    Done,
+}
+
+impl SingleEntryPredicate {
+    pub(super) const fn is_done(&self) -> bool {
+        matches!(self, SingleEntryPredicate::Done)
+    }
+}
+
+impl Default for SingleEntryPredicate {
+    fn default() -> Self {
+        SingleEntryPredicate::Entry { depth: 0 }
+    }
+}
+
+impl FitsEndPredicate for SingleEntryPredicate {
+    fn is_end(&mut self, element: &FormatElement) -> PrintResult<bool> {
+        let result = match self {
+            SingleEntryPredicate::Done => true,
+            SingleEntryPredicate::Entry { depth } => match element {
+                FormatElement::Tag(Tag::StartEntry) => {
+                    *depth += 1;
+
+                    false
+                }
+                FormatElement::Tag(Tag::EndEntry) => {
+                    if *depth == 0 {
+                        return invalid_end_tag(TagKind::Entry, None);
+                    }
+
+                    *depth -= 1;
+
+                    let is_end = *depth == 0;
+
+                    if is_end {
+                        *self = SingleEntryPredicate::Done;
+                    }
+
+                    is_end
+                }
+                FormatElement::Interned(_) => false,
+                element if *depth == 0 => {
+                    return invalid_start_tag(TagKind::Entry, Some(element));
+                }
+                _ => false,
+            },
+        };
+
+        Ok(result)
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/printer/stack.rs
+++ b/crates/oxc_formatter_core/src/formatter/printer/stack.rs
@@ -1,0 +1,130 @@
+/// A school book stack. Allows adding, removing, and inspecting elements at the back.
+pub(super) trait Stack<T> {
+    /// Removes the last element if any and returns it
+    fn pop(&mut self) -> Option<T>;
+
+    /// Pushes a new element at the back
+    fn push(&mut self, value: T);
+
+    /// Returns the last element if any
+    fn top(&self) -> Option<&T>;
+}
+
+impl<T> Stack<T> for Vec<T> {
+    fn pop(&mut self) -> Option<T> {
+        self.pop()
+    }
+
+    fn push(&mut self, value: T) {
+        self.push(value);
+    }
+
+    fn top(&self) -> Option<&T> {
+        self.last()
+    }
+}
+
+/// A Stack that is stacked on top of another stack. Guarantees that the underlying stack remains unchanged.
+#[derive(Debug, Clone)]
+pub(super) struct StackedStack<'a, T> {
+    /// The content of the original stack.
+    original: &'a [T],
+
+    /// Items that have been pushed since the creation of this stack and aren't part of the `original` stack.
+    stack: Vec<T>,
+}
+
+impl<'a, T> StackedStack<'a, T> {
+    #[cfg(test)]
+    pub(super) fn new(original: &'a [T]) -> Self {
+        Self::with_vec(original, Vec::new())
+    }
+
+    /// Creates a new stack that uses `stack` for storing its elements.
+    pub(super) fn with_vec(original: &'a [T], stack: Vec<T>) -> Self {
+        Self { original, stack }
+    }
+
+    /// Returns the underlying `stack` vector.
+    pub(super) fn into_vec(self) -> Vec<T> {
+        self.stack
+    }
+}
+
+impl<T> Stack<T> for StackedStack<'_, T>
+where
+    T: Copy,
+{
+    fn pop(&mut self) -> Option<T> {
+        self.stack.pop().or_else(|| match self.original {
+            [rest @ .., last] => {
+                self.original = rest;
+                Some(*last)
+            }
+            _ => None,
+        })
+    }
+
+    fn push(&mut self, value: T) {
+        self.stack.push(value);
+    }
+
+    fn top(&self) -> Option<&T> {
+        self.stack.last().or_else(|| self.original.last())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Stack, StackedStack};
+
+    #[test]
+    fn restore_consumed_stack() {
+        let original = vec![1, 2, 3];
+        let mut restorable = StackedStack::new(&original);
+
+        restorable.push(4);
+
+        assert_eq!(restorable.pop(), Some(4));
+        assert_eq!(restorable.pop(), Some(3));
+        assert_eq!(restorable.pop(), Some(2));
+        assert_eq!(restorable.pop(), Some(1));
+        assert_eq!(restorable.pop(), None);
+
+        assert_eq!(original, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn restore_partially_consumed_stack() {
+        let original = vec![1, 2, 3];
+        let mut restorable = StackedStack::new(&original);
+
+        restorable.push(4);
+
+        assert_eq!(restorable.pop(), Some(4));
+        assert_eq!(restorable.pop(), Some(3));
+        assert_eq!(restorable.pop(), Some(2));
+        restorable.push(5);
+        restorable.push(6);
+        restorable.push(7);
+
+        assert_eq!(original, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn restore_stack() {
+        let original = vec![1, 2, 3];
+        let mut restorable = StackedStack::new(&original);
+
+        restorable.push(4);
+        restorable.push(5);
+        restorable.push(6);
+        restorable.push(7);
+
+        assert_eq!(restorable.pop(), Some(7));
+        assert_eq!(restorable.pop(), Some(6));
+        assert_eq!(restorable.pop(), Some(5));
+
+        assert_eq!(original, vec![1, 2, 3]);
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/separated.rs
+++ b/crates/oxc_formatter_core/src/formatter/separated.rs
@@ -1,0 +1,124 @@
+use std::ops::Deref;
+
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    formatter::{
+        Format, FormatContext, Formatter,
+        prelude::{group, if_group_breaks},
+    },
+    options::TrailingSeparator,
+};
+
+use super::GroupId;
+
+/// Formats a single element inside a separated list.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FormatSeparatedElement<E: GetSpan> {
+    // Public this field to make it easier to get the element span from `FormatSeparatedElement`.
+    element: E,
+    is_last: bool,
+    /// The separator to write if the element has no separator yet.
+    separator: &'static str,
+    options: FormatSeparatedOptions,
+}
+
+impl<T: GetSpan> Deref for FormatSeparatedElement<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.element
+    }
+}
+
+impl<T: GetSpan> GetSpan for FormatSeparatedElement<T> {
+    fn span(&self) -> Span {
+        self.element.span()
+    }
+}
+
+impl<'a, Ctx, E> Format<'a, Ctx> for FormatSeparatedElement<E>
+where
+    Ctx: FormatContext<'a>,
+    E: Format<'a, Ctx> + GetSpan,
+{
+    fn fmt(&self, f: &mut Formatter<'_, 'a, Ctx>) {
+        if self.options.nodes_grouped {
+            group(&self.element).fmt(f);
+        } else {
+            self.element.fmt(f);
+        }
+        if self.is_last {
+            match self.options.trailing_separator {
+                TrailingSeparator::Allowed => {
+                    if_group_breaks(&self.separator).with_group_id(self.options.group_id).fmt(f);
+                }
+                TrailingSeparator::Mandatory => self.separator.fmt(f),
+                TrailingSeparator::Disallowed | TrailingSeparator::Omit => (),
+            }
+        } else {
+            self.separator.fmt(f);
+        }
+    }
+}
+
+/// Iterator for formatting separated elements. Prints the separator between each element and
+/// inserts a trailing separator if necessary
+pub struct FormatSeparatedIter<I, E: GetSpan> {
+    next: Option<E>,
+    inner: I,
+    separator: &'static str,
+    options: FormatSeparatedOptions,
+}
+
+impl<I, E: GetSpan> FormatSeparatedIter<I, E>
+where
+    I: Iterator<Item = E>,
+{
+    pub fn new(inner: I, separator: &'static str) -> Self {
+        Self { inner, separator, next: None, options: FormatSeparatedOptions::default() }
+    }
+
+    /// Wraps every node inside of a group
+    #[expect(unused)]
+    pub fn nodes_grouped(mut self) -> Self {
+        self.options.nodes_grouped = true;
+        self
+    }
+
+    pub fn with_trailing_separator(mut self, separator: TrailingSeparator) -> Self {
+        self.options.trailing_separator = separator;
+        self
+    }
+
+    pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
+        self.options.group_id = group_id;
+        self
+    }
+}
+
+impl<I, E: GetSpan> Iterator for FormatSeparatedIter<I, E>
+where
+    I: Iterator<Item = E>,
+{
+    type Item = FormatSeparatedElement<E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let element = self.next.take().or_else(|| self.inner.next())?;
+        self.next = self.inner.next();
+        let is_last = self.next.is_none();
+        Some(FormatSeparatedElement {
+            element,
+            is_last,
+            separator: self.separator,
+            options: self.options,
+        })
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub struct FormatSeparatedOptions {
+    trailing_separator: TrailingSeparator,
+    group_id: Option<GroupId>,
+    nodes_grouped: bool,
+}

--- a/crates/oxc_formatter_core/src/formatter/source_text.rs
+++ b/crates/oxc_formatter_core/src/formatter/source_text.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 
-use oxc_formatter_core::SourceTextExt;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::{
     identifier::is_white_space_single_line,
@@ -254,12 +253,6 @@ impl<'a> SourceText<'a> {
         }
 
         0
-    }
-}
-
-impl<'a> SourceTextExt<Comments<'a>> for SourceText<'a> {
-    fn get_lines_before(&self, span: Span, comments: &Comments<'a>) -> usize {
-        SourceText::get_lines_before(self, span, comments)
     }
 }
 

--- a/crates/oxc_formatter_core/src/formatter/state.rs
+++ b/crates/oxc_formatter_core/src/formatter/state.rs
@@ -1,0 +1,68 @@
+use rustc_hash::FxHashMap;
+
+use super::{FormatContext, GroupId, UniqueGroupIdBuilder, prelude::Interned};
+
+/// This structure stores the state that is relevant for the formatting of the whole document.
+///
+/// This structure is different from [crate::Formatter] in that the formatting infrastructure
+/// creates a new [crate::Formatter] for every [crate::write!] call, whereas this structure stays alive
+/// for the whole process of formatting a root with [crate::format!].
+pub struct FormatState<'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    context: Ctx,
+    group_id_builder: UniqueGroupIdBuilder,
+    // For the document IR printing process
+    /// The interned elements that have been printed to this point
+    printed_interned_elements: FxHashMap<Interned<'ast>, usize>,
+}
+
+impl<Ctx> std::fmt::Debug for FormatState<'_, Ctx>
+where
+    for<'ast> Ctx: FormatContext<'ast>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("FormatState").finish()
+    }
+}
+
+impl<'ast, Ctx> FormatState<'ast, Ctx>
+where
+    Ctx: FormatContext<'ast>,
+{
+    /// Creates a new state with the given language specific context
+    pub fn new(context: Ctx) -> Self {
+        Self {
+            context,
+            group_id_builder: UniqueGroupIdBuilder::default(),
+            printed_interned_elements: FxHashMap::default(),
+        }
+    }
+
+    pub fn into_context(self) -> Ctx {
+        self.context
+    }
+
+    /// Returns the context specifying how to format the current CST
+    pub fn context(&self) -> &Ctx {
+        &self.context
+    }
+
+    /// Returns a mutable reference to the context
+    pub fn context_mut(&mut self) -> &mut Ctx {
+        &mut self.context
+    }
+
+    /// Creates a new group id that is unique to this document. The passed debug name is used in the
+    /// [std::fmt::Debug] of the document if this is a debug build.
+    /// The name is unused for production builds and has no meaning on the equality of two group ids.
+    pub fn group_id(&self, debug_name: &'static str) -> GroupId {
+        self.group_id_builder.group_id(debug_name)
+    }
+
+    #[expect(clippy::mutable_key_type)]
+    pub fn printed_interned_elements(&mut self) -> &mut FxHashMap<Interned<'ast>, usize> {
+        &mut self.printed_interned_elements
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/text_range.rs
+++ b/crates/oxc_formatter_core/src/formatter/text_range.rs
@@ -1,0 +1,3 @@
+use oxc_span::Span;
+
+pub type TextRange = Span;

--- a/crates/oxc_formatter_core/src/formatter/token/mod.rs
+++ b/crates/oxc_formatter_core/src/formatter/token/mod.rs
@@ -1,0 +1,2 @@
+pub mod number;
+pub mod string;

--- a/crates/oxc_formatter_core/src/formatter/token/string.rs
+++ b/crates/oxc_formatter_core/src/formatter/token/string.rs
@@ -1,0 +1,116 @@
+use std::borrow::Cow;
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum Quote {
+    Double,
+    Single,
+}
+
+impl Quote {
+    pub fn as_char(self) -> char {
+        match self {
+            Quote::Double => '"',
+            Quote::Single => '\'',
+        }
+    }
+
+    pub fn as_byte(self) -> u8 {
+        self.as_char() as u8
+    }
+
+    /// Given the current quote, it returns the other one
+    #[must_use]
+    pub fn other(self) -> Self {
+        match self {
+            Quote::Double => Quote::Single,
+            Quote::Single => Quote::Double,
+        }
+    }
+}
+
+/// This function is responsible of:
+///
+/// - escaping `preferred_quote`
+/// - unescape alternate quotes of `preferred_quote` if `quotes_will_change`
+/// - normalize the new lines by replacing `\r\n` with `\n` and '\r' with '\n'.
+///
+/// The function allocates a new string only if at least one change is performed.
+///
+/// In the following example `"` is escaped and the newline is normalized.
+///
+/// ```
+/// use biome_formatter::token::string::{normalize_string, Quote};
+/// assert_eq!(
+///     normalize_string(" \"He\\llo\\tworld\" \\' \\' \r\n ", Quote::Double, true),
+///     " \\\"He\\llo\\tworld\\\" ' ' \n ",
+/// );
+/// ```
+#[expect(unused)]
+pub fn normalize_string(
+    raw_content: &str,
+    preferred_quote: Quote,
+    quotes_will_change: bool,
+) -> Cow<'_, str> {
+    let alternate_quote = preferred_quote.other().as_byte();
+    let preferred_quote = preferred_quote.as_byte();
+    let capacity = if quotes_will_change {
+        // If quotes change, we might need to escape some quotes, so preallocate enough space for the `\` character.
+        raw_content.len() + raw_content.bytes().filter(|&b| b == preferred_quote).count()
+    } else {
+        // If quotes are not changing, then no `\` will be added, so the original length is sufficient.
+        raw_content.len()
+    };
+    let mut reduced_string = String::with_capacity(capacity);
+    let mut copy_start = 0;
+    let mut bytes = raw_content.bytes().enumerate();
+    while let Some((byte_index, byte)) = bytes.next() {
+        match byte {
+            // If the next character is escaped
+            b'\\' => {
+                if let Some((escaped_index, escaped)) = bytes.next() {
+                    if escaped == b'\r' {
+                        reduced_string.push_str(&raw_content[copy_start..escaped_index]);
+                        copy_start = escaped_index + 1;
+                        if !matches!(bytes.next(), Some((_, b'\n'))) {
+                            reduced_string.push('\n');
+                        }
+                    } else if quotes_will_change && escaped == alternate_quote {
+                        // Unescape alternate quotes if quotes are changing
+                        reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                        copy_start = escaped_index;
+                    }
+                }
+            }
+            b'\r' => {
+                reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                copy_start = byte_index + 1;
+                if !matches!(bytes.next(), Some((_, b'\n'))) {
+                    reduced_string.push('\n');
+                }
+            }
+            _ => {
+                // If we encounter a preferred quote and it's not escaped, we have to replace it with
+                // an escaped version.
+                // This is done because of how the enclosed strings can change.
+                // Check `computed_preferred_quote` for more details.
+                if byte == preferred_quote {
+                    reduced_string.push_str(&raw_content[copy_start..byte_index]);
+                    reduced_string.push('\\');
+                    copy_start = byte_index;
+                }
+            }
+        }
+    }
+
+    if copy_start == 0 && reduced_string.is_empty() {
+        Cow::Borrowed(raw_content)
+    } else {
+        // Copy the remaining characters
+        reduced_string.push_str(&raw_content[copy_start..]);
+        debug_assert!(
+            reduced_string.len() <= capacity,
+            "Something went wrong with the capacity calculation"
+        );
+        Cow::Owned(reduced_string)
+    }
+}

--- a/crates/oxc_formatter_core/src/formatter/trivia.rs
+++ b/crates/oxc_formatter_core/src/formatter/trivia.rs
@@ -1,0 +1,496 @@
+//! High-level comment formatting interface for the on-demand comment system.
+//!
+//! This module provides the formatting implementations that work with the cursor-based
+//! comment tracking system in [`crate::formatter::comments`]. It handles the actual
+//! rendering of comments with proper spacing, line breaks, and indentation.
+//!
+//! ## Integration with Comment Architecture
+//!
+//! This module is the "formatting layer" of our on-demand comment system:
+//!
+//! 1. **AST formatting code calls** the format functions in this module
+//! 2. **These functions query** the comment system for relevant comments
+//! 3. **Comments are formatted** with appropriate spacing and breaks
+//! 4. **The cursor is advanced** to mark comments as processed
+//!
+//! ## Comment Formatting Implementation
+//!
+//! ### Leading Comment Formatting ([`FormatLeadingComments`])
+//! ```rust,ignore
+//! // In AST node formatting:
+//! write!(f, [format_leading_comments(node.span)]);
+//! write!(f, [node]);
+//! ```
+//!
+//! **Implementation**:
+//! 1. Calls `comments_before(node.span.start)` to get unprinted leading comments
+//! 2. Formats each comment with spacing based on line breaks in original source
+//! 3. Advances cursor by calling `increment_printed_count()` for each comment
+//! 4. Handles special cases like JSDoc comment "nestling"
+//!
+//! ### Trailing Comment Formatting ([`FormatTrailingComments`])
+//! ```rust,ignore
+//! // In AST node formatting:
+//! write!(f, [node]);
+//! write!(f, [format_trailing_comments(enclosing, preceding, following)]);
+//! ```
+//!
+//! **Implementation**:
+//! 1. Calls `get_trailing_comments()` with node context to determine ownership
+//! 2. Uses line suffixes to prevent comments from interfering with code layout
+//! 3. Handles complex spacing rules for different comment types
+//! 4. Advances cursor after processing each comment
+//!
+//! ### Dangling Comment Formatting ([`FormatDanglingComments`])
+//! ```rust,ignore
+//! // In container node formatting:
+//! write!(f, [
+//!     "{",
+//!     format_dangling_comments(container.span).with_block_indent(),
+//!     "}"
+//! ]);
+//! ```
+//!
+//! **Implementation**:
+//! 1. Calls `comments_between()` to find internal comments not owned by children
+//! 2. Applies indentation based on container type (block, soft, none)
+//! 3. Preserves comment relationships and spacing
+//! 4. Advances cursor for processed comments
+use oxc_allocator::StringBuilder;
+use oxc_ast::{Comment, CommentContent, CommentKind};
+use oxc_span::Span;
+use oxc_syntax::line_terminator::LineTerminatorSplitter;
+
+use crate::{JsLabels, write};
+
+use super::prelude::*;
+
+/// Returns true if:
+/// - `next_comment` is Some, and
+/// - both comments are documentation comments, and
+/// - both comments are multiline, and
+/// - the two comments are immediately adjacent to each other, with no characters between them.
+///
+/// In this case, the comments are considered "nestled" - a pattern that JSDoc uses to represent
+/// overloaded types, which get merged together to create the final type for the subject. The
+/// comments must be kept immediately adjacent after formatting to preserve this behavior.
+///
+/// There isn't much documentation about this behavior, but it is mentioned on the JSDoc repo
+/// for documentation: <https://github.com/jsdoc/jsdoc.github.io/issues/40>. Prettier also
+/// implements the same behavior: <https://github.com/prettier/prettier/pull/13445/files#diff-3d5eaa2a1593372823589e6e55e7ca905f7c64203ecada0aa4b3b0cdddd5c3ddR160-R178>
+fn should_nestle_adjacent_doc_comments(current: &Comment, next: &Comment) -> bool {
+    matches!(current.content, CommentContent::Jsdoc)
+        && matches!(next.content, CommentContent::Jsdoc)
+        && current.is_multiline_block()
+        && next.is_multiline_block()
+        && current.span.end == next.span.start
+}
+
+/// Formats the leading comments of `node`
+#[inline]
+pub const fn format_leading_comments<'a>(span: Span) -> FormatLeadingComments<'a> {
+    FormatLeadingComments::Node(span)
+}
+
+/// Formats the leading comments of a node.
+#[derive(Debug, Copy, Clone)]
+pub enum FormatLeadingComments<'a> {
+    Node(Span),
+    Comments(&'a [Comment]),
+}
+
+impl<'a> Format<'a> for FormatLeadingComments<'a> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        fn format_leading_comments_impl<'a>(
+            comments: impl IntoIterator<Item = &'a Comment>,
+            f: &mut Formatter<'_, 'a>,
+        ) {
+            let mut leading_comments_iter = comments.into_iter().peekable();
+            while let Some(comment) = leading_comments_iter.next() {
+                f.context_mut().comments_mut().increment_printed_count();
+                write!(f, comment);
+
+                match comment.kind {
+                    CommentKind::SingleLineBlock | CommentKind::MultiLineBlock => {
+                        match f.source_text().lines_after(comment.span.end) {
+                            0 => {
+                                let should_nestle =
+                                    leading_comments_iter.peek().is_some_and(|next_comment| {
+                                        should_nestle_adjacent_doc_comments(comment, next_comment)
+                                    });
+
+                                write!(f, [maybe_space(!should_nestle)]);
+                            }
+                            1 => {
+                                if f.source_text().get_lines_before(comment.span, f.comments()) == 0
+                                {
+                                    write!(f, [soft_line_break_or_space()]);
+                                } else {
+                                    write!(f, [hard_line_break()]);
+                                }
+                            }
+                            _ => write!(f, [empty_line()]),
+                        }
+                    }
+                    CommentKind::Line => match f.source_text().lines_after(comment.span.end) {
+                        0 | 1 => write!(f, [hard_line_break()]),
+                        _ => write!(f, [empty_line()]),
+                    },
+                }
+            }
+        }
+
+        match self {
+            Self::Node(span) => {
+                let leading_comments = f.context().comments().comments_before(span.start);
+                if leading_comments.is_empty() {
+                    return;
+                }
+                format_leading_comments_impl(leading_comments, f);
+            }
+            Self::Comments(comments) => {
+                if comments.is_empty() {
+                    return;
+                }
+                format_leading_comments_impl(*comments, f);
+            }
+        }
+    }
+}
+
+/// Formats the trailing comments of `node`.
+#[inline]
+pub const fn format_trailing_comments<'a>(
+    enclosing_span: Span,
+    preceding_span: Span,
+    following_span_start: u32,
+) -> FormatTrailingComments<'a> {
+    FormatTrailingComments::Node((enclosing_span, preceding_span, following_span_start))
+}
+
+/// Formats the trailing comments of `node`
+#[derive(Debug, Clone, Copy)]
+pub enum FormatTrailingComments<'a> {
+    // (enclosing_span, preceding_span, following_span_start)
+    Node((Span, Span, u32)),
+    Comments(&'a [Comment]),
+}
+
+impl<'a> Format<'a> for FormatTrailingComments<'a> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        fn format_trailing_comments_impl<'a>(
+            comments: impl IntoIterator<Item = &'a Comment>,
+            f: &mut Formatter<'_, 'a>,
+        ) {
+            let mut total_lines_before = 0;
+            let mut previous_comment: Option<&Comment> = None;
+
+            for comment in comments {
+                f.context_mut().comments_mut().increment_printed_count();
+
+                let lines_before = f.source_text().get_lines_before(comment.span, f.comments());
+                total_lines_before += lines_before;
+
+                let should_nestle = previous_comment.is_some_and(|previous_comment| {
+                    should_nestle_adjacent_doc_comments(previous_comment, comment)
+                });
+
+                // This allows comments at the end of nested structures:
+                // {
+                //   x: 1,
+                //   y: 2
+                //   // A comment
+                // }
+                // Those kinds of comments are almost always leading comments, but
+                // here it doesn't go "outside" the block and turns it into a
+                // trailing comment for `2`. We can simulate the above by checking
+                // if this a comment on its own line; normal trailing comments are
+                // always at the end of another expression.
+                if total_lines_before > 0
+                    || previous_comment.is_some_and(|comment| comment.is_line())
+                {
+                    write!(
+                        f,
+                        [line_suffix(&format_with(|f| {
+                            match lines_before {
+                                _ if should_nestle => {}
+                                0 => {
+                                    // If the comment is immediately following a block-like comment,
+                                    // then it can stay on the same line with just a space between.
+                                    // Otherwise, it gets a hard break.
+                                    //
+                                    //   [>* hello <] // hi
+                                    //   [>*
+                                    //    * docs
+                                    //   */ [> still on the same line <]
+                                    if previous_comment.copied().is_some_and(Comment::is_line) {
+                                        write!(f, [hard_line_break()]);
+                                    } else {
+                                        write!(f, [space()]);
+                                    }
+                                }
+                                1 => write!(f, [hard_line_break()]),
+                                _ => write!(f, [empty_line()]),
+                            }
+
+                            write!(f, [comment]);
+                        }))]
+                    );
+                } else {
+                    let content =
+                        format_with(|f| write!(f, [maybe_space(!should_nestle), comment]));
+
+                    if comment.is_line() {
+                        write!(f, [line_suffix(&content), expand_parent()]);
+                    } else {
+                        write!(f, [content]);
+                    }
+                }
+
+                previous_comment = Some(comment);
+            }
+        }
+
+        match self {
+            Self::Node((enclosing_span, preceding_span, following_span_start)) => {
+                let comments = f.context().comments().get_trailing_comments(
+                    *enclosing_span,
+                    *preceding_span,
+                    *following_span_start,
+                );
+
+                if comments.is_empty() {
+                    return;
+                }
+
+                format_trailing_comments_impl(comments, f);
+            }
+            Self::Comments(comments) => {
+                if comments.is_empty() {
+                    return;
+                }
+
+                format_trailing_comments_impl(*comments, f);
+            }
+        }
+    }
+}
+
+/// Formats the dangling comments of `node`.
+#[inline]
+pub const fn format_dangling_comments<'a>(span: Span) -> FormatDanglingComments<'a> {
+    FormatDanglingComments::Node { span, indent: DanglingIndentMode::None }
+}
+
+/// Formats the dangling trivia of `token`.
+pub enum FormatDanglingComments<'a> {
+    Node { span: Span, indent: DanglingIndentMode },
+    Comments { comments: &'a [Comment], indent: DanglingIndentMode },
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DanglingIndentMode {
+    /// Writes every comment on its own line and indents them with a block indent.
+    ///
+    /// # Examples
+    /// ```ignore
+    /// [
+    ///     /* comment */
+    /// ]
+    ///
+    /// [
+    ///     /* comment */
+    ///     /* multiple */
+    /// ]
+    /// ```
+    Block,
+
+    /// Writes every comment on its own line and indents them with a soft line indent.
+    /// Guarantees to write a line break if the last formatted comment is a [line](CommentKind::Line) comment.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// [/* comment */]
+    ///
+    /// [
+    ///     /* comment */
+    ///     /* other */
+    /// ]
+    ///
+    /// [
+    ///     // line
+    /// ]
+    /// ```
+    Soft,
+
+    /// Writes every comment on its own line.
+    None,
+}
+
+impl FormatDanglingComments<'_> {
+    /// Indents the comments with a [block](DanglingIndentMode::Block) indent.
+    pub fn with_block_indent(self) -> Self {
+        self.with_indent_mode(DanglingIndentMode::Block)
+    }
+
+    /// Indents the comments with a [soft block](DanglingIndentMode::Soft) indent.
+    pub fn with_soft_block_indent(self) -> Self {
+        self.with_indent_mode(DanglingIndentMode::Soft)
+    }
+
+    fn with_indent_mode(mut self, mode: DanglingIndentMode) -> Self {
+        match &mut self {
+            FormatDanglingComments::Node { indent, .. }
+            | FormatDanglingComments::Comments { indent, .. } => *indent = mode,
+        }
+        self
+    }
+}
+
+impl<'a> Format<'a> for FormatDanglingComments<'a> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        fn format_dangling_comments_impl<'a>(
+            comments: impl IntoIterator<Item = &'a Comment>,
+            indent: DanglingIndentMode,
+            f: &mut Formatter<'_, 'a>,
+        ) {
+            // Write all comments up to the first skipped token trivia or the token
+            let format_dangling_comments = format_once(|f| {
+                let mut previous_comment: Option<&Comment> = None;
+
+                for comment in comments {
+                    f.context_mut().comments_mut().increment_printed_count();
+
+                    let should_nestle = previous_comment.is_some_and(|previous_comment| {
+                        should_nestle_adjacent_doc_comments(previous_comment, comment)
+                    });
+
+                    write!(
+                        f,
+                        [
+                            (previous_comment.is_some() && !should_nestle)
+                                .then_some(hard_line_break()),
+                            comment
+                        ]
+                    );
+
+                    previous_comment = Some(comment);
+                }
+
+                if matches!(indent, DanglingIndentMode::Soft)
+                    && previous_comment.copied().is_some_and(Comment::is_line)
+                {
+                    write!(f, [hard_line_break()]);
+                }
+            });
+
+            match indent {
+                DanglingIndentMode::Block => {
+                    write!(f, [block_indent(&format_dangling_comments)]);
+                }
+                DanglingIndentMode::Soft => {
+                    write!(f, [group(&soft_block_indent(&format_dangling_comments))]);
+                }
+                DanglingIndentMode::None => {
+                    write!(f, [format_dangling_comments]);
+                }
+            }
+        }
+
+        match self {
+            FormatDanglingComments::Node { span, indent } => {
+                let dangling_comments = f.context().comments().comments_before(span.end);
+                if dangling_comments.is_empty() {
+                    return;
+                }
+                format_dangling_comments_impl(dangling_comments, *indent, f);
+            }
+            FormatDanglingComments::Comments { comments, indent } => {
+                if comments.is_empty() {
+                    return;
+                }
+                format_dangling_comments_impl(*comments, *indent, f);
+            }
+        }
+    }
+}
+
+impl<'a> Format<'a> for Comment {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let content = f.source_text().text_for(&self.span);
+        if self.is_multiline_block() {
+            let mut lines = LineTerminatorSplitter::new(content);
+            if is_alignable_comment(content) {
+                // Using `write_element` directly instead of `labelled()`
+                // to avoid allocating a `Vec` for `lines` iter
+                let sort_imports_enabled = f.options().experimental_sort_imports.is_some();
+                if sort_imports_enabled {
+                    f.write_element(FormatElement::Tag(Tag::StartLabelled(LabelId::of(
+                        JsLabels::AlignableBlockComment,
+                    ))));
+                }
+
+                // `unwrap` is safe because `content` contains at least one line.
+                let first_line = lines.next().unwrap();
+                write!(f, [text(first_line.trim_end())]);
+
+                // Indent the remaining lines by one space so that all `*` are aligned.
+                for line in lines {
+                    write!(f, [hard_line_break(), " ", text(line.trim())]);
+                }
+
+                if sort_imports_enabled {
+                    f.write_element(FormatElement::Tag(Tag::EndLabelled));
+                }
+            } else {
+                // Normalize line endings `\r\n` to `\n`
+                let mut string = StringBuilder::with_capacity_in(content.len(), f.allocator());
+                // `unwrap` is safe because `content` contains at least one line.
+                string.push_str(lines.next().unwrap().trim_end());
+
+                for str in lines {
+                    string.push('\n');
+                    string.push_str(str);
+                }
+                write!(f, [text(string.into_str())]);
+            }
+        } else {
+            write!(f, [text(content.trim_end())]);
+        }
+    }
+}
+
+/// Returns `true` if `comment` is a multi line block comment where each line
+/// starts with a star (`*`). These comments can be formatted to always have
+/// the leading stars line up in a column.
+///
+/// # Examples
+///
+/// ```rs,ignore
+/// assert!(is_alignable_comment(&parse_comment(r#"
+///     /**
+///      * Multiline doc comment
+///      */
+/// "#)));
+///
+/// assert!(is_alignable_comment(&parse_comment(r#"
+///     /*
+///      * Single star
+///      */
+/// "#)));
+///
+///
+/// // Non indentable-comments
+/// assert!(!is_alignable_comment(&parse_comment(r#"/** has no line break */"#)));
+///
+/// assert!(!is_alignable_comment(&parse_comment(r#"
+/// /*
+///  *
+///  this line doesn't start with a star
+///  */
+/// "#)));
+/// ```
+pub fn is_alignable_comment(lines: &str) -> bool {
+    LineTerminatorSplitter::new(lines).skip(1).all(|line| line.trim_start().starts_with('*'))
+}

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod formatter;
+pub mod options;
+
+pub use formatter::{
+    Argument, Arguments, Buffer, BufferExtensions, Format, FormatContext, FormatElement,
+    FormatState, Formatted, Formatter, GroupId, PrintError, PrintResult, Printed,
+    SimpleFormatContext, SimpleFormatOptions, builders, format, format_element, format_extensions,
+    prelude, printer, separated, token,
+};
+
+pub use formatter::{FormatContextExt, SourceTextExt};
+
+pub use options::{
+    IndentStyle, IndentWidth, IndentWidthProvider, LineEnding, LineWidth, TrailingSeparator,
+};

--- a/crates/oxc_formatter_core/src/options.rs
+++ b/crates/oxc_formatter_core/src/options.rs
@@ -1,0 +1,310 @@
+use std::{fmt, num::ParseIntError, str::FromStr};
+
+#[derive(Debug, Default, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum IndentStyle {
+    /// Tab
+    Tab,
+    /// Space
+    #[default]
+    Space,
+}
+
+impl IndentStyle {
+    pub const DEFAULT_SPACES: u8 = 2;
+
+    /// Returns `true` if this is an [IndentStyle::Tab].
+    pub const fn is_tab(self) -> bool {
+        matches!(self, IndentStyle::Tab)
+    }
+
+    /// Returns `true` if this is an [IndentStyle::Space].
+    pub const fn is_space(self) -> bool {
+        matches!(self, IndentStyle::Space)
+    }
+}
+
+impl FromStr for IndentStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tab" => Ok(Self::Tab),
+            "space" => Ok(Self::Space),
+            // TODO: replace this error with a diagnostic
+            _ => Err("Unsupported value for this option"),
+        }
+    }
+}
+
+impl fmt::Display for IndentStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            IndentStyle::Tab => "Tab",
+            IndentStyle::Space => "Space",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Default)]
+pub enum LineEnding {
+    ///  Line Feed only (\n), common on Linux and macOS as well as inside git repos
+    #[default]
+    Lf,
+    /// Carriage Return + Line Feed characters (\r\n), common on Windows
+    Crlf,
+    /// Carriage Return character only (\r), used very rarely
+    Cr,
+}
+
+impl LineEnding {
+    #[inline]
+    pub const fn as_bytes(self) -> &'static [u8] {
+        match self {
+            LineEnding::Lf => b"\n",
+            LineEnding::Crlf => b"\r\n",
+            LineEnding::Cr => b"\r",
+        }
+    }
+
+    /// Returns `true` if this is a [LineEnding::Lf].
+    pub const fn is_line_feed(self) -> bool {
+        matches!(self, LineEnding::Lf)
+    }
+
+    /// Returns `true` if this is a [LineEnding::Crlf].
+    pub const fn is_carriage_return_line_feed(self) -> bool {
+        matches!(self, LineEnding::Crlf)
+    }
+
+    /// Returns `true` if this is a [LineEnding::Cr].
+    pub const fn is_carriage_return(self) -> bool {
+        matches!(self, LineEnding::Cr)
+    }
+}
+
+impl FromStr for LineEnding {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lf" => Ok(Self::Lf),
+            "crlf" => Ok(Self::Crlf),
+            "cr" => Ok(Self::Cr),
+            _ => Err("Value not supported for LineEnding"),
+        }
+    }
+}
+
+impl fmt::Display for LineEnding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            LineEnding::Lf => "LF",
+            LineEnding::Crlf => "CRLF",
+            LineEnding::Cr => "CR",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub struct IndentWidth(u8);
+
+impl IndentWidth {
+    pub const MAX: u8 = 24;
+    pub const MIN: u8 = 0;
+
+    /// Return the numeric value for this [IndentWidth]
+    pub fn value(self) -> u8 {
+        self.0
+    }
+}
+
+impl Default for IndentWidth {
+    fn default() -> Self {
+        Self(2)
+    }
+}
+
+impl FromStr for IndentWidth {
+    type Err = ParseFormatNumberError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = u8::from_str(s).map_err(ParseFormatNumberError::ParseError)?;
+        let value = Self::try_from(value).map_err(ParseFormatNumberError::TryFromU8Error)?;
+        Ok(value)
+    }
+}
+
+impl TryFrom<u8> for IndentWidth {
+    type Error = IndentWidthFromIntError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        if (Self::MIN..=Self::MAX).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(IndentWidthFromIntError(value))
+        }
+    }
+}
+
+impl fmt::Display for IndentWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = self.value();
+        f.write_str(&std::format!("{value}"))
+    }
+}
+
+impl fmt::Debug for IndentWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+/// Validated value for the `line_width` formatter options
+///
+/// The allowed range of values is 1..=320
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct LineWidth(u16);
+
+impl LineWidth {
+    /// Maximum allowed value for a valid [LineWidth]
+    pub const MAX: u16 = 320;
+    /// Minimum allowed value for a valid [LineWidth]
+    pub const MIN: u16 = 1;
+
+    /// Return the numeric value for this [LineWidth]
+    pub fn value(self) -> u16 {
+        self.0
+    }
+}
+
+impl Default for LineWidth {
+    fn default() -> Self {
+        Self(100)
+    }
+}
+
+impl fmt::Display for LineWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = self.value();
+        f.write_str(&std::format!("{value}"))
+    }
+}
+
+impl fmt::Debug for LineWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+/// Error type returned when parsing a [LineWidth] or [IndentWidth] from a string fails
+#[expect(clippy::enum_variant_names)]
+pub enum ParseFormatNumberError {
+    /// The string could not be parsed to a number
+    ParseError(ParseIntError),
+    /// The `u16` value of the string is not a valid [LineWidth]
+    TryFromU16Error(LineWidthFromIntError),
+    /// The `u8 value of the string is not a valid [IndentWidth]
+    TryFromU8Error(IndentWidthFromIntError),
+}
+
+impl From<IndentWidthFromIntError> for ParseFormatNumberError {
+    fn from(value: IndentWidthFromIntError) -> Self {
+        Self::TryFromU8Error(value)
+    }
+}
+
+impl From<LineWidthFromIntError> for ParseFormatNumberError {
+    fn from(value: LineWidthFromIntError) -> Self {
+        Self::TryFromU16Error(value)
+    }
+}
+
+impl From<ParseIntError> for ParseFormatNumberError {
+    fn from(value: ParseIntError) -> Self {
+        Self::ParseError(value)
+    }
+}
+
+impl fmt::Debug for ParseFormatNumberError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for ParseFormatNumberError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseFormatNumberError::ParseError(err) => fmt::Display::fmt(err, fmt),
+            ParseFormatNumberError::TryFromU16Error(err) => fmt::Display::fmt(err, fmt),
+            ParseFormatNumberError::TryFromU8Error(err) => fmt::Display::fmt(err, fmt),
+        }
+    }
+}
+
+impl TryFrom<u16> for LineWidth {
+    type Error = LineWidthFromIntError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        if (Self::MIN..=Self::MAX).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(LineWidthFromIntError(value))
+        }
+    }
+}
+
+impl FromStr for LineWidth {
+    type Err = ParseFormatNumberError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = u16::from_str(s).map_err(ParseFormatNumberError::ParseError)?;
+        let value = Self::try_from(value).map_err(ParseFormatNumberError::TryFromU16Error)?;
+        Ok(value)
+    }
+}
+
+/// Error type returned when converting a u16 to a [LineWidth] fails
+#[derive(Clone, Copy, Debug)]
+pub struct IndentWidthFromIntError(pub u8);
+
+impl fmt::Display for IndentWidthFromIntError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "The indent width should be between {} and {}", LineWidth::MIN, LineWidth::MAX,)
+    }
+}
+
+/// Error type returned when converting a u16 to a [LineWidth] fails
+#[derive(Clone, Copy, Debug)]
+pub struct LineWidthFromIntError(pub u16);
+
+impl fmt::Display for LineWidthFromIntError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "The line width should be between {} and {}", LineWidth::MIN, LineWidth::MAX,)
+    }
+}
+
+impl From<LineWidth> for u16 {
+    fn from(value: LineWidth) -> Self {
+        value.0
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+pub enum TrailingSeparator {
+    /// A trailing separator is allowed and preferred
+    #[default]
+    Allowed,
+    /// A trailing separator is not allowed
+    Disallowed,
+    /// A trailing separator is mandatory for the syntax to be correct
+    Mandatory,
+    /// A trailing separator might be present, but the consumer
+    /// decides to remove it
+    Omit,
+}
+
+pub trait IndentWidthProvider {
+    fn indent_width(&self) -> IndentWidth;
+}

--- a/crates/oxc_formatter_core/src/printer.rs
+++ b/crates/oxc_formatter_core/src/printer.rs
@@ -1,0 +1,119 @@
+use crate::format_element::{FormatElement, LineMode};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum IndentStyle {
+    Tab,
+    Space,
+}
+
+impl Default for IndentStyle {
+    fn default() -> Self {
+        Self::Space
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum LineEnding {
+    Lf,
+    Crlf,
+    Cr,
+}
+
+impl Default for LineEnding {
+    fn default() -> Self {
+        Self::Lf
+    }
+}
+
+impl LineEnding {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Lf => "\n",
+            Self::Crlf => "\r\n",
+            Self::Cr => "\r",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct PrinterOptions {
+    pub indent_style: IndentStyle,
+    pub indent_width: u8,
+    pub line_ending: LineEnding,
+    pub line_width: u16,
+}
+
+impl Default for PrinterOptions {
+    fn default() -> Self {
+        Self {
+            indent_style: IndentStyle::Space,
+            indent_width: 2,
+            line_ending: LineEnding::Lf,
+            line_width: 80,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Printer {
+    options: PrinterOptions,
+}
+
+impl Printer {
+    pub fn new(options: PrinterOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn print(&self, elements: &[FormatElement]) -> String {
+        let mut output = String::new();
+        let mut indent_level: usize = 0;
+        let mut at_line_start = true;
+
+        for element in elements {
+            match element {
+                FormatElement::Text(text) => {
+                    if at_line_start {
+                        Self::write_indent(&mut output, indent_level, self.options);
+                        at_line_start = false;
+                    }
+                    output.push_str(text);
+                }
+                FormatElement::Space => {
+                    if at_line_start {
+                        Self::write_indent(&mut output, indent_level, self.options);
+                        at_line_start = false;
+                    }
+                    output.push(' ');
+                }
+                FormatElement::Line(LineMode::Hard) => {
+                    output.push_str(self.options.line_ending.as_str());
+                    at_line_start = true;
+                }
+                FormatElement::IndentStart => {
+                    indent_level += 1;
+                }
+                FormatElement::IndentEnd => {
+                    indent_level = indent_level.saturating_sub(1);
+                }
+            }
+        }
+
+        output
+    }
+
+    fn write_indent(output: &mut String, indent_level: usize, options: PrinterOptions) {
+        match options.indent_style {
+            IndentStyle::Tab => {
+                for _ in 0..indent_level {
+                    output.push('\t');
+                }
+            }
+            IndentStyle::Space => {
+                let count = indent_level * usize::from(options.indent_width.max(1));
+                for _ in 0..count {
+                    output.push(' ');
+                }
+            }
+        }
+    }
+}

--- a/crates/oxc_formatter_json/Cargo.toml
+++ b/crates/oxc_formatter_json/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "oxc_formatter_json"
+version = "0.1.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description = "Native JSON formatter for oxfmt using json5-compatible parsing."
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc_formatter_core = { workspace = true }
+oxc_allocator = { workspace = true }
+
+json5 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/oxc_formatter_json/src/context.rs
+++ b/crates/oxc_formatter_json/src/context.rs
@@ -1,0 +1,32 @@
+use oxc_allocator::Allocator;
+use oxc_formatter_core::FormatContext;
+
+use crate::JsonFormatOptions;
+
+#[derive(Clone, Copy)]
+pub struct JsonFormatContext<'ast> {
+    options: JsonFormatOptions,
+    allocator: &'ast Allocator,
+}
+
+impl<'ast> JsonFormatContext<'ast> {
+    pub fn new(allocator: &'ast Allocator, options: JsonFormatOptions) -> Self {
+        Self { options, allocator }
+    }
+
+    pub fn options(self) -> JsonFormatOptions {
+        self.options
+    }
+}
+
+impl<'ast> FormatContext<'ast> for JsonFormatContext<'ast> {
+    type Options = JsonFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn allocator(&self) -> &'ast Allocator {
+        self.allocator
+    }
+}

--- a/crates/oxc_formatter_json/src/lib.rs
+++ b/crates/oxc_formatter_json/src/lib.rs
@@ -1,0 +1,7 @@
+mod context;
+mod options;
+mod print;
+
+pub use context::JsonFormatContext;
+pub use options::JsonFormatOptions;
+pub use print::{JsonFormatError, format_json};

--- a/crates/oxc_formatter_json/src/options.rs
+++ b/crates/oxc_formatter_json/src/options.rs
@@ -1,0 +1,39 @@
+use oxc_formatter_core::formatter::printer::{AsPrinterOptions, PrinterOptions};
+use oxc_formatter_core::{IndentStyle, IndentWidth, IndentWidthProvider, LineEnding, LineWidth};
+
+#[derive(Debug, Clone, Copy)]
+pub struct JsonFormatOptions {
+    pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
+    pub line_ending: LineEnding,
+    pub line_width: LineWidth,
+    pub always_expand: bool,
+}
+
+impl Default for JsonFormatOptions {
+    fn default() -> Self {
+        Self {
+            indent_style: IndentStyle::Space,
+            indent_width: IndentWidth::default(),
+            line_ending: LineEnding::Lf,
+            line_width: LineWidth::default(),
+            always_expand: false,
+        }
+    }
+}
+
+impl AsPrinterOptions for JsonFormatOptions {
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::default()
+            .with_indent_style(self.indent_style)
+            .with_indent_width(self.indent_width)
+            .with_print_width(self.line_width.into())
+            .with_line_ending(self.line_ending)
+    }
+}
+
+impl IndentWidthProvider for JsonFormatOptions {
+    fn indent_width(&self) -> IndentWidth {
+        self.indent_width
+    }
+}

--- a/crates/oxc_formatter_json/src/print.rs
+++ b/crates/oxc_formatter_json/src/print.rs
@@ -1,0 +1,384 @@
+use std::fmt;
+
+use oxc_allocator::Allocator;
+use oxc_formatter_core::formatter::prelude::*;
+use oxc_formatter_core::formatter::{Argument, Arguments, Format, Formatter};
+use oxc_formatter_core::write;
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+use crate::{JsonFormatContext, JsonFormatOptions};
+
+#[derive(Debug)]
+pub enum JsonFormatError {
+    Parse(String),
+}
+
+impl JsonFormatError {
+    pub fn is_parse_error(&self) -> bool {
+        matches!(self, Self::Parse(_))
+    }
+}
+
+impl fmt::Display for JsonFormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Parse(err) => {
+                f.write_str("JSON parse error: ")?;
+                f.write_str(err)
+            }
+        }
+    }
+}
+
+impl std::error::Error for JsonFormatError {}
+
+#[derive(Debug, Clone)]
+enum JsonValue {
+    Null,
+    Bool(bool),
+    Number(JsonNumber),
+    String(String),
+    Array(Vec<JsonValue>),
+    Object(Vec<(String, JsonValue)>),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum JsonNumber {
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Infinity,
+    NegInfinity,
+    NaN,
+}
+
+impl JsonNumber {
+    fn from_f64(value: f64) -> Self {
+        if value.is_nan() {
+            return Self::NaN;
+        }
+        if value == f64::INFINITY {
+            return Self::Infinity;
+        }
+        if value == f64::NEG_INFINITY {
+            return Self::NegInfinity;
+        }
+        Self::F64(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct JsonValueVisitor;
+
+        impl<'de> Visitor<'de> for JsonValueVisitor {
+            type Value = JsonValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON/JSON5 value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+                Ok(JsonValue::Bool(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+                Ok(JsonValue::Number(JsonNumber::I64(value)))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+                Ok(JsonValue::Number(JsonNumber::U64(value)))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
+                Ok(JsonValue::Number(JsonNumber::from_f64(value)))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+                Ok(JsonValue::String(value.to_string()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+                Ok(JsonValue::String(value))
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E> {
+                Ok(JsonValue::Null)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(JsonValue::Null)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut values = Vec::new();
+                while let Some(value) = seq.next_element::<JsonValue>()? {
+                    values.push(value);
+                }
+                Ok(JsonValue::Array(values))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut entries = Vec::new();
+                while let Some((key, value)) = map.next_entry::<String, JsonValue>()? {
+                    entries.push((key, value));
+                }
+                Ok(JsonValue::Object(entries))
+            }
+        }
+
+        deserializer.deserialize_any(JsonValueVisitor)
+    }
+}
+
+fn format_finite_number(value: f64) -> String {
+    let mut number = serde_json::Number::from_f64(value)
+        .map(|number| {
+            serde_json::to_string(&number)
+                .expect("serializing a JSON number into string should not fail")
+        })
+        .expect("finite f64 must be representable as a JSON number");
+
+    // `json5` can deserialize integer-like values as floats (`1e10` -> `10000000000.0`).
+    // Match Prettier's json-stringify behavior by removing the trailing `.0`.
+    if number.ends_with(".0") {
+        number.truncate(number.len() - 2);
+    }
+
+    number
+}
+
+pub fn format_json(
+    source_text: &str,
+    options: JsonFormatOptions,
+) -> Result<String, JsonFormatError> {
+    let value: JsonValue =
+        json5::from_str(source_text).map_err(|err| JsonFormatError::Parse(err.to_string()))?;
+
+    Ok(format_json_value(&value, options))
+}
+
+fn format_json_value(value: &JsonValue, options: JsonFormatOptions) -> String {
+    let allocator = Allocator::default();
+    let context = JsonFormatContext::new(&allocator, options);
+
+    let formatted =
+        oxc_formatter_core::formatter::format(context, Arguments::new(&[Argument::new(value)]));
+    let printed = formatted.print().expect("printing JSON formatter output should not fail");
+
+    let mut code = printed.into_code();
+    code.push_str(match options.line_ending {
+        oxc_formatter_core::LineEnding::Lf => "\n",
+        oxc_formatter_core::LineEnding::Crlf => "\r\n",
+        oxc_formatter_core::LineEnding::Cr => "\r",
+    });
+    code
+}
+
+impl<'ast> Format<'ast, JsonFormatContext<'ast>> for JsonValue {
+    fn fmt(&self, f: &mut Formatter<'_, 'ast, JsonFormatContext<'ast>>) {
+        match self {
+            JsonValue::Null => write!(f, [token("null")]),
+            JsonValue::Bool(value) => {
+                if *value {
+                    write!(f, [token("true")]);
+                } else {
+                    write!(f, [token("false")]);
+                }
+            }
+            JsonValue::Number(number) => {
+                let number = match number {
+                    JsonNumber::I64(value) => value.to_string(),
+                    JsonNumber::U64(value) => value.to_string(),
+                    JsonNumber::F64(value) => format_finite_number(*value),
+                    JsonNumber::Infinity => "Infinity".to_string(),
+                    JsonNumber::NegInfinity => "-Infinity".to_string(),
+                    JsonNumber::NaN => "NaN".to_string(),
+                };
+                let number = f.context().allocator().alloc_str(&number);
+                write!(f, [text(number)]);
+            }
+            JsonValue::String(value) => {
+                let string = serde_json::to_string(value)
+                    .expect("serializing a JSON string into string should not fail");
+                let string = f.context().allocator().alloc_str(&string);
+                write!(f, [text(string)]);
+            }
+            JsonValue::Array(items) => {
+                if items.is_empty() {
+                    write!(f, [token("[]")]);
+                    return;
+                }
+
+                if f.options().always_expand {
+                    write!(
+                        f,
+                        [
+                            token("["),
+                            block_indent(&format_with(
+                                |f: &mut Formatter<'_, 'ast, JsonFormatContext<'ast>>| {
+                                    for (index, value) in items.iter().enumerate() {
+                                        value.fmt(f);
+                                        if index + 1 != items.len() {
+                                            write!(f, [token(","), hard_line_break()]);
+                                        }
+                                    }
+                                }
+                            )),
+                            token("]")
+                        ]
+                    );
+                    return;
+                }
+
+                write!(
+                    f,
+                    [group(&oxc_formatter_core::format_args!(
+                        token("["),
+                        soft_block_indent(&format_with(
+                            |f: &mut Formatter<'_, 'ast, JsonFormatContext<'ast>>| {
+                                for (index, value) in items.iter().enumerate() {
+                                    value.fmt(f);
+                                    if index + 1 != items.len() {
+                                        write!(f, [token(","), soft_line_break_or_space()]);
+                                    }
+                                }
+                            }
+                        )),
+                        token("]")
+                    ))]
+                );
+            }
+            JsonValue::Object(entries) => {
+                if entries.is_empty() {
+                    write!(f, [token("{}")]);
+                    return;
+                }
+
+                if f.options().always_expand {
+                    write!(
+                        f,
+                        [
+                            token("{"),
+                            block_indent(&format_with(
+                                |f: &mut Formatter<'_, 'ast, JsonFormatContext<'ast>>| {
+                                    for (index, (key, value)) in entries.iter().enumerate() {
+                                        let key_string = serde_json::to_string(key).expect(
+                                            "serializing an object key into string should not fail",
+                                        );
+                                        let key_string =
+                                            f.context().allocator().alloc_str(&key_string);
+                                        write!(f, [text(key_string), token(": ")]);
+                                        value.fmt(f);
+
+                                        if index + 1 != entries.len() {
+                                            write!(f, [token(","), hard_line_break()]);
+                                        }
+                                    }
+                                }
+                            )),
+                            token("}")
+                        ]
+                    );
+                    return;
+                }
+
+                write!(
+                    f,
+                    [group(&oxc_formatter_core::format_args!(
+                        token("{"),
+                        soft_block_indent(&format_with(
+                            |f: &mut Formatter<'_, 'ast, JsonFormatContext<'ast>>| {
+                                for (index, (key, value)) in entries.iter().enumerate() {
+                                    let key_string = serde_json::to_string(key).expect(
+                                        "serializing an object key into string should not fail",
+                                    );
+                                    let key_string = f.context().allocator().alloc_str(&key_string);
+                                    write!(f, [text(key_string), token(": ")]);
+                                    value.fmt(f);
+
+                                    if index + 1 != entries.len() {
+                                        write!(f, [token(","), soft_line_break_or_space()]);
+                                    }
+                                }
+                            }
+                        )),
+                        token("}")
+                    ))]
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_json5_comments_and_trailing_commas() {
+        let input = r#"
+        {
+          // Comment
+          "a": 1,
+          "b": [2, 3,],
+        }
+        "#;
+
+        let output = format_json(input, JsonFormatOptions::default()).unwrap();
+        assert_eq!(output, "{\"a\": 1, \"b\": [2, 3]}\n");
+    }
+
+    #[test]
+    fn formats_primitives() {
+        let input = r#"{"s":"\n","n":1.50,"b":true,"z":null}"#;
+        let output = format_json(input, JsonFormatOptions::default()).unwrap();
+        assert_eq!(output, "{\"s\": \"\\n\", \"n\": 1.5, \"b\": true, \"z\": null}\n");
+    }
+
+    #[test]
+    fn formats_json_stringify_style() {
+        let input = r#"{"a":1,"b":[2,3]}"#;
+        let output = format_json(
+            input,
+            JsonFormatOptions { always_expand: true, ..JsonFormatOptions::default() },
+        )
+        .unwrap();
+        assert_eq!(output, "{\n  \"a\": 1,\n  \"b\": [\n    2,\n    3\n  ]\n}\n");
+    }
+
+    #[test]
+    fn normalizes_integer_like_float_numbers() {
+        let input = r#"{"n":1e10,"m":1e-3}"#;
+        let output = format_json(
+            input,
+            JsonFormatOptions { always_expand: true, ..JsonFormatOptions::default() },
+        )
+        .unwrap();
+        assert_eq!(output, "{\n  \"n\": 10000000000,\n  \"m\": 0.001\n}\n");
+    }
+
+    #[test]
+    fn preserves_non_finite_numbers_and_duplicate_keys() {
+        let input = r#"{Infinity: NaN, NaN: Infinity, NaN: -Infinity}"#;
+        let output = format_json(
+            input,
+            JsonFormatOptions { always_expand: true, ..JsonFormatOptions::default() },
+        )
+        .unwrap();
+        assert_eq!(
+            output,
+            "{\n  \"Infinity\": NaN,\n  \"NaN\": Infinity,\n  \"NaN\": -Infinity\n}\n"
+        );
+    }
+}

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -27,6 +27,8 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_formatter = { workspace = true }
+oxc_formatter_core = { workspace = true }
+oxc_formatter_json = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_tasks_common = { workspace = true }

--- a/tasks/prettier_conformance/snapshots/prettier.json.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.json.snap.md
@@ -1,0 +1,6 @@
+json compatibility: 14/14 (100.00%)
+
+# Failed
+
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -17,5 +17,6 @@ fn main() {
     };
 
     TestRunner::new(options.clone()).run();
-    TestRunner::new(TestRunnerOptions { language: TestLanguage::Ts, ..options }).run();
+    TestRunner::new(TestRunnerOptions { language: TestLanguage::Ts, ..options.clone() }).run();
+    TestRunner::new(TestRunnerOptions { language: TestLanguage::Json, ..options }).run();
 }

--- a/tasks/prettier_conformance/src/options.rs
+++ b/tasks/prettier_conformance/src/options.rs
@@ -12,6 +12,7 @@ pub enum TestLanguage {
     #[default]
     Js,
     Ts,
+    Json,
 }
 
 impl TestLanguage {
@@ -19,6 +20,7 @@ impl TestLanguage {
         match self {
             Self::Js => "js",
             Self::Ts => "ts",
+            Self::Json => "json",
         }
     }
 
@@ -29,6 +31,7 @@ impl TestLanguage {
             // There is no `tsx` directory, just check it works with TS
             // `SourceType`.`variant` is handled by spec file extension
             Self::Ts => ["typescript", "jsx"],
+            Self::Json => return vec![base.join("json").join("json")],
         }
         .iter()
         .map(|dir| base.join(dir))


### PR DESCRIPTION
# Experimental
--- 
refactor(formatter): decouple JS/TS specifics to enable language-agnostic formatting

feat(formatter-json): add native JSON formatter and Prettier JSON conformance

feat(oxfmt): route .json to native formatter with parse-error fallback

fix(oxfmt): address clippy unused_self in JSON formatter path
