### PR TITLE
refactor(str): replace Borrow<str> on Ident with hashbrown Equivalent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,7 @@ name = "oxc_str"
 version = "0.112.0"
 dependencies = [
  "compact_str",
+ "hashbrown 0.16.1",
  "oxc-schemars",
  "oxc_allocator",
  "oxc_estree",

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -13,7 +13,7 @@ use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{Atom, GetSpan, SPAN, SourceType};
+use oxc_span::{Atom, GetSpan, IdentHashSet, SPAN, SourceType};
 
 use crate::{diagnostics::function_with_assigning_properties, scope::ScopeTree};
 
@@ -575,7 +575,7 @@ impl<'a> IsolatedDeclarations<'a> {
         let assignable_properties_for_namespace =
             IsolatedDeclarations::get_assignable_properties_for_namespaces(stmts);
 
-        let mut can_expando_function_names = FxHashSet::default();
+        let mut can_expando_function_names = IdentHashSet::default();
         for stmt in stmts {
             match stmt {
                 Statement::ExportNamedDeclaration(decl) => match decl.declaration.as_ref() {

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -24,6 +24,7 @@ oxc_allocator = { workspace = true }
 oxc_estree = { workspace = true }
 
 compact_str = { workspace = true }
+hashbrown = { workspace = true }
 rustc-hash = { workspace = true }
 
 schemars = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

- Remove `Borrow<str>` impl from `Ident` — preparation for interning `Ident` with precomputed hash, where `Borrow<str>` is incompatible with `PassthroughBuildHasher` (introduced in #19046)
- Add `Equivalent<Ident<'_>> for str` so `&str` lookups still work on hashbrown maps via `.get(name.as_str())`
- Switch `IdentHashMap` / `IdentHashSet` type aliases from std (`FxHashMap` / `FxHashSet`) to hashbrown for consistent `Equivalent` support
- Use `IdentHashSet` in `oxc_isolated_declarations` instead of `FxHashSet`

Part of the Ident interning plan (Phase 0c). Follows #19046 (Phase 0a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)