### PR TITLE
refactor(semantic): use `Ident` as HashMap key instead of `&str`/`Atom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ dependencies = [
  "oxc-schemars",
  "oxc_allocator",
  "oxc_estree",
+ "rustc-hash",
  "serde",
 ]
 

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -79,7 +79,7 @@ impl Rule for NoJasmineGlobals {
             .scoping()
             .root_unresolved_references()
             .iter()
-            .filter(|(key, _)| NON_JASMINE_PROPERTY_NAMES.contains(key));
+            .filter(|(key, _)| NON_JASMINE_PROPERTY_NAMES.contains(&key.as_str()));
 
         for (name, reference_ids) in jasmine_references {
             for &reference_id in reference_ids {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -65,7 +65,7 @@ impl Rule for PreferGlobalThis {
 
         if !matches!(ident.name.as_str(), "window" | "self" | "global")
             || is_computed_member_expression_object(node, ctx)
-            || !ctx.scoping().root_unresolved_references().contains_key(&ident.name.as_str())
+            || !ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
         {
             return;
         }

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -260,7 +260,7 @@ fn collect_ids_referenced_to_global<'c>(
         .scoping()
         .root_unresolved_references()
         .iter()
-        .filter(|(name, _)| JEST_METHOD_NAMES.contains(name))
+        .filter(|(name, _)| JEST_METHOD_NAMES.contains(&name.as_str()))
         .flat_map(|(_, reference_ids)| reference_ids.iter().copied())
 }
 

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -11,7 +11,7 @@ use oxc_allocator::{Allocator, BitSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, SymbolId};
-use oxc_span::{Atom, CompactStr};
+use oxc_span::{Atom, CompactStr, Ident};
 
 pub(crate) mod base54;
 mod keep_names;
@@ -333,8 +333,8 @@ impl<'t> Mangler<'t> {
             // Scopes with direct eval: collect binding names as reserved (they can be
             // accessed by eval at runtime) and skip slot assignment (keep original names).
             if scoping.scope_flags(scope_id).contains_direct_eval() {
-                for (&name, _) in bindings {
-                    eval_reserved_names.insert(name);
+                for (name, _) in bindings {
+                    eval_reserved_names.insert(name.as_str());
                 }
                 continue;
             }
@@ -527,7 +527,7 @@ impl<'t> Mangler<'t> {
             // rename the variables
             for (symbol_to_rename, new_name) in symbols_to_rename_with_new_names {
                 for &symbol_id in &symbol_to_rename.symbol_ids {
-                    scoping.set_symbol_name(symbol_id, new_name);
+                    scoping.set_symbol_name(symbol_id, Ident::from(new_name.as_str()));
                 }
             }
         }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -16,7 +16,7 @@ use oxc_cfg::{
     IterationInstructionKind, ReturnInstructionKind,
 };
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{Atom, SourceType, Span};
+use oxc_span::{Ident, IdentHashMap, SourceType, Span};
 use oxc_syntax::{
     node::{NodeFlags, NodeId},
     reference::{Reference, ReferenceFlags, ReferenceId},
@@ -84,7 +84,7 @@ pub struct SemanticBuilder<'a> {
     pub(crate) current_function_node_id: NodeId,
     pub(crate) module_instance_state_cache: FxHashMap<Address, ModuleInstanceState>,
     current_reference_flags: ReferenceFlags,
-    pub(crate) hoisting_variables: FxHashMap<ScopeId, FxHashMap<Atom<'a>, SymbolId>>,
+    pub(crate) hoisting_variables: FxHashMap<ScopeId, IdentHashMap<'a, SymbolId>>,
 
     // builders
     pub(crate) nodes: AstNodes<'a>,
@@ -276,9 +276,8 @@ impl<'a> SemanticBuilder<'a> {
         }
 
         debug_assert_eq!(self.unresolved_references.scope_depth(), 1);
-        self.scoping.set_root_unresolved_references(
-            self.unresolved_references.into_root().into_iter().map(|(k, v)| (k.as_str(), v)),
-        );
+        self.scoping
+            .set_root_unresolved_references(self.unresolved_references.into_root().into_iter());
 
         #[cfg(feature = "linter")]
         let jsdoc = self.jsdoc.build();
@@ -401,12 +400,14 @@ impl<'a> SemanticBuilder<'a> {
     pub(crate) fn declare_symbol_on_scope(
         &mut self,
         span: Span,
-        name: &str,
+        name: Ident<'a>,
         scope_id: ScopeId,
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
-        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
+        if let Some(symbol_id) =
+            self.check_redeclaration(scope_id, span, name.as_str(), excludes, true)
+        {
             self.add_redeclare_variable(symbol_id, includes, span);
             self.scoping.union_symbol_flag(symbol_id, includes);
             return symbol_id;
@@ -423,7 +424,7 @@ impl<'a> SemanticBuilder<'a> {
     pub(crate) fn declare_symbol(
         &mut self,
         span: Span,
-        name: &str,
+        name: Ident<'a>,
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
@@ -478,7 +479,7 @@ impl<'a> SemanticBuilder<'a> {
     /// # Panics
     pub(crate) fn declare_reference(
         &mut self,
-        name: Atom<'a>,
+        name: Ident<'a>,
         reference: Reference,
     ) -> ReferenceId {
         let reference_id = self.scoping.create_reference(reference);
@@ -490,7 +491,7 @@ impl<'a> SemanticBuilder<'a> {
     /// Declares a `Symbol` for the node, shadowing previous declarations in the same scope.
     pub(crate) fn declare_shadow_symbol(
         &mut self,
-        name: &str,
+        name: Ident<'a>,
         span: Span,
         scope_id: ScopeId,
         includes: SymbolFlags,
@@ -2519,7 +2520,7 @@ impl<'a> SemanticBuilder<'a> {
     fn reference_identifier(&mut self, ident: &IdentifierReference<'a>) {
         let flags = self.resolve_reference_usages();
         let reference = Reference::new(self.current_node_id, self.current_scope_id, flags);
-        let reference_id = self.declare_reference(ident.name.into(), reference);
+        let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }
 

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -3,9 +3,9 @@ use std::{collections::hash_map::Entry, fmt, mem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use self_cell::self_cell;
 
-use oxc_allocator::{Allocator, CloneIn, FromIn, HashMap as ArenaHashMap, Vec as ArenaVec};
+use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_index::IndexVec;
-use oxc_span::{Atom, Span};
+use oxc_span::{ArenaIdentHashMap, Ident, Span};
 use oxc_syntax::{
     node::NodeId,
     reference::{Reference, ReferenceId},
@@ -13,8 +13,8 @@ use oxc_syntax::{
     symbol::{SymbolFlags, SymbolId},
 };
 
-pub type Bindings<'a> = ArenaHashMap<'a, &'a str, SymbolId>;
-pub type UnresolvedReferences<'a> = ArenaHashMap<'a, &'a str, ArenaVec<'a, ReferenceId>>;
+pub type Bindings<'a> = ArenaIdentHashMap<'a, SymbolId>;
+pub type UnresolvedReferences<'a> = ArenaIdentHashMap<'a, ArenaVec<'a, ReferenceId>>;
 
 #[derive(Clone, Debug)]
 pub struct Redeclaration {
@@ -249,7 +249,7 @@ use crate::unresolved_stack::ReferenceIds;
 
 pub struct ScopingInner<'cell> {
     /* Symbol Table Fields */
-    symbol_names: ArenaVec<'cell, Atom<'cell>>,
+    symbol_names: ArenaVec<'cell, Ident<'cell>>,
     resolved_references: ArenaVec<'cell, ArenaVec<'cell, ReferenceId>>,
     /// Redeclarations of a symbol.
     ///
@@ -282,7 +282,7 @@ impl Scoping {
     }
 
     pub fn symbol_names(&self) -> impl Iterator<Item = &str> + '_ {
-        self.cell.borrow_dependent().symbol_names.iter().map(Atom::as_str)
+        self.cell.borrow_dependent().symbol_names.iter().map(Ident::as_str)
     }
 
     pub fn resolved_references(&self) -> impl Iterator<Item = &ArenaVec<'_, ReferenceId>> + '_ {
@@ -310,16 +310,22 @@ impl Scoping {
     /// Get the identifier name a symbol is bound to.
     #[inline]
     pub fn symbol_name(&self, symbol_id: SymbolId) -> &str {
-        &self.cell.borrow_dependent().symbol_names[symbol_id.index()]
+        self.cell.borrow_dependent().symbol_names[symbol_id.index()].as_str()
+    }
+
+    /// Get the [`Ident`] for the identifier name a symbol is bound to.
+    #[inline]
+    pub fn symbol_ident(&self, symbol_id: SymbolId) -> Ident<'_> {
+        self.cell.borrow_dependent().symbol_names[symbol_id.index()]
     }
 
     /// Rename a symbol.
     ///
     /// Returns the old name.
     #[inline]
-    pub fn set_symbol_name(&mut self, symbol_id: SymbolId, name: &str) {
+    pub fn set_symbol_name(&mut self, symbol_id: SymbolId, name: Ident<'_>) {
         self.cell.with_dependent_mut(|allocator, cell| {
-            cell.symbol_names[symbol_id.index()] = Atom::from_in(name, allocator);
+            cell.symbol_names[symbol_id.index()] = name.clone_in(allocator);
         });
     }
 
@@ -381,13 +387,13 @@ impl Scoping {
     pub fn create_symbol(
         &mut self,
         span: Span,
-        name: &str,
+        name: Ident<'_>,
         flags: SymbolFlags,
         scope_id: ScopeId,
         node_id: NodeId,
     ) -> SymbolId {
         self.cell.with_dependent_mut(|allocator, cell| {
-            cell.symbol_names.push(Atom::from_in(name, allocator));
+            cell.symbol_names.push(name.clone_in(allocator));
             cell.resolved_references.push(ArenaVec::new_in(allocator));
         });
         self.symbol_spans.push(span);
@@ -616,11 +622,11 @@ impl Scoping {
 
     pub(crate) fn set_root_unresolved_references<'a>(
         &mut self,
-        entries: impl Iterator<Item = (&'a str, ReferenceIds)>,
+        entries: impl Iterator<Item = (Ident<'a>, ReferenceIds)>,
     ) {
         self.cell.with_dependent_mut(|allocator, cell| {
             for (k, v) in entries {
-                let k = allocator.alloc_str(k);
+                let k = k.clone_in(allocator);
                 let v = ArenaVec::from_iter_in(v, allocator);
                 cell.root_unresolved_references.insert(k, v);
             }
@@ -635,16 +641,12 @@ impl Scoping {
     /// # Panics
     /// Panics if there is no unresolved reference for provided `name` and `reference_id`.
     #[inline]
-    pub fn delete_root_unresolved_reference(&mut self, name: &str, reference_id: ReferenceId) {
-        // It would be better to use `Entry` API to avoid 2 hash table lookups when deleting,
-        // but `map.entry` requires an owned key to be provided. Currently we use `CompactStr`s as keys
-        // which are not cheap to construct, so this is best we can do at present.
-        // TODO: Switch to `Entry` API once we use `&str`s or `Atom`s as keys.
+    pub fn delete_root_unresolved_reference(&mut self, name: Ident<'_>, reference_id: ReferenceId) {
         self.cell.with_dependent_mut(|_allocator, cell| {
-            let reference_ids = cell.root_unresolved_references.get_mut(name).unwrap();
+            let reference_ids = cell.root_unresolved_references.get_mut(name.as_str()).unwrap();
             if reference_ids.len() == 1 {
                 assert_eq!(reference_ids[0], reference_id);
-                cell.root_unresolved_references.remove(name);
+                cell.root_unresolved_references.remove(name.as_str());
             } else {
                 let index = reference_ids.iter().position(|&id| id == reference_id).unwrap();
                 reference_ids.swap_remove(index);
@@ -690,9 +692,9 @@ impl Scoping {
         self.get_binding(self.root_scope_id(), name)
     }
 
-    pub fn add_root_unresolved_reference(&mut self, name: &str, reference_id: ReferenceId) {
+    pub fn add_root_unresolved_reference(&mut self, name: Ident<'_>, reference_id: ReferenceId) {
         self.cell.with_dependent_mut(|allocator, cell| {
-            let name = allocator.alloc_str(name);
+            let name = name.clone_in(allocator);
             cell.root_unresolved_references
                 .entry(name)
                 .or_insert_with(|| ArenaVec::new_in(allocator))
@@ -760,9 +762,14 @@ impl Scoping {
     }
 
     #[inline]
-    pub(crate) fn insert_binding(&mut self, scope_id: ScopeId, name: &str, symbol_id: SymbolId) {
+    pub(crate) fn insert_binding(
+        &mut self,
+        scope_id: ScopeId,
+        name: Ident<'_>,
+        symbol_id: SymbolId,
+    ) {
         self.cell.with_dependent_mut(|allocator, cell| {
-            let name = allocator.alloc_str(name);
+            let name = name.clone_in(allocator);
             cell.bindings[scope_id].insert(name, symbol_id);
         });
     }
@@ -786,25 +793,25 @@ impl Scoping {
     }
 
     /// Add a binding to a scope.
-    pub fn add_binding(&mut self, scope_id: ScopeId, name: &str, symbol_id: SymbolId) {
+    pub fn add_binding(&mut self, scope_id: ScopeId, name: Ident<'_>, symbol_id: SymbolId) {
         self.cell.with_dependent_mut(|allocator, cell| {
-            let name = allocator.alloc_str(name);
+            let name = name.clone_in(allocator);
             cell.bindings[scope_id].insert(name, symbol_id);
         });
     }
 
     /// Remove an existing binding from a scope.
-    pub fn remove_binding(&mut self, scope_id: ScopeId, name: &str) {
+    pub fn remove_binding(&mut self, scope_id: ScopeId, name: Ident<'_>) {
         self.cell.with_dependent_mut(|_allocator, cell| {
-            cell.bindings[scope_id].remove(name);
+            cell.bindings[scope_id].remove(name.as_str());
         });
     }
 
     /// Move a binding from one scope to another.
-    pub fn move_binding(&mut self, from: ScopeId, to: ScopeId, name: &str) {
+    pub fn move_binding(&mut self, from: ScopeId, to: ScopeId, name: Ident<'_>) {
         self.cell.with_dependent_mut(|_allocator, cell| {
             let from_map = &mut cell.bindings[from];
-            if let Some((name, symbol_id)) = from_map.remove_entry(name) {
+            if let Some((name, symbol_id)) = from_map.remove_entry(name.as_str()) {
                 cell.bindings[to].insert(name, symbol_id);
             }
         });
@@ -822,14 +829,14 @@ impl Scoping {
         &mut self,
         scope_id: ScopeId,
         symbol_id: SymbolId,
-        old_name: &str,
-        new_name: &str,
+        old_name: Ident<'_>,
+        new_name: Ident<'_>,
     ) {
         self.cell.with_dependent_mut(|allocator, cell| {
             let bindings = &mut cell.bindings[scope_id];
-            let old_symbol_id = bindings.remove(old_name);
+            let old_symbol_id = bindings.remove(old_name.as_str());
             debug_assert_eq!(old_symbol_id, Some(symbol_id));
-            let new_name = allocator.alloc_str(new_name);
+            let new_name = new_name.clone_in(allocator);
             let existing_symbol_id = bindings.insert(new_name, symbol_id);
             debug_assert!(existing_symbol_id.is_none());
         });
@@ -842,10 +849,10 @@ impl Scoping {
     /// * No binding already exists in scope for `new_name`.
     ///
     /// Panics in debug mode if either of the above are not satisfied.
-    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: Ident<'_>) {
         self.cell.with_dependent_mut(|allocator, cell| {
             // Rename symbol
-            let new_name = Atom::from_in(new_name, allocator);
+            let new_name = new_name.clone_in(allocator);
             let old_name = mem::replace(&mut cell.symbol_names[symbol_id.index()], new_name);
 
             // Rename binding, same as `Self::rename_binding`, we cannot call it directly
@@ -853,7 +860,7 @@ impl Scoping {
             let bindings = &mut cell.bindings[scope_id];
             let old_symbol_id = bindings.remove(old_name.as_str());
             debug_assert_eq!(old_symbol_id, Some(symbol_id));
-            let existing_symbol_id = bindings.insert(new_name.as_str(), symbol_id);
+            let existing_symbol_id = bindings.insert(new_name, symbol_id);
             debug_assert!(existing_symbol_id.is_none());
         });
     }

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,8 +1,7 @@
-use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use oxc_data_structures::assert_unchecked;
-use oxc_span::Atom;
+use oxc_span::IdentHashMap;
 use oxc_syntax::reference::ReferenceId;
 
 /// Stores reference IDs for a single identifier name within a scope.
@@ -10,9 +9,9 @@ use oxc_syntax::reference::ReferenceId;
 /// is referenced only a few times within a given scope.
 pub type ReferenceIds = SmallVec<[ReferenceId; 8]>;
 
-/// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Atom` as the key,
+/// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Ident` as the key,
 /// and uses a heap-allocated hashmap (not arena-allocated)
