### PR TITLE
refactor(ast): centralize Ident creation through AstBuilder methods

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use oxc_allocator::{Allocator, AllocatorAccessor, Box, FromIn, IntoIn, Vec};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{Atom, Ident, SPAN, Span};
 use oxc_syntax::{
     comment_node::CommentNodeId, number::NumberBase, operator::UnaryOperator, scope::ScopeId,
 };
@@ -96,6 +96,29 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn str(self, value: &str) -> &'a str {
         self.allocator.alloc_str(value)
+    }
+
+    /// Allocate an [`Ident`] from a string slice.
+    #[inline]
+    pub fn ident(self, value: &str) -> Ident<'a> {
+        Ident::from_in(value, self.allocator)
+    }
+
+    /// Allocate an [`Ident`] from an array of string slices.
+    #[inline]
+    pub fn ident_from_strs_array<const N: usize>(self, strings: [&str; N]) -> Ident<'a> {
+        Ident::from_strs_array_in(strings, self.allocator)
+    }
+
+    /// Convert a [`Cow<'a, str>`] to an [`Ident<'a>`].
+    ///
+    /// If the `Cow` borrows a string from arena, returns an `Ident` which references that same string,
+    /// without allocating a new one.
+    ///
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Ident`.
+    #[inline]
+    pub fn ident_from_cow(self, value: &Cow<'a, str>) -> Ident<'a> {
+        Ident::from_cow_in(value, self.allocator)
     }
 
     /// Allocate an [`Atom`] from a string slice.

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -7,8 +7,8 @@ use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, Det
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
 use oxc_semantic::ReferenceFlags;
+use oxc_span::GetSpan;
 use oxc_span::SPAN;
-use oxc_span::{GetSpan, Ident};
 use oxc_syntax::precedence::GetPrecedence;
 use oxc_syntax::{
     number::NumberBase,
@@ -1225,8 +1225,8 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                let reference_id =
-                    ctx.create_unbound_reference(Ident::new_const("Object"), ReferenceFlags::Read);
+                let object = ctx.ast.ident("Object");
+                let reference_id = ctx.create_unbound_reference(object, ReferenceFlags::Read);
                 call_expr.callee = ctx.ast.expression_identifier_with_reference_id(
                     call_expr.callee.span(),
                     "Object",

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -18,11 +18,15 @@ use crate::{Atom, CompactStr};
 #[derive(Clone, Copy, Eq)]
 pub struct Ident<'a>(&'a str);
 
-impl Ident<'static> {
-    /// Get an [`Ident`] containing a static string.
+impl<'a> Ident<'a> {
+    /// Create a new [`Ident`] from a string slice.
+    ///
+    /// This is a const, no-op wrapper.
+    /// Use this for strings that already have the correct lifetime
+    /// (e.g. arena-allocated strings, or `'static` string literals).
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
-    pub const fn new_const(s: &'static str) -> Self {
+    pub const fn new_const(s: &'a str) -> Self {
         Ident(s)
     }
 
@@ -31,9 +35,7 @@ impl Ident<'static> {
     pub const fn empty() -> Self {
         Self::new_const("")
     }
-}
 
