### PR TITLE
refactor(semantic): accept `Ident` in `check_redeclaration` and `TraverseScoping::add_binding`

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 };
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_semantic::{AstNode, AstNodes, IsGlobalReference, NodeId, ReferenceId, Semantic, SymbolId};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 use oxc_syntax::{
     identifier::is_irregular_whitespace,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -405,7 +405,7 @@ pub fn is_global_require_call(call_expr: &CallExpression, ctx: &Semantic) -> boo
     if call_expr.arguments.len() != 1 {
         return false;
     }
-    call_expr.callee.is_global_reference_name("require", ctx.scoping())
+    call_expr.callee.is_global_reference_name(Ident::new_const("require"), ctx.scoping())
 }
 
 pub fn is_function_node(node: &AstNode) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -79,7 +79,7 @@ impl Rule for NoArrayConstructor {
         let last_arg_is_spread = arguments.last().is_some_and(Argument::is_spread);
         let arg_len = arguments.len();
 
-        if ident.is_global_reference_name("Array", ctx.scoping())
+        if ident.is_global_reference_name(Ident::new_const("Array"), ctx.scoping())
             && (arg_len != 1 || last_arg_is_spread)
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -179,10 +179,7 @@ impl NoConstantBinaryExpression {
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     return ["Boolean", "String", "Number"].contains(&ident.name.as_str())
-                        && ctx
-                            .scoping()
-                            .root_unresolved_references()
-                            .contains_key(ident.name.as_str());
+                        && ctx.scoping().root_unresolved_references().contains_key(&ident.name);
                 }
                 false
             }
