### PR TITLE
refactor(linter/plugins): simplify fix type and validation

### DIFF
--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -9,7 +9,7 @@ import { sourceText } from "./source_code.ts";
 import { debugAssertIsNonNull, typeAssertIs } from "../utils/asserts.ts";
 
 import type { RequireAtLeastOne } from "type-fest";
-import type { Fix, FixFn } from "./fix.ts";
+import type { FixFn, FixReport } from "./fix.ts";
 import type { RuleDetails } from "./load.ts";
 import type { LineColumn, Ranged } from "./location.ts";
 
@@ -67,7 +67,7 @@ interface SuggestionBase {
  */
 export interface SuggestionReport {
   message: string;
-  fixes: Fix[];
+  fixes: FixReport[];
 }
 
 // Diagnostic in form sent to Rust.
@@ -77,7 +77,7 @@ export interface DiagnosticReport {
   start: number;
   end: number;
   ruleIndex: number;
-  fixes: Fix[] | null;
+  fixes: FixReport[] | null;
   suggestions: SuggestionReport[] | null;
   messageId: string | null;
   // Only used in conformance tests

--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -5,7 +5,7 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 111
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 116
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -17,7 +17,7 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 119
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 124
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_after_end.js
@@ -29,11 +29,11 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 111
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 110
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 119
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 118
 
   x fixes-plugin(fixes): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]

--- a/apps/oxlint/test/fixtures/fixes/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/output.snap.md
@@ -5,7 +5,7 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 111
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 116
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -17,7 +17,7 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 119
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 124
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_after_end.js
@@ -29,11 +29,11 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 111
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 110
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 119
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 118
 
   x fixes-plugin(fixes): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]

--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -5,7 +5,7 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 163
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -17,7 +17,7 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 171
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_after_end.js
@@ -29,11 +29,11 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 157
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 165
 
   x suggestions-plugin(suggestions): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]

--- a/apps/oxlint/test/fixtures/suggestions/fix.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix.snap.md
@@ -5,19 +5,19 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 163
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 171
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 157
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 165
 
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]

--- a/apps/oxlint/test/fixtures/suggestions/output.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/output.snap.md
@@ -5,19 +5,19 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 163
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 171
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 158
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-10`, expected u32 at line 1 column 157
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 166
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967296`, expected u32 at line 1 column 165
 
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -86,7 +86,8 @@ pub struct LintFileResult {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsFix {
-    pub range: [u32; 2],
+    pub start: u32,
+    pub end: u32,
     pub text: String,
 }
 
@@ -109,7 +110,7 @@ pub fn convert_and_merge_js_fixes(
     let is_single = fixes.len() == 1;
 
     let mut fixes = fixes.into_iter().map(|fix| {
-        let mut span = Span::new(fix.range[0], fix.range[1]);
+        let mut span = Span::new(fix.start, fix.end);
         span_converter.convert_span_back(&mut span);
         Fix::new(fix.text, span)
     });


### PR DESCRIPTION
Refactor. Simplify the type used to represent a fix when sending from JS to Rust.

Previously we avoided creating new objects by using the same fix object returned by `fix` function, and so were locked to ESLint's design.

That worked, but the code was excessively complicated. Fixes should be fairly rare, so this optimization is on a cold path - it's not worth it.

Simplify implementation by converting `Fix`es to a simpler type (`FixReport`) before sending to Rust.