### PR TITLE
refactor(semantic): accept `Ident` instead of `&str` in binding/symbol APIs

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/accessor_pairs.rs
@@ -358,7 +358,7 @@ impl AccessorPairs {
         };
 
         let object_name = match member.object.without_parentheses() {
-            Expression::Identifier(id) => &id.name,
+            Expression::Identifier(id) => id.name,
             _ => return None,
         };
 

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -10,7 +10,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 use oxc_syntax::{identifier::is_identifier_name, keyword::is_reserved_keyword_or_global_object};
 
 use schemars::JsonSchema;
@@ -234,7 +234,7 @@ impl Rule for FuncNames {
             if is_invalid_function(config, func, parent_node) {
                 // For named functions, check if they're recursive (need their name for recursion)
                 if let Some(func_name) = func.name()
-                    && is_recursive_function(func, func_name.as_str(), ctx)
+                    && is_recursive_function(func, func_name, ctx)
                 {
                     return;
                 }
@@ -244,7 +244,7 @@ impl Rule for FuncNames {
     }
 }
 
-fn is_recursive_function(func: &Function, func_name: &str, ctx: &LintContext) -> bool {
+fn is_recursive_function(func: &Function, func_name: Ident<'_>, ctx: &LintContext) -> bool {
     let Some(func_scope_id) = func.scope_id.get() else {
         return false;
     };
@@ -299,7 +299,7 @@ fn diagnostic_invalid_function(
     let function_name = guess_function_name(ctx, node.id()).map(Cow::into_owned);
 
     let is_safe_fix =
-        function_name.as_ref().is_some_and(|name| can_safely_apply_fix(func, name, ctx));
+        function_name.as_ref().is_some_and(|name| can_safely_apply_fix(func, name.as_str().into(), ctx));
 
     let msg = unnamed_diagnostic(&func_name_complete, report_span);
 
@@ -415,7 +415,7 @@ fn is_invalid_function(
 }
 
 /// Returns whether it's safe to insert a function name without breaking shadowing rules
-fn can_safely_apply_fix(func: &Function, name: &str, ctx: &LintContext) -> bool {
+fn can_safely_apply_fix(func: &Function, name: Ident<'_>, ctx: &LintContext) -> bool {
     !ctx.scoping().find_binding(func.scope_id(), name).is_some_and(|shadowed_var| {
         ctx.semantic().symbol_references(shadowed_var).any(|reference| {
             func.span.contains_inclusive(ctx.nodes().get_node(reference.node_id()).kind().span())

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -298,8 +298,9 @@ fn diagnostic_invalid_function(
 
     let function_name = guess_function_name(ctx, node.id()).map(Cow::into_owned);
 
-    let is_safe_fix =
-        function_name.as_ref().is_some_and(|name| can_safely_apply_fix(func, name.as_str().into(), ctx));
+    let is_safe_fix = function_name
+        .as_ref()
+        .is_some_and(|name| can_safely_apply_fix(func, name.as_str().into(), ctx));
 
     let msg = unnamed_diagnostic(&func_name_complete, report_span);
 

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -64,7 +64,7 @@ impl Rule for NoLabelVar {
         let AstKind::LabeledStatement(labeled_stmt) = node.kind() else { return };
 
         if let Some(symbol_id) =
-            ctx.scoping().find_binding(node.scope_id(), &labeled_stmt.label.name)
+            ctx.scoping().find_binding(node.scope_id(), labeled_stmt.label.name)
         {
             let decl_span = ctx.scoping().symbol_span(symbol_id);
             let label_decl = labeled_stmt.span.start;

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -87,7 +87,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
         return Some(ident.name.as_str());
     }
 
-    let Some(binding_id) = scope.find_binding(scope_id, &ident.name) else {
+    let Some(binding_id) = scope.find_binding(scope_id, ident.name) else {
         // Panic in debug builds, but fail gracefully in release builds.
         debug_assert!(
             false,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -3,7 +3,7 @@ use oxc_ast::{
     ast::{Expression, ForInStatement, ForOfStatement, VariableDeclarator},
 };
 use oxc_semantic::NodeId;
-use oxc_span::{CompactStr, GetSpan};
+use oxc_span::{CompactStr, GetSpan, Ident};
 
 use super::{BindingInfo, NoUnusedVars, Symbol, count_whitespace_or_commas};
 use crate::{
@@ -138,7 +138,7 @@ impl NoUnusedVars {
         let scope_id = symbol.scope_id();
         let mut i = 0;
         let mut new_name = ignored_name.clone();
-        while scopes.scope_has_binding(scope_id, &new_name) {
+        while scopes.scope_has_binding(scope_id, Ident::from(new_name.as_str())) {
             new_name = format!("{ignored_name}{i}");
             i += 1;
         }

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
 
@@ -75,7 +75,7 @@ impl Rule for PreferObjectHasOwn {
 
         let object_property_name = object.static_property_name();
         let is_object = has_left_hand_object(object);
-        let is_global_scope = ctx.scoping().find_binding(node.scope_id(), "Object").is_none();
+        let is_global_scope = ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Object")).is_none();
 
         if is_method_call(call_expr, None, Some(&["call"]), Some(2), Some(2))
             && object_property_name == Some("hasOwnProperty")

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -75,7 +75,8 @@ impl Rule for PreferObjectHasOwn {
 
         let object_property_name = object.static_property_name();
         let is_object = has_left_hand_object(object);
-        let is_global_scope = ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Object")).is_none();
+        let is_global_scope =
+            ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Object")).is_none();
 
         if is_method_call(call_expr, None, Some(&["call"]), Some(2), Some(2))
             && object_property_name == Some("hasOwnProperty")

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -73,7 +73,8 @@ impl Rule for PreferRestParams {
             {
                 return;
             }
-            let binding = ctx.scoping().find_binding(node.scope_id(), Ident::new_const("arguments"));
+            let binding =
+                ctx.scoping().find_binding(node.scope_id(), Ident::new_const("arguments"));
             if binding.is_none() {
                 ctx.diagnostic(prefer_rest_params_diagnostic(node.span()));
             }

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -2,7 +2,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 fn prefer_rest_params_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use the rest parameters instead of `arguments`.").with_label(span)
@@ -73,7 +73,7 @@ impl Rule for PreferRestParams {
             {
                 return;
             }
-            let binding = ctx.scoping().find_binding(node.scope_id(), "arguments");
+            let binding = ctx.scoping().find_binding(node.scope_id(), Ident::new_const("arguments"));
             if binding.is_none() {
                 ctx.diagnostic(prefer_rest_params_diagnostic(node.span()));
             }

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -158,7 +158,7 @@ impl Rule for Namespace {
                 return;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(entry.local_name.name()) else {
+            let Some(symbol_id) = ctx.scoping().get_root_binding(entry.local_name.name().into()) else {
                 return;
             };
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -158,7 +158,8 @@ impl Rule for Namespace {
                 return;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(entry.local_name.name().into()) else {
+            let Some(symbol_id) = ctx.scoping().get_root_binding(entry.local_name.name().into())
+            else {
                 return;
             };
 

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -233,7 +233,7 @@ impl Rule for NoCommonjs {
                     return;
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), "require").is_some() {
+                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require")).is_some() {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -233,7 +233,11 @@ impl Rule for NoCommonjs {
                     return;
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require")).is_some() {
+                if ctx
+                    .scoping()
+                    .find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require"))
+                    .is_some()
+                {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -91,7 +91,8 @@ impl Rule for NoNamedAsDefaultMember {
                 continue;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(import_entry.local_name.name().into())
+            let Some(symbol_id) =
+                ctx.scoping().get_root_binding(import_entry.local_name.name().into())
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -91,7 +91,7 @@ impl Rule for NoNamedAsDefaultMember {
                 continue;
             }
 
-            let Some(symbol_id) = ctx.scoping().get_root_binding(import_entry.local_name.name())
+            let Some(symbol_id) = ctx.scoping().get_root_binding(import_entry.local_name.name().into())
             else {
                 return;
             };

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -60,7 +60,11 @@ impl Rule for ApproxConstant {
                 ctx.diagnostic_with_suggestion(
                     approx_constant_diagnostic(number_literal.span, name),
                     |fixer| {
-                        if ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Math")).is_some() {
+                        if ctx
+                            .scoping()
+                            .find_binding(node.scope_id(), Ident::new_const("Math"))
+                            .is_some()
+                        {
                             fixer.noop()
                         } else {
                             Self::fix_with_math_constant(fixer, number_literal.span, name)

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -5,7 +5,7 @@ use std::f64::consts as f64;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{Ident, Span};
 
 use crate::{AstNode, context::LintContext, fixer::RuleFixer, rule::Rule};
 
@@ -60,7 +60,7 @@ impl Rule for ApproxConstant {
                 ctx.diagnostic_with_suggestion(
                     approx_constant_diagnostic(number_literal.span, name),
                     |fixer| {
-                        if ctx.scoping().find_binding(node.scope_id(), "Math").is_some() {
+                        if ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Math")).is_some() {
                             fixer.noop()
                         } else {
                             Self::fix_with_math_constant(fixer, number_literal.span, name)

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::Span;
+use oxc_span::{Ident, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -91,7 +91,7 @@ impl Rule for NoDangerWithChildren {
                             is_object_with_prop_name(&obj_expr.properties, "children")
                         }
                         Expression::Identifier(ident) => {
-                            does_object_var_have_prop_name(ctx, node, &ident.name, "children")
+                            does_object_var_have_prop_name(ctx, node, ident.name, "children")
                         }
                         _ => false,
                     }
@@ -110,7 +110,7 @@ impl Rule for NoDangerWithChildren {
                     Expression::Identifier(ident) => does_object_var_have_prop_name(
                         ctx,
                         node,
-                        &ident.name,
+                        ident.name,
                         "dangerouslySetInnerHTML",
                     ),
                     _ => false,
@@ -270,7 +270,7 @@ fn has_jsx_prop(ctx: &LintContext, node: &AstNode, prop_name: &'static str) -> b
             let Some(ident) = attr.argument.get_identifier_reference() else {
                 return false;
             };
-            does_object_var_have_prop_name(ctx, node, ident.name.as_str(), prop_name)
+            does_object_var_have_prop_name(ctx, node, ident.name, prop_name)
         }
     })
 }
@@ -280,7 +280,7 @@ fn has_jsx_prop(ctx: &LintContext, node: &AstNode, prop_name: &'static str) -> b
 fn does_object_var_have_prop_name(
     ctx: &LintContext,
     node: &AstNode,
-    name: &str,
+    name: Ident<'_>,
     prop_name: &str,
 ) -> bool {
     let Some(symbol) = &find_var_in_scope(ctx, node, name) else {
@@ -309,13 +309,13 @@ fn does_object_var_have_prop_name(
             };
             // If the next symbol is the same as the current symbol, then there is a cycle,
             // for example: `const props = {...props}`, so we will stop searching.
-            if let Some(next_symbol) = find_var_in_scope(ctx, node, ident.name.as_str())
+            if let Some(next_symbol) = find_var_in_scope(ctx, node, ident.name)
                 && next_symbol.id() == symbol.id()
             {
                 return false;
             }
 
-            does_object_var_have_prop_name(ctx, symbol, ident.name.as_str(), prop_name)
+            does_object_var_have_prop_name(ctx, symbol, ident.name, prop_name)
         }
     })
 }
@@ -324,7 +324,7 @@ fn does_object_var_have_prop_name(
 fn find_var_in_scope<'c>(
     ctx: &'c LintContext,
     node: &AstNode,
-    name: &str,
+    name: Ident<'_>,
 ) -> Option<&'c AstNode<'c>> {
     ctx.scoping()
         .find_binding(node.scope_id(), name)

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{
     AstNode,
@@ -64,7 +64,7 @@ impl Rule for ReactInJsxScope {
             _ => return,
         };
         let scope = ctx.scoping();
-        let react_name = "React";
+        let react_name = Ident::new_const("React");
         if scope.get_binding(scope.root_scope_id(), react_name).is_some() {
             return;
         }

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -72,7 +72,7 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
         let Expression::TSNonNullExpression(ts_non_null_expr) = &expr.left else { return };
         if let Expression::Identifier(ident) = &ts_non_null_expr.expression
-            && let Some(symbol_id) = ctx.scoping().get_binding(node.scope_id(), &ident.name)
+            && let Some(symbol_id) = ctx.scoping().get_binding(node.scope_id(), ident.name)
             && !has_assignment_before_node(symbol_id, ctx, expr.span.end)
         {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -170,7 +170,11 @@ impl Rule for NoRequireImports {
                     }
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require")).is_some() {
+                if ctx
+                    .scoping()
+                    .find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require"))
+                    .is_some()
+                {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, Span};
+use oxc_span::{CompactStr, Ident, Span};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -170,7 +170,7 @@ impl Rule for NoRequireImports {
                     }
                 }
 
-                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), "require").is_some() {
+                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require")).is_some() {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
@@ -153,7 +153,7 @@ fn check_setup_in_object<'a>(obj_expr: &ObjectExpression<'a>, ctx: &LintContext<
         if !LIFECYCLE_HOOKS.contains(&import_name) {
             continue;
         }
-        if let Some(symbol_id) = scoping.get_root_binding(import_entry.local_name.name()) {
+        if let Some(symbol_id) = scoping.get_root_binding(import_entry.local_name.name().into()) {
             symbol_to_import_entry.insert(symbol_id, import_entry);
         }
     }

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -104,7 +104,7 @@ pub fn check_define_macro_call_expression(
 }
 
 fn is_non_local_reference(identifier: &IdentifierReference, ctx: &LintContext<'_>) -> bool {
-    if let Some(symbol_id) = ctx.semantic().scoping().get_root_binding(&identifier.name) {
+    if let Some(symbol_id) = ctx.semantic().scoping().get_root_binding(identifier.name) {
         return matches!(
             ctx.semantic().symbol_declaration(symbol_id).kind(),
             AstKind::ImportSpecifier(_)

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -7,7 +7,7 @@ use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, Det
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Ident};
 use oxc_span::SPAN;
 use oxc_syntax::precedence::GetPrecedence;
 use oxc_syntax::{
@@ -1225,7 +1225,7 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                let reference_id = ctx.create_unbound_reference("Object", ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(Ident::new_const("Object"), ReferenceFlags::Read);
                 call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
                     call_expr.callee.span(),
                     "Object",

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -7,8 +7,8 @@ use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, Det
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{GetSpan, Ident};
 use oxc_span::SPAN;
+use oxc_span::{GetSpan, Ident};
 use oxc_syntax::precedence::GetPrecedence;
 use oxc_syntax::{
     number::NumberBase,
@@ -1225,7 +1225,8 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                let reference_id = ctx.create_unbound_reference(Ident::new_const("Object"), ReferenceFlags::Read);
+                let reference_id =
+                    ctx.create_unbound_reference(Ident::new_const("Object"), ReferenceFlags::Read);
                 call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
                     call_expr.callee.span(),
                     "Object",

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -71,7 +71,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 
                         // Hoist current symbol to target scope when it is not already declared
                         // in the target scope.
-                        if !builder.scoping.scope_has_binding(target_scope_id, &name) {
+                        if !builder.scoping.scope_has_binding(target_scope_id, name) {
                             // remove current scope binding and add to target scope
                             // avoid same symbols appear in multi-scopes
                             builder.scoping.remove_binding(scope_id, name);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -443,7 +443,7 @@ impl<'a> SemanticBuilder<'a> {
         excludes: SymbolFlags,
         report_error: bool,
     ) -> Option<SymbolId> {
-        let symbol_id = self.scoping.get_binding(scope_id, name).or_else(|| {
+        let symbol_id = self.scoping.get_binding(scope_id, name.into()).or_else(|| {
             self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(name).copied())
         })?;
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -285,8 +285,10 @@ mod tests {
         let allocator = Allocator::default();
         let semantic = get_semantic(&allocator, source, SourceType::default());
 
-        let top_level_a =
-            semantic.scoping().get_binding(semantic.scoping().root_scope_id(), Ident::new_const("a")).unwrap();
+        let top_level_a = semantic
+            .scoping()
+            .get_binding(semantic.scoping().root_scope_id(), Ident::new_const("a"))
+            .unwrap();
 
         let decl = semantic.symbol_declaration(top_level_a);
         match decl.kind() {
@@ -448,8 +450,10 @@ mod tests {
 
         for (source_type, source, flags) in sources {
             let semantic = get_semantic(&alloc, source, source_type);
-            let a_id =
-                semantic.scoping().get_root_binding(target_symbol_name.as_str().into()).unwrap_or_else(|| {
+            let a_id = semantic
+                .scoping()
+                .get_root_binding(target_symbol_name.as_str().into())
+                .unwrap_or_else(|| {
                     panic!("no references for '{target_symbol_name}' found");
                 });
             let a_refs: Vec<_> = semantic.symbol_references(a_id).collect();

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -257,7 +257,7 @@ impl<'a> Semantic<'a> {
 mod tests {
     use oxc_allocator::Allocator;
     use oxc_ast::{AstKind, ast::VariableDeclarationKind};
-    use oxc_span::{Atom, SourceType};
+    use oxc_span::{Atom, Ident, SourceType};
 
     use super::*;
 
@@ -286,7 +286,7 @@ mod tests {
         let semantic = get_semantic(&allocator, source, SourceType::default());
 
         let top_level_a =
-            semantic.scoping().get_binding(semantic.scoping().root_scope_id(), "a").unwrap();
+            semantic.scoping().get_binding(semantic.scoping().root_scope_id(), Ident::new_const("a")).unwrap();
 
         let decl = semantic.symbol_declaration(top_level_a);
         match decl.kind() {
@@ -307,7 +307,7 @@ mod tests {
         let semantic = get_semantic(&allocator, source, SourceType::default());
         let scopes = semantic.scoping();
 
-        assert!(scopes.get_binding(scopes.root_scope_id(), "Fn").is_some());
+        assert!(scopes.get_binding(scopes.root_scope_id(), Ident::new_const("Fn")).is_some());
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod tests {
         for (source_type, source, flags) in sources {
             let semantic = get_semantic(&alloc, source, source_type);
             let a_id =
-                semantic.scoping().get_root_binding(&target_symbol_name).unwrap_or_else(|| {
+                semantic.scoping().get_root_binding(target_symbol_name.as_str().into()).unwrap_or_else(|| {
                     panic!("no references for '{target_symbol_name}' found");
                 });
             let a_refs: Vec<_> = semantic.symbol_references(a_id).collect();

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -689,7 +689,7 @@ impl Scoping {
 
     /// Get a variable binding by name that was declared in the top-level scope
     #[inline]
-    pub fn get_root_binding(&self, name: &str) -> Option<SymbolId> {
+    pub fn get_root_binding(&self, name: Ident<'_>) -> Option<SymbolId> {
         self.get_binding(self.root_scope_id(), name)
     }
 
@@ -704,8 +704,8 @@ impl Scoping {
     }
 
     /// Check if a symbol is declared in a certain scope.
-    pub fn scope_has_binding(&self, scope_id: ScopeId, name: &str) -> bool {
-        self.cell.borrow_dependent().bindings[scope_id].contains_key(name)
+    pub fn scope_has_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> bool {
+        self.cell.borrow_dependent().bindings[scope_id].contains_key(name.as_str())
     }
 
     /// Get the symbol bound to an identifier name in a scope.
@@ -716,15 +716,15 @@ impl Scoping {
     /// binding that might be declared in a parent scope, use [`find_binding`].
     ///
     /// [`find_binding`]: Scoping::find_binding
-    pub fn get_binding(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
-        self.cell.borrow_dependent().bindings[scope_id].get(name).copied()
+    pub fn get_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
+        self.cell.borrow_dependent().bindings[scope_id].get(name.as_str()).copied()
     }
 
     /// Find a binding by name in a scope or its ancestors.
     ///
     /// Bindings are resolved by walking up the scope tree until a binding is
     /// found. If no binding is found, [`None`] is returned.
-    pub fn find_binding(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
+    pub fn find_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
         for scope_id in self.scope_ancestors(scope_id) {
             if let Some(symbol_id) = self.get_binding(scope_id, name) {
                 return Some(symbol_id);

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -45,7 +45,8 @@ impl<'a> SymbolTester<'a> {
         semantic: Semantic<'a>,
         target: &str,
     ) -> Self {
-        let decl = semantic.scoping().get_binding(semantic.scoping().root_scope_id(), target.into());
+        let decl =
+            semantic.scoping().get_binding(semantic.scoping().root_scope_id(), target.into());
         let data = decl.map_or_else(
             || Err(OxcDiagnostic::error(format!("Could not find declaration for {target}"))),
             Ok,

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -45,7 +45,7 @@ impl<'a> SymbolTester<'a> {
         semantic: Semantic<'a>,
         target: &str,
     ) -> Self {
-        let decl = semantic.scoping().get_binding(semantic.scoping().root_scope_id(), target);
+        let decl = semantic.scoping().get_binding(semantic.scoping().root_scope_id(), target.into());
         let data = decl.map_or_else(
             || Err(OxcDiagnostic::error(format!("Could not find declaration for {target}"))),
             Ok,

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -323,7 +323,8 @@ impl<'a> HelperLoaderStore<'a> {
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const(HELPER_VAR));
+        let symbol_id =
+            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const(HELPER_VAR));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const(HELPER_VAR),

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -323,7 +323,7 @@ impl<'a> HelperLoaderStore<'a> {
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), HELPER_VAR);
+        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const(HELPER_VAR));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const(HELPER_VAR),

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -182,7 +182,7 @@ impl<'a> ModuleImportsStore<'a> {
             return;
         }
 
-        let require_symbol_id = ctx.scoping().get_root_binding("require");
+        let require_symbol_id = ctx.scoping().get_root_binding(Ident::new_const("require"));
         let stmts = imports
             .drain(..)
             .map(|(source, names)| Self::get_require(source, names, require_symbol_id, ctx));

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -536,7 +536,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
         right: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Math");
+        let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Math"));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const("Math"),

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -536,7 +536,8 @@ impl<'a> ExponentiationOperator<'a, '_> {
         right: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Math"));
+        let math_symbol_id =
+            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Math"));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const("Math"),

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -651,7 +651,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         bound_ident: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "arguments");
+        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("arguments"));
         let arguments_ident = Argument::from(ctx.create_ident_expr(
             SPAN,
             Ident::new_const("arguments"),

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -651,7 +651,8 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         bound_ident: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("arguments"));
+        let symbol_id =
+            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("arguments"));
         let arguments_ident = Argument::from(ctx.create_ident_expr(
             SPAN,
             Ident::new_const("arguments"),

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -889,7 +889,7 @@ fn create_new_weakmap<'a>(
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
     let symbol_id = *symbol_id
-        .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), "WeakMap"));
+        .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakMap")));
     let ident =
         ctx.create_ident_expr(SPAN, Ident::new_const("WeakMap"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
@@ -897,7 +897,7 @@ fn create_new_weakmap<'a>(
 
 /// Create `new WeakSet()` expression.
 fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-    let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "WeakSet");
+    let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakSet"));
     let ident =
         ctx.create_ident_expr(SPAN, Ident::new_const("WeakSet"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -888,8 +888,9 @@ fn create_new_weakmap<'a>(
     symbol_id: &mut Option<Option<SymbolId>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let symbol_id = *symbol_id
-        .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakMap")));
+    let symbol_id = *symbol_id.get_or_insert_with(|| {
+        ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakMap"))
+    });
     let ident =
         ctx.create_ident_expr(SPAN, Ident::new_const("WeakMap"), symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -127,7 +127,7 @@ impl<'a> InstanceInitializerVisitor<'a, '_> {
         // with same `ScopeId` every time here, but `ScopeTree` doesn't allow that, and we also
         // take a `&mut ScopeTree` in `reparent_scope`, so borrow-checker doesn't allow that.
         let Some(constructor_symbol_id) =
-            self.ctx.scoping().get_binding(self.constructor_scope_id, &ident.name)
+            self.ctx.scoping().get_binding(self.constructor_scope_id, ident.name)
         else {
             return;
         };

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -341,7 +341,7 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // `Object.defineProperty`
-        let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Object");
+        let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Object"));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const("Object"),

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -341,7 +341,8 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // `Object.defineProperty`
-        let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Object"));
+        let object_symbol_id =
+            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Object"));
         let object = ctx.create_ident_expr(
             SPAN,
             Ident::new_const("Object"),

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -1197,7 +1197,8 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let reference_id = ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
+    let reference_id =
+        ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
     let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
     Expression::Identifier(ident)
 }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -93,7 +93,7 @@ use oxc_allocator::{
 };
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     identifier::is_white_space_single_line, line_terminator::is_line_terminator,
     reference::ReferenceFlags, symbol::SymbolFlags, xml_entities::XML_ENTITIES,
@@ -1197,7 +1197,7 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let reference_id = ctx.create_reference_in_current_scope(name.as_str(), ReferenceFlags::Read);
+    let reference_id = ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
     let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
     Expression::Identifier(ident)
 }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -78,7 +78,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
     pub fn to_expression(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         match self {
             Self::Identifier(ident) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,
@@ -86,7 +86,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 )
             }
             Self::Member((ident, property)) => {
-                let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
+                let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
                 let ident = ctx.ast.expression_identifier_with_reference_id(
                     ident.span,
                     ident.name,
@@ -353,7 +353,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a, '_> {
                     ctx.scoping()
                         .find_binding(
                             ctx.scoping().scope_parent_id(ctx.current_scope_id()).unwrap(),
-                            binding_name.as_str(),
+                            binding_name,
                         )
                         .map(|symbol_id| {
                             let mut expr = ctx.create_bound_ident_expr(

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -163,7 +163,8 @@ impl<'a> RegExp<'a, '_> {
         }
 
         let callee = {
-            let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("RegExp"));
+            let symbol_id =
+                ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("RegExp"));
             ctx.create_ident_expr(
                 SPAN,
                 Ident::new_const("RegExp"),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -163,7 +163,7 @@ impl<'a> RegExp<'a, '_> {
         }
 
         let callee = {
-            let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "RegExp");
+            let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("RegExp"));
             ctx.create_ident_expr(
                 SPAN,
                 Ident::new_const("RegExp"),

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -328,7 +328,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         // Infinity
         let expr = if value.is_infinite() {
-            let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), "Infinity");
+            let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Infinity"));
             ctx.create_ident_expr(
                 SPAN,
                 Ident::new_const("Infinity"),

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -328,7 +328,8 @@ impl<'a> TypeScriptEnum<'a> {
 
         // Infinity
         let expr = if value.is_infinite() {
-            let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Infinity"));
+            let infinity_symbol_id =
+                ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Infinity"));
             ctx.create_ident_expr(
                 SPAN,
                 Ident::new_const("Infinity"),

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -72,8 +72,10 @@ impl<'a> TypeScriptModule<'a, '_> {
 
         // module.exports
         let module_exports = {
-            let reference_id =
-                ctx.create_reference_in_current_scope(Ident::new_const("module"), ReferenceFlags::Read);
+            let reference_id = ctx.create_reference_in_current_scope(
+                Ident::new_const("module"),
+                ReferenceFlags::Read,
+            );
             let reference =
                 ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, "module", reference_id);
             let object = Expression::Identifier(reference);

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -73,7 +73,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         // module.exports
         let module_exports = {
             let reference_id =
-                ctx.create_reference_in_current_scope("module", ReferenceFlags::Read);
+                ctx.create_reference_in_current_scope(Ident::new_const("module"), ReferenceFlags::Read);
             let reference =
                 ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, "module", reference_id);
             let object = Expression::Identifier(reference);
@@ -150,7 +150,7 @@ impl<'a> TypeScriptModule<'a, '_> {
                 }
 
                 let require_symbol_id =
-                    ctx.scoping().find_binding(ctx.current_scope_id(), "require");
+                    ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("require"));
                 let callee = ctx.create_ident_expr(
                     SPAN,
                     Ident::new_const("require"),

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -766,7 +766,7 @@ struct UpdateReplacedExpression<'a, 'b> {
 impl VisitMut<'_> for UpdateReplacedExpression<'_, '_> {
     fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'_>) {
         let reference_id =
-            self.ctx.create_reference_in_current_scope(ident.name.as_str(), ReferenceFlags::Read);
+            self.ctx.create_reference_in_current_scope(ident.name, ReferenceFlags::Read);
         ident.set_reference_id(reference_id);
         walk_mut::walk_identifier_reference(self, ident);
     }

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -537,7 +537,11 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
     #[inline]
-    pub fn create_unbound_reference(&mut self, name: Ident<'_>, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flags)
     }
 

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -537,7 +537,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
     #[inline]
-    pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(&mut self, name: Ident<'_>, flags: ReferenceFlags) -> ReferenceId {
         self.scoping.create_unbound_reference(name, flags)
     }
 
@@ -548,7 +548,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         name: Ident<'a>,
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
-        let reference_id = self.create_unbound_reference(&name, flags);
+        let reference_id = self.create_unbound_reference(name, flags);
         self.ast.identifier_reference_with_reference_id(span, name, reference_id)
     }
 
@@ -572,7 +572,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
@@ -621,7 +621,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     #[inline]
     pub fn create_reference_in_current_scope(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
         self.scoping.create_reference_in_current_scope(name, flags)
@@ -632,7 +632,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// Provided `name` must match `reference_id`.
     ///
     /// This is a shortcut for `ctx.scoping.delete_reference`.
-    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
         self.scoping.delete_reference(reference_id, name);
     }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -298,7 +298,11 @@ impl<'a> TraverseScoping<'a> {
     }
 
     /// Create an unbound reference
-    pub fn create_unbound_reference(&mut self, name: Ident<'_>, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
         let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
         self.scoping.add_root_unresolved_reference(name, reference_id);

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -298,10 +298,10 @@ impl<'a> TraverseScoping<'a> {
     }
 
     /// Create an unbound reference
-    pub fn create_unbound_reference(&mut self, name: &str, flags: ReferenceFlags) -> ReferenceId {
+    pub fn create_unbound_reference(&mut self, name: Ident<'_>, flags: ReferenceFlags) -> ReferenceId {
         let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
         let reference_id = self.scoping.create_reference(reference);
-        self.scoping.add_root_unresolved_reference(Ident::from(name), reference_id);
+        self.scoping.add_root_unresolved_reference(name, reference_id);
         reference_id
     }
 
@@ -311,7 +311,7 @@ impl<'a> TraverseScoping<'a> {
     /// or `TraverseCtx::create_unbound_reference`.
     pub fn create_reference(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         symbol_id: Option<SymbolId>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
@@ -325,7 +325,7 @@ impl<'a> TraverseScoping<'a> {
     /// Create reference in current scope, looking up binding for `name`
     pub fn create_reference_in_current_scope(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         flags: ReferenceFlags,
     ) -> ReferenceId {
         let symbol_id = self.scoping.find_binding(self.current_scope_id, name);
@@ -335,18 +335,18 @@ impl<'a> TraverseScoping<'a> {
     /// Delete a reference.
     ///
     /// Provided `name` must match `reference_id`.
-    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: &str) {
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
         let symbol_id = self.scoping.get_reference(reference_id).symbol_id();
         if let Some(symbol_id) = symbol_id {
             self.scoping.delete_resolved_reference(symbol_id, reference_id);
         } else {
-            self.scoping.delete_root_unresolved_reference(Ident::from(name), reference_id);
+            self.scoping.delete_root_unresolved_reference(name, reference_id);
         }
     }
 
     /// Delete reference for an `IdentifierReference`.
     pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
-        self.delete_reference(ident.reference_id(), &ident.name);
+        self.delete_reference(ident.reference_id(), ident.name);
     }
 }
 


### PR DESCRIPTION
## Summary

- Change `Scoping` methods (`get_binding`, `find_binding`, `scope_has_binding`, `get_root_binding`) to accept `Ident` instead of `&str`
- Propagate `Ident` through `TraverseScoping`/`TraverseCtx` methods (`create_reference`, `create_unbound_reference`, `create_reference_in_current_scope`, `delete_reference`)
- Update all callers across semantic, traverse, transformer, linter, minifier, and transformer_plugins crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)