@@ -307,14 +304,12 @@ impl NoConstantBinaryExpression {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     let unresolved_references = ctx.scoping().root_unresolved_references();
                     if (ident.name == "String" || ident.name == "Number")
-                        && unresolved_references.contains_key(ident.name.as_str())
+                        && unresolved_references.contains_key(&ident.name)
                     {
                         return true;
                     }
 
-                    if ident.name == "Boolean"
-                        && unresolved_references.contains_key(ident.name.as_str())
-                    {
+                    if ident.name == "Boolean" && unresolved_references.contains_key(&ident.name) {
                         return call_expr
                             .arguments
                             .iter()
@@ -356,10 +351,7 @@ impl NoConstantBinaryExpression {
             Expression::NewExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     return ctx.env_contains_var(ident.name.as_str())
-                        && ctx
-                            .scoping()
-                            .root_unresolved_references()
-                            .contains_key(ident.name.as_str());
+                        && ctx.scoping().root_unresolved_references().contains_key(&ident.name);
                 }
                 false
             }

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -2,7 +2,7 @@ use oxc_ast::{AstKind, ast::IdentifierReference};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -104,7 +104,7 @@ impl Rule for NoNewFunc {
 }
 
 fn check(ident: &IdentifierReference, span: Span, ctx: &LintContext) {
-    if ident.is_global_reference_name("Function", ctx.scoping()) {
+    if ident.is_global_reference_name(Ident::new_const("Function"), ctx.scoping()) {
         ctx.diagnostic(no_new_func(span));
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -57,7 +57,7 @@ impl Rule for NoNewNativeNonconstructor {
             return;
         };
         if matches!(ident.name.as_str(), "Symbol" | "BigInt")
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
         {
             let start = expr.span.start;
             let end = start + 3;

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -92,7 +92,7 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str()) {
+            if ctx.scoping().root_unresolved_references().contains_key(&ident.name) {
                 let reference = ctx.scoping().get_reference(ident.reference_id());
                 if !reference.is_type() {
                     ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -91,16 +91,14 @@ impl Rule for PreferObjectSpread {
 
         match callee.object().get_inner_expression() {
             Expression::Identifier(ident) => {
-                if ident.name != "Object"
-                    || !unresolved_references.contains_key(ident.name.as_str())
-                {
+                if ident.name != "Object" || !unresolved_references.contains_key(&ident.name) {
                     return;
                 }
             }
             Expression::StaticMemberExpression(member_expr) => {
                 if let Expression::Identifier(ident) = member_expr.object.get_inner_expression() {
                     if ident.name != "globalThis"
-                        || !unresolved_references.contains_key(ident.name.as_str())
+                        || !unresolved_references.contains_key(&ident.name)
                     {
                         return;
                     }

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -7,7 +7,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -198,13 +198,13 @@ fn is_builtin_error_constructor(expr: &Expression, ctx: &LintContext) -> bool {
         return false;
     };
 
-    ident.is_global_reference_name("Error", ctx.scoping())
-        || ident.is_global_reference_name("TypeError", ctx.scoping())
+    ident.is_global_reference_name(Ident::new_const("Error"), ctx.scoping())
+        || ident.is_global_reference_name(Ident::new_const("TypeError"), ctx.scoping())
         || is_aggregate_error(ident, ctx)
 }
 
 fn is_aggregate_error(ident: &IdentifierReference, ctx: &LintContext) -> bool {
-    ident.is_global_reference_name("AggregateError", ctx.scoping())
+    ident.is_global_reference_name(Ident::new_const("AggregateError"), ctx.scoping())
 }
 
 fn has_cause_property(

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -64,7 +64,7 @@ impl Rule for SymbolDescription {
 
         if ident.name == "Symbol"
             && call_expr.arguments.is_empty()
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
         {
             ctx.diagnostic(symbol_description_diagnostic(call_expr.span));
         }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -144,7 +144,7 @@ impl Rule for ValidTypeof {
 
         if let Expression::Identifier(ident) = sibling
             && ident.name == "undefined"
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
         {
             ctx.diagnostic_with_fix(
                 if self.require_string_literals {

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Span};
+use oxc_span::{GetSpan, Ident, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,7 +19,7 @@ fn is_exports(node: &AssignmentTarget, ctx: &LintContext) -> bool {
     let AssignmentTarget::AssignmentTargetIdentifier(id) = node else {
         return false;
     };
-    id.is_global_reference_name("exports", ctx.scoping())
+    id.is_global_reference_name(Ident::new_const("exports"), ctx.scoping())
 }
 
 fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool {
@@ -32,7 +32,7 @@ fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool
     };
 
     mem_expr.static_property_name() == Some("exports")
-        && obj_id.is_global_reference_name("module", ctx.scoping())
+        && obj_id.is_global_reference_name(Ident::new_const("module"), ctx.scoping())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -2,7 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, GetSpan, Span};
+use oxc_span::{CompactStr, GetSpan, Ident, Span};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
     let Some(obj_id) = object_expr.get_identifier_reference() else {
         return false;
     };
-    obj_id.is_global_reference_name("process", ctx.scoping())
+    obj_id.is_global_reference_name(Ident::new_const("process"), ctx.scoping())
 }
 
 impl Rule for NoProcessEnv {

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -54,7 +54,7 @@ impl Rule for AvoidNew {
         };
 
         if ident.name == "Promise"
-            && ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            && ctx.scoping().root_unresolved_references().contains_key(&ident.name)
         {
             ctx.diagnostic(avoid_new_promise_diagnostic(expr.span));
         }

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -133,7 +133,7 @@ impl Rule for NoRequireImports {
             AstKind::CallExpression(call_expr) => {
                 if node.scope_id() != ctx.scoping().root_scope_id()
                     && let Some(id) = call_expr.callee.get_identifier_reference()
-                    && !id.is_global_reference_name("require", ctx.scoping())
+                    && !id.is_global_reference_name(Ident::new_const("require"), ctx.scoping())
                 {
                     return;
                 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -65,7 +65,7 @@ impl Rule for PreferGlobalThis {
 
         if !matches!(ident.name.as_str(), "window" | "self" | "global")
             || is_computed_member_expression_object(node, ctx)
-            || !ctx.scoping().root_unresolved_references().contains_key(ident.name.as_str())
+            || !ctx.scoping().root_unresolved_references().contains_key(&ident.name)
         {
             return;
         }

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 };
 use oxc_regular_expression::{ConstructorParser, Options, ast::Pattern};
 use oxc_semantic::IsGlobalReference;
-use oxc_span::Span;
+use oxc_span::{Ident, Span};
 
 use crate::{AstNode, context::LintContext};
 
@@ -94,13 +94,13 @@ where
 
 // Accepts both RegExp and globalThis.RegExp
 fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
-    if callee.is_global_reference_name("RegExp", ctx.semantic().scoping()) {
+    if callee.is_global_reference_name(Ident::new_const("RegExp"), ctx.semantic().scoping()) {
         return true;
     }
     // Check for globalThis.RegExp (StaticMemberExpression)
     if let Expression::StaticMemberExpression(member) = callee
         && let Expression::Identifier(obj) = &member.object
-        && obj.is_global_reference_name("globalThis", ctx.semantic().scoping())
+        && obj.is_global_reference_name(Ident::new_const("globalThis"), ctx.semantic().scoping())
         && member.property.name == "RegExp"
     {
         return true;

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -64,7 +64,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
 
                 for &scope_id in &var_scope_ids {
                     if let Some(symbol_id) =
-                        builder.check_redeclaration(scope_id, span, &name, excludes, true)
+                        builder.check_redeclaration(scope_id, span, name, excludes, true)
                     {
                         builder.add_redeclare_variable(symbol_id, includes, span);
                         declared_symbol_id = Some(symbol_id);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -405,9 +405,7 @@ impl<'a> SemanticBuilder<'a> {
         includes: SymbolFlags,
         excludes: SymbolFlags,
     ) -> SymbolId {
-        if let Some(symbol_id) =
-            self.check_redeclaration(scope_id, span, name, excludes, true)
-        {
+        if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
             self.add_redeclare_variable(symbol_id, includes, span);
             self.scoping.union_symbol_flag(symbol_id, includes);
             return symbol_id;
@@ -444,7 +442,9 @@ impl<'a> SemanticBuilder<'a> {
         report_error: bool,
     ) -> Option<SymbolId> {
         let symbol_id = self.scoping.get_binding(scope_id, name).or_else(|| {
-            self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(name.as_str()).copied())
+            self.hoisting_variables
+                .get(&scope_id)
+                .and_then(|symbols| symbols.get(name.as_str()).copied())
         })?;
 
         // `(function n(n) {})()`

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -406,7 +406,7 @@ impl<'a> SemanticBuilder<'a> {
         excludes: SymbolFlags,
     ) -> SymbolId {
         if let Some(symbol_id) =
-            self.check_redeclaration(scope_id, span, name.as_str(), excludes, true)
+            self.check_redeclaration(scope_id, span, name, excludes, true)
         {
             self.add_redeclare_variable(symbol_id, includes, span);
             self.scoping.union_symbol_flag(symbol_id, includes);
@@ -439,12 +439,12 @@ impl<'a> SemanticBuilder<'a> {
         &self,
         scope_id: ScopeId,
         span: Span,
-        name: &str,
+        name: Ident<'_>,
         excludes: SymbolFlags,
         report_error: bool,
     ) -> Option<SymbolId> {
-        let symbol_id = self.scoping.get_binding(scope_id, name.into()).or_else(|| {
-            self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(name).copied())
+        let symbol_id = self.scoping.get_binding(scope_id, name).or_else(|| {
+            self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(name.as_str()).copied())
         })?;
 
         // `(function n(n) {})()`
@@ -467,7 +467,7 @@ impl<'a> SemanticBuilder<'a> {
             let flags = self.scoping.symbol_flags(symbol_id);
             if flags.intersects(excludes) {
                 let symbol_span = self.scoping.symbol_span(symbol_id);
-                self.error(redeclaration(name, symbol_span, span));
+                self.error(redeclaration(&name, symbol_span, span));
             }
         }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -442,9 +442,7 @@ impl<'a> SemanticBuilder<'a> {
         report_error: bool,
     ) -> Option<SymbolId> {
         let symbol_id = self.scoping.get_binding(scope_id, name).or_else(|| {
-            self.hoisting_variables
-                .get(&scope_id)
-                .and_then(|symbols| symbols.get(name.as_str()).copied())
+            self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(&name).copied())
         })?;
 
         // `(function n(n) {})()`
@@ -541,7 +539,7 @@ impl<'a> SemanticBuilder<'a> {
             // Try to resolve a reference.
             // If unresolved, transfer it to parent scope's unresolved references.
             let bindings = self.scoping.get_bindings(self.current_scope_id);
-            if let Some(symbol_id) = bindings.get(name.as_str()).copied() {
+            if let Some(symbol_id) = bindings.get(&name).copied() {
                 let symbol_flags = self.scoping.symbol_flags(symbol_id);
                 references.retain(|reference_id| {
                     let reference_id = *reference_id;

--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -1,4 +1,5 @@
 use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_span::Ident;
 
 use crate::{ReferenceId, Scoping};
 
@@ -26,7 +27,7 @@ use crate::{ReferenceId, Scoping};
 /// See: <https://github.com/oxc-project/oxc/issues/8365>
 pub trait IsGlobalReference {
     fn is_global_reference(&self, scoping: &Scoping) -> bool;
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool;
+    fn is_global_reference_name(&self, name: Ident<'_>, scoping: &Scoping) -> bool;
 }
 
 impl IsGlobalReference for ReferenceId {
@@ -34,7 +35,7 @@ impl IsGlobalReference for ReferenceId {
         scoping.references[*self].symbol_id().is_none()
     }
 
-    fn is_global_reference_name(&self, _name: &str, _scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, _name: Ident<'_>, _scoping: &Scoping) -> bool {
         panic!("This function is pointless to be called.");
     }
 }
@@ -46,7 +47,7 @@ impl IsGlobalReference for IdentifierReference<'_> {
             .is_some_and(|reference_id| reference_id.is_global_reference(scoping))
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, name: Ident<'_>, scoping: &Scoping) -> bool {
         self.name == name && self.is_global_reference(scoping)
     }
 }
@@ -59,7 +60,7 @@ impl IsGlobalReference for Expression<'_> {
         false
     }
 
-    fn is_global_reference_name(&self, name: &str, scoping: &Scoping) -> bool {
+    fn is_global_reference_name(&self, name: Ident<'_>, scoping: &Scoping) -> bool {
         if let Expression::Identifier(ident) = self {
             return ident.is_global_reference_name(name, scoping);
         }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -215,7 +215,7 @@ impl<'a> Semantic<'a> {
         let AstKind::IdentifierReference(id) = reference_node.kind() else {
             return false;
         };
-        self.scoping.root_unresolved_references().contains_key(id.name.as_str())
+        self.scoping.root_unresolved_references().contains_key(&id.name)
     }
 
     /// Find which scope a symbol is declared in
@@ -236,7 +236,7 @@ impl<'a> Semantic<'a> {
     }
 
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
-        self.scoping.root_unresolved_references().contains_key(ident.name.as_str())
+        self.scoping.root_unresolved_references().contains_key(&ident.name)
     }
 
     pub fn reference_name(&self, reference: &Reference) -> &str {
@@ -452,7 +452,7 @@ mod tests {
             let semantic = get_semantic(&alloc, source, source_type);
             let a_id = semantic
                 .scoping()
-                .get_root_binding(target_symbol_name.as_str().into())
+                .get_root_binding(target_symbol_name.into())
                 .unwrap_or_else(|| {
                     panic!("no references for '{target_symbol_name}' found");
                 });

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -705,7 +705,7 @@ impl Scoping {
 
     /// Check if a symbol is declared in a certain scope.
     pub fn scope_has_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> bool {
-        self.cell.borrow_dependent().bindings[scope_id].contains_key(name.as_str())
+        self.cell.borrow_dependent().bindings[scope_id].contains_key(&name)
     }
 
     /// Get the symbol bound to an identifier name in a scope.
@@ -717,7 +717,7 @@ impl Scoping {
     ///
     /// [`find_binding`]: Scoping::find_binding
     pub fn get_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
-        self.cell.borrow_dependent().bindings[scope_id].get(name.as_str()).copied()
+        self.cell.borrow_dependent().bindings[scope_id].get(&name).copied()
     }
 
     /// Find a binding by name in a scope or its ancestors.

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -415,7 +415,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ) -> BoundIdentifier<'a> {
         // Get name for UID
         let name = self.generate_uid_name(name);
-        let symbol_id = self.scoping.add_binding(&name, scope_id, flags);
+        let symbol_id = self.scoping.add_binding(name, scope_id, flags);
         BoundIdentifier::new(name, symbol_id)
     }
 

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -232,11 +232,10 @@ impl<'a> TraverseScoping<'a> {
     #[inline]
     pub(crate) fn add_binding(
         &mut self,
-        name: &str,
+        name: Ident<'_>,
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> SymbolId {
-        let name = Ident::from(name);
         let symbol_id = self.scoping.create_symbol(SPAN, name, flags, scope_id, NodeId::DUMMY);
         self.scoping.add_binding(scope_id, name, symbol_id);
 
@@ -252,7 +251,7 @@ impl<'a> TraverseScoping<'a> {
         scope_id: ScopeId,
         flags: SymbolFlags,
     ) -> BoundIdentifier<'a> {
-        let symbol_id = self.add_binding(name.as_str(), scope_id, flags);
+        let symbol_id = self.add_binding(name, scope_id, flags);
         BoundIdentifier::new(name, symbol_id)
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #19089. Change remaining `&str` name parameters to `Ident`:
- `SemanticBuilder::check_redeclaration`
- `TraverseScoping::add_binding`

🤖 Generated with [Claude Code](https://claude.com/claude-code)