### PR TITLE
fix(linter/jsdoc): false positive in `check-tag-names` for `@` in email addresses and npm scopes

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -631,6 +631,27 @@ fn test() {
           None,
           None,
       ),
+      (
+          "
+          /**
+           * @license bcrypt.js (c) 2013 Daniel Wirtz <dcode@dcode.io>
+           * Released under the Apache License, Version 2.0
+           */
+          function quux () { }
+      ",
+          None,
+          None,
+      ),
+      (
+          "
+          /**
+           * @see Uses @vue/shared package
+           */
+          function quux () { }
+      ",
+          None,
+          None,
+      ),
     ];
 
     let fail = vec![

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -82,7 +82,12 @@ line2
     #[test]
     fn jsdoc_comment() {
         for (source_text, parsed, span_text, tag_len) in [
-            ("/** single line @k1 c1 @k2 */", "single line", " single line ", 2),
+            (
+                "/** single line @k1 c1 @k2 */",
+                "single line @k1 c1 @k2",
+                " single line @k1 c1 @k2 ",
+                0,
+            ),
             (
                 "/**
              * multi
@@ -162,9 +167,9 @@ line2
                 "
     /** ハロー @comment だよ*/
 ",
-                "ハロー",
-                " ハロー ",
-                1,
+                "ハロー @comment だよ",
+                " ハロー @comment だよ",
+                0,
             ),
         ] {
             let allocator = Allocator::default();

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -203,15 +203,6 @@ mod test {
             (
                 "
                 /**
-                 * multi
-                 * line @k1 c1
-                 */
-                ",
-                "@k1 c1\n                 ",
-            ),
-            (
-                "
-                /**
                  * @k2 c2a
                  * c2b
                  *
@@ -228,7 +219,6 @@ mod test {
                 ",
                 "@k3 c3\n                 ",
             ),
-            ("/** single line @k4 c4 */", "@k4 c4 "),
             (
                 "
                 /**
@@ -257,8 +247,6 @@ mod test {
     #[test]
     fn jsdoc_tag_kind() {
         for (source_text, tag_kind, tag_kind_span_text) in [
-            ("/** single line @k1 c1 */", "k1", "@k1"),
-            ("/** single line @k2*/", "k2", "@k2"),
             (
                 "/**
              * multi
@@ -269,16 +257,8 @@ mod test {
                 "k3",
                 "@k3",
             ),
-            (
-                "/**
-             * multi
-             * line @k4
-             */",
-                "k4",
-                "@k4",
-            ),
             (" /**@*/ ", "", "@"),
-            (" /**@@*/ ", "", "@"),
+            (" /**@@*/ ", "@", "@@"),
             (" /** @あいう え */ ", "あいう", "@あいう"),
         ] {
             let allocator = Allocator::default();
@@ -294,8 +274,6 @@ mod test {
     #[test]
     fn jsdoc_tag_comment() {
         for (source_text, parsed_comment_part) in [
-            ("/** single line @k1 c1 */", ("c1", " c1 ")),
-            ("/** single line @k2*/", ("", "")),
             (
                 "/**
              * multi
@@ -304,13 +282,6 @@ mod test {
              * c3b
              */",
                 ("c3a\nc3b", " c3a\n             * c3b\n             "),
-            ),
-            (
-                "/**
-             * multi
-             * line @k4
-             */",
-                ("", "\n             "),
             ),
             ("/**@k5 c5 w/ {@inline}!*/", ("c5 w/ {@inline}!", " c5 w/ {@inline}!")),
             (" /**@k6 */ ", ("", " ")),


### PR DESCRIPTION
## Summary
- Only recognize `@` as a JSDoc tag start when it appears at the logical start of a line (after optional whitespace and `*` markers), matching the JSDoc specification for block tags
- Fixes false positives where email addresses (e.g. `<dcode@dcode.io>`) and npm scoped packages (e.g. `@vue/shared`) in tag descriptions were incorrectly parsed as new tags

Closes #18380

🤖 Generated with [Claude Code](https://claude.com/claude-code)