### PR TITLE
fix(formatter): remove unnecessary parentheses for single-member union types

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/ts/union-type/single-member.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union-type/single-member.ts
@@ -1,0 +1,9 @@
+// Issue #18941 - single-member unions should not have unnecessary parentheses
+type Items = ( | number)[];
+type Items2 = ( & number)[];
+
+// Multi-member unions should keep parentheses
+type Items3 = (string | number)[];
+
+// Simple case without array
+type Simple = | number;

--- a/crates/oxc_formatter/tests/fixtures/ts/union-type/single-member.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union-type/single-member.ts.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18941 - single-member unions should not have unnecessary parentheses
+type Items = ( | number)[];
+type Items2 = ( & number)[];
+
+// Multi-member unions should keep parentheses
+type Items3 = (string | number)[];
+
+// Simple case without array
+type Simple = | number;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18941 - single-member unions should not have unnecessary parentheses
+type Items = number[];
+type Items2 = number[];
+
+// Multi-member unions should keep parentheses
+type Items3 = (string | number)[];
+
+// Simple case without array
+type Simple = number;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18941 - single-member unions should not have unnecessary parentheses
+type Items = number[];
+type Items2 = number[];
+
+// Multi-member unions should keep parentheses
+type Items3 = (string | number)[];
+
+// Simple case without array
+type Simple = number;
+
+===================== End =====================


### PR DESCRIPTION
Single-member union/intersection types (e.g., `(| number)[]`) were getting unnecessary parentheses, outputting `(number)[]` instead of `number[]`.

In Prettier's Babel AST, single-member unions don't exist (they're unwrapped by the parser), so parenthesization never triggers. In oxc, the parser creates these nodes, so the fix:

1. Makes single-member unions/intersections return `false` from `needs_parentheses`
2. Adds `effective_parent` helper that looks through single-member unions/intersections so inner types correctly check against the grandparent context (e.g., `keyof T` inside a single-member union inside `TSArrayType` correctly sees `TSArrayType` as its parent)

Closes #18941