### PR TITLE
fix(oxfmt): Do not override `babel-ts` for now

### DIFF
--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt.ts
@@ -65,7 +65,6 @@ export const options: SupportOptions = {
 export const parsers: Record<string, Parser> = {
   // Override default JS/TS parsers
   babel: oxfmtParser,
-  "babel-ts": oxfmtParser,
   typescript: oxfmtParser,
 };
 


### PR DESCRIPTION
Just for sure.

There is no specific reason to do this until we override `__ts_expression`.