-type TempUnresolvedReferences<'a> = FxHashMap<Atom<'a>, ReferenceIds>;
+type TempUnresolvedReferences<'a> = IdentHashMap<'a, ReferenceIds>;
 
 // Stack used to accumulate unresolved refs while traversing scopes.
 // Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -10,8 +10,8 @@ mod span;
 
 pub use cmp::ContentEq;
 pub use oxc_str::{
-    Atom, CompactStr, Ident, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom,
-    format_compact_str, format_ident,
+    ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet,
+    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -24,6 +24,7 @@ oxc_allocator = { workspace = true }
 oxc_estree = { workspace = true }
 
 compact_str = { workspace = true }
+rustc-hash = { workspace = true }
 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -309,6 +309,15 @@ impl ESTree for Ident<'_> {
     }
 }
 
+/// Hash map keyed by [`Ident`].
+pub type IdentHashMap<'a, V> = rustc_hash::FxHashMap<Ident<'a>, V>;
+
+/// Arena-allocated hash map keyed by [`Ident`].
+pub type ArenaIdentHashMap<'alloc, V> = oxc_allocator::HashMap<'alloc, Ident<'alloc>, V>;
+
+/// Hash set of [`Ident`].
+pub type IdentHashSet<'a> = rustc_hash::FxHashSet<Ident<'a>>;
+
 /// Creates an [`Ident`] using interpolation of runtime expressions.
 ///
 /// Identical to [`std`'s `format!` macro](std::format), except:

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -10,7 +10,7 @@ mod ident;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
-pub use ident::Ident;
+pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet};
 
 #[doc(hidden)]
 pub mod __internal {

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -96,7 +96,7 @@ use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
@@ -879,7 +879,11 @@ impl<'a> ArrowFunctionConverter<'a> {
         let original_scope_id = ctx.scoping().symbol_scope_id(binding.symbol_id);
         if target_scope_id != original_scope_id {
             ctx.scoping_mut().set_symbol_scope_id(binding.symbol_id, target_scope_id);
-            ctx.scoping_mut().move_binding(original_scope_id, target_scope_id, &binding.name);
+            ctx.scoping_mut().move_binding(
+                original_scope_id,
+                target_scope_id,
+                Ident::from(binding.name),
+            );
         }
     }
 
@@ -1023,7 +1027,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, name.as_str());
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name));
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.
@@ -1062,7 +1066,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         if symbol_id.is_none() {
             let reference = ctx.scoping_mut().get_reference_mut(reference_id);
             reference.set_symbol_id(binding.symbol_id);
-            ctx.scoping_mut().delete_root_unresolved_reference(&ident.name, reference_id);
+            ctx.scoping_mut().delete_root_unresolved_reference(ident.name, reference_id);
             ctx.scoping_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -889,7 +889,7 @@ impl<'a> Visit<'a> for BindingMover<'a, '_> {
         let symbol_id = ident.symbol_id();
         let current_scope_id = symbols.symbol_scope_id(symbol_id);
         let scopes = self.ctx.scoping_mut();
-        scopes.move_binding(current_scope_id, self.target_scope_id, ident.name.as_str());
+        scopes.move_binding(current_scope_id, self.target_scope_id, ident.name);
         let symbols = self.ctx.scoping_mut();
         symbols.set_symbol_scope_id(symbol_id, self.target_scope_id);
     }

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -635,7 +635,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 // Move the bindings from the for init scope to scope of the loop body.
                 for ident in bound_names {
                     ctx.scoping_mut().set_symbol_scope_id(ident.symbol_id(), new_scope_id);
-                    ctx.scoping_mut().move_binding(scope_id, new_scope_id, ident.name.into());
+                    ctx.scoping_mut().move_binding(scope_id, new_scope_id, ident.name);
                 }
             }
         }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -106,7 +106,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::{
     node::NodeId,
     scope::{ScopeFlags, ScopeId},
@@ -432,7 +432,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, new_name.as_str());
+            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, Ident::from(new_name));
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -109,7 +109,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         {
             // No value reference, we will remove this declaration in `TypeScriptAnnotations`
             let scope_id = ctx.current_scope_id();
-            ctx.scoping_mut().remove_binding(scope_id, &decl.id.name);
+            ctx.scoping_mut().remove_binding(scope_id, decl.id.name);
             return None;
         }
 

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -54,7 +54,7 @@ use oxc_allocator::{Allocator, Box as ArenaBox, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::identifier::is_identifier_name;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, traverse_mut};
 
