### PR TITLE
perf(mangler): use BitSet for exported symbols set

### DIFF
--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           3995 |           1675 ||         152600 |          28244
+checker.ts                 | 2.92 MB        ||           3990 |           1675 ||         152600 |          28244
 
-cal.com.tsx                | 1.06 MB        ||          21119 |            474 ||          37138 |           4586
+cal.com.tsx                | 1.06 MB        ||          21108 |            474 ||          37138 |           4586
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             54 |              0 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             52 |              0 ||             30 |              6
 
-pdf.mjs                    | 567.30 kB      ||           4679 |            572 ||          47462 |           7734
+pdf.mjs                    | 567.30 kB      ||           4680 |            572 ||          47462 |           7734
 
 antd.js                    | 6.69 MB        ||          10703 |           2517 ||         331644 |          69358
 
-binder.ts                  | 193.08 kB      ||            420 |            123 ||           7075 |            824
+binder.ts                  | 193.08 kB      ||            416 |            123 ||           7075 |            824
 


### PR DESCRIPTION
Similar to #19028, use BitSet for exported symbols set.