### PR TITLE
fix(linter): Update `import/no-named-as-default` to allow named import if equivalent to the default import

### DIFF
--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-alias-misleading-source.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-alias-misleading-source.js
@@ -1,0 +1,5 @@
+const defaultUserEvent = {};
+const userEvent = {};
+
+export default defaultUserEvent;
+export { userEvent };

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-alias-misleading.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-alias-misleading.js
@@ -1,0 +1,7 @@
+// Re-export default and named exports through local aliases that map to
+// different remote symbols. This should not be allowed by the
+// no-named-as-default rule.
+import userEvent, { userEvent as namedUserEvent } from './re-export-default-and-named-alias-misleading-source';
+
+export { userEvent as default };
+export { namedUserEvent as userEvent };

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-different-binding-source.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-different-binding-source.js
@@ -1,0 +1,2 @@
+export const userEvent = {};
+export const otherEvent = {};

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-different-binding.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-different-binding.js
@@ -1,0 +1,4 @@
+// Re-export default and named from the same source but different bindings.
+// This should not be allowed by the no-named-as-default rule.
+export { otherEvent as default } from './re-export-default-and-named-different-binding-source';
+export { userEvent } from './re-export-default-and-named-different-binding-source';

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-import-then-export.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-import-then-export.js
@@ -1,0 +1,7 @@
+// Import-then-export of the same named binding as both default and named.
+// This should be allowed by the no-named-as-default rule because both
+// the default and named exports refer to the same source binding.
+import { userEvent } from './re-export-default-and-named-source';
+
+export { userEvent as default };
+export { userEvent };

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-misleading.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-misleading.js
@@ -1,0 +1,4 @@
+// Re-export default and named exports from different sources. This should
+// not be allowed by the no-named-as-default rule.
+export { userEvent as default } from './re-export-default-and-named-source';
+export { foo as userEvent } from './bar';

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named-source.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named-source.js
@@ -1,0 +1,1 @@
+export const userEvent = {};

--- a/crates/oxc_linter/fixtures/import/re-export-default-and-named.js
+++ b/crates/oxc_linter/fixtures/import/re-export-default-and-named.js
@@ -1,0 +1,4 @@
+// Re-export default and named exports from the same source. This
+// should be allowed by the no-named-as-default rule.
+export { userEvent as default } from './re-export-default-and-named-source';
+export { userEvent } from './re-export-default-and-named-source';

--- a/crates/oxc_linter/src/snapshots/import_no_named_as_default.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_named_as_default.snap
@@ -29,3 +29,24 @@ source: crates/oxc_linter/src/tester.rs
    ·        ───
    ╰────
   help: Using default import as "foo" can be confusing. Use another name for default import to avoid confusion.
+
+  ⚠ eslint-plugin-import(no-named-as-default): Module "./re-export-default-and-named-misleading" has named export "userEvent"
+   ╭─[index.js:1:8]
+ 1 │ import userEvent from "./re-export-default-and-named-misleading"
+   ·        ─────────
+   ╰────
+  help: Using default import as "userEvent" can be confusing. Use another name for default import to avoid confusion.
+
+  ⚠ eslint-plugin-import(no-named-as-default): Module "./re-export-default-and-named-alias-misleading" has named export "userEvent"
+   ╭─[index.js:1:8]
+ 1 │ import userEvent from "./re-export-default-and-named-alias-misleading"
+   ·        ─────────
+   ╰────
+  help: Using default import as "userEvent" can be confusing. Use another name for default import to avoid confusion.
+
+  ⚠ eslint-plugin-import(no-named-as-default): Module "./re-export-default-and-named-different-binding" has named export "userEvent"
+   ╭─[index.js:1:8]
+ 1 │ import userEvent from "./re-export-default-and-named-different-binding"
+   ·        ─────────
+   ╰────
+  help: Using default import as "userEvent" can be confusing. Use another name for default import to avoid confusion.


### PR DESCRIPTION
Fixes #19099. The way this logically works is a bit weird, but basically the idea is that some libraries have exports done via re-export of the same identifier as both a named _and_ default export. In that case, we should allow `import name from 'foo.js';` *and* `import { name } from 'foo.js';`. This allows the rule to better match the upstream rule's behavior.

Confirmed by running the built binary from this branch against [my issue reproduction repo](https://github.com/connorshea/oxlint-repro-default-export/blob/main/test.js) and confirming it no longer had any violations.

```js
/*
 * This is what the @testing-library/user-event package exports:
 * ```js
 * export { userEvent as default } from './setup';
 * export { userEvent } from './setup';
 * ```
 * 
 * It should not error when we import the default export as `userEvent`, because it refers to the same exact value as if we had imported it via `import { userEvent } from '@testing-library/user-event';`.
 */
import userEvent from '@testing-library/user-event';

// With oxlint 1.43.0 and earlier, it currently gets reported as a violation. The original ESLint rule does not report this.
```

AI Disclosure: Built with Claude Code, Opus 4.6. Based on [the changes from the upstream rule](https://github.com/import-js/eslint-plugin-import/pull/3032/changes).