-impl<'a> Ident<'a> {
     /// Borrow a string slice.
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1110,18 +1110,15 @@ impl<'a> ArrowFunctionConverter<'a> {
 
         Self::adjust_binding_scope(target_scope_id, &arguments_var, ctx);
 
-        let mut init = ctx.create_unbound_ident_expr(
-            SPAN,
-            Ident::new_const("arguments"),
-            ReferenceFlags::Read,
-        );
+        let mut init =
+            ctx.create_unbound_ident_expr(SPAN, ctx.ast.ident("arguments"), ReferenceFlags::Read);
 
         // Top level may not have `arguments`, so we need to check it.
         // `typeof arguments === "undefined" ? void 0 : arguments;`
         if ctx.scoping().root_scope_id() == target_scope_id {
             let argument = ctx.create_unbound_ident_expr(
                 SPAN,
-                Ident::new_const("arguments"),
+                ctx.ast.ident("arguments"),
                 ReferenceFlags::Read,
             );
             let typeof_arguments = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, argument);

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -76,7 +76,7 @@ use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
-use oxc_span::{Atom, Ident, SPAN, Span};
+use oxc_span::{Atom, SPAN, Span};
 use oxc_traverse::BoundIdentifier;
 
 use crate::context::{TransformCtx, TraverseCtx};
@@ -323,14 +323,9 @@ impl<'a> HelperLoaderStore<'a> {
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         static HELPER_VAR: &str = "babelHelpers";
 
-        let symbol_id =
-            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const(HELPER_VAR));
-        let object = ctx.create_ident_expr(
-            SPAN,
-            Ident::new_const(HELPER_VAR),
-            symbol_id,
-            ReferenceFlags::Read,
-        );
+        let helper_var = ctx.ast.ident(HELPER_VAR);
+        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), helper_var);
+        let object = ctx.create_ident_expr(SPAN, helper_var, symbol_id, ReferenceFlags::Read);
         let property = ctx.ast.identifier_name(SPAN, helper.name());
         Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
     }

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -38,7 +38,7 @@ use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Atom, Ident, SPAN};
+use oxc_span::{Atom, SPAN};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -182,7 +182,7 @@ impl<'a> ModuleImportsStore<'a> {
             return;
         }
 
-        let require_symbol_id = ctx.scoping().get_root_binding(Ident::new_const("require"));
+        let require_symbol_id = ctx.scoping().get_root_binding(ctx.ast.ident("require"));
         let stmts = imports
             .drain(..)
             .map(|(source, names)| Self::get_require(source, names, require_symbol_id, ctx));
@@ -228,7 +228,7 @@ impl<'a> ModuleImportsStore<'a> {
     ) -> Statement<'a> {
         let callee = ctx.create_ident_expr(
             SPAN,
-            Ident::new_const("require"),
+            ctx.ast.ident("require"),
             require_symbol_id,
             ReferenceFlags::read(),
         );

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -91,7 +91,7 @@ use oxc_allocator::{Box as ArenaBox, TakeIn};
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_semantic::{Reference, ReferenceFlags, SymbolId};
-use oxc_span::{ContentEq, Ident, SPAN};
+use oxc_span::{ContentEq, SPAN};
 use oxc_traverse::{MaybeBoundIdentifier, Traverse};
 use rustc_hash::FxHashMap;
 
@@ -695,7 +695,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
 
     #[inline]
     fn create_global_identifier(ident: &'static str, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-        ctx.create_unbound_ident_expr(SPAN, Ident::new_const(ident), ReferenceFlags::Read)
+        ctx.create_unbound_ident_expr(SPAN, ctx.ast.ident(ident), ReferenceFlags::Read)
     }
 
     #[inline]

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -35,7 +35,7 @@
 use oxc_allocator::{CloneIn, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -536,14 +536,9 @@ impl<'a> ExponentiationOperator<'a, '_> {
         right: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let math_symbol_id =
-            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Math"));
-        let object = ctx.create_ident_expr(
-            SPAN,
-            Ident::new_const("Math"),
-            math_symbol_id,
-            ReferenceFlags::Read,
-        );
+        let math = ctx.ast.ident("Math");
+        let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), math);
+        let object = ctx.create_ident_expr(SPAN, math, math_symbol_id, ReferenceFlags::Read);
         let property = ctx.ast.identifier_name(SPAN, "pow");
         let callee =
             Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false));

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -277,7 +277,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
             let this_argument = Argument::from(ctx.ast.expression_this(SPAN));
             let arguments_argument = Argument::from(ctx.create_unbound_ident_expr(
                 SPAN,
-                Ident::new_const("arguments"),
+                ctx.ast.ident("arguments"),
                 ReferenceFlags::Read,
             ));
             (callee, ctx.ast.vec_from_array([this_argument, arguments_argument]))
@@ -574,7 +574,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
     fn normalize_function_name(input: &Cow<'a, str>, ctx: &TraverseCtx<'a>) -> Ident<'a> {
         let input_str = input.as_ref();
         if !is_reserved_keyword(input_str) && is_identifier_name(input_str) {
-            return Ident::from_cow_in(input, ctx.ast.allocator);
+            return ctx.ast.ident_from_cow(input);
         }
 
         let mut name = ArenaStringBuilder::with_capacity_in(input_str.len() + 1, ctx.ast.allocator);
