### PR TITLE
ci(loongarch64):Add loongarch64 build

### DIFF
--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -100,6 +100,19 @@ jobs:
               pnpm build --target riscv64gc-unknown-linux-gnu
 
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-13-loongarch64-linux-gnu g++-13-loongarch64-linux-gnu -y
+              export TARGET_CC=loongarch64-linux-gnu-gcc-13
+              export CXX=loongarch64-linux-gnu-g++-13
+              pnpm build --target loongarch64-unknown-linux-gnu
+
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            build: pnpm build --target loongarch64-unknown-linux-musl -x
+
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-ohos
             build: pnpm build --target aarch64-unknown-linux-ohos
 
@@ -142,7 +155,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build
         working-directory: napi/${{ inputs.name }}

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -66,6 +66,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -106,6 +106,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -67,6 +67,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",


### PR DESCRIPTION
Loongarch64 is a new architecture that can be successfully built in napi dir using ubuntu: latest and zig 0.14.0