### PR TITLE
feat(ci): add riscv64 and s390x napi targets for oxlint and oxfmt

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -104,6 +104,23 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             build: pnpm run build-napi-release --target powerpc64le-unknown-linux-gnu --use-napi-cross
 
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y
+              export TARGET_CC=riscv64-linux-gnu-gcc
+              export CXX=riscv64-linux-gnu-g++
+              pnpm run build-napi-release --target riscv64gc-unknown-linux-gnu
+
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-musl
+            build: pnpm run build-napi-release --target riscv64gc-unknown-linux-musl -x
+
+          - os: ubuntu-latest
+            target: s390x-unknown-linux-gnu
+            build: export CFLAGS="-fuse-ld=lld" && pnpm run build-napi-release --target s390x-unknown-linux-gnu --use-napi-cross
+
     name: Build Oxlint ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
@@ -141,8 +158,14 @@ jobs:
         run: ${{ matrix.build }}
 
       - name: Build Rust binary
-        if: ${{ !contains(matrix.target, 'wasm') && !contains(matrix.target, 'android') && !contains(matrix.target, 'ohos') }}
+        if: ${{ !contains(matrix.target, 'wasm') && !contains(matrix.target, 'android') && !contains(matrix.target, 'ohos') && !contains(matrix.target, 'riscv64gc-unknown-linux-musl') }}
         run: cross build --release -p oxlint --features allocator --target=${{ matrix.target }}
+
+      - name: Build Rust binary (zigbuild)
+        if: ${{ contains(matrix.target, 'riscv64gc-unknown-linux-musl') }}
+        run: |
+          pip3 install cargo-zigbuild
+          cargo zigbuild --release -p oxlint --features allocator --target=${{ matrix.target }}
 
       - name: Upload NAPI artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -357,6 +380,23 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             build: pnpm run build-napi-release --target powerpc64le-unknown-linux-gnu --use-napi-cross
 
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y
+              export TARGET_CC=riscv64-linux-gnu-gcc
+              export CXX=riscv64-linux-gnu-g++
+              pnpm run build-napi-release --target riscv64gc-unknown-linux-gnu
+
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-musl
+            build: pnpm run build-napi-release --target riscv64gc-unknown-linux-musl -x
+
+          - os: ubuntu-latest
+            target: s390x-unknown-linux-gnu
+            build: export CFLAGS="-fuse-ld=lld" && pnpm run build-napi-release --target s390x-unknown-linux-gnu --use-napi-cross
+
     name: Build Oxfmt ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
@@ -394,8 +434,14 @@ jobs:
         run: ${{ matrix.build }}
 
       - name: Build Rust binary
-        if: ${{ !contains(matrix.target, 'wasm') && !contains(matrix.target, 'android') && !contains(matrix.target, 'ohos') }}
+        if: ${{ !contains(matrix.target, 'wasm') && !contains(matrix.target, 'android') && !contains(matrix.target, 'ohos') && !contains(matrix.target, 'riscv64gc-unknown-linux-musl') }}
         run: cross build --release -p oxfmt --no-default-features --features allocator --target=${{ matrix.target }}
+
+      - name: Build Rust binary (zigbuild)
+        if: ${{ contains(matrix.target, 'riscv64gc-unknown-linux-musl') }}
+        run: |
+          pip3 install cargo-zigbuild
+          cargo zigbuild --release -p oxfmt --no-default-features --features allocator --target=${{ matrix.target }}
 
       - name: Upload NAPI artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -66,10 +66,10 @@ napi-build = { workspace = true }
 
 [dev-dependencies]
 
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_arch = "riscv64", target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
 
-[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64"), not(target_arch = "riscv64")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -13,7 +13,13 @@ pub use main_napi::*;
 
 #[cfg(all(
     feature = "allocator",
-    not(any(target_arch = "arm", miri, target_os = "freebsd", target_family = "wasm"))
+    not(any(
+        target_arch = "arm",
+        target_arch = "riscv64",
+        miri,
+        target_os = "freebsd",
+        target_family = "wasm"
+    ))
 ))]
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -54,10 +54,10 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
 tower-lsp-server = { workspace = true, features = ["proposed"] }
 
-[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_family = "wasm")))'.dependencies]
+[target.'cfg(not(any(target_os = "linux", target_os = "freebsd", target_arch = "arm", target_arch = "riscv64", target_family = "wasm")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = ["skip_collect_on_exit"] }
 
-[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(target_arch = "arm"), not(target_arch = "aarch64"), not(target_arch = "riscv64")))'.dependencies]
 mimalloc-safe = { workspace = true, optional = true, features = [
   "skip_collect_on_exit",
   "local_dynamic_tls",

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -45,7 +45,13 @@ mod js_plugins;
 // `--features allocator` is only used in release builds.
 #[cfg(all(
     feature = "allocator",
-    not(any(target_arch = "arm", miri, target_os = "freebsd", target_family = "wasm"))
+    not(any(
+        target_arch = "arm",
+        target_arch = "riscv64",
+        miri,
+        target_os = "freebsd",
+        target_family = "wasm"
+    ))
 ))]
 #[global_allocator]
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;


### PR DESCRIPTION
## Summary

- Add missing napi targets for oxlint and oxfmt to match the napi packages (parser, transform, minify):
  - `riscv64gc-unknown-linux-gnu`
  - `riscv64gc-unknown-linux-musl`
  - `s390x-unknown-linux-gnu`
- Add corresponding CI build matrix entries in `release_apps.yml`
- Add `Cross.toml` pre-build commands to install `cmake` in Docker containers for riscv64 targets (required by `mimalloc`)
- Install `gcc-riscv64-linux-gnu` for riscv64-musl zigbuild so `cmake` can find C/C++ compilers on the host