### PR TITLE
fix(semantic): report redeclaration error for `function a() {} var a` in module mode

### DIFF
--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -444,3 +444,11 @@ fn test_redeclaration() {
         .has_number_of_references(0) // no references to the function
         .test();
 }
+
+// https://github.com/oxc-project/oxc/issues/18719
+#[test]
+fn test_function_var_redeclaration_in_module() {
+    // Both orderings should produce a redeclaration error in module mode
+    SemanticTester::js("function a() {} var a = ''").has_error("already been declared");
+    SemanticTester::js("var a = ''; function a() {}").has_error("already been declared");
+}


### PR DESCRIPTION
## Summary

Fixes #18719.

- In module mode, function declarations are lexically scoped (part of `LexicallyDeclaredNames`), so `function a() {} var a = ''` is a redeclaration error per the ECMAScript spec
- The checker was only reporting the error when the `var` appeared **before** the function (`var a = ''; function a() {}`) but not the other way around, due to AST visit ordering
- `check_variable_declarator_redeclaration` unconditionally skipped the check at `Top | Function` scopes — now it falls through to the redeclaration check when in module mode at the top scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)