### PR TITLE
fix(semantic/jsdoc): inline tags like `{@link}` break jsdoc parsing

### DIFF
--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -342,7 +342,7 @@ mod test {
                 Some(("t2", "{t2}")),
             ),
             ("/** @k3 { t3  } */", Some(("t3", "{ t3  }"))),
-            ("/** @k4 x{t4}y */", Some(("t4", "{t4}"))),
+            ("/** @k4 x{t4}y */", None),
             ("/** @k5 {t5}} */", Some(("t5", "{t5}"))),
             ("/** @k6  */", None),
             ("/** @k7 x */", None),
@@ -467,6 +467,24 @@ c7 */",
             ),
             ("/** @param {t15}a */", Some(("t15", "{t15}")), Some(("a", "a")), ("", " ")),
             ("/** @type{t16}n16*/", Some(("t16", "{t16}")), Some(("n16", "n16")), ("", "")),
+            (
+                "/** @param entries Entries in the {@link SearchableMap} */",
+                None,
+                Some(("entries", "entries")),
+                ("Entries in the {@link SearchableMap}", " Entries in the {@link SearchableMap} "),
+            ),
+            (
+                "/** @param bar - With braces {} */",
+                None,
+                Some(("bar", "bar")),
+                ("- With braces {}", " - With braces {} "),
+            ),
+            (
+                "/** @param {string} name See {@link Foo} */",
+                Some(("string", "{string}")),
+                Some(("name", "name")),
+                ("See {@link Foo}", " See {@link Foo} "),
+            ),
         ] {
             let allocator = Allocator::default();
             let semantic = build_semantic(&allocator, source_text);


### PR DESCRIPTION
## Summary

- `find_type_range()` searched for the first `{...}` pair anywhere in the tag body, so `{@link Type}` or `{}` in descriptions were incorrectly treated as type annotations, causing false "missing param description" lint errors
- Now only matches `{...}` at the start of the tag body (after whitespace), matching the JSDoc spec that type annotations must come first

Closes #18724

🤖 Generated with [Claude Code](https://claude.com/claude-code)