@@ -601,7 +601,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         }
 
         if name.is_empty() {
-            return Ident::new_const("_");
+            return ctx.ast.ident("_");
         }
 
         if is_reserved_keyword(name.as_str()) {
@@ -651,14 +651,10 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         bound_ident: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let symbol_id =
-            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("arguments"));
-        let arguments_ident = Argument::from(ctx.create_ident_expr(
-            SPAN,
-            Ident::new_const("arguments"),
-            symbol_id,
-            ReferenceFlags::Read,
-        ));
+        let arguments = ctx.ast.ident("arguments");
+        let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), arguments);
+        let arguments_ident =
+            Argument::from(ctx.create_ident_expr(SPAN, arguments, symbol_id, ReferenceFlags::Read));
 
         // (this, arguments)
         let this = Argument::from(ctx.ast.expression_this(SPAN));

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::{TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_traverse::{Ancestor, BoundIdentifier};
 
 use crate::{common::helper_loader::Helper, context::TraverseCtx};
@@ -343,7 +343,7 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
             let catch_scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::CatchClause);
             let block_scope_id = ctx.create_child_scope(catch_scope_id, ScopeFlags::empty());
             let err_ident = ctx.generate_binding(
-                Ident::new_const("err"),
+                ctx.ast.ident("err"),
                 block_scope_id,
                 SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
             );

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -888,18 +888,17 @@ fn create_new_weakmap<'a>(
     symbol_id: &mut Option<Option<SymbolId>>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let symbol_id = *symbol_id.get_or_insert_with(|| {
-        ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakMap"))
-    });
-    let ident =
-        ctx.create_ident_expr(SPAN, Ident::new_const("WeakMap"), symbol_id, ReferenceFlags::Read);
+    let weak_map = ctx.ast.ident("WeakMap");
+    let symbol_id = *symbol_id
+        .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), weak_map));
+    let ident = ctx.create_ident_expr(SPAN, weak_map, symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }
 
 /// Create `new WeakSet()` expression.
 fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
-    let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("WeakSet"));
-    let ident =
-        ctx.create_ident_expr(SPAN, Ident::new_const("WeakSet"), symbol_id, ReferenceFlags::Read);
+    let weak_set = ctx.ast.ident("WeakSet");
+    let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), weak_set);
+    let ident = ctx.create_ident_expr(SPAN, weak_set, symbol_id, ReferenceFlags::Read);
     ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,7 +2,7 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_ast::{NONE, ast::*};
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 
 use crate::{
@@ -341,14 +341,10 @@ impl<'a> ClassProperties<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // `Object.defineProperty`
-        let object_symbol_id =
-            ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Object"));
-        let object = ctx.create_ident_expr(
-            SPAN,
-            Ident::new_const("Object"),
-            object_symbol_id,
-            ReferenceFlags::Read,
-        );
+        let object_name = ctx.ast.ident("Object");
+        let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), object_name);
+        let object =
+            ctx.create_ident_expr(SPAN, object_name, object_symbol_id, ReferenceFlags::Read);
         let property = ctx.ast.identifier_name(SPAN, "defineProperty");
         let callee =
             Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false));

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -41,7 +41,7 @@ use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVe
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, Traverse};
 
 use crate::{
@@ -341,7 +341,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a, '_>
                             }
                             _ => (
                                 ctx.generate_binding_in_current_scope(
-                                    Ident::new_const("_default"),
+                                    ctx.ast.ident("_default"),
                                     SymbolFlags::FunctionScopedVariable,
                                 ),
                                 SPAN,
@@ -812,7 +812,7 @@ impl<'a> ExplicitResourceManagement<'a, '_> {
         // We can skip using `generate_uid` here as no code within the `catch` block which can use a
         // binding called `_`. `using_ctx` is a UID with prefix `_usingCtx`.
         let ident = ctx.generate_binding(
-            Ident::new_const("_"),
+            ctx.ast.ident("_"),
             block_scope_id,
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -49,7 +49,7 @@ use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
 };
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_traverse::Traverse;
 
 use crate::{
@@ -163,14 +163,9 @@ impl<'a> RegExp<'a, '_> {
         }
 
         let callee = {
-            let symbol_id =
-                ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("RegExp"));
-            ctx.create_ident_expr(
-                SPAN,
-                Ident::new_const("RegExp"),
-                symbol_id,
-                ReferenceFlags::read(),
-            )
+            let regexp = ctx.ast.ident("RegExp");
+            let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), regexp);
+            ctx.create_ident_expr(SPAN, regexp, symbol_id, ReferenceFlags::read())
         };
 
         let arguments = ctx.ast.vec_from_array([

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -328,14 +328,9 @@ impl<'a> TypeScriptEnum<'a> {
 
         // Infinity
         let expr = if value.is_infinite() {
-            let infinity_symbol_id =
-                ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("Infinity"));
-            ctx.create_ident_expr(
-                SPAN,
-                Ident::new_const("Infinity"),
-                infinity_symbol_id,
-                ReferenceFlags::Read,
-            )
+            let infinity = ctx.ast.ident("Infinity");
+            let infinity_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), infinity);
+            ctx.create_ident_expr(SPAN, infinity, infinity_symbol_id, ReferenceFlags::Read)
         } else {
             let value = if is_negative { -value } else { value };
             Self::get_number_literal_expression(value, ctx)

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
-use oxc_span::{Ident, SPAN};
+use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::Traverse;
 
@@ -72,10 +72,8 @@ impl<'a> TypeScriptModule<'a, '_> {
 
         // module.exports
         let module_exports = {
-            let reference_id = ctx.create_reference_in_current_scope(
-                Ident::new_const("module"),
-                ReferenceFlags::Read,
-            );
+            let reference_id = ctx
+                .create_reference_in_current_scope(ctx.ast.ident("module"), ReferenceFlags::Read);
             let reference =
                 ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, "module", reference_id);
             let object = Expression::Identifier(reference);
@@ -151,14 +149,10 @@ impl<'a> TypeScriptModule<'a, '_> {
                     self.ctx.error(diagnostics::import_equals_cannot_be_used_in_esm(decl_span));
                 }
 
