### PR TITLE
fix(formatter): preserve comment between callee and optional chaining operator

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/comments/calls/optional-chaining.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/calls/optional-chaining.js
@@ -1,0 +1,2 @@
+// Issue #18969 - comment between callee and optional chaining operator
+alert/* comment */?.('value')

--- a/crates/oxc_formatter/tests/fixtures/js/comments/calls/optional-chaining.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/calls/optional-chaining.js.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #18969 - comment between callee and optional chaining operator
+alert/* comment */?.('value')
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #18969 - comment between callee and optional chaining operator
+alert /* comment */?.("value");
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #18969 - comment between callee and optional chaining operator
+alert /* comment */?.("value");
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fix comment placement for `alert/* comment */?.('value')`.

Previously, the comment was incorrectly moved inside the arguments:
```
alert?.(/* comment */ "value");
```

Now it is preserved between the callee and `?.` as Prettier does:
```
alert /* comment */?.("value");
```

The issue was that `FormatNodeWithoutTrailingComments` strips trailing comments from the callee, but they were only re-added when arguments were empty. For optional calls with arguments, comments between the callee and `?.` need to be explicitly printed before the operator.

Closes #18969

## Test plan

- Added test fixture `js/comments/calls/optional-chaining.js`
- All 157 formatter tests pass
- Prettier conformance unchanged: js 746/753 (99.07%), ts 590/601 (98.17%)
- No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)