### PR TITLE
test(oxfmt): remove unnecessary timeout from Tailwind CSS test

### DIFF
--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -2,26 +2,20 @@ import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
 describe("Tailwind CSS Sorting", () => {
-  // First test triggers Tailwind CSS initialization which is slow on Windows CI
-  // https://github.com/oxc-project/oxc/issues/18072
-  it(
-    "should sort Tailwind classes when experimentalTailwindcss is enabled",
-    { timeout: 30_000 },
-    async () => {
-      // Unsorted: p-4 comes before flex
-      const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
+  it("should sort Tailwind classes when experimentalTailwindcss is enabled", async () => {
+    // Unsorted: p-4 comes before flex
+    const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;
 
-      const result = await format("test.tsx", input, {
-        experimentalTailwindcss: {},
-      });
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {},
+    });
 
-      // After sorting, flex should come before p-4 (display before spacing)
-      // The exact order of bg-red-500 and text-white may vary by Tailwind version
-      expect(result.code).toContain('className="flex');
-      expect(result.code).not.toContain('className="p-4 flex'); // p-4 should not be before flex
-      expect(result.errors).toStrictEqual([]);
-    },
-  );
+    // After sorting, flex should come before p-4 (display before spacing)
+    // The exact order of bg-red-500 and text-white may vary by Tailwind version
+    expect(result.code).toContain('className="flex');
+    expect(result.code).not.toContain('className="p-4 flex'); // p-4 should not be before flex
+    expect(result.errors).toStrictEqual([]);
+  });
 
   it("should NOT sort Tailwind classes when experimentalTailwindcss is disabled (default)", async () => {
     const input = `const A = <div className="p-4 flex bg-red-500 text-white">Hello</div>;`;


### PR DESCRIPTION
## Summary
- Remove the 30s timeout and associated comment from the first Tailwind CSS sorting test, added in #18339

🤖 Generated with [Claude Code](https://claude.com/claude-code)