-                let require_symbol_id =
-                    ctx.scoping().find_binding(ctx.current_scope_id(), Ident::new_const("require"));
-                let callee = ctx.create_ident_expr(
-                    SPAN,
-                    Ident::new_const("require"),
-                    require_symbol_id,
-                    ReferenceFlags::Read,
-                );
+                let require = ctx.ast.ident("require");
+                let require_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), require);
+                let callee =
+                    ctx.create_ident_expr(SPAN, require, require_symbol_id, ReferenceFlags::Read);
                 let arguments =
                     ctx.ast.vec1(Argument::StringLiteral(ctx.alloc(reference.expression.clone())));
                 (

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -651,7 +651,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let mut buffer = ItoaBuffer::new();
         let uid_str = buffer.format(self.import_uid);
         self.import_uid += 1;
-        Ident::from_strs_array_in(["__vite_ssr_import_", uid_str, "__"], ctx.ast.allocator)
+        ctx.ast.ident_from_strs_array(["__vite_ssr_import_", uid_str, "__"])
     }
 
     /// Generate a unique import binding whose name is like `__vite_ssr_import_{uid}__`.
@@ -703,7 +703,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let object =
-            ctx.create_unbound_ident_expr(SPAN, Ident::new_const("Object"), ReferenceFlags::Read);
+            ctx.create_unbound_ident_expr(SPAN, ctx.ast.ident("Object"), ReferenceFlags::Read);
         let member = create_member_callee(object, "defineProperty", ctx);
         ctx.ast.expression_call(SPAN, member, NONE, arguments, false)
     }


### PR DESCRIPTION
## Summary
- Add `ident_from_strs_array` and `ident_from_cow` methods to `AstBuilder`, mirroring the existing `atom_from_strs_array` and `atom_from_cow` methods
- Replace `Ident::new_const("...")` with `ctx.ast.ident("...")` across transformer, minifier, and transformer_plugins crates to route all `Ident` creation through `AstBuilder`
- Move `Ident::new_const` from `impl Ident<'static>` to `impl<'a> Ident<'a>` so it works for any lifetime
- Clean up unused `Ident` imports in 10 files

Linter crate usages, `const`/`static` declarations, and `UidGenerator` (no `AstBuilder` access) are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)