### PR TITLE
refactor(traverse): store Ident instead of Atom in BoundIdentifier/MaybeBoundIdentifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_semantic",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
 ]

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -879,11 +879,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         let original_scope_id = ctx.scoping().symbol_scope_id(binding.symbol_id);
         if target_scope_id != original_scope_id {
             ctx.scoping_mut().set_symbol_scope_id(binding.symbol_id, target_scope_id);
-            ctx.scoping_mut().move_binding(
-                original_scope_id,
-                target_scope_id,
-                Ident::from(binding.name),
-            );
+            ctx.scoping_mut().move_binding(original_scope_id, target_scope_id, binding.name);
         }
     }
 
@@ -1025,9 +1021,9 @@ impl<'a> ArrowFunctionConverter<'a> {
     }
 
     /// Rename the `arguments` symbol to a new name.
-    fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn rename_arguments_symbol(symbol_id: SymbolId, name: Ident<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, Ident::from(name));
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, name);
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.
@@ -1070,7 +1066,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             ctx.scoping_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }
 
-        ident.name = binding.name.into();
+        ident.name = binding.name;
     }
 
     /// Transform the binding identifier for `arguments` if it's affected after transformation.
@@ -1089,7 +1085,7 @@ impl<'a> ArrowFunctionConverter<'a> {
 
         self.arguments_var_stack.last_or_init(|| {
             let arguments_name = ctx.generate_uid_name("arguments");
-            ident.name = arguments_name.into();
+            ident.name = arguments_name;
             let symbol_id = ident.symbol_id();
             Self::rename_arguments_symbol(symbol_id, arguments_name, ctx);
             // Record the symbol ID as a renamed `arguments` variable.
@@ -1114,14 +1110,20 @@ impl<'a> ArrowFunctionConverter<'a> {
 
         Self::adjust_binding_scope(target_scope_id, &arguments_var, ctx);
 
-        let mut init =
-            ctx.create_unbound_ident_expr(SPAN, Atom::from("arguments"), ReferenceFlags::Read);
+        let mut init = ctx.create_unbound_ident_expr(
+            SPAN,
+            Ident::new_const("arguments"),
+            ReferenceFlags::Read,
+        );
 
         // Top level may not have `arguments`, so we need to check it.
         // `typeof arguments === "undefined" ? void 0 : arguments;`
         if ctx.scoping().root_scope_id() == target_scope_id {
-            let argument =
-                ctx.create_unbound_ident_expr(SPAN, Atom::from("arguments"), ReferenceFlags::Read);
+            let argument = ctx.create_unbound_ident_expr(
+                SPAN,
+                Ident::new_const("arguments"),
+                ReferenceFlags::Read,
+            );
             let typeof_arguments = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, argument);
             let undefined_literal = ctx.ast.expression_string_literal(SPAN, "undefined", None);
             let test = ctx.ast.expression_binary(

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -93,7 +93,7 @@ impl<'a> TransformCtx<'a> {
                         || !ctx.scoping().symbol_is_mutated(symbol_id))
                 {
                     // Reading bound identifier cannot have side effects, so no need for temp var
-                    let binding = BoundIdentifier::new(ident.name.into(), symbol_id);
+                    let binding = BoundIdentifier::new(ident.name, symbol_id);
                     let references =
                         array::from_fn(|_| binding.create_spanned_read_expression(ident.span, ctx));
                     return (expr, references);

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -76,7 +76,7 @@ use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_traverse::BoundIdentifier;
 
 use crate::context::{TransformCtx, TraverseCtx};
@@ -324,9 +324,13 @@ impl<'a> HelperLoaderStore<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
         let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), HELPER_VAR);
-        let object =
-            ctx.create_ident_expr(SPAN, Atom::from(HELPER_VAR), symbol_id, ReferenceFlags::Read);
-        let property = ctx.ast.identifier_name(SPAN, Atom::from(helper.name()));
+        let object = ctx.create_ident_expr(
+            SPAN,
+            Ident::new_const(HELPER_VAR),
+            symbol_id,
+            ReferenceFlags::Read,
+        );
+        let property = ctx.ast.identifier_name(SPAN, helper.name());
         Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
     }
 }

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -38,7 +38,7 @@ use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Atom, SPAN};
+use oxc_span::{Atom, Ident, SPAN};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -228,7 +228,7 @@ impl<'a> ModuleImportsStore<'a> {
     ) -> Statement<'a> {
         let callee = ctx.create_ident_expr(
             SPAN,
-            Atom::from("require"),
+            Ident::new_const("require"),
             require_symbol_id,
             ReferenceFlags::read(),
         );

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -91,7 +91,7 @@ use oxc_allocator::{Box as ArenaBox, TakeIn};
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_semantic::{Reference, ReferenceFlags, SymbolId};
-use oxc_span::{ContentEq, SPAN};
+use oxc_span::{ContentEq, Ident, SPAN};
 use oxc_traverse::{MaybeBoundIdentifier, Traverse};
 use rustc_hash::FxHashMap;
 
@@ -695,7 +695,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
 
     #[inline]
     fn create_global_identifier(ident: &'static str, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-        ctx.create_unbound_ident_expr(SPAN, Atom::new_const(ident), ReferenceFlags::Read)
+        ctx.create_unbound_ident_expr(SPAN, Ident::new_const(ident), ReferenceFlags::Read)
     }
 
     #[inline]

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -613,13 +613,13 @@ impl<'a> LegacyDecorator<'a, '_> {
         // After: `class C {}` -> `let C = class {}`
         let class_binding = class.id.as_ref().map(|ident| {
             let new_class_binding =
-                ctx.generate_binding(ident.name.into(), class.scope_id(), SymbolFlags::Class);
+                ctx.generate_binding(ident.name, class.scope_id(), SymbolFlags::Class);
             let old_class_symbol_id = ident.symbol_id.replace(Some(new_class_binding.symbol_id));
             let old_class_symbol_id = old_class_symbol_id.expect("class always has a symbol id");
 
             *ctx.scoping_mut().symbol_flags_mut(old_class_symbol_id) =
                 SymbolFlags::BlockScopedVariable;
-            BoundIdentifier::new(ident.name.into(), old_class_symbol_id)
+            BoundIdentifier::new(ident.name, old_class_symbol_id)
         });
         let class_alias_binding = class_binding.as_ref().and_then(|id| {
             ClassReferenceChanger::new(id.clone(), ctx, self.ctx)

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -35,7 +35,7 @@
 use oxc_allocator::{CloneIn, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -162,12 +162,11 @@ impl<'a> ExponentiationOperator<'a, '_> {
         let pow_left = if let Some(symbol_id) = reference.symbol_id() {
             // This variable is declared in scope so evaluating it multiple times can't trigger a getter.
             // No need for a temp var.
-            ctx.create_bound_ident_expr(SPAN, ident.name.into(), symbol_id, ReferenceFlags::Read)
+            ctx.create_bound_ident_expr(SPAN, ident.name, symbol_id, ReferenceFlags::Read)
         } else {
             // Unbound reference. Could possibly trigger a getter so we need to only evaluate it once.
             // Assign to a temp var.
-            let reference =
-                ctx.create_unbound_ident_expr(SPAN, ident.name.into(), ReferenceFlags::Read);
+            let reference = ctx.create_unbound_ident_expr(SPAN, ident.name, ReferenceFlags::Read);
             let binding = self.create_temp_var(reference, &mut temp_var_inits, ctx);
             binding.create_read_expression(ctx)
         };
@@ -489,7 +488,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
                     // No need for a temp var.
                     return ctx.create_bound_ident_expr(
                         SPAN,
-                        ident.name.into(),
+                        ident.name,
                         symbol_id,
                         ReferenceFlags::Read,
                     );
@@ -538,8 +537,12 @@ impl<'a> ExponentiationOperator<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Math");
-        let object =
-            ctx.create_ident_expr(SPAN, Atom::from("Math"), math_symbol_id, ReferenceFlags::Read);
+        let object = ctx.create_ident_expr(
+            SPAN,
+            Ident::new_const("Math"),
+            math_symbol_id,
+            ReferenceFlags::Read,
+        );
         let property = ctx.ast.identifier_name(SPAN, "pow");
         let callee =
             Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false));

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -57,7 +57,7 @@ use oxc_allocator::{Box as ArenaBox, StringBuilder as ArenaStringBuilder, TakeIn
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_syntax::{
     identifier::{is_identifier_name, is_identifier_part, is_identifier_start},
     keyword::is_reserved_keyword,
@@ -277,7 +277,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             let this_argument = Argument::from(ctx.ast.expression_this(SPAN));
             let arguments_argument = Argument::from(ctx.create_unbound_ident_expr(
                 SPAN,
-                Atom::new_const("arguments"),
+                Ident::new_const("arguments"),
                 ReferenceFlags::Read,
             ));
             (callee, ctx.ast.vec_from_array([this_argument, arguments_argument]))
@@ -365,7 +365,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 // `function foo() { ... }` -> `function foo() {} return foo;`
                 let reference = ctx.create_bound_ident_expr(
                     SPAN,
-                    id.name.into(),
+                    id.name,
                     id.symbol_id(),
                     ReferenceFlags::Read,
                 );
@@ -546,11 +546,11 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
     }
 
     /// Infers the function name from the [`TraverseCtx::parent`].
-    fn infer_function_name_from_parent_node(ctx: &TraverseCtx<'a>) -> Option<Atom<'a>> {
+    fn infer_function_name_from_parent_node(ctx: &TraverseCtx<'a>) -> Option<Ident<'a>> {
         match ctx.parent() {
             // infer `foo` from `const foo = async function() {}`
             Ancestor::VariableDeclaratorInit(declarator) => {
-                declarator.id().get_binding_identifier().map(|id| id.name.into())
+                declarator.id().get_binding_identifier().map(|id| id.name)
             }
             // infer `foo` from `({ foo: async function() {} })`
             Ancestor::ObjectPropertyValue(property) if !*property.method() => {
@@ -571,10 +571,10 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
     ///   // Reserved keyword
     /// * `this` -> `_this`
     /// * `arguments` -> `_arguments`
-    fn normalize_function_name(input: &Cow<'a, str>, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn normalize_function_name(input: &Cow<'a, str>, ctx: &TraverseCtx<'a>) -> Ident<'a> {
         let input_str = input.as_ref();
         if !is_reserved_keyword(input_str) && is_identifier_name(input_str) {
-            return ctx.ast.atom_from_cow(input);
+            return Ident::from_cow_in(input, ctx.ast.allocator);
         }
 
         let mut name = ArenaStringBuilder::with_capacity_in(input_str.len() + 1, ctx.ast.allocator);
@@ -601,14 +601,14 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         }
 
         if name.is_empty() {
-            return Atom::from("_");
+            return Ident::new_const("_");
         }
 
         if is_reserved_keyword(name.as_str()) {
             name.push_ascii_byte_start(b'_');
         }
 
-        Atom::from(name)
+        Ident::from(name)
     }
 
     /// Creates a [`Function`] with the specified params, body and scope_id.
@@ -654,7 +654,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "arguments");
         let arguments_ident = Argument::from(ctx.create_ident_expr(
             SPAN,
-            Atom::from("arguments"),
+            Ident::new_const("arguments"),
             symbol_id,
             ReferenceFlags::Read,
         ));

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::{TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_traverse::{Ancestor, BoundIdentifier};
 
 use crate::{common::helper_loader::Helper, context::TraverseCtx};
@@ -343,7 +343,7 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
             let catch_scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::CatchClause);
             let block_scope_id = ctx.create_child_scope(catch_scope_id, ScopeFlags::empty());
             let err_ident = ctx.generate_binding(
-                Atom::from("err"),
+                Ident::new_const("err"),
                 block_scope_id,
                 SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
             );

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -94,7 +94,7 @@ impl<'a> NullishCoalescingOperator<'a, '_> {
                     // Check binding is not mutated.
                     // TODO(improve-on-babel): Remove this check. Whether binding is mutated or not is not relevant.
                     if ctx.scoping().get_resolved_references(symbol_id).all(|r| !r.is_write()) {
-                        let binding = BoundIdentifier::new(ident.name.into(), symbol_id);
+                        let binding = BoundIdentifier::new(ident.name, symbol_id);
                         let ident_span = ident.span;
                         return Self::create_conditional_expression(
                             logical_expr.left,

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -146,8 +146,7 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
         let symbol_id = reference.symbol_id();
         let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
 
-        let ident =
-            ctx.create_ident_reference(SPAN, ident.name.into(), symbol_id, ReferenceFlags::Write);
+        let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);
         let assign_target = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident));
         (left_expr, assign_target)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -4,7 +4,7 @@
 use indexmap::map::Entry;
 use oxc_allocator::{Address, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::{NONE, ast::*};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::{
     node::NodeId,
     reference::ReferenceFlags,
@@ -155,7 +155,7 @@ impl<'a> ClassProperties<'a, '_> {
                     // TODO: Not sure what we should do here.
                     // Only added this to prevent panics in TS conformance tests.
                     if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
-                        let dummy_binding = BoundIdentifier::new(Atom::empty(), SymbolId::new(0));
+                        let dummy_binding = BoundIdentifier::new(Ident::empty(), SymbolId::new(0));
                         private_props.insert(
                             ident.name.into(),
                             PrivateProp::new(dummy_binding, prop.r#static, None, true),
@@ -890,13 +890,15 @@ fn create_new_weakmap<'a>(
 ) -> Expression<'a> {
     let symbol_id = *symbol_id
         .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), "WeakMap"));
-    let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakMap"), symbol_id, ReferenceFlags::Read);
+    let ident =
+        ctx.create_ident_expr(SPAN, Ident::new_const("WeakMap"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }
 
 /// Create `new WeakSet()` expression.
 fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
     let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "WeakSet");
-    let ident = ctx.create_ident_expr(SPAN, Atom::from("WeakSet"), symbol_id, ReferenceFlags::Read);
+    let ident =
+        ctx.create_ident_expr(SPAN, Ident::new_const("WeakSet"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -432,7 +432,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, Ident::from(new_name));
+            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, new_name);
         }
 
         // Rename identifiers for clashing symbols in constructor params and body
@@ -769,13 +769,13 @@ impl<'a> ConstructorBodySuperReplacer<'a, '_> {
 
 /// Visitor to rename bindings and references.
 struct ConstructorSymbolRenamer<'a, 'v> {
-    clashing_symbols: &'v mut FxHashMap<SymbolId, Atom<'a>>,
+    clashing_symbols: &'v mut FxHashMap<SymbolId, Ident<'a>>,
     ctx: &'v TraverseCtx<'a>,
 }
 
 impl<'a, 'v> ConstructorSymbolRenamer<'a, 'v> {
     fn new(
-        clashing_symbols: &'v mut FxHashMap<SymbolId, Atom<'a>>,
+        clashing_symbols: &'v mut FxHashMap<SymbolId, Ident<'a>>,
         ctx: &'v TraverseCtx<'a>,
     ) -> Self {
         Self { clashing_symbols, ctx }
@@ -786,7 +786,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
     fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
         let symbol_id = ident.symbol_id();
         if let Some(new_name) = self.clashing_symbols.get(&symbol_id) {
-            ident.name = (*new_name).into();
+            ident.name = *new_name;
         }
     }
 
@@ -795,7 +795,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
         if let Some(symbol_id) = self.ctx.scoping().get_reference(reference_id).symbol_id()
             && let Some(new_name) = self.clashing_symbols.get(&symbol_id)
         {
-            ident.name = (*new_name).into();
+            ident.name = *new_name;
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_data_structures::stack::Stack;
-use oxc_span::Atom;
+use oxc_span::Ident;
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolId,
@@ -63,7 +63,7 @@ struct InstanceInitializerVisitor<'a, 'v> {
     /// Constructor's scope, for checking symbol clashes against
     constructor_scope_id: ScopeId,
     /// Clashing symbols
-    clashing_symbols: &'v mut FxHashMap<SymbolId, Atom<'a>>,
+    clashing_symbols: &'v mut FxHashMap<SymbolId, Ident<'a>>,
     /// `TransCtx` object.
     ctx: &'v mut TraverseCtx<'a>,
 }
@@ -146,7 +146,7 @@ impl<'a> InstanceInitializerVisitor<'a, '_> {
         }
 
         // Record the symbol clash. Symbol in constructor needs to be renamed.
-        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name.into());
+        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name);
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -202,7 +202,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::Deserialize;
 
 use oxc_ast::ast::*;
-use oxc_span::Atom;
+use oxc_span::Ident;
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::Traverse;
 
@@ -276,7 +276,7 @@ pub struct ClassProperties<'a, 'ctx> {
     /// Symbols in constructor which clash with instance prop initializers.
     /// Keys are symbols' IDs.
     /// Values are initially the original name of binding, later on the name of new UID name.
-    clashing_constructor_symbols: FxHashMap<SymbolId, Atom<'a>>,
+    clashing_constructor_symbols: FxHashMap<SymbolId, Ident<'a>>,
 
     // ----- State used only during exit phase -----
     //

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,7 +2,7 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_ast::{NONE, ast::*};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::reference::ReferenceFlags;
 
 use crate::{
@@ -344,7 +344,7 @@ impl<'a> ClassProperties<'a, '_> {
         let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Object");
         let object = ctx.create_ident_expr(
             SPAN,
-            Atom::from("Object"),
+            Ident::new_const("Object"),
             object_symbol_id,
             ReferenceFlags::Read,
         );

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -123,7 +123,7 @@ impl<'a> ClassProperties<'a, '_> {
 
         // Identifier is reference to class name. Rename it.
         let temp_binding = class_details.bindings.get_or_init_static_binding(ctx);
-        ident.name = temp_binding.name.into();
+        ident.name = temp_binding.name;
 
         let symbols = ctx.scoping_mut();
         symbols.get_reference_mut(reference_id).set_symbol_id(temp_binding.symbol_id);

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -41,7 +41,7 @@ use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVe
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Atom, Ident, SPAN};
+use oxc_span::{Ident, SPAN};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
 use crate::{
@@ -173,11 +173,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
             );
 
             ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, static_block_new_scope_id);
-            ctx.scoping_mut().move_binding(
-                scope_id,
-                static_block_new_scope_id,
-                Ident::from(using_ctx.name),
-            );
+            ctx.scoping_mut().move_binding(scope_id, static_block_new_scope_id, using_ctx.name);
             *ctx.scoping_mut().scope_flags_mut(scope_id) = ScopeFlags::StrictMode;
 
             block.set_scope_id(static_block_new_scope_id);
@@ -292,11 +288,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
             let current_hoist_scope_id = ctx.current_hoist_scope_id();
             node.block.set_scope_id(block_stmt_scope_id);
             ctx.scoping_mut().set_symbol_scope_id(using_ctx.symbol_id, current_hoist_scope_id);
-            ctx.scoping_mut().move_binding(
-                scope_id,
-                current_hoist_scope_id,
-                Ident::from(using_ctx.name),
-            );
+            ctx.scoping_mut().move_binding(scope_id, current_hoist_scope_id, using_ctx.name);
 
             ctx.scoping_mut().change_scope_parent_id(scope_id, Some(block_stmt_scope_id));
         }
@@ -349,7 +341,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
                             }
                             _ => (
                                 ctx.generate_binding_in_current_scope(
-                                    Atom::from("_default"),
+                                    Ident::new_const("_default"),
                                     SymbolFlags::FunctionScopedVariable,
                                 ),
                                 SPAN,
@@ -820,7 +812,7 @@ impl<'a> ExplicitResourceManagement<'a, '_> {
         // We can skip using `generate_uid` here as no code within the `catch` block which can use a
         // binding called `_`. `using_ctx` is a UID with prefix `_usingCtx`.
         let ident = ctx.generate_binding(
-            Atom::from("_"),
+            Ident::new_const("_"),
             block_scope_id,
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -17,7 +17,7 @@ use oxc_ast_visit::{
     walk::{walk_call_expression, walk_declaration},
 };
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{Atom, GetSpan, Ident, SPAN};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse};
 
@@ -336,11 +336,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a, '_> {
 
         if !is_builtin_hook(&hook_name) {
             // Check if a corresponding binding exists where we emit the signature.
-            let (binding_name, is_member_expression): (Option<Atom>, _) = match &call_expr.callee {
-                Expression::Identifier(ident) => (Some(ident.name.into()), false),
+            let (binding_name, is_member_expression): (Option<Ident>, _) = match &call_expr.callee {
+                Expression::Identifier(ident) => (Some(ident.name), false),
                 Expression::StaticMemberExpression(member) => {
                     if let Expression::Identifier(object) = &member.object {
-                        (Some(object.name.into()), true)
+                        (Some(object.name), true)
                     } else {
                         (None, false)
                     }
@@ -531,7 +531,7 @@ impl<'a> ReactRefresh<'a, '_> {
     ) -> Statement<'a> {
         let left = self.create_registration(id.name.into(), ctx);
         let right =
-            ctx.create_bound_ident_expr(SPAN, id.name.into(), id.symbol_id(), ReferenceFlags::Read);
+            ctx.create_bound_ident_expr(SPAN, id.name, id.symbol_id(), ReferenceFlags::Read);
         let expr = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
         ctx.ast.statement_expression(SPAN, expr)
     }

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -49,7 +49,7 @@ use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
 };
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Atom, SPAN};
+use oxc_span::{Ident, SPAN};
 use oxc_traverse::Traverse;
 
 use crate::{
@@ -164,7 +164,12 @@ impl<'a> RegExp<'a, '_> {
 
         let callee = {
             let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "RegExp");
-            ctx.create_ident_expr(SPAN, Atom::from("RegExp"), symbol_id, ReferenceFlags::read())
+            ctx.create_ident_expr(
+                SPAN,
+                Ident::new_const("RegExp"),
+                symbol_id,
+                ReferenceFlags::read(),
+            )
         };
 
         let arguments = ctx.ast.vec_from_array([

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -8,7 +8,7 @@ use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_ecmascript::{ToInt32, ToUint32};
 use oxc_semantic::{ScopeFlags, ScopeId};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     number::{NumberBase, ToJsString},
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -23,7 +23,7 @@ use crate::{context::TraverseCtx, state::TransformState};
 type PrevMembers<'a> = FxHashMap<Atom<'a>, Option<ConstantValue<'a>>>;
 
 pub struct TypeScriptEnum<'a> {
-    enums: FxHashMap<Atom<'a>, PrevMembers<'a>>,
+    enums: FxHashMap<Ident<'a>, PrevMembers<'a>>,
 }
 
 impl TypeScriptEnum<'_> {
@@ -84,7 +84,7 @@ impl<'a> TypeScriptEnum<'a> {
         let is_export = export_span.is_some();
         let is_not_top_scope = !ctx.scoping().scope_flags(ctx.current_scope_id()).is_top();
 
-        let enum_name: Atom = decl.id.name.into();
+        let enum_name: Ident = decl.id.name;
         let func_scope_id = decl.body.scope_id();
         let param_binding =
             ctx.generate_binding(enum_name, func_scope_id, SymbolFlags::FunctionScopedVariable);
@@ -331,7 +331,7 @@ impl<'a> TypeScriptEnum<'a> {
             let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Infinity");
             ctx.create_ident_expr(
                 SPAN,
-                Atom::from("Infinity"),
+                Ident::new_const("Infinity"),
                 infinity_symbol_id,
                 ReferenceFlags::Read,
             )
@@ -375,7 +375,7 @@ impl<'a> TypeScriptEnum<'a> {
             match_member_expression!(Expression) => {
                 let expr = expr.to_member_expression();
                 let Expression::Identifier(ident) = expr.object() else { return None };
-                let members = self.enums.get(&Atom::from(ident.name))?;
+                let members = self.enums.get(&ident.name)?;
                 let property = expr.static_property_name()?;
                 *members.get(property)?
             }
@@ -560,7 +560,7 @@ impl<'a> TypeScriptEnum<'a> {
 /// }
 /// ```
 struct IdentifierReferenceRename<'a, 'ctx, 'members> {
-    enum_name: Atom<'a>,
+    enum_name: Ident<'a>,
     previous_enum_members: &'members PrevMembers<'a>,
     scope_stack: NonEmptyStack<ScopeId>,
     ctx: &'ctx TraverseCtx<'a>,
@@ -568,7 +568,7 @@ struct IdentifierReferenceRename<'a, 'ctx, 'members> {
 
 impl<'a, 'ctx, 'members> IdentifierReferenceRename<'a, 'ctx, 'members> {
     fn new(
-        enum_name: Atom<'a>,
+        enum_name: Ident<'a>,
         enum_scope_id: ScopeId,
         previous_enum_members: &'members PrevMembers<'a>,
         ctx: &'ctx TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
-use oxc_span::SPAN;
+use oxc_span::{Ident, SPAN};
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::Traverse;
 
@@ -153,7 +153,7 @@ impl<'a> TypeScriptModule<'a, '_> {
                     ctx.scoping().find_binding(ctx.current_scope_id(), "require");
                 let callee = ctx.create_ident_expr(
                     SPAN,
-                    Atom::from("require"),
+                    Ident::new_const("require"),
                     require_symbol_id,
                     ReferenceFlags::Read,
                 );

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -96,13 +96,13 @@ impl<'a> ModuleRunnerTransform<'a> {
     }
 }
 
-const SSR_MODULE_EXPORTS_KEY: Atom<'static> = Atom::new_const("__vite_ssr_exports__");
-const SSR_EXPORT_DEFAULT_KEY: Atom<'static> = Atom::new_const("__vite_ssr_export_default__");
-const SSR_IMPORT_KEY: Atom<'static> = Atom::new_const("__vite_ssr_import__");
-const SSR_DYNAMIC_IMPORT_KEY: Atom<'static> = Atom::new_const("__vite_ssr_dynamic_import__");
-const SSR_EXPORT_ALL_KEY: Atom<'static> = Atom::new_const("__vite_ssr_exportAll__");
-const SSR_IMPORT_META_KEY: Atom<'static> = Atom::new_const("__vite_ssr_import_meta__");
-const DEFAULT: Atom<'static> = Atom::new_const("default");
+const SSR_MODULE_EXPORTS_KEY: Ident<'static> = Ident::new_const("__vite_ssr_exports__");
+const SSR_EXPORT_DEFAULT_KEY: Ident<'static> = Ident::new_const("__vite_ssr_export_default__");
+const SSR_IMPORT_KEY: Ident<'static> = Ident::new_const("__vite_ssr_import__");
+const SSR_DYNAMIC_IMPORT_KEY: Ident<'static> = Ident::new_const("__vite_ssr_dynamic_import__");
+const SSR_EXPORT_ALL_KEY: Ident<'static> = Ident::new_const("__vite_ssr_exportAll__");
+const SSR_IMPORT_META_KEY: Ident<'static> = Ident::new_const("__vite_ssr_import_meta__");
+const DEFAULT: Ident<'static> = Ident::new_const("default");
 
 impl<'a> Traverse<'a, ()> for ModuleRunnerTransform<'a> {
     #[inline]
@@ -327,9 +327,9 @@ impl<'a> ModuleRunnerTransform<'a> {
 
                 // Reuse the `vue` binding identifier by renaming it to `__vite_ssr_import_0__`
                 let mut local = specifier.unbox().local;
-                local.name = self.generate_import_binding_name(ctx).into();
+                local.name = self.generate_import_binding_name(ctx);
                 let binding = BoundIdentifier::from_binding_ident(&local);
-                ctx.scoping_mut().set_symbol_name(binding.symbol_id, Ident::from(binding.name));
+                ctx.scoping_mut().set_symbol_name(binding.symbol_id, binding.name);
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
                 BindingPattern::BindingIdentifier(ctx.alloc(local))
@@ -460,7 +460,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                     };
                     Expression::Identifier(ctx.ast.alloc(ident))
                 };
-                Self::create_export(span, expr, exported.name(), ctx)
+                Self::create_export(span, expr, exported.name().into(), ctx)
             }));
         }
     }
@@ -502,7 +502,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         if let Some(exported) = exported {
             // `export * as foo from 'vue'` ->
             // `Object.defineProperty(__vite_ssr_exports__, 'foo', { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ } });`
-            let export = Self::create_export(span, ident, exported.name(), ctx);
+            let export = Self::create_export(span, ident, exported.name().into(), ctx);
             hoist_imports.push(import);
             hoist_exports.push(export);
         } else {
@@ -603,7 +603,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                 }
                 ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
                     let ImportDefaultSpecifier { span, local } = specifier.unbox();
-                    self.insert_import_binding(span, binding, local, DEFAULT, ctx)
+                    self.insert_import_binding(span, binding, local, DEFAULT.into(), ctx)
                 }
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(_) => {
                     unreachable!()
@@ -647,11 +647,11 @@ impl<'a> ModuleRunnerTransform<'a> {
     }
 
     /// Generate a unique import binding name like `__vite_ssr_import_{uid}__`.
-    fn generate_import_binding_name(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn generate_import_binding_name(&mut self, ctx: &TraverseCtx<'a>) -> Ident<'a> {
         let mut buffer = ItoaBuffer::new();
         let uid_str = buffer.format(self.import_uid);
         self.import_uid += 1;
-        ctx.ast.atom_from_strs_array(["__vite_ssr_import_", uid_str, "__"])
+        Ident::from_strs_array_in(["__vite_ssr_import_", uid_str, "__"], ctx.ast.allocator)
     }
 
     /// Generate a unique import binding whose name is like `__vite_ssr_import_{uid}__`.
@@ -703,7 +703,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let object =
-            ctx.create_unbound_ident_expr(SPAN, Atom::from("Object"), ReferenceFlags::Read);
+            ctx.create_unbound_ident_expr(SPAN, Ident::new_const("Object"), ReferenceFlags::Read);
         let member = create_member_callee(object, "defineProperty", ctx);
         ctx.ast.expression_call(SPAN, member, NONE, arguments, false)
     }
@@ -759,7 +759,7 @@ impl<'a> ModuleRunnerTransform<'a> {
     fn create_export(
         span: Span,
         expr: Expression<'a>,
-        exported_name: Atom<'a>,
+        exported_name: Ident<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let getter = Self::create_function_with_return_statement(expr, ctx);

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -30,6 +30,7 @@ oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 
 itoa = { workspace = true }

--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -2,7 +2,8 @@ use oxc_ast::ast::{
     AssignmentTarget, BindingIdentifier, BindingPattern, Expression, IdentifierReference,
     SimpleAssignmentTarget,
 };
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{SPAN, Span};
+use oxc_str::Ident;
 use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
 
 use crate::TraverseCtx;
@@ -34,23 +35,23 @@ use super::MaybeBoundIdentifier;
 /// * `BoundIdentifier` is smaller than `BindingIdentifier`, so takes less memory when you store
 ///   it for later use.
 /// * `BoundIdentifier` is `Clone` (unlike `BindingIdentifier`).
-/// * `BoundIdentifier` re-uses the same `Atom` for all `BindingIdentifier` / `IdentifierReference`s
+/// * `BoundIdentifier` re-uses the same `Ident` for all `BindingIdentifier` / `IdentifierReference`s
 ///   created from it.
 #[derive(Debug, Clone)]
 pub struct BoundIdentifier<'a> {
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
     pub symbol_id: SymbolId,
 }
 
 impl<'a> BoundIdentifier<'a> {
     /// Create `BoundIdentifier` for `name` and `symbol_id`
-    pub fn new(name: Atom<'a>, symbol_id: SymbolId) -> Self {
+    pub fn new(name: Ident<'a>, symbol_id: SymbolId) -> Self {
         Self { name, symbol_id }
     }
 
     /// Create `BoundIdentifier` from a `BindingIdentifier`
     pub fn from_binding_ident(ident: &BindingIdentifier<'a>) -> Self {
-        Self { name: ident.name.into(), symbol_id: ident.symbol_id() }
+        Self { name: ident.name, symbol_id: ident.symbol_id() }
     }
 
     /// Convert `BoundIdentifier` to `MaybeBoundIdentifier`

--- a/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::{AssignmentTarget, Expression, IdentifierReference, SimpleAssignmentTarget};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{SPAN, Span};
+use oxc_str::Ident;
 use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
 
 use crate::TraverseCtx;
@@ -24,18 +25,18 @@ use super::BoundIdentifier;
 /// * The original `IdentifierReference` must also be used in the AST, or it'll be a dangling reference.
 /// * `MaybeBoundIdentifier` is smaller than `IdentifierReference`, so takes less memory when you store
 ///   it for later use.
-/// * `MaybeBoundIdentifier` re-uses the same `Atom` for all `BindingIdentifier` / `IdentifierReference`s
+/// * `MaybeBoundIdentifier` re-uses the same `Ident` for all `BindingIdentifier` / `IdentifierReference`s
 ///   created from it.
 /// * `MaybeBoundIdentifier` looks up the `SymbolId` for the reference only once.
 #[derive(Debug, Clone)]
 pub struct MaybeBoundIdentifier<'a> {
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
     pub symbol_id: Option<SymbolId>,
 }
 
 impl<'a> MaybeBoundIdentifier<'a> {
     /// Create `MaybeBoundIdentifier` for `name` and `Option<SymbolId>`
-    pub fn new(name: Atom<'a>, symbol_id: Option<SymbolId>) -> Self {
+    pub fn new(name: Ident<'a>, symbol_id: Option<SymbolId>) -> Self {
         Self { name, symbol_id }
     }
 
@@ -45,7 +46,7 @@ impl<'a> MaybeBoundIdentifier<'a> {
         ctx: &TraverseCtx<'a, State>,
     ) -> Self {
         let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id();
-        Self { name: ident.name.into(), symbol_id }
+        Self { name: ident.name, symbol_id }
     }
 
     /// Convert `MaybeBoundIdentifier` to `BoundIdentifier`.

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -4,7 +4,8 @@ use oxc_ast::{
     ast::{Expression, IdentifierReference, Statement},
 };
 use oxc_semantic::Scoping;
-use oxc_span::{Atom, Span};
+use oxc_span::Span;
+use oxc_str::Ident;
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -369,7 +370,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// This is a shortcut for `ctx.scoping.generate_binding`.
     pub fn generate_binding(
         &mut self,
-        name: Atom<'a>,
+        name: Ident<'a>,
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
@@ -383,7 +384,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// This is a shortcut for `ctx.scoping.generate_binding_in_current_scope`.
     pub fn generate_binding_in_current_scope(
         &mut self,
-        name: Atom<'a>,
+        name: Ident<'a>,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
         self.scoping.generate_binding_in_current_scope(name, flags)
@@ -397,7 +398,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// There are some potential "gotchas".
     ///
     /// This is a shortcut for `ctx.scoping.generate_uid_name`.
-    pub fn generate_uid_name(&mut self, name: &str) -> Atom<'a> {
+    pub fn generate_uid_name(&mut self, name: &str) -> Ident<'a> {
         self.scoping.generate_uid_name(name, self.ast.allocator)
     }
 
@@ -512,7 +513,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_bound_ident_reference(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         symbol_id: SymbolId,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
@@ -524,7 +525,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_bound_ident_expr(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         symbol_id: SymbolId,
         flags: ReferenceFlags,
     ) -> Expression<'a> {
@@ -544,10 +545,10 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_unbound_ident_reference(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_unbound_reference(name.as_str(), flags);
+        let reference_id = self.create_unbound_reference(&name, flags);
         self.ast.identifier_reference_with_reference_id(span, name, reference_id)
     }
 
@@ -555,7 +556,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_unbound_ident_expr(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         flags: ReferenceFlags,
     ) -> Expression<'a> {
         let ident = self.create_unbound_ident_reference(span, name, flags);
@@ -585,7 +586,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_ident_reference(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
@@ -603,7 +604,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     pub fn create_ident_expr(
         &mut self,
         span: Span,
-        name: Atom<'a>,
+        name: Ident<'a>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> Expression<'a> {

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -248,7 +248,7 @@ impl<'a> TraverseScoping<'a> {
     /// Creates a symbol with the provided name and flags and adds it to the specified scope.
     pub fn generate_binding(
         &mut self,
-        name: Atom<'a>,
+        name: Ident<'a>,
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
@@ -261,7 +261,7 @@ impl<'a> TraverseScoping<'a> {
     /// Creates a symbol with the provided name and flags and adds it to the current scope.
     pub fn generate_binding_in_current_scope(
         &mut self,
-        name: Atom<'a>,
+        name: Ident<'a>,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
         self.generate_binding(name, self.current_scope_id, flags)
@@ -276,7 +276,7 @@ impl<'a> TraverseScoping<'a> {
     /// starting with a digit (0-9) is fine.
     ///
     /// See comments on `UidGenerator` for further details.
-    pub fn generate_uid_name(&mut self, name: &str, allocator: &'a Allocator) -> Atom<'a> {
+    pub fn generate_uid_name(&mut self, name: &str, allocator: &'a Allocator) -> Ident<'a> {
         // If `uid_generator` is not already populated, initialize it
         let uid_generator =
             self.uid_generator.get_or_insert_with(|| UidGenerator::new(&self.scoping, allocator));

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Allocator, StringBuilder as ArenaStringBuilder};
 use oxc_semantic::Scoping;
-use oxc_span::Atom;
+use oxc_str::Ident;
 
 /// Unique identifier generator.
 ///
@@ -245,7 +245,7 @@ impl<'a> UidGenerator<'a> {
     /// starting with a digit (0-9) is fine.
     ///
     /// Please see docs for [`UidGenerator`] for further info.
-    pub(super) fn create(&mut self, name: &str) -> Atom<'a> {
+    pub(super) fn create(&mut self, name: &str) -> Ident<'a> {
         // Get the base name, with `_`s trimmed from start, and digits trimmed from end.
         // i.e. `__foo123` -> `foo`.
         // Equivalent to `name.trim_start_matches('_').trim_end_matches(|c: char| c.is_ascii_digit())`
@@ -286,7 +286,7 @@ impl<'a> UidGenerator<'a> {
             let digits = buffer.format(uid_name.postfix);
 
             if uid_name.underscore_count == 1 {
-                Atom::from_strs_array_in(["_", base, digits], self.allocator)
+                Ident::from_strs_array_in(["_", base, digits], self.allocator)
             } else {
                 let mut uid = ArenaStringBuilder::with_capacity_in(
                     uid_name.underscore_count as usize + base.len() + digits.len(),
@@ -295,10 +295,10 @@ impl<'a> UidGenerator<'a> {
                 uid.push_ascii_byte_repeat(b'_', uid_name.underscore_count as usize);
                 uid.push_str(base);
                 uid.push_str(digits);
-                Atom::from(uid)
+                Ident::from(uid)
             }
         } else {
-            let uid = Atom::from_strs_array_in(["_", base], self.allocator);
+            let uid = Ident::from_strs_array_in(["_", base], self.allocator);
             // SAFETY: String starts with `_`, so trimming off that byte leaves a valid UTF-8 string
             let base = unsafe { uid.as_str().get_unchecked(1..) };
             self.names.insert(base, UidName { underscore_count: 1, postfix: 1 });


### PR DESCRIPTION
## Summary

- Change `BoundIdentifier.name` and `MaybeBoundIdentifier.name` from `Atom<'a>` to `Ident<'a>`
- Update all `TraverseCtx` / `TraverseScoping` / `UidGenerator` APIs to accept and return `Ident<'a>` instead of `Atom<'a>`
- Remove unnecessary `.into()` conversions at ~30 call sites across `oxc_transformer` and `oxc_transformer_plugins`

`BindingIdentifier` and `IdentifierReference` in the AST already use `Ident<'a>` for their `name` field. This aligns the traverse helper types with the AST, eliminating redundant conversions since `Ident` and `Atom` are zero-cost convertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)