### PR TITLE
feat(linter/plugins): `RuleTester` test suggestions

### DIFF
--- a/apps/oxlint/conformance/snapshots/eslint.md
+++ b/apps/oxlint/conformance/snapshots/eslint.md
@@ -18,9 +18,9 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests | 33159 | 100.0% |
-| Passing     | 32881 |  99.2% |
+| Passing     | 32880 |  99.2% |
 | Failing     |     0 |   0.0% |
-| Skipped     |   278 |   0.8% |
+| Skipped     |   279 |   0.8% |
 
 ## Fully Passing Rules
 
@@ -278,7 +278,7 @@
 - `prefer-object-spread` (87 tests) (3 skipped)
 - `prefer-promise-reject-errors` (65 tests)
 - `prefer-reflect` (49 tests)
-- `prefer-regex-literals` (251 tests) (2 skipped)
+- `prefer-regex-literals` (251 tests) (3 skipped)
 - `prefer-rest-params` (11 tests)
 - `prefer-spread` (33 tests)
 - `prefer-template` (78 tests)

--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -42,6 +42,21 @@ const group: TestGroup = {
       return true;
     }
 
+    // Oxlint's suggestion message differs from ESLint's, but in a completely cosmetic way
+    if (
+      ruleName === "prefer-regex-literals" &&
+      code === "new RegExp(/a/ig, 'g');" &&
+      err.message.startsWith(
+        "Suggestion at index 1: Hydrated message " +
+          `"Replace with a regular expression literal with flags 'ig'."` +
+          " does not match " +
+          `"Replace with a regular expression literal with flags 'gi'."` +
+          "\n",
+      )
+    ) {
+      return true;
+    }
+
     // TypeScript parser does not support HTML comments
     if (ruleName === "prefer-object-spread" && code.includes("<!--")) return true;
 

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -24,7 +24,7 @@ import type { RequireAtLeastOne } from "type-fest";
 import type { FixReport } from "../plugins/fix.ts";
 import type { Plugin, Rule } from "../plugins/load.ts";
 import type { Options } from "../plugins/options.ts";
-import type { DiagnosticData, Suggestion } from "../plugins/report.ts";
+import type { DiagnosticData, SuggestionReport } from "../plugins/report.ts";
 import type { Settings } from "../plugins/settings.ts";
 import type { ParseOptions } from "./parse.ts";
 
@@ -342,6 +342,17 @@ interface ErrorBase {
   column?: number;
   endLine?: number | undefined;
   endColumn?: number | undefined;
+  suggestions?: ErrorSuggestion[] | null;
+}
+
+/**
+ * Expected suggestion in a test case error.
+ */
+interface ErrorSuggestion {
+  desc?: string;
+  messageId?: string;
+  data?: DiagnosticData;
+  output: string;
 }
 
 /**
@@ -369,7 +380,7 @@ interface Diagnostic {
   endLine: number;
   endColumn: number;
   fixes: FixReport[] | null;
-  suggestions: Suggestion[] | null;
+  suggestions: SuggestionReport[] | null;
 }
 
 // Default path (without extension) for test cases if not provided
@@ -638,7 +649,15 @@ function assertInvalidTestCasePasses(test: InvalidTestCase, plugin: Plugin, conf
         assertInvalidTestCaseMessageIsCorrect(diagnostic, error, messages);
         assertInvalidTestCaseLocationIsCorrect(diagnostic, error, test);
 
-        // TODO: Test suggestions
+        // Test suggestions
+        if (Object.hasOwn(error, "suggestions")) {
+          if (error.suggestions == null) {
+            // `suggestions: null` means "expect no suggestions"
+            assert(diagnostic.suggestions === null, "Rule produced suggestions");
+          } else {
+            assertSuggestionsAreCorrect(diagnostic, error, messages, test);
+          }
+        }
       }
     }
   }
@@ -717,7 +736,6 @@ function assertInvalidTestCaseMessageIsCorrect(
 ): void {
   // Check `message` property
   if (Object.hasOwn(error, "message")) {
-    // Check `message` property
     assert(
       !Object.hasOwn(error, "messageId"),
       "Error should not specify both `message` and a `messageId`",
@@ -733,53 +751,80 @@ function assertInvalidTestCaseMessageIsCorrect(
   );
 
   // Check `messageId` property
+  assertMessageIdIsCorrect(
+    diagnostic.messageId,
+    diagnostic.message,
+    error.messageId!,
+    error.data,
+    messages,
+    "",
+  );
+}
+
+/**
+ * Assert that a `messageId` used by the rule under test is correct, and validate `data` (if provided).
+ *
+ * @param reportedMessageId - `messageId` from the diagnostic or suggestion
+ * @param reportedMessage - Message from the diagnostic or suggestion
+ * @param messageId - Expected `messageId` from the test case
+ * @param data - Data from the test case (if provided)
+ * @param messages - Messages from the rule under test
+ * @param prefix - Prefix for assertion error messages (e.g. "" or "Suggestion at index 0: ")
+ * @throws {AssertionError} If messageId is not correct
+ * @throws {AssertionError} If message tenplate with placeholder data inserted does not match reported message
+ */
+function assertMessageIdIsCorrect(
+  reportedMessageId: string | null,
+  reportedMessage: string,
+  messageId: string,
+  data: DiagnosticData | undefined,
+  messages: Record<string, string> | null,
+  prefix: string,
+): void {
   assert(
     messages !== null,
-    "Error can not use `messageId` if rule under test doesn't define `meta.messages`",
+    `${prefix}Cannot use 'messageId' if rule under test doesn't define 'meta.messages'`,
   );
 
-  const messageId: string = error.messageId!;
   if (!Object.hasOwn(messages, messageId)) {
     const legalMessageIds = `[${Object.keys(messages)
       .map((key) => `'${key}'`)
       .join(", ")}]`;
-    assert.fail(`Invalid messageId '${messageId}'. Expected one of ${legalMessageIds}`);
+    assert.fail(`${prefix}Invalid messageId '${messageId}'. Expected one of ${legalMessageIds}.`);
   }
 
   assert.strictEqual(
-    diagnostic.messageId,
+    reportedMessageId,
     messageId,
-    `messageId '${diagnostic.messageId}' does not match expected messageId '${messageId}'`,
+    `${prefix}messageId '${reportedMessageId}' does not match expected messageId '${messageId}'`,
   );
 
-  const reportedMessage = diagnostic.message;
+  // Check if message contains placeholders for which no data was provided
   const ruleMessage = messages[messageId];
-
   const unsubstitutedPlaceholders = getUnsubstitutedMessagePlaceholders(
     reportedMessage,
     ruleMessage,
-    error.data,
+    data,
   );
   if (unsubstitutedPlaceholders.length !== 0) {
     assert.fail(
-      "The reported message has " +
+      `${prefix}The reported message has ` +
         (unsubstitutedPlaceholders.length > 1
           ? `unsubstituted placeholders: ${unsubstitutedPlaceholders.map((name) => `'${name}'`).join(", ")}`
           : `an unsubstituted placeholder '${unsubstitutedPlaceholders[0]}'`) +
         `. Please provide the missing ${unsubstitutedPlaceholders.length > 1 ? "values" : "value"} ` +
-        "via the `data` property on the error object.",
+        "via the `data` property.",
     );
   }
 
-  if (Object.hasOwn(error, "data")) {
-    // If data was provided, then directly compare the returned message to a synthetic
-    // interpolated message using the same message ID and data provided in the test
-    const rehydratedMessage = replacePlaceholders(ruleMessage, error.data!);
-
+  // Check `data` is correct by filling in placeholders in the message with provided data and checking that
+  // rehydrated message matches the reported message
+  if (data !== undefined) {
+    const rehydratedMessage = replacePlaceholders(ruleMessage, data);
     assert.strictEqual(
       reportedMessage,
       rehydratedMessage,
-      `Hydrated message "${rehydratedMessage}" does not match "${reportedMessage}"`,
+      `${prefix}Hydrated message "${rehydratedMessage}" does not match "${reportedMessage}"`,
     );
   }
 }
@@ -855,6 +900,110 @@ function assertInvalidTestCaseLocationIsCorrect(
       "Actual error location does not match expected error location.",
     );
   }
+}
+
+/**
+ * Assert that suggestions reported by the rule under test match expected suggestions.
+ * @param diagnostic - Diagnostic emitted by the rule under test
+ * @param error - Error object from the test case
+ * @param messages - Messages from the rule under test
+ * @param test - Test case
+ * @throws {AssertionError} If suggestions do not match
+ */
+function assertSuggestionsAreCorrect(
+  diagnostic: Diagnostic,
+  error: Error,
+  messages: Record<string, string> | null,
+  test: TestCase,
+): void {
+  const actualSuggestions = diagnostic.suggestions ?? [];
+  const expectedSuggestions = error.suggestions!;
+
+  assert.strictEqual(
+    actualSuggestions.length,
+    expectedSuggestions.length,
+    `Error should have ${expectedSuggestions.length} suggestion${expectedSuggestions.length > 1 ? "s" : ""}. ` +
+      `Instead found ${actualSuggestions.length} suggestion${actualSuggestions.length > 1 ? "s" : ""}.`,
+  );
+
+  const eslintCompat = test.eslintCompat === true;
+
+  for (let i = 0; i < expectedSuggestions.length; i++) {
+    const actual = actualSuggestions[i]!;
+    const expected = expectedSuggestions[i]!;
+    const prefix = `Suggestion at index ${i}`;
+
+    // Validate suggestion message (`desc` or `messageId` + `data`)
+    assertSuggestionMessageIsCorrect(actual, expected, messages, prefix);
+
+    // Validate output
+    assert(Object.hasOwn(expected, "output"), `${prefix}: \`output\` property is required`);
+
+    const suggestedCode = applyFixes(test.code, JSON.stringify([actual.fixes]), eslintCompat);
+    assert(suggestedCode !== null, `${prefix}: Failed to apply suggestion fix`);
+
+    assert.strictEqual(
+      suggestedCode,
+      expected.output,
+      `${prefix}: Expected the applied suggestion fix to match the test suggestion output`,
+    );
+
+    assert.notStrictEqual(
+      expected.output,
+      test.code,
+      `${prefix}: The output of a suggestion should differ from the original source code`,
+    );
+  }
+}
+
+/**
+ * Assert that a suggestion's message matches expectations.
+ * @param actual - Actual suggestion from the diagnostic
+ * @param expected - Expected suggestion from the test case
+ * @param messages - Messages from the rule under test
+ * @param prefix - Prefix for assertion error messages
+ * @throws {AssertionError} If suggestion message does not match
+ */
+function assertSuggestionMessageIsCorrect(
+  actual: SuggestionReport,
+  expected: ErrorSuggestion,
+  messages: Record<string, string> | null,
+  prefix: string,
+): void {
+  if (Object.hasOwn(expected, "desc")) {
+    assert(
+      !Object.hasOwn(expected, "messageId"),
+      `${prefix}: Test should not specify both \`desc\` and \`messageId\``,
+    );
+    assert(
+      !Object.hasOwn(expected, "data"),
+      `${prefix}: Test should not specify both \`desc\` and \`data\``,
+    );
+    assert.strictEqual(
+      actual.message,
+      expected.desc,
+      `${prefix}: \`desc\` should be "${expected.desc}" but got "${actual.message}" instead`,
+    );
+    return;
+  }
+
+  if (Object.hasOwn(expected, "messageId")) {
+    assertMessageIdIsCorrect(
+      actual.messageId,
+      actual.message,
+      expected.messageId!,
+      expected.data,
+      messages,
+      `${prefix}: `,
+    );
+    return;
+  }
+
+  if (Object.hasOwn(expected, "data")) {
+    assert.fail(`${prefix}: Test must specify \`messageId\` if \`data\` is used`);
+  }
+
+  assert.fail(`${prefix}: Test must specify either \`messageId\` or \`desc\``);
 }
 
 /**
@@ -1148,7 +1297,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
         endLine,
         endColumn,
         fixes: diagnostic.fixes,
-        suggestions: null, // TODO
+        suggestions: diagnostic.suggestions,
       };
     });
   } finally {
@@ -1628,6 +1777,7 @@ type _ValidTestCase = ValidTestCase;
 type _InvalidTestCase = InvalidTestCase;
 type _TestCases = TestCases;
 type _Error = Error;
+type _ErrorSuggestion = ErrorSuggestion;
 
 export namespace RuleTester {
   export type Config = _Config;
@@ -1644,4 +1794,5 @@ export namespace RuleTester {
   export type InvalidTestCase = _InvalidTestCase;
   export type TestCases = _TestCases;
   export type Error = _Error;
+  export type ErrorSuggestion = _ErrorSuggestion;
 }

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -163,7 +163,7 @@ export function getSuggestions(
 
     // Call fix function - drop suggestion if fix function produces no fixes
     const fixes = getFixesFromFixFn(fix, suggestion);
-    if (fixes !== null) suggestions.push({ message, fixes });
+    if (fixes !== null) suggestions.push({ message, messageId, fixes });
   }
 
   if (suggestions.length === 0) return null;

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -67,6 +67,8 @@ interface SuggestionBase {
  */
 export interface SuggestionReport {
   message: string;
+  // Not needed on Rust side, but `RuleTester` needs it
+  messageId: string | null;
   fixes: FixReport[];
 }
 

--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -5,7 +5,7 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 176
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -17,7 +17,7 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 185
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_after_end.js
@@ -29,11 +29,11 @@
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 163
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 172
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
 
   x suggestions-plugin(suggestions): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]

--- a/apps/oxlint/test/fixtures/suggestions/fix.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix.snap.md
@@ -5,19 +5,19 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 176
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 185
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 163
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 172
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
 
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]

--- a/apps/oxlint/test/fixtures/suggestions/output.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/output.snap.md
@@ -5,19 +5,19 @@
 ```
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 176
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 185
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 163
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
 
   x Error running JS plugin.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 172
+  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
 
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]


### PR DESCRIPTION
`RuleTester` test that suggestions provided by the rule match what's expected in the test case - that code after applying each suggestion matches the test case's `output` property, and that suggestions' descriptions also match those specified in test cases.

Skip one conformance test for ESLint's `prefer-regex-literals` rule where the suggestion description in Oxlint is different from ESLint, but in a completely cosmetic way. There's no need to match it exactly. That apart, no change to conformance test results, which strongly suggests that Oxlint is treating suggestions correctly.