### PR TITLE
fix(coverage): remove TransportStream.ts from ignored TypeScript tests

### DIFF
--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 95e3aaa9
 parser_typescript Summary:
 AST Parsed     : 9842/9842 (100.00%)
 Positive Passed: 9841/9842 (99.99%)
-Negative Passed: 1529/2557 (59.80%)
+Negative Passed: 1530/2558 (59.81%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -2320,6 +2320,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/Va
    ·              ─────────────
  5 │ }
    ╰────
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/compiler/TransportStream.ts:1:2]
+ 1 │ G@�G@�G@�
+   ·  ▲
+   ╰────
+  help: Try inserting a semicolon here
 
   × Getters and setters must have an implementation.
     ╭─[typescript/tests/cases/compiler/abstractPropertyNegative.ts:16:9]

--- a/tasks/coverage/src/typescript/constants.rs
+++ b/tasks/coverage/src/typescript/constants.rs
@@ -92,9 +92,6 @@ pub static NOT_SUPPORTED_TEST_PATHS: phf::Set<&'static str> = phf::phf_set![
     // TSC: Parse without error, they support BOM
     // OXC: We do not ignore or exclude BOM, will be invalid character error
     "bom-utf16be.ts",
-    // TSC: This is just a binary file, but their test project skips reading
-    // OXC: Try to parse, and fail
-    "TransportStream.ts",
     // TSC: Allows `catch({x}) { var x; }` (destructured catch param + var redeclaration)
     // OXC: Reports redeclaration error per Annex B §B.3.4 (only simple identifiers are exempt)
     "asyncWithVarShadowing_es6.ts",


### PR DESCRIPTION
## Summary

- Remove `TransportStream.ts` from `NOT_SUPPORTED_TEST_PATHS`
- TypeScript now detects binary files and reports TS1490 (since microsoft/TypeScript#57008), so this file is no longer skipped by TSC
- oxc correctly produces parse errors on this binary file, counting as a negative pass (1530/2558)

🤖 Generated with [Claude Code](https://claude.com/claude-code)