### PR TITLE
feat(formatter/sort_imports)!: Replace prefix match with glob pattern in `customGroups.elementNamePattern`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ name = "oxc_formatter"
 version = "0.28.0"
 dependencies = [
  "cow-utils",
+ "fast-glob",
  "insta",
  "natord",
  "nodejs-built-in-modules",

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -688,7 +688,7 @@ impl SortGroupItemConfig {
 pub struct CustomGroupItemConfig {
     /// Name of the custom group, used in the `groups` option.
     pub group_name: String,
-    /// List of import name prefixes to match for this group.
+    /// List of glob patterns to match import sources for this group.
     pub element_name_pattern: Vec<String>,
 }
 

--- a/apps/oxfmt/test/api/sort_imports.test.ts
+++ b/apps/oxfmt/test/api/sort_imports.test.ts
@@ -11,8 +11,8 @@ import { store } from "~/stores/store";
       experimentalSortImports: {
         newlinesBetween: false,
         customGroups: [
-          { elementNamePattern: ["~/stores/"], groupName: "stores" },
-          { elementNamePattern: ["~/utils/"], groupName: "utils" },
+          { elementNamePattern: ["~/stores/*"], groupName: "stores" },
+          { elementNamePattern: ["~/utils/*"], groupName: "utils" },
         ],
         groups: ["stores", "utils", "sibling"],
       },

--- a/apps/oxfmt/test/cli/sort_imports/fixtures/custom_groups/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/sort_imports/fixtures/custom_groups/.oxfmtrc.json
@@ -1,8 +1,8 @@
 {
     "experimentalSortImports": {
         "customGroups": [
-            { "elementNamePattern": ["~/stores/"], "groupName": "stores" },
-            { "elementNamePattern": ["~/utils/"], "groupName": "utils" }
+            { "elementNamePattern": ["~/stores/*"], "groupName": "stores" },
+            { "elementNamePattern": ["~/utils/*"], "groupName": "utils" }
         ],
         "groups": ["stores", "utils", "sibling"]
     }

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -29,6 +29,7 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 cow-utils = { workspace = true }
+fast-glob = { workspace = true }
 natord = { workspace = true }
 nodejs-built-in-modules = { workspace = true }
 phf = { workspace = true, features = ["macros"] }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/group_matcher.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/group_matcher.rs
@@ -65,7 +65,7 @@ impl GroupMatcher {
             let is_match = custom_group
                 .element_name_pattern
                 .iter()
-                .any(|pattern| import_metadata.source.starts_with(pattern));
+                .any(|pattern| fast_glob::glob_match(pattern, import_metadata.source));
             if is_match {
                 return *index;
             }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -97,7 +97,9 @@ impl fmt::Display for SortOrder {
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct CustomGroupDefinition {
+    /// The identifier used in `groups` representing this group.
     pub group_name: String,
+    /// List of glob patterns to match import sources for this group.
     pub element_name_pattern: Vec<String>,
 }
 

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
@@ -81,47 +81,47 @@ import CartComponentB from "./cart/CartComponentB.vue";
     "experimentalSortImports": {
         "customGroups": [
             {
-                "elementNamePattern": ["~/validators/"],
+                "elementNamePattern": ["~/validators/*"],
                 "groupName": "validators"
             },
             {
-                "elementNamePattern": ["~/composable/"],
+                "elementNamePattern": ["~/composable/*"],
                 "groupName": "composable"
             },
             {
-                "elementNamePattern": ["~/components/"],
+                "elementNamePattern": ["~/components/*"],
                 "groupName": "components"
             },
             {
-                "elementNamePattern": ["~/services/"],
+                "elementNamePattern": ["~/services/*"],
                 "groupName": "services"
             },
             {
-                "elementNamePattern": ["~/widgets/"],
+                "elementNamePattern": ["~/widgets/*"],
                 "groupName": "widgets"
             },
             {
-                "elementNamePattern": ["~/stores/"],
+                "elementNamePattern": ["~/stores/*"],
                 "groupName": "stores"
             },
             {
-                "elementNamePattern": ["~/logics/"],
+                "elementNamePattern": ["~/logics/*"],
                 "groupName": "logics"
             },
             {
-                "elementNamePattern": ["~/assets/"],
+                "elementNamePattern": ["~/assets/*"],
                 "groupName": "assets"
             },
             {
-                "elementNamePattern": ["~/utils/"],
+                "elementNamePattern": ["~/utils/*"],
                 "groupName": "utils"
             },
             {
-                "elementNamePattern": ["~/pages/"],
+                "elementNamePattern": ["~/pages/*"],
                 "groupName": "pages"
             },
             {
-                "elementNamePattern": ["~/ui/"],
+                "elementNamePattern": ["~/ui/*"],
                 "groupName": "ui"
             }
         ],
@@ -196,47 +196,47 @@ import ComponentC from "~/components/ComponentC.vue";
     "experimentalSortImports": {
         "customGroups": [
             {
-                "elementNamePattern": ["~/validators/"],
+                "elementNamePattern": ["~/validators/*"],
                 "groupName": "validators"
             },
             {
-                "elementNamePattern": ["~/composable/"],
+                "elementNamePattern": ["~/composable/*"],
                 "groupName": "composable"
             },
             {
-                "elementNamePattern": ["~/components/"],
+                "elementNamePattern": ["~/components/*"],
                 "groupName": "components"
             },
             {
-                "elementNamePattern": ["~/services/"],
+                "elementNamePattern": ["~/services/*"],
                 "groupName": "services"
             },
             {
-                "elementNamePattern": ["~/widgets/"],
+                "elementNamePattern": ["~/widgets/*"],
                 "groupName": "widgets"
             },
             {
-                "elementNamePattern": ["~/stores/"],
+                "elementNamePattern": ["~/stores/*"],
                 "groupName": "stores"
             },
             {
-                "elementNamePattern": ["~/logics/"],
+                "elementNamePattern": ["~/logics/*"],
                 "groupName": "logics"
             },
             {
-                "elementNamePattern": ["~/assets/"],
+                "elementNamePattern": ["~/assets/*"],
                 "groupName": "assets"
             },
             {
-                "elementNamePattern": ["~/utils/"],
+                "elementNamePattern": ["~/utils/*"],
                 "groupName": "utils"
             },
             {
-                "elementNamePattern": ["~/pages/"],
+                "elementNamePattern": ["~/pages/*"],
                 "groupName": "pages"
             },
             {
-                "elementNamePattern": ["~/ui/"],
+                "elementNamePattern": ["~/ui/*"],
                 "groupName": "ui"
             }
         ],
@@ -283,6 +283,101 @@ import ComponentC from "~/components/ComponentC.vue";
 
 import CartComponentA from "./cart/CartComponentA.vue";
 import CartComponentB from "./cart/CartComponentB.vue";
+"#,
+    );
+}
+
+#[test]
+fn glob_pattern_suffix_matching() {
+    assert_format(
+        r#"
+import { setup } from "./setup.mock.ts";
+import { a } from "./a.ts";
+"#,
+        r#"
+{
+    "experimentalSortImports": {
+        "customGroups": [
+            {
+                "groupName": "mocks",
+                "elementNamePattern": ["**/*.mock.ts"]
+            }
+        ],
+        "groups": [
+            "mocks",
+            "unknown"
+        ]
+    }
+}
+"#,
+        r#"
+import { setup } from "./setup.mock.ts";
+
+import { a } from "./a.ts";
+"#,
+    );
+}
+
+#[test]
+fn glob_pattern_brace_expansion() {
+    assert_format(
+        r#"
+import { createApp } from "vue";
+import React from "react";
+import Vuetify from "vuetify";
+"#,
+        r#"
+{
+    "experimentalSortImports": {
+        "customGroups": [
+            {
+                "groupName": "frameworks",
+                "elementNamePattern": ["{react,vue}"]
+            }
+        ],
+        "groups": [
+            "frameworks",
+            "unknown"
+        ]
+    }
+}
+"#,
+        r#"
+import React from "react";
+import { createApp } from "vue";
+
+import Vuetify from "vuetify";
+"#,
+    );
+}
+
+#[test]
+fn glob_pattern_exact_match() {
+    assert_format(
+        r#"
+import { createApp } from "vue";
+import Vuetify from "vuetify";
+"#,
+        r#"
+{
+    "experimentalSortImports": {
+        "customGroups": [
+            {
+                "groupName": "vue-core",
+                "elementNamePattern": ["vue"]
+            }
+        ],
+        "groups": [
+            "vue-core",
+            "unknown"
+        ]
+    }
+}
+"#,
+        r#"
+import { createApp } from "vue";
+
+import Vuetify from "vuetify";
 "#,
     );
 }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -265,13 +265,13 @@
       "type": "object",
       "properties": {
         "elementNamePattern": {
-          "description": "List of import name prefixes to match for this group.",
+          "description": "List of glob patterns to match import sources for this group.",
           "default": [],
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of import name prefixes to match for this group."
+          "markdownDescription": "List of glob patterns to match import sources for this group."
         },
         "groupName": {
           "description": "Name of the custom group, used in the `groups` option.",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -269,13 +269,13 @@ expression: json
       "type": "object",
       "properties": {
         "elementNamePattern": {
-          "description": "List of import name prefixes to match for this group.",
+          "description": "List of glob patterns to match import sources for this group.",
           "default": [],
           "type": "array",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "List of import name prefixes to match for this group."
+          "markdownDescription": "List of glob patterns to match import sources for this group."
         },
         "groupName": {
           "description": "Name of the custom group, used in the `groups` option.",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -111,7 +111,7 @@ type: `string[]`
 
 default: `[]`
 
-List of import name prefixes to match for this group.
+List of glob patterns to match import sources for this group.
 
 
 ##### experimentalSortImports.customGroups[n].groupName
@@ -599,7 +599,7 @@ type: `string[]`
 
 default: `[]`
 
-List of import name prefixes to match for this group.
+List of glob patterns to match import sources for this group.
 
 
 ######## overrides[n].options.experimentalSortImports.customGroups[n].groupName


### PR DESCRIPTION
Fixes #18726

Support glob matching instead of prefix matching.

The original (eslint-plugin-perfectionist) used regex, but there was no necessity for it, and this approach offers better performance.

In any case, it will be a braking change.

```js
// before: Matches react, reactify, react-router, etc
"elementNamePattern": ["react"]
// after: Matches react only

// before: Matches loot-core, loot-core/foo, etc
"elementNamePattern": ["loot-core"]
// after: Matches only loot-core, should update to match under loot-core/*
// "elementNamePattern": ["loot-core/**"]
```