### PR TITLE
fix(linter/plugins): fix error messages for invalid suggestions

### DIFF
--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -7,11 +7,11 @@
   | File path: <fixture>/files/range_end_negative.js
   | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
 
-  x Plugin `suggestions-plugin/suggestions` returned invalid fixes.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_out_of_bounds.js
   | Invalid range: 7..7
 
-  x Plugin `suggestions-plugin/suggestions` returned invalid fixes.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_out_of_bounds.js
   | Invalid range: 7..7
 
@@ -19,11 +19,11 @@
   | File path: <fixture>/files/range_end_too_large.js
   | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
 
-  x Plugin `suggestions-plugin/suggestions` returned invalid fixes.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_after_end.js
   | Negative range is invalid: Span { start: 3, end: 2 }
 
-  x Plugin `suggestions-plugin/suggestions` returned invalid fixes.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_after_end.js
   | Negative range is invalid: Span { start: 3, end: 2 }
 

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -9,7 +9,7 @@ use oxc_span::Span;
 use crate::{
     config::{OxlintEnv, OxlintGlobals},
     context::ContextHost,
-    fixer::{CompositeFix, Fix, FixKind, MergeFixesError},
+    fixer::{CompositeFix, Fix, MergeFixesError},
 };
 
 pub type ExternalLinterCreateWorkspaceCb =
@@ -111,7 +111,7 @@ pub fn convert_and_merge_js_fixes(
     let mut fixes = fixes.into_iter().map(|fix| {
         let mut span = Span::new(fix.range[0], fix.range[1]);
         span_converter.convert_span_back(&mut span);
-        Fix::new(fix.text, span).with_kind(FixKind::Fix)
+        Fix::new(fix.text, span)
     });
 
     if is_single {


### PR DESCRIPTION
Fix the error message when a rule provides invalid suggestions.

```diff
- Plugin `whatever` returned invalid fixes.
+ Plugin `whatever` returned invalid suggestions.
```
