### PR TITLE
fix(coverage): ignore asyncWithVarShadowing_es6.ts in TypeScript conformance

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 95e3aaa9
 
 codegen_typescript Summary:
-AST Parsed     : 9843/9843 (100.00%)
-Positive Passed: 9843/9843 (100.00%)
+AST Parsed     : 9842/9842 (100.00%)
+Positive Passed: 9842/9842 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 estree_typescript Summary:
-AST Parsed     : 9776/9776 (100.00%)
-Positive Passed: 9758/9776 (99.82%)
+AST Parsed     : 9775/9775 (100.00%)
+Positive Passed: 9757/9775 (99.82%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 formatter_typescript Summary:
-AST Parsed     : 9843/9843 (100.00%)
-Positive Passed: 9791/9843 (99.47%)
+AST Parsed     : 9842/9842 (100.00%)
+Positive Passed: 9790/9842 (99.47%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 parser_typescript Summary:
-AST Parsed     : 9843/9843 (100.00%)
-Positive Passed: 9841/9843 (99.98%)
+AST Parsed     : 9842/9842 (100.00%)
+Positive Passed: 9841/9842 (99.99%)
 Negative Passed: 1529/2557 (59.80%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
@@ -2059,20 +2059,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
-
-  × Identifier `x` has already been declared
-     ╭─[typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts:130:14]
- 129 │     }
- 130 │     catch ({ x }) {
-     ·              ┬
-     ·              ╰── `x` has already been declared here
- 131 │         var x;
-     ·             ┬
-     ·             ╰── It can not be redeclared here
- 132 │     }
-     ╰────
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 semantic_typescript Summary:
-AST Parsed     : 5484/5484 (100.00%)
-Positive Passed: 2951/5484 (53.81%)
+AST Parsed     : 5483/5483 (100.00%)
+Positive Passed: 2951/5483 (53.82%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -21645,9 +21645,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Promise", "arguments", "require"]
 rebuilt        : ["a", "arguments", "p", "require"]
-
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
-Identifier `x` has already been declared
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
 Bindings mismatch:

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 transformer_typescript Summary:
-AST Parsed     : 9843/9843 (100.00%)
-Positive Passed: 9821/9843 (99.78%)
+AST Parsed     : 9842/9842 (100.00%)
+Positive Passed: 9820/9842 (99.78%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -95,6 +95,9 @@ pub static NOT_SUPPORTED_TEST_PATHS: phf::Set<&'static str> = phf::phf_set![
     // TSC: This is just a binary file, but their test project skips reading
     // OXC: Try to parse, and fail
     "TransportStream.ts",
+    // TSC: Allows `catch({x}) { var x; }` (destructured catch param + var redeclaration)
+    // OXC: Reports redeclaration error per Annex B §B.3.4 (only simple identifiers are exempt)
+    "asyncWithVarShadowing_es6.ts",
 ];
 // spellchecker:on
 


### PR DESCRIPTION
## Summary
- Exclude `asyncWithVarShadowing_es6.ts` from TypeScript conformance tests
- TSC allows `catch({x}) { var x; }` (destructured catch param + var redeclaration), but per Annex B §B.3.4 only simple identifier catch params are exempt from the redeclaration error
- OXC correctly follows the spec, so this is a known behavioral difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)