### PR TITLE
fix(oxfmt): Temporarily disable the override for js-in-xxx (not ready yet)

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -866,8 +866,8 @@ static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
 static OXFMT_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     // "html",
     // "vue",
-    "markdown",
-    "mdx",
+    // "markdown",
+    // "mdx",
 };
 
 /// Finalizes external options by adding plugin-specific flags based on the formatting strategy.

--- a/apps/oxfmt/test/api/js-in-markdown.test.ts
+++ b/apps/oxfmt/test/api/js-in-markdown.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
-describe("Format js-in-markdown with prettier-plugin-oxfmt", () => {
+// oxlint-disable jest/no-disabled-tests
+describe.skip("Format js-in-markdown with prettier-plugin-oxfmt", () => {
   it("should format .md w/o duplicating TS lines", async () => {
     // https://prettier.io/playground/#N4Igxg9gdgLgprEAuEADdMDOAdKBDAdzwEsYACABQCcIBbYzOAOirkwgBsA3OACjLLYQXPBwCucIQICUAblyES5YLgEwAFgl7SyKqAIC+AGlwH5UAPQWyAFXUMykWrQTk8UACZkARnA4QCMgJiDg4fODIPMQAHDmIwPHgPBSJSMgBzOBhqOgY+aVx0VBAjEAhomGJoTGRQPCoaAgp6hBqUUSIATxrS7yo8MABrLIBlPBcAGWIoOGQAM1FGUohvACs4MBgAdX7o5BBo1kYqHhKQPoHhmBHogen05BgqCVLGekfnuFK4AA9ouCoxBcsFEAHl-v0YBAqBQIJhSFUoPsEB4zr8IUDXKIbAD8IC2PNFl8QPCoOkOHAAIpiCDwQkcJYgVaYH4je4U6m02ZIBYM4kARxp8By0TaIDwmAAtDM4B5ZWcniQ4mSAMJ0Wh4faiDhnUnkuAAQRgT2I3jEwoBUxm9MZ6hgtA4W3s8EwtzAcBGrQRXFInX2YEwPWEEgAkp5XCMwICKgbPCMYJ0KTbiYc4XAdng9ihDmwAadvp5QXMrdyQBw5mdpsdsv10hrk6VblRjvsNVRBh4AkjG4DYFtiB4NMgABwABlKrEFxFY1Dwdc1PKJpRgeG8-cH6mQACZSmJGDZV21eYy4LRfB45R4Ju50mI53AAGLQjXG+5a80QEAGAxAA
     const input = `

--- a/apps/oxfmt/test/api/js-in-mdx.test.ts
+++ b/apps/oxfmt/test/api/js-in-mdx.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
-describe("Format js-in-mdx with prettier-plugin-oxfmt", () => {
+// oxlint-disable jest/no-disabled-tests
+describe.skip("Format js-in-mdx with prettier-plugin-oxfmt", () => {
   it("should format code block in .mdx", async () => {
     const input = `
 # MDX


### PR DESCRIPTION
Unfortunately...

Once override a built-in for `markdown`, it applies to all embedded formatting within that file!

This means that overrides occur with js-in-**vue**-in-markdown, and since we haven't addressed this yet, the code breaks.

````md
# MD

```vue
<!-- VUE -->
<script>
  // JS
</script>

<template>
  <li v-for="function _(IT_BREAKS_HERE 💥) {} in items"></li>
</template>
````