### PR TITLE
refactor(tools): remove unnecessary ignore patterns from oxfmt config

### DIFF
--- a/oxfmtrc.jsonc
+++ b/oxfmtrc.jsonc
@@ -34,8 +34,5 @@
     "npm/oxc-types/types.d.ts",
     "npm/oxfmt/configuration_schema.json",
     "npm/oxlint/configuration_schema.json",
-    "npm/oxlint-plugins/index.js",
-    "npm/oxlint-plugins/index.cjs",
-    "npm/oxlint-plugins/index.d.ts",
   ],
 }


### PR DESCRIPTION
These ignores are no longer required since #18903.