### PR TITLE
fix(coverage): implement package.json lookup for moduleDetection

### DIFF
--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,12 +2,22 @@ commit: 95e3aaa9
 
 estree_typescript Summary:
 AST Parsed     : 9776/9776 (100.00%)
-Positive Passed: 9768/9776 (99.92%)
+Positive Passed: 9758/9776 (99.82%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension2.ts
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension5.ts
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/sideEffectImports2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension7.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension8.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/cjsErrors.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emitModuleCommonJS.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importDefer/importDeferComments.ts
 
@@ -18,4 +28,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/allowJs/nodeModulesAllowJsCjsFromJs.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports1.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports2.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/esmModuleExports3.ts
+
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
 


### PR DESCRIPTION
## Summary

- Implement package.json `"type"` field lookup for `moduleDetection: auto` in TypeScript conformance tests, matching TypeScript's `getPackageScopeForPath` behavior
- When `moduleDetection` is unset and `module` is `node16`..`nodenext`, default to `force` (matching TypeScript's `_computedOptions.moduleDetection`)
- Refactor stringly-typed `get_module_detection_mode` → `is_forced_module` returning `bool`

The estree_typescript snapshot regresses because the baselines in the estree-conformance submodule were generated with the same old incorrect logic. The JS port (`typescript-make-units-from-test.cjs`) needs the same fix and baselines need regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)