### PR TITLE
refactor(semantic): use `Ident` instead of `&str`/`Atom` for identifier names

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -733,7 +733,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         let kind = AstKind::BreakStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(label) = &stmt.label {
-            self.unused_labels.reference(label.name.as_str());
+            self.unused_labels.reference(label.name);
         }
 
         /* cfg */
@@ -829,7 +829,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         let kind = AstKind::ContinueStatement(self.alloc(stmt));
         self.enter_node(kind);
         if let Some(label) = &stmt.label {
-            self.unused_labels.reference(label.name.as_str());
+            self.unused_labels.reference(label.name);
         }
 
         /* cfg */
@@ -1385,7 +1385,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         let kind = AstKind::LabeledStatement(self.alloc(stmt));
         self.enter_node(kind);
         control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
-        self.unused_labels.add(stmt.label.name.as_str(), self.current_node_id);
+        self.unused_labels.add(stmt.label.name, self.current_node_id);
 
         /* cfg */
         #[cfg(feature = "cfg")]

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -338,9 +338,7 @@ fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
     if let Some(class_id) = ctx.class_table_builder.current_class_id {
         for reference in ctx.class_table_builder.classes.iter_private_identifiers(class_id) {
             if !ctx.class_table_builder.classes.ancestors(class_id).any(|class_id| {
-                ctx.class_table_builder
-                    .classes
-                    .has_private_definition(class_id, reference.name.into())
+                ctx.class_table_builder.classes.has_private_definition(class_id, reference.name)
             }) {
                 ctx.error(diagnostics::private_field_undeclared(&reference.name, reference.span));
             }

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -338,7 +338,9 @@ fn check_private_identifier(ctx: &SemanticBuilder<'_>) {
     if let Some(class_id) = ctx.class_table_builder.current_class_id {
         for reference in ctx.class_table_builder.classes.iter_private_identifiers(class_id) {
             if !ctx.class_table_builder.classes.ancestors(class_id).any(|class_id| {
-                ctx.class_table_builder.classes.has_private_definition(class_id, &reference.name)
+                ctx.class_table_builder
+                    .classes
+                    .has_private_definition(class_id, reference.name.into())
             }) {
                 ctx.error(diagnostics::private_field_undeclared(&reference.name, reference.span));
             }

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -108,7 +108,7 @@ impl<'a> ClassTableBuilder<'a> {
             && let Some(class_id) = self.current_class_id
         {
             let element_ids =
-                self.classes.get_element_ids(class_id, &ident.name, /* is_private */ true);
+                self.classes.get_element_ids(class_id, ident.name, /* is_private */ true);
 
             let reference = PrivateIdentifierReference::new(
                 current_node_id,

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -112,7 +112,7 @@ impl<'a> ClassTableBuilder<'a> {
 
             let reference = PrivateIdentifierReference::new(
                 current_node_id,
-                ident.name.into(),
+                ident.name,
                 ident.span,
                 element_ids,
             );

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::FxHashMap;
 
 use oxc_index::IndexVec;
-use oxc_span::{Atom, Ident, Span};
+use oxc_span::{Ident, Span};
 use oxc_syntax::{
     class::{ClassId, ElementId, ElementKind},
     node::NodeId,
@@ -33,13 +33,13 @@ impl<'a> Element<'a> {
 #[derive(Debug)]
 pub struct PrivateIdentifierReference<'a> {
     pub id: NodeId,
-    pub name: Atom<'a>,
+    pub name: Ident<'a>,
     pub span: Span,
     pub element_ids: Vec<ElementId>,
 }
 
 impl<'a> PrivateIdentifierReference<'a> {
-    pub fn new(id: NodeId, name: Atom<'a>, span: Span, element_ids: Vec<ElementId>) -> Self {
+    pub fn new(id: NodeId, name: Ident<'a>, span: Span, element_ids: Vec<ElementId>) -> Self {
         Self { id, name, span, element_ids }
     }
 }

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rustc_hash::FxHashMap;
 
 use oxc_index::IndexVec;
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, Ident, Span};
 use oxc_syntax::{
     class::{ClassId, ElementId, ElementKind},
     node::NodeId,
@@ -82,7 +82,7 @@ impl<'a> ClassTable<'a> {
     pub fn get_element_ids(
         &self,
         class_id: ClassId,
-        name: &str,
+        name: Ident<'_>,
         is_private: bool,
     ) -> Vec<ElementId> {
         let mut element_ids = vec![];
@@ -105,7 +105,7 @@ impl<'a> ClassTable<'a> {
         element_ids
     }
 
-    pub fn has_private_definition(&self, class_id: ClassId, name: &str) -> bool {
+    pub fn has_private_definition(&self, class_id: ClassId, name: Ident<'_>) -> bool {
         self.elements[class_id].iter().any(|p| p.is_private && p.name == name)
     }
 

--- a/crates/oxc_semantic/src/label.rs
+++ b/crates/oxc_semantic/src/label.rs
@@ -1,8 +1,9 @@
+use oxc_span::Ident;
 use oxc_syntax::node::NodeId;
 
 #[derive(Debug)]
 pub struct LabeledScope<'a> {
-    pub name: &'a str,
+    pub name: Ident<'a>,
     pub used: bool,
     pub node_id: NodeId,
 }
@@ -14,11 +15,11 @@ pub struct UnusedLabels<'a> {
 }
 
 impl<'a> UnusedLabels<'a> {
-    pub fn add(&mut self, name: &'a str, node_id: NodeId) {
+    pub fn add(&mut self, name: Ident<'a>, node_id: NodeId) {
         self.stack.push(LabeledScope { name, used: false, node_id });
     }
 
-    pub fn reference(&mut self, name: &'a str) {
+    pub fn reference(&mut self, name: Ident<'_>) {
         for scope in self.stack.iter_mut().rev() {
             if scope.name == name {
                 scope.used = true;


### PR DESCRIPTION
## Summary
- Change `LabeledScope::name` from `&str` to `Ident`
- Change `ClassTable::get_element_ids` and `has_private_definition` to accept `Ident`
- Change `PrivateIdentifierReference::name` from `Atom` to `Ident`

🤖 Generated with [Claude Code](https://claude.com/claude-code)