@@ -329,7 +329,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                 let mut local = specifier.unbox().local;
                 local.name = self.generate_import_binding_name(ctx).into();
                 let binding = BoundIdentifier::from_binding_ident(&local);
-                ctx.scoping_mut().set_symbol_name(binding.symbol_id, &binding.name);
+                ctx.scoping_mut().set_symbol_name(binding.symbol_id, Ident::from(binding.name));
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
                 BindingPattern::BindingIdentifier(ctx.alloc(local))
@@ -624,7 +624,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let BindingIdentifier { name, symbol_id, .. } = ident;
 
         let scopes = ctx.scoping_mut();
-        scopes.remove_binding(scopes.root_scope_id(), &name);
+        scopes.remove_binding(scopes.root_scope_id(), name);
 
         let symbol_id = symbol_id.get().unwrap();
         // Do not need to insert if there no identifiers that point to this symbol

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -4,7 +4,7 @@ use oxc_allocator::{Allocator, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -236,6 +236,7 @@ impl<'a> TraverseScoping<'a> {
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> SymbolId {
+        let name = Ident::from(name);
         let symbol_id = self.scoping.create_symbol(SPAN, name, flags, scope_id, NodeId::DUMMY);
         self.scoping.add_binding(scope_id, name, symbol_id);
 
@@ -300,7 +301,7 @@ impl<'a> TraverseScoping<'a> {
     pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
         let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
-        self.scoping.add_root_unresolved_reference(name, reference_id);
+        self.scoping.add_root_unresolved_reference(Ident::from(name), reference_id);
         reference_id
     }
 
@@ -339,7 +340,7 @@ impl<'a> TraverseScoping<'a> {
         if let Some(symbol_id) = symbol_id {
             self.scoping.delete_resolved_reference(symbol_id, reference_id);
         } else {
-            self.scoping.delete_root_unresolved_reference(name, reference_id);
+            self.scoping.delete_root_unresolved_reference(Ident::from(name), reference_id);
         }
     }
 

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -143,8 +143,8 @@ impl<'a> UidGenerator<'a> {
         for name in scoping.symbol_names() {
             generator.add(name);
         }
-        for &name in scoping.root_unresolved_references().keys() {
-            generator.add(name);
+        for name in scoping.root_unresolved_references().keys() {
+            generator.add(name.as_str());
         }
 
         generator


### PR DESCRIPTION
## Summary

- Add `IdentHashMap`, `ArenaIdentHashMap`, `IdentHashSet` type aliases in `oxc_str`
- Change `Bindings`, `UnresolvedReferences`, `symbol_names`, and `hoisting_variables` to use `Ident<'a>` keys
- Update all callsites across semantic, traverse, mangler, transformer, and linter crates

This aligns identifier-keyed HashMap keys with the AST's `Ident<'a>` type, preparing for a future optimization where `Ident` carries a precomputed hash for O(1) hash computation in HashMap lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)