### PR TITLE
fix(coverage): ignore usingDeclarations.14.ts in TypeScript conformance

### DIFF
--- a/tasks/coverage/snapshots/codegen_typescript.snap
+++ b/tasks/coverage/snapshots/codegen_typescript.snap
@@ -1,5 +1,5 @@
 commit: 95e3aaa9
 
 codegen_typescript Summary:
-AST Parsed     : 9842/9842 (100.00%)
-Positive Passed: 9842/9842 (100.00%)
+AST Parsed     : 9841/9841 (100.00%)
+Positive Passed: 9841/9841 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 estree_typescript Summary:
-AST Parsed     : 9775/9775 (100.00%)
-Positive Passed: 9757/9775 (99.82%)
+AST Parsed     : 9774/9774 (100.00%)
+Positive Passed: 9756/9774 (99.82%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDetectionIsolatedModulesCjsFileScope.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts

--- a/tasks/coverage/snapshots/formatter_typescript.snap
+++ b/tasks/coverage/snapshots/formatter_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 formatter_typescript Summary:
-AST Parsed     : 9842/9842 (100.00%)
-Positive Passed: 9790/9842 (99.47%)
+AST Parsed     : 9841/9841 (100.00%)
+Positive Passed: 9789/9841 (99.47%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdLikeInputDeclarationEmit.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 parser_typescript Summary:
-AST Parsed     : 9842/9842 (100.00%)
-Positive Passed: 9841/9842 (99.99%)
+AST Parsed     : 9841/9841 (100.00%)
+Positive Passed: 9841/9841 (100.00%)
 Negative Passed: 1529/2557 (59.80%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
@@ -2059,15 +2059,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uni
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
-
-  × 'using' declarations are not allowed at the top level of a script
-   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts:1:1]
- 1 │ using x = {};
-   · ─────────────
-   ╰────
-  help: Wrap this code in a block or use a module
 
 
   × TS(1090): 'public' modifier cannot appear on a parameter.

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -1,8 +1,8 @@
 commit: 95e3aaa9
 
 transformer_typescript Summary:
-AST Parsed     : 9842/9842 (100.00%)
-Positive Passed: 9820/9842 (99.78%)
+AST Parsed     : 9841/9841 (100.00%)
+Positive Passed: 9819/9841 (99.78%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -98,6 +98,9 @@ pub static NOT_SUPPORTED_TEST_PATHS: phf::Set<&'static str> = phf::phf_set![
     // TSC: Allows `catch({x}) { var x; }` (destructured catch param + var redeclaration)
     // OXC: Reports redeclaration error per Annex B §B.3.4 (only simple identifiers are exempt)
     "asyncWithVarShadowing_es6.ts",
+    // TSC: Allows top-level `using` in scripts (no import/export)
+    // OXC: Rejects per TC39 spec — `using` is not allowed at the top level of scripts
+    "usingDeclarations.14.ts",
 ];
 // spellchecker:on
 


### PR DESCRIPTION
## Summary

- Ignore `usingDeclarations.14.ts` in TypeScript conformance tests
- TypeScript allows top-level `using` in scripts (no import/export), but oxc rejects it per TC39 spec — `using` is not allowed at the top level of scripts
- This brings parser_typescript conformance to 100.00%

🤖 Generated with [Claude Code](https://claude.com/claude-code)