### PR TITLE
fix(semantic): skip TS2391 for standalone computed-name class methods

### DIFF
--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12029,14 +12029,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × TS(2391): Function implementation is missing or not immediately following the declaration.
-   ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/input.js:3:3]
- 2 │   method();
- 3 │   #method();
-   ·   ───────
- 4 │   declare method();
-   ╰────
-
-  × TS(2391): Function implementation is missing or not immediately following the declaration.
    ╭─[babel/packages/babel-parser/test/fixtures/estree/typescript/invalid-class-method-empty-body/input.js:4:11]
  3 │   #method();
  4 │   declare method();

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,7 +2,7 @@ commit: 95e3aaa9
 
 parser_typescript Summary:
 AST Parsed     : 9843/9843 (100.00%)
-Positive Passed: 9839/9843 (99.96%)
+Positive Passed: 9841/9843 (99.98%)
 Negative Passed: 1529/2557 (59.80%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
@@ -2073,26 +2073,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asy
      ·             ╰── It can not be redeclared here
  132 │     }
      ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
-
-  × TS(2391): Function implementation is missing or not immediately following the declaration.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts:2:5]
- 1 │ class C {
- 2 │    [e]();
-   ·     ─
- 3 │ }
-   ╰────
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
-
-  × TS(2391): Function implementation is missing or not immediately following the declaration.
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts:2:5]
- 1 │ class C {
- 2 │    [e]();
-   ·     ─
- 3 │ }
-   ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
 


### PR DESCRIPTION
## Summary

- Don't report "Function implementation is missing" (TS2391) for computed property name methods like `[e]()` that aren't part of an overload group, matching TypeScript's behavior
- TypeScript only checks TS2391 when it can resolve the method to a symbol, which isn't possible for dynamic computed names
- Computed-name overload groups like `[Symbol.iterator]` still correctly report the error

**TypeScript**: Positive passed 9839 → 9841 (+2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)