### PR TITLE
refactor(linter/plugins): `getMessage` return `messageId`

### DIFF
--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -148,15 +148,8 @@ export function getSuggestions(
     if (typeof fix !== "function") throw new TypeError("Suggestion without a fix function");
 
     // Get suggestion message
-    let messageId: string | null = null;
-    if (Object.hasOwn(suggestion, "messageId")) {
-      (messageId as string | null | undefined) = suggestion.messageId;
-      if (messageId === undefined) messageId = null;
-    }
-
-    const message = getMessage(
+    const { message, messageId } = getMessage(
       Object.hasOwn(suggestion, "desc") ? suggestion.desc : null,
-      messageId,
       suggestion,
       ruleDetails,
     );

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -104,15 +104,8 @@ export const PLACEHOLDER_REGEX = /\{\{([^{}]+)\}\}/gu;
 export function report(diagnostic: Diagnostic, ruleDetails: RuleDetails): void {
   if (filePath === null) throw new Error("Cannot report errors in `createOnce`");
 
-  let messageId: string | null = null;
-  if (Object.hasOwn(diagnostic, "messageId")) {
-    (messageId as string | null | undefined) = diagnostic.messageId;
-    if (messageId === undefined) messageId = null;
-  }
-
-  const message = getMessage(
+  const { message, messageId } = getMessage(
     Object.hasOwn(diagnostic, "message") ? diagnostic.message : null,
-    messageId,
     diagnostic,
     ruleDetails,
   );
@@ -208,19 +201,20 @@ export function report(diagnostic: Diagnostic, ruleDetails: RuleDetails): void {
  * Resolve message from `messageId` if present, and interpolate placeholders {{key}} with data values.
  *
  * @param message - Provided message string
- * @param messageId - Provided message ID
- * @param descriptor - Diagnostic or suggestion object
+ * @param descriptor - `Diagnostic` or `Suggestion` object
  * @param ruleDetails - `RuleDetails` object, containing rule-specific `messages`
- * @returns Message string
+ * @returns Object containing message string and message ID (if present in `descriptor`)
  * @throws {Error|TypeError} If neither `message` nor `messageId` provided, or of wrong type
  */
 export function getMessage(
   message: string | null | undefined,
-  messageId: string | null,
   descriptor: Diagnostic | Suggestion,
   ruleDetails: RuleDetails,
-): string {
+): { message: string; messageId: string | null } {
   // Resolve from `messageId` if present, otherwise use `message`
+  let messageId: string | null = null;
+  if (Object.hasOwn(descriptor, "messageId")) messageId = descriptor.messageId ?? null;
+
   if (messageId !== null) {
     if (typeof messageId !== "string") throw new TypeError("`messageId` must be a string");
     message = resolveMessageFromMessageId(messageId, ruleDetails);
@@ -236,7 +230,7 @@ export function getMessage(
     if (data != null) message = replacePlaceholders(message, data);
   }
 
-  return message;
+  return { message, messageId };
 }
 
 /**


### PR DESCRIPTION
Pure refactor. Remove duplicated code at 2 x call sites for `getMessage`, and move the logic into `getMessage` itself instead.