### PR TITLE
feat(minifier): local traverse ctx and generated minifier traverse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,6 +2089,7 @@ version = "0.112.0"
 dependencies = [
  "cow-utils",
  "insta",
+ "itoa",
  "javascript-globals",
  "oxc_allocator",
  "oxc_ast",
@@ -2104,6 +2105,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_sourcemap",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "oxc_traverse",
  "pico-args",

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -33,10 +33,12 @@ oxc_parser = { workspace = true }
 oxc_regular_expression = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_str = { workspace = true }
 oxc_syntax = { workspace = true }
 oxc_traverse = { workspace = true }
 
 cow-utils = { workspace = true }
+itoa = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -1,10 +1,9 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_semantic::{Scoping, SemanticBuilder};
-use oxc_traverse::ReusableTraverseCtx;
 
 use crate::{
-    CompressOptions,
+    CompressOptions, ReusableTraverseCtx,
     peephole::{Normalize, NormalizeOptions, PeepholeOptimizations},
     state::MinifierState,
 };
@@ -70,7 +69,7 @@ impl<'a> Compressor<'a> {
     fn run_in_loop(
         max_iterations: Option<u8>,
         program: &mut Program<'a>,
-        ctx: &mut ReusableTraverseCtx<'a, MinifierState<'a>>,
+        ctx: &mut ReusableTraverseCtx<'a>,
     ) -> u8 {
         let mut iteration = 0u8;
         loop {

--- a/crates/oxc_minifier/src/generated/mod.rs
+++ b/crates/oxc_minifier/src/generated/mod.rs
@@ -1,0 +1,5 @@
+#[expect(clippy::redundant_pub_crate)]
+#[path = "../../../oxc_traverse/src/generated/ancestor.rs"]
+pub mod ancestor;
+pub mod traverse;
+pub mod walk;

--- a/crates/oxc_minifier/src/generated/traverse.rs
+++ b/crates/oxc_minifier/src/generated/traverse.rs
@@ -1,0 +1,2488 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/minifier_traverse/mod.rs`.
+
+use oxc_allocator::Vec;
+use oxc_ast::ast::*;
+
+use crate::TraverseCtx;
+
+#[expect(unused_variables)]
+pub trait Traverse<'a> {
+    #[inline]
+    fn enter_program(&mut self, node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_program(&mut self, node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_expression(&mut self, node: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_identifier_name(&mut self, node: &mut IdentifierName<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_identifier_reference(
+        &mut self,
+        node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_identifier_reference(
+        &mut self,
+        node: &mut IdentifierReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_binding_identifier(
+        &mut self,
+        node: &mut BindingIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_binding_identifier(
+        &mut self,
+        node: &mut BindingIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_label_identifier(
+        &mut self,
+        node: &mut LabelIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_label_identifier(&mut self, node: &mut LabelIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_this_expression(&mut self, node: &mut ThisExpression, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_this_expression(&mut self, node: &mut ThisExpression, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_array_expression(
+        &mut self,
+        node: &mut ArrayExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_array_expression(&mut self, node: &mut ArrayExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_array_expression_element(
+        &mut self,
+        node: &mut ArrayExpressionElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_array_expression_element(
+        &mut self,
+        node: &mut ArrayExpressionElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_elision(&mut self, node: &mut Elision, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_elision(&mut self, node: &mut Elision, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_object_expression(
+        &mut self,
+        node: &mut ObjectExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_object_expression(
+        &mut self,
+        node: &mut ObjectExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_object_property_kind(
+        &mut self,
+        node: &mut ObjectPropertyKind<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_object_property_kind(
+        &mut self,
+        node: &mut ObjectPropertyKind<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_object_property(&mut self, node: &mut ObjectProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_property_key(&mut self, node: &mut PropertyKey<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_template_literal(
+        &mut self,
+        node: &mut TemplateLiteral<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_template_literal(&mut self, node: &mut TemplateLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_tagged_template_expression(
+        &mut self,
+        node: &mut TaggedTemplateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_tagged_template_expression(
+        &mut self,
+        node: &mut TaggedTemplateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_template_element(
+        &mut self,
+        node: &mut TemplateElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_template_element(&mut self, node: &mut TemplateElement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_member_expression(
+        &mut self,
+        node: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_member_expression(
+        &mut self,
+        node: &mut MemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_computed_member_expression(
+        &mut self,
+        node: &mut ComputedMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_computed_member_expression(
+        &mut self,
+        node: &mut ComputedMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_static_member_expression(
+        &mut self,
+        node: &mut StaticMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_static_member_expression(
+        &mut self,
+        node: &mut StaticMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_private_field_expression(
+        &mut self,
+        node: &mut PrivateFieldExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_private_field_expression(
+        &mut self,
+        node: &mut PrivateFieldExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_call_expression(&mut self, node: &mut CallExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_new_expression(&mut self, node: &mut NewExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_meta_property(&mut self, node: &mut MetaProperty<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_spread_element(&mut self, node: &mut SpreadElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_argument(&mut self, node: &mut Argument<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_argument(&mut self, node: &mut Argument<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_update_expression(
+        &mut self,
+        node: &mut UpdateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_update_expression(
+        &mut self,
+        node: &mut UpdateExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_unary_expression(
+        &mut self,
+        node: &mut UnaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_unary_expression(&mut self, node: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_binary_expression(
+        &mut self,
+        node: &mut BinaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_binary_expression(
+        &mut self,
+        node: &mut BinaryExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_private_in_expression(
+        &mut self,
+        node: &mut PrivateInExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_private_in_expression(
+        &mut self,
+        node: &mut PrivateInExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_logical_expression(
+        &mut self,
+        node: &mut LogicalExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_logical_expression(
+        &mut self,
+        node: &mut LogicalExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_conditional_expression(
+        &mut self,
+        node: &mut ConditionalExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_conditional_expression(
+        &mut self,
+        node: &mut ConditionalExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_expression(
+        &mut self,
+        node: &mut AssignmentExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_expression(
+        &mut self,
+        node: &mut AssignmentExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target(
+        &mut self,
+        node: &mut AssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target(
+        &mut self,
+        node: &mut AssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_simple_assignment_target(
+        &mut self,
+        node: &mut SimpleAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_simple_assignment_target(
+        &mut self,
+        node: &mut SimpleAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_pattern(
+        &mut self,
+        node: &mut AssignmentTargetPattern<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_pattern(
+        &mut self,
+        node: &mut AssignmentTargetPattern<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_array_assignment_target(
+        &mut self,
+        node: &mut ArrayAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_array_assignment_target(
+        &mut self,
+        node: &mut ArrayAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_object_assignment_target(
+        &mut self,
+        node: &mut ObjectAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_object_assignment_target(
+        &mut self,
+        node: &mut ObjectAssignmentTarget<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_rest(
+        &mut self,
+        node: &mut AssignmentTargetRest<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_rest(
+        &mut self,
+        node: &mut AssignmentTargetRest<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_maybe_default(
+        &mut self,
+        node: &mut AssignmentTargetMaybeDefault<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_maybe_default(
+        &mut self,
+        node: &mut AssignmentTargetMaybeDefault<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_with_default(
+        &mut self,
+        node: &mut AssignmentTargetWithDefault<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_with_default(
+        &mut self,
+        node: &mut AssignmentTargetWithDefault<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_property(
+        &mut self,
+        node: &mut AssignmentTargetProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_property(
+        &mut self,
+        node: &mut AssignmentTargetProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_property_identifier(
+        &mut self,
+        node: &mut AssignmentTargetPropertyIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_property_identifier(
+        &mut self,
+        node: &mut AssignmentTargetPropertyIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_assignment_target_property_property(
+        &mut self,
+        node: &mut AssignmentTargetPropertyProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_target_property_property(
+        &mut self,
+        node: &mut AssignmentTargetPropertyProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_sequence_expression(
+        &mut self,
+        node: &mut SequenceExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_sequence_expression(
+        &mut self,
+        node: &mut SequenceExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_super(&mut self, node: &mut Super, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_super(&mut self, node: &mut Super, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_await_expression(
+        &mut self,
+        node: &mut AwaitExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_await_expression(&mut self, node: &mut AwaitExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_chain_expression(
+        &mut self,
+        node: &mut ChainExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_chain_expression(&mut self, node: &mut ChainExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_chain_element(&mut self, node: &mut ChainElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_parenthesized_expression(
+        &mut self,
+        node: &mut ParenthesizedExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_parenthesized_expression(
+        &mut self,
+        node: &mut ParenthesizedExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_statement(&mut self, node: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_statement(&mut self, node: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_directive(&mut self, node: &mut Directive<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_directive(&mut self, node: &mut Directive<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_hashbang(&mut self, node: &mut Hashbang<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_declaration(&mut self, node: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_declaration(&mut self, node: &mut Declaration<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_variable_declaration(
+        &mut self,
+        node: &mut VariableDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_variable_declaration(
+        &mut self,
+        node: &mut VariableDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_variable_declarator(
+        &mut self,
+        node: &mut VariableDeclarator<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_empty_statement(&mut self, node: &mut EmptyStatement, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_expression_statement(
+        &mut self,
+        node: &mut ExpressionStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_expression_statement(
+        &mut self,
+        node: &mut ExpressionStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_if_statement(&mut self, node: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_do_while_statement(
+        &mut self,
+        node: &mut DoWhileStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_do_while_statement(
+        &mut self,
+        node: &mut DoWhileStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_while_statement(&mut self, node: &mut WhileStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_for_statement(&mut self, node: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_for_statement_init(
+        &mut self,
+        node: &mut ForStatementInit<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_for_statement_init(
+        &mut self,
+        node: &mut ForStatementInit<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_for_in_statement(&mut self, node: &mut ForInStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_for_statement_left(
+        &mut self,
+        node: &mut ForStatementLeft<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_for_statement_left(
+        &mut self,
+        node: &mut ForStatementLeft<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_for_of_statement(&mut self, node: &mut ForOfStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_continue_statement(
+        &mut self,
+        node: &mut ContinueStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_continue_statement(
+        &mut self,
+        node: &mut ContinueStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_break_statement(&mut self, node: &mut BreakStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_return_statement(
+        &mut self,
+        node: &mut ReturnStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_return_statement(&mut self, node: &mut ReturnStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_with_statement(&mut self, node: &mut WithStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_switch_statement(
+        &mut self,
+        node: &mut SwitchStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_switch_statement(&mut self, node: &mut SwitchStatement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_switch_case(&mut self, node: &mut SwitchCase<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_labeled_statement(
+        &mut self,
+        node: &mut LabeledStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_labeled_statement(
+        &mut self,
+        node: &mut LabeledStatement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_throw_statement(&mut self, node: &mut ThrowStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_try_statement(&mut self, node: &mut TryStatement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_catch_clause(&mut self, node: &mut CatchClause<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_catch_parameter(&mut self, node: &mut CatchParameter<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_debugger_statement(
+        &mut self,
+        node: &mut DebuggerStatement,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_debugger_statement(&mut self, node: &mut DebuggerStatement, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_binding_pattern(&mut self, node: &mut BindingPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_assignment_pattern(
+        &mut self,
+        node: &mut AssignmentPattern<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_assignment_pattern(
+        &mut self,
+        node: &mut AssignmentPattern<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_object_pattern(&mut self, node: &mut ObjectPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_binding_property(
+        &mut self,
+        node: &mut BindingProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_binding_property(&mut self, node: &mut BindingProperty<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_array_pattern(&mut self, node: &mut ArrayPattern<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_binding_rest_element(
+        &mut self,
+        node: &mut BindingRestElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_binding_rest_element(
+        &mut self,
+        node: &mut BindingRestElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_function(&mut self, node: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_formal_parameters(
+        &mut self,
+        node: &mut FormalParameters<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_formal_parameters(
+        &mut self,
+        node: &mut FormalParameters<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_formal_parameter(
+        &mut self,
+        node: &mut FormalParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_formal_parameter(&mut self, node: &mut FormalParameter<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_formal_parameter_rest(
+        &mut self,
+        node: &mut FormalParameterRest<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_formal_parameter_rest(
+        &mut self,
+        node: &mut FormalParameterRest<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_function_body(&mut self, node: &mut FunctionBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_arrow_function_expression(
+        &mut self,
+        node: &mut ArrowFunctionExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_arrow_function_expression(
+        &mut self,
+        node: &mut ArrowFunctionExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_yield_expression(
+        &mut self,
+        node: &mut YieldExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_yield_expression(&mut self, node: &mut YieldExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_class_body(&mut self, node: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_class_element(&mut self, node: &mut ClassElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_method_definition(
+        &mut self,
+        node: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_method_definition(
+        &mut self,
+        node: &mut MethodDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_property_definition(
+        &mut self,
+        node: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_property_definition(
+        &mut self,
+        node: &mut PropertyDefinition<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_private_identifier(
+        &mut self,
+        node: &mut PrivateIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_private_identifier(
+        &mut self,
+        node: &mut PrivateIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_static_block(&mut self, node: &mut StaticBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_module_declaration(
+        &mut self,
+        node: &mut ModuleDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_module_declaration(
+        &mut self,
+        node: &mut ModuleDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_accessor_property(
+        &mut self,
+        node: &mut AccessorProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_import_expression(
+        &mut self,
+        node: &mut ImportExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_expression(
+        &mut self,
+        node: &mut ImportExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_import_declaration(
+        &mut self,
+        node: &mut ImportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_declaration(
+        &mut self,
+        node: &mut ImportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_import_declaration_specifier(
+        &mut self,
+        node: &mut ImportDeclarationSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_declaration_specifier(
+        &mut self,
+        node: &mut ImportDeclarationSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_import_specifier(
+        &mut self,
+        node: &mut ImportSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_specifier(&mut self, node: &mut ImportSpecifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_import_default_specifier(
+        &mut self,
+        node: &mut ImportDefaultSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_default_specifier(
+        &mut self,
+        node: &mut ImportDefaultSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_import_namespace_specifier(
+        &mut self,
+        node: &mut ImportNamespaceSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_namespace_specifier(
+        &mut self,
+        node: &mut ImportNamespaceSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_with_clause(&mut self, node: &mut WithClause<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_import_attribute(
+        &mut self,
+        node: &mut ImportAttribute<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_attribute(&mut self, node: &mut ImportAttribute<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_import_attribute_key(
+        &mut self,
+        node: &mut ImportAttributeKey<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_import_attribute_key(
+        &mut self,
+        node: &mut ImportAttributeKey<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_export_named_declaration(
+        &mut self,
+        node: &mut ExportNamedDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_export_named_declaration(
+        &mut self,
+        node: &mut ExportNamedDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_export_default_declaration(
+        &mut self,
+        node: &mut ExportDefaultDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_export_default_declaration(
+        &mut self,
+        node: &mut ExportDefaultDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_export_all_declaration(
+        &mut self,
+        node: &mut ExportAllDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_export_all_declaration(
+        &mut self,
+        node: &mut ExportAllDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_export_specifier(
+        &mut self,
+        node: &mut ExportSpecifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_export_specifier(&mut self, node: &mut ExportSpecifier<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_export_default_declaration_kind(
+        &mut self,
+        node: &mut ExportDefaultDeclarationKind<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_export_default_declaration_kind(
+        &mut self,
+        node: &mut ExportDefaultDeclarationKind<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_module_export_name(
+        &mut self,
+        node: &mut ModuleExportName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_module_export_name(
+        &mut self,
+        node: &mut ModuleExportName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_v8_intrinsic_expression(
+        &mut self,
+        node: &mut V8IntrinsicExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_v8_intrinsic_expression(
+        &mut self,
+        node: &mut V8IntrinsicExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_boolean_literal(&mut self, node: &mut BooleanLiteral, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_null_literal(&mut self, node: &mut NullLiteral, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_null_literal(&mut self, node: &mut NullLiteral, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_numeric_literal(&mut self, node: &mut NumericLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_string_literal(&mut self, node: &mut StringLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_reg_exp_literal(&mut self, node: &mut RegExpLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_element(&mut self, node: &mut JSXElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_opening_element(
+        &mut self,
+        node: &mut JSXOpeningElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_opening_element(
+        &mut self,
+        node: &mut JSXOpeningElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_closing_element(
+        &mut self,
+        node: &mut JSXClosingElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_closing_element(
+        &mut self,
+        node: &mut JSXClosingElement<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_opening_fragment(
+        &mut self,
+        node: &mut JSXOpeningFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_opening_fragment(
+        &mut self,
+        node: &mut JSXOpeningFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_closing_fragment(
+        &mut self,
+        node: &mut JSXClosingFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_closing_fragment(
+        &mut self,
+        node: &mut JSXClosingFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_namespaced_name(
+        &mut self,
+        node: &mut JSXNamespacedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_namespaced_name(
+        &mut self,
+        node: &mut JSXNamespacedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_member_expression(
+        &mut self,
+        node: &mut JSXMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_member_expression(
+        &mut self,
+        node: &mut JSXMemberExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_member_expression_object(
+        &mut self,
+        node: &mut JSXMemberExpressionObject<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_member_expression_object(
+        &mut self,
+        node: &mut JSXMemberExpressionObject<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_expression_container(
+        &mut self,
+        node: &mut JSXExpressionContainer<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_expression_container(
+        &mut self,
+        node: &mut JSXExpressionContainer<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_expression(&mut self, node: &mut JSXExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_empty_expression(
+        &mut self,
+        node: &mut JSXEmptyExpression,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_empty_expression(
+        &mut self,
+        node: &mut JSXEmptyExpression,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_attribute_item(
+        &mut self,
+        node: &mut JSXAttributeItem<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_attribute_item(
+        &mut self,
+        node: &mut JSXAttributeItem<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_attribute(&mut self, node: &mut JSXAttribute<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_spread_attribute(
+        &mut self,
+        node: &mut JSXSpreadAttribute<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_spread_attribute(
+        &mut self,
+        node: &mut JSXSpreadAttribute<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_attribute_name(
+        &mut self,
+        node: &mut JSXAttributeName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_attribute_name(
+        &mut self,
+        node: &mut JSXAttributeName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_attribute_value(
+        &mut self,
+        node: &mut JSXAttributeValue<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_attribute_value(
+        &mut self,
+        node: &mut JSXAttributeValue<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_identifier(&mut self, node: &mut JSXIdentifier<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_child(&mut self, node: &mut JSXChild<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_jsx_spread_child(&mut self, node: &mut JSXSpreadChild<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_jsx_text(&mut self, node: &mut JSXText<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_this_parameter(
+        &mut self,
+        node: &mut TSThisParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_this_parameter(
+        &mut self,
+        node: &mut TSThisParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_enum_declaration(
+        &mut self,
+        node: &mut TSEnumDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_enum_declaration(
+        &mut self,
+        node: &mut TSEnumDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_enum_body(&mut self, node: &mut TSEnumBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_enum_body(&mut self, node: &mut TSEnumBody<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_enum_member(&mut self, node: &mut TSEnumMember<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_enum_member_name(
+        &mut self,
+        node: &mut TSEnumMemberName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_enum_member_name(
+        &mut self,
+        node: &mut TSEnumMemberName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_annotation(
+        &mut self,
+        node: &mut TSTypeAnnotation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_annotation(
+        &mut self,
+        node: &mut TSTypeAnnotation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_literal_type(&mut self, node: &mut TSLiteralType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_literal(&mut self, node: &mut TSLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type(&mut self, node: &mut TSType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_type(&mut self, node: &mut TSType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_conditional_type(
+        &mut self,
+        node: &mut TSConditionalType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_conditional_type(
+        &mut self,
+        node: &mut TSConditionalType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_union_type(&mut self, node: &mut TSUnionType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_intersection_type(
+        &mut self,
+        node: &mut TSIntersectionType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_intersection_type(
+        &mut self,
+        node: &mut TSIntersectionType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_parenthesized_type(
+        &mut self,
+        node: &mut TSParenthesizedType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_parenthesized_type(
+        &mut self,
+        node: &mut TSParenthesizedType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_type_operator(&mut self, node: &mut TSTypeOperator<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_array_type(&mut self, node: &mut TSArrayType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_indexed_access_type(
+        &mut self,
+        node: &mut TSIndexedAccessType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_indexed_access_type(
+        &mut self,
+        node: &mut TSIndexedAccessType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_tuple_type(&mut self, node: &mut TSTupleType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_named_tuple_member(
+        &mut self,
+        node: &mut TSNamedTupleMember<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_named_tuple_member(
+        &mut self,
+        node: &mut TSNamedTupleMember<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_optional_type(&mut self, node: &mut TSOptionalType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_rest_type(&mut self, node: &mut TSRestType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_tuple_element(&mut self, node: &mut TSTupleElement<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_any_keyword(&mut self, node: &mut TSAnyKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_string_keyword(&mut self, node: &mut TSStringKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_boolean_keyword(&mut self, node: &mut TSBooleanKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_number_keyword(&mut self, node: &mut TSNumberKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_never_keyword(&mut self, node: &mut TSNeverKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_intrinsic_keyword(
+        &mut self,
+        node: &mut TSIntrinsicKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_intrinsic_keyword(
+        &mut self,
+        node: &mut TSIntrinsicKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_unknown_keyword(&mut self, node: &mut TSUnknownKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_null_keyword(&mut self, node: &mut TSNullKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_undefined_keyword(
+        &mut self,
+        node: &mut TSUndefinedKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_undefined_keyword(
+        &mut self,
+        node: &mut TSUndefinedKeyword,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_void_keyword(&mut self, node: &mut TSVoidKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_symbol_keyword(&mut self, node: &mut TSSymbolKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_this_type(&mut self, node: &mut TSThisType, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_this_type(&mut self, node: &mut TSThisType, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_object_keyword(&mut self, node: &mut TSObjectKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_big_int_keyword(&mut self, node: &mut TSBigIntKeyword, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type_reference(
+        &mut self,
+        node: &mut TSTypeReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_reference(
+        &mut self,
+        node: &mut TSTypeReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_type_name(&mut self, node: &mut TSTypeName<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_qualified_name(
+        &mut self,
+        node: &mut TSQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_qualified_name(
+        &mut self,
+        node: &mut TSQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_parameter_instantiation(
+        &mut self,
+        node: &mut TSTypeParameterInstantiation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_parameter_instantiation(
+        &mut self,
+        node: &mut TSTypeParameterInstantiation<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_parameter(
+        &mut self,
+        node: &mut TSTypeParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_parameter(
+        &mut self,
+        node: &mut TSTypeParameter<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_parameter_declaration(
+        &mut self,
+        node: &mut TSTypeParameterDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_parameter_declaration(
+        &mut self,
+        node: &mut TSTypeParameterDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_alias_declaration(
+        &mut self,
+        node: &mut TSTypeAliasDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_alias_declaration(
+        &mut self,
+        node: &mut TSTypeAliasDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_class_implements(
+        &mut self,
+        node: &mut TSClassImplements<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_class_implements(
+        &mut self,
+        node: &mut TSClassImplements<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_interface_declaration(
+        &mut self,
+        node: &mut TSInterfaceDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_interface_declaration(
+        &mut self,
+        node: &mut TSInterfaceDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_interface_body(
+        &mut self,
+        node: &mut TSInterfaceBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_interface_body(
+        &mut self,
+        node: &mut TSInterfaceBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_property_signature(
+        &mut self,
+        node: &mut TSPropertySignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_property_signature(
+        &mut self,
+        node: &mut TSPropertySignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_signature(&mut self, node: &mut TSSignature<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_index_signature(
+        &mut self,
+        node: &mut TSIndexSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_index_signature(
+        &mut self,
+        node: &mut TSIndexSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_call_signature_declaration(
+        &mut self,
+        node: &mut TSCallSignatureDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_call_signature_declaration(
+        &mut self,
+        node: &mut TSCallSignatureDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_method_signature(
+        &mut self,
+        node: &mut TSMethodSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_method_signature(
+        &mut self,
+        node: &mut TSMethodSignature<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_construct_signature_declaration(
+        &mut self,
+        node: &mut TSConstructSignatureDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_construct_signature_declaration(
+        &mut self,
+        node: &mut TSConstructSignatureDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_index_signature_name(
+        &mut self,
+        node: &mut TSIndexSignatureName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_index_signature_name(
+        &mut self,
+        node: &mut TSIndexSignatureName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_interface_heritage(
+        &mut self,
+        node: &mut TSInterfaceHeritage<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_interface_heritage(
+        &mut self,
+        node: &mut TSInterfaceHeritage<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_predicate(
+        &mut self,
+        node: &mut TSTypePredicate<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_predicate(
+        &mut self,
+        node: &mut TSTypePredicate<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_predicate_name(
+        &mut self,
+        node: &mut TSTypePredicateName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_predicate_name(
+        &mut self,
+        node: &mut TSTypePredicateName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_module_declaration(
+        &mut self,
+        node: &mut TSModuleDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_module_declaration(
+        &mut self,
+        node: &mut TSModuleDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_module_declaration_name(
+        &mut self,
+        node: &mut TSModuleDeclarationName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_module_declaration_name(
+        &mut self,
+        node: &mut TSModuleDeclarationName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_module_declaration_body(
+        &mut self,
+        node: &mut TSModuleDeclarationBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_module_declaration_body(
+        &mut self,
+        node: &mut TSModuleDeclarationBody<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_global_declaration(
+        &mut self,
+        node: &mut TSGlobalDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_global_declaration(
+        &mut self,
+        node: &mut TSGlobalDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_module_block(&mut self, node: &mut TSModuleBlock<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_type_literal(&mut self, node: &mut TSTypeLiteral<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_infer_type(&mut self, node: &mut TSInferType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_type_query(&mut self, node: &mut TSTypeQuery<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_type_query_expr_name(
+        &mut self,
+        node: &mut TSTypeQueryExprName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_query_expr_name(
+        &mut self,
+        node: &mut TSTypeQueryExprName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_import_type_qualifier(
+        &mut self,
+        node: &mut TSImportTypeQualifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_import_type_qualifier(
+        &mut self,
+        node: &mut TSImportTypeQualifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_import_type_qualified_name(
+        &mut self,
+        node: &mut TSImportTypeQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_import_type_qualified_name(
+        &mut self,
+        node: &mut TSImportTypeQualifiedName<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_constructor_type(
+        &mut self,
+        node: &mut TSConstructorType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_constructor_type(
+        &mut self,
+        node: &mut TSConstructorType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_ts_mapped_type(&mut self, node: &mut TSMappedType<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_template_literal_type(
+        &mut self,
+        node: &mut TSTemplateLiteralType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_template_literal_type(
+        &mut self,
+        node: &mut TSTemplateLiteralType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+    }
+    #[inline]
+    fn exit_ts_as_expression(&mut self, node: &mut TSAsExpression<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_satisfies_expression(
+        &mut self,
+        node: &mut TSSatisfiesExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_satisfies_expression(
+        &mut self,
+        node: &mut TSSatisfiesExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_type_assertion(
+        &mut self,
+        node: &mut TSTypeAssertion<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_type_assertion(
+        &mut self,
+        node: &mut TSTypeAssertion<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_import_equals_declaration(
+        &mut self,
+        node: &mut TSImportEqualsDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_import_equals_declaration(
+        &mut self,
+        node: &mut TSImportEqualsDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_module_reference(
+        &mut self,
+        node: &mut TSModuleReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_module_reference(
+        &mut self,
+        node: &mut TSModuleReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_external_module_reference(
+        &mut self,
+        node: &mut TSExternalModuleReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_external_module_reference(
+        &mut self,
+        node: &mut TSExternalModuleReference<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_non_null_expression(
+        &mut self,
+        node: &mut TSNonNullExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_non_null_expression(
+        &mut self,
+        node: &mut TSNonNullExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_decorator(&mut self, node: &mut Decorator<'a>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_decorator(&mut self, node: &mut Decorator<'a>, ctx: &mut TraverseCtx<'a>) {}
+
+    #[inline]
+    fn enter_ts_export_assignment(
+        &mut self,
+        node: &mut TSExportAssignment<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_export_assignment(
+        &mut self,
+        node: &mut TSExportAssignment<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_namespace_export_declaration(
+        &mut self,
+        node: &mut TSNamespaceExportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_namespace_export_declaration(
+        &mut self,
+        node: &mut TSNamespaceExportDeclaration<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_ts_instantiation_expression(
+        &mut self,
+        node: &mut TSInstantiationExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_ts_instantiation_expression(
+        &mut self,
+        node: &mut TSInstantiationExpression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_js_doc_nullable_type(
+        &mut self,
+        node: &mut JSDocNullableType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_js_doc_nullable_type(
+        &mut self,
+        node: &mut JSDocNullableType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_js_doc_non_nullable_type(
+        &mut self,
+        node: &mut JSDocNonNullableType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_js_doc_non_nullable_type(
+        &mut self,
+        node: &mut JSDocNonNullableType<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_js_doc_unknown_type(
+        &mut self,
+        node: &mut JSDocUnknownType,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_js_doc_unknown_type(&mut self, node: &mut JSDocUnknownType, ctx: &mut TraverseCtx<'a>) {
+    }
+
+    #[inline]
+    fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
+    #[inline]
+    fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
+}

--- a/crates/oxc_minifier/src/generated/walk.rs
+++ b/crates/oxc_minifier/src/generated/walk.rs
@@ -1,0 +1,5741 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/minifier_traverse/mod.rs`.
+
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    clippy::ptr_as_ptr,
+    clippy::ref_as_ptr,
+    clippy::cast_ptr_alignment,
+    clippy::borrow_as_ptr,
+    clippy::match_same_arms,
+    unsafe_op_in_unsafe_fn
+)]
+
+use std::{cell::Cell, marker::PhantomData};
+
+use oxc_allocator::Vec;
+use oxc_ast::ast::*;
+use oxc_syntax::scope::ScopeId;
+
+use crate::{
+    Traverse, TraverseCtx,
+    generated::ancestor::{self, Ancestor, AncestorType},
+};
+
+/// Walk AST with `Traverse` impl.
+///
+/// # SAFETY
+/// * `program` must be a pointer to a valid `Program` which has lifetime `'a`
+///   (`Program<'a>`).
+/// * `ctx` must contain a `TraverseAncestry<'a>` with single `Ancestor::None` on its stack.
+#[inline]
+pub unsafe fn walk_ast<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    program: *mut Program<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    walk_program(traverser, program, ctx);
+}
+
+unsafe fn walk_program<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Program<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_program(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_PROGRAM_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token = ctx
+        .push_stack(Ancestor::ProgramHashbang(ancestor::ProgramWithoutHashbang(node, PhantomData)));
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_HASHBANG) as *mut Option<Hashbang>)
+    {
+        walk_hashbang(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ProgramDirectives);
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES) as *mut Vec<Directive>)
+    {
+        walk_directive(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ProgramBody);
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_program(&mut *node, ctx);
+}
+
+unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Expression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_expression(&mut *node, ctx);
+    match &mut *node {
+        Expression::BooleanLiteral(node) => {
+            walk_boolean_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::NullLiteral(node) => walk_null_literal(traverser, (&mut **node) as *mut _, ctx),
+        Expression::NumericLiteral(node) => {
+            walk_numeric_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::BigIntLiteral(node) => {
+            walk_big_int_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::RegExpLiteral(node) => {
+            walk_reg_exp_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::StringLiteral(node) => {
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TemplateLiteral(node) => {
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::Identifier(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::MetaProperty(node) => {
+            walk_meta_property(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::Super(node) => walk_super(traverser, (&mut **node) as *mut _, ctx),
+        Expression::ArrayExpression(node) => {
+            walk_array_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ArrowFunctionExpression(node) => {
+            walk_arrow_function_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::AssignmentExpression(node) => {
+            walk_assignment_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::AwaitExpression(node) => {
+            walk_await_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::BinaryExpression(node) => {
+            walk_binary_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::CallExpression(node) => {
+            walk_call_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ChainExpression(node) => {
+            walk_chain_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ClassExpression(node) => walk_class(traverser, (&mut **node) as *mut _, ctx),
+        Expression::ConditionalExpression(node) => {
+            walk_conditional_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::FunctionExpression(node) => {
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ImportExpression(node) => {
+            walk_import_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::LogicalExpression(node) => {
+            walk_logical_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::NewExpression(node) => {
+            walk_new_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ObjectExpression(node) => {
+            walk_object_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ParenthesizedExpression(node) => {
+            walk_parenthesized_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::SequenceExpression(node) => {
+            walk_sequence_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TaggedTemplateExpression(node) => {
+            walk_tagged_template_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ThisExpression(node) => {
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::UnaryExpression(node) => {
+            walk_unary_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::UpdateExpression(node) => {
+            walk_update_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::YieldExpression(node) => {
+            walk_yield_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::PrivateInExpression(node) => {
+            walk_private_in_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::JSXElement(node) => walk_jsx_element(traverser, (&mut **node) as *mut _, ctx),
+        Expression::JSXFragment(node) => walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx),
+        Expression::TSAsExpression(node) => {
+            walk_ts_as_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TSSatisfiesExpression(node) => {
+            walk_ts_satisfies_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TSTypeAssertion(node) => {
+            walk_ts_type_assertion(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TSNonNullExpression(node) => {
+            walk_ts_non_null_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::TSInstantiationExpression(node) => {
+            walk_ts_instantiation_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::V8IntrinsicExpression(node) => {
+            walk_v8_intrinsic_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Expression::ComputedMemberExpression(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => {
+            walk_member_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_identifier_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut IdentifierName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_identifier_name(&mut *node, ctx);
+    traverser.exit_identifier_name(&mut *node, ctx);
+}
+
+unsafe fn walk_identifier_reference<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut IdentifierReference<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_identifier_reference(&mut *node, ctx);
+    traverser.exit_identifier_reference(&mut *node, ctx);
+}
+
+unsafe fn walk_binding_identifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BindingIdentifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_binding_identifier(&mut *node, ctx);
+    traverser.exit_binding_identifier(&mut *node, ctx);
+}
+
+unsafe fn walk_label_identifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut LabelIdentifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_label_identifier(&mut *node, ctx);
+    traverser.exit_label_identifier(&mut *node, ctx);
+}
+
+unsafe fn walk_this_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ThisExpression,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_this_expression(&mut *node, ctx);
+    traverser.exit_this_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ArrayExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_array_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ArrayExpressionElements(
+        ancestor::ArrayExpressionWithoutElements(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_EXPRESSION_ELEMENTS)
+        as *mut Vec<ArrayExpressionElement>)
+    {
+        walk_array_expression_element(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_array_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ArrayExpressionElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_array_expression_element(&mut *node, ctx);
+    match &mut *node {
+        ArrayExpressionElement::SpreadElement(node) => {
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ArrayExpressionElement::Elision(node) => walk_elision(traverser, node as *mut _, ctx),
+        ArrayExpressionElement::BooleanLiteral(_)
+        | ArrayExpressionElement::NullLiteral(_)
+        | ArrayExpressionElement::NumericLiteral(_)
+        | ArrayExpressionElement::BigIntLiteral(_)
+        | ArrayExpressionElement::RegExpLiteral(_)
+        | ArrayExpressionElement::StringLiteral(_)
+        | ArrayExpressionElement::TemplateLiteral(_)
+        | ArrayExpressionElement::Identifier(_)
+        | ArrayExpressionElement::MetaProperty(_)
+        | ArrayExpressionElement::Super(_)
+        | ArrayExpressionElement::ArrayExpression(_)
+        | ArrayExpressionElement::ArrowFunctionExpression(_)
+        | ArrayExpressionElement::AssignmentExpression(_)
+        | ArrayExpressionElement::AwaitExpression(_)
+        | ArrayExpressionElement::BinaryExpression(_)
+        | ArrayExpressionElement::CallExpression(_)
+        | ArrayExpressionElement::ChainExpression(_)
+        | ArrayExpressionElement::ClassExpression(_)
+        | ArrayExpressionElement::ConditionalExpression(_)
+        | ArrayExpressionElement::FunctionExpression(_)
+        | ArrayExpressionElement::ImportExpression(_)
+        | ArrayExpressionElement::LogicalExpression(_)
+        | ArrayExpressionElement::NewExpression(_)
+        | ArrayExpressionElement::ObjectExpression(_)
+        | ArrayExpressionElement::ParenthesizedExpression(_)
+        | ArrayExpressionElement::SequenceExpression(_)
+        | ArrayExpressionElement::TaggedTemplateExpression(_)
+        | ArrayExpressionElement::ThisExpression(_)
+        | ArrayExpressionElement::UnaryExpression(_)
+        | ArrayExpressionElement::UpdateExpression(_)
+        | ArrayExpressionElement::YieldExpression(_)
+        | ArrayExpressionElement::PrivateInExpression(_)
+        | ArrayExpressionElement::JSXElement(_)
+        | ArrayExpressionElement::JSXFragment(_)
+        | ArrayExpressionElement::TSAsExpression(_)
+        | ArrayExpressionElement::TSSatisfiesExpression(_)
+        | ArrayExpressionElement::TSTypeAssertion(_)
+        | ArrayExpressionElement::TSNonNullExpression(_)
+        | ArrayExpressionElement::TSInstantiationExpression(_)
+        | ArrayExpressionElement::V8IntrinsicExpression(_)
+        | ArrayExpressionElement::ComputedMemberExpression(_)
+        | ArrayExpressionElement::StaticMemberExpression(_)
+        | ArrayExpressionElement::PrivateFieldExpression(_) => {
+            walk_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_array_expression_element(&mut *node, ctx);
+}
+
+unsafe fn walk_elision<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Elision,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_elision(&mut *node, ctx);
+    traverser.exit_elision(&mut *node, ctx);
+}
+
+unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ObjectExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_object_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ObjectExpressionProperties(
+        ancestor::ObjectExpressionWithoutProperties(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_EXPRESSION_PROPERTIES)
+        as *mut Vec<ObjectPropertyKind>)
+    {
+        walk_object_property_kind(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_object_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_object_property_kind<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ObjectPropertyKind<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_object_property_kind(&mut *node, ctx);
+    match &mut *node {
+        ObjectPropertyKind::ObjectProperty(node) => {
+            walk_object_property(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ObjectPropertyKind::SpreadProperty(node) => {
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_object_property_kind(&mut *node, ctx);
+}
+
+unsafe fn walk_object_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ObjectProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_object_property(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ObjectPropertyKey(
+        ancestor::ObjectPropertyWithoutKey(node, PhantomData),
+    ));
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_OBJECT_PROPERTY_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ObjectPropertyValue);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_OBJECT_PROPERTY_VALUE) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_object_property(&mut *node, ctx);
+}
+
+unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut PropertyKey<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_property_key(&mut *node, ctx);
+    match &mut *node {
+        PropertyKey::StaticIdentifier(node) => {
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        PropertyKey::PrivateIdentifier(node) => {
+            walk_private_identifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        PropertyKey::BooleanLiteral(_)
+        | PropertyKey::NullLiteral(_)
+        | PropertyKey::NumericLiteral(_)
+        | PropertyKey::BigIntLiteral(_)
+        | PropertyKey::RegExpLiteral(_)
+        | PropertyKey::StringLiteral(_)
+        | PropertyKey::TemplateLiteral(_)
+        | PropertyKey::Identifier(_)
+        | PropertyKey::MetaProperty(_)
+        | PropertyKey::Super(_)
+        | PropertyKey::ArrayExpression(_)
+        | PropertyKey::ArrowFunctionExpression(_)
+        | PropertyKey::AssignmentExpression(_)
+        | PropertyKey::AwaitExpression(_)
+        | PropertyKey::BinaryExpression(_)
+        | PropertyKey::CallExpression(_)
+        | PropertyKey::ChainExpression(_)
+        | PropertyKey::ClassExpression(_)
+        | PropertyKey::ConditionalExpression(_)
+        | PropertyKey::FunctionExpression(_)
+        | PropertyKey::ImportExpression(_)
+        | PropertyKey::LogicalExpression(_)
+        | PropertyKey::NewExpression(_)
+        | PropertyKey::ObjectExpression(_)
+        | PropertyKey::ParenthesizedExpression(_)
+        | PropertyKey::SequenceExpression(_)
+        | PropertyKey::TaggedTemplateExpression(_)
+        | PropertyKey::ThisExpression(_)
+        | PropertyKey::UnaryExpression(_)
+        | PropertyKey::UpdateExpression(_)
+        | PropertyKey::YieldExpression(_)
+        | PropertyKey::PrivateInExpression(_)
+        | PropertyKey::JSXElement(_)
+        | PropertyKey::JSXFragment(_)
+        | PropertyKey::TSAsExpression(_)
+        | PropertyKey::TSSatisfiesExpression(_)
+        | PropertyKey::TSTypeAssertion(_)
+        | PropertyKey::TSNonNullExpression(_)
+        | PropertyKey::TSInstantiationExpression(_)
+        | PropertyKey::V8IntrinsicExpression(_)
+        | PropertyKey::ComputedMemberExpression(_)
+        | PropertyKey::StaticMemberExpression(_)
+        | PropertyKey::PrivateFieldExpression(_) => walk_expression(traverser, node as *mut _, ctx),
+    }
+    traverser.exit_property_key(&mut *node, ctx);
+}
+
+unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TemplateLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_template_literal(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TemplateLiteralQuasis(
+        ancestor::TemplateLiteralWithoutQuasis(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_QUASIS)
+        as *mut Vec<TemplateElement>)
+    {
+        walk_template_element(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TemplateLiteralExpressions);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
+        as *mut Vec<Expression>)
+    {
+        walk_expression(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_template_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TaggedTemplateExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_tagged_template_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TaggedTemplateExpressionTag(
+        ancestor::TaggedTemplateExpressionWithoutTag(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TAG) as *mut Expression,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TaggedTemplateExpressionQuasi);
+    walk_template_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI)
+            as *mut TemplateLiteral,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_tagged_template_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_template_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TemplateElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_template_element(&mut *node, ctx);
+    traverser.exit_template_element(&mut *node, ctx);
+}
+
+unsafe fn walk_member_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut MemberExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_member_expression(&mut *node, ctx);
+    match &mut *node {
+        MemberExpression::ComputedMemberExpression(node) => {
+            walk_computed_member_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        MemberExpression::StaticMemberExpression(node) => {
+            walk_static_member_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        MemberExpression::PrivateFieldExpression(node) => {
+            walk_private_field_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_member_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_computed_member_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ComputedMemberExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_computed_member_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ComputedMemberExpressionObject(
+        ancestor::ComputedMemberExpressionWithoutObject(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_OBJECT)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ComputedMemberExpressionExpression);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_COMPUTED_MEMBER_EXPRESSION_EXPRESSION)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_computed_member_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_static_member_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut StaticMemberExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_static_member_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::StaticMemberExpressionObject(
+        ancestor::StaticMemberExpressionWithoutObject(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_OBJECT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::StaticMemberExpressionProperty);
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_MEMBER_EXPRESSION_PROPERTY)
+            as *mut IdentifierName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_static_member_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_private_field_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut PrivateFieldExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_private_field_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::PrivateFieldExpressionObject(
+        ancestor::PrivateFieldExpressionWithoutObject(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_OBJECT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::PrivateFieldExpressionField);
+    walk_private_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_FIELD_EXPRESSION_FIELD)
+            as *mut PrivateIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_private_field_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut CallExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_call_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::CallExpressionCallee(
+        ancestor::CallExpressionWithoutCallee(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_CALLEE) as *mut Expression,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::CallExpressionTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::CallExpressionArguments);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>)
+    {
+        walk_argument(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_call_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut NewExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_new_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::NewExpressionCallee(
+        ancestor::NewExpressionWithoutCallee(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_CALLEE) as *mut Expression,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::NewExpressionTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::NewExpressionArguments);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>)
+    {
+        walk_argument(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_new_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_meta_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut MetaProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_meta_property(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::MetaPropertyMeta(ancestor::MetaPropertyWithoutMeta(
+        node,
+        PhantomData,
+    )));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_META_PROPERTY_META) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::MetaPropertyProperty);
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_META_PROPERTY_PROPERTY) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_meta_property(&mut *node, ctx);
+}
+
+unsafe fn walk_spread_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut SpreadElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_spread_element(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::SpreadElementArgument(
+        ancestor::SpreadElementWithoutArgument(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_SPREAD_ELEMENT_ARGUMENT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_spread_element(&mut *node, ctx);
+}
+
+unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Argument<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_argument(&mut *node, ctx);
+    match &mut *node {
+        Argument::SpreadElement(node) => {
+            walk_spread_element(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Argument::BooleanLiteral(_)
+        | Argument::NullLiteral(_)
+        | Argument::NumericLiteral(_)
+        | Argument::BigIntLiteral(_)
+        | Argument::RegExpLiteral(_)
+        | Argument::StringLiteral(_)
+        | Argument::TemplateLiteral(_)
+        | Argument::Identifier(_)
+        | Argument::MetaProperty(_)
+        | Argument::Super(_)
+        | Argument::ArrayExpression(_)
+        | Argument::ArrowFunctionExpression(_)
+        | Argument::AssignmentExpression(_)
+        | Argument::AwaitExpression(_)
+        | Argument::BinaryExpression(_)
+        | Argument::CallExpression(_)
+        | Argument::ChainExpression(_)
+        | Argument::ClassExpression(_)
+        | Argument::ConditionalExpression(_)
+        | Argument::FunctionExpression(_)
+        | Argument::ImportExpression(_)
+        | Argument::LogicalExpression(_)
+        | Argument::NewExpression(_)
+        | Argument::ObjectExpression(_)
+        | Argument::ParenthesizedExpression(_)
+        | Argument::SequenceExpression(_)
+        | Argument::TaggedTemplateExpression(_)
+        | Argument::ThisExpression(_)
+        | Argument::UnaryExpression(_)
+        | Argument::UpdateExpression(_)
+        | Argument::YieldExpression(_)
+        | Argument::PrivateInExpression(_)
+        | Argument::JSXElement(_)
+        | Argument::JSXFragment(_)
+        | Argument::TSAsExpression(_)
+        | Argument::TSSatisfiesExpression(_)
+        | Argument::TSTypeAssertion(_)
+        | Argument::TSNonNullExpression(_)
+        | Argument::TSInstantiationExpression(_)
+        | Argument::V8IntrinsicExpression(_)
+        | Argument::ComputedMemberExpression(_)
+        | Argument::StaticMemberExpression(_)
+        | Argument::PrivateFieldExpression(_) => walk_expression(traverser, node as *mut _, ctx),
+    }
+    traverser.exit_argument(&mut *node, ctx);
+}
+
+unsafe fn walk_update_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut UpdateExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_update_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::UpdateExpressionArgument(
+        ancestor::UpdateExpressionWithoutArgument(node, PhantomData),
+    ));
+    walk_simple_assignment_target(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_UPDATE_EXPRESSION_ARGUMENT)
+            as *mut SimpleAssignmentTarget,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_update_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_unary_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut UnaryExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_unary_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::UnaryExpressionArgument(
+        ancestor::UnaryExpressionWithoutArgument(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_UNARY_EXPRESSION_ARGUMENT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_unary_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_binary_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BinaryExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_binary_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::BinaryExpressionLeft(
+        ancestor::BinaryExpressionWithoutLeft(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BINARY_EXPRESSION_LEFT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::BinaryExpressionRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BINARY_EXPRESSION_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_binary_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_private_in_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut PrivateInExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_private_in_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::PrivateInExpressionLeft(
+        ancestor::PrivateInExpressionWithoutLeft(node, PhantomData),
+    ));
+    walk_private_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_LEFT)
+            as *mut PrivateIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::PrivateInExpressionRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PRIVATE_IN_EXPRESSION_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_private_in_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_logical_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut LogicalExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_logical_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::LogicalExpressionLeft(
+        ancestor::LogicalExpressionWithoutLeft(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_LOGICAL_EXPRESSION_LEFT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::LogicalExpressionRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_LOGICAL_EXPRESSION_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_logical_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_conditional_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ConditionalExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_conditional_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ConditionalExpressionTest(
+        ancestor::ConditionalExpressionWithoutTest(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_TEST) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ConditionalExpressionConsequent);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_CONSEQUENT)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ConditionalExpressionAlternate);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CONDITIONAL_EXPRESSION_ALTERNATE) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_conditional_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentExpressionLeft(
+        ancestor::AssignmentExpressionWithoutLeft(node, PhantomData),
+    ));
+    walk_assignment_target(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_LEFT) as *mut AssignmentTarget,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::AssignmentExpressionRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_EXPRESSION_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTarget<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target(&mut *node, ctx);
+    match &mut *node {
+        AssignmentTarget::AssignmentTargetIdentifier(_)
+        | AssignmentTarget::TSAsExpression(_)
+        | AssignmentTarget::TSSatisfiesExpression(_)
+        | AssignmentTarget::TSNonNullExpression(_)
+        | AssignmentTarget::TSTypeAssertion(_)
+        | AssignmentTarget::ComputedMemberExpression(_)
+        | AssignmentTarget::StaticMemberExpression(_)
+        | AssignmentTarget::PrivateFieldExpression(_) => {
+            walk_simple_assignment_target(traverser, node as *mut _, ctx)
+        }
+        AssignmentTarget::ArrayAssignmentTarget(_)
+        | AssignmentTarget::ObjectAssignmentTarget(_) => {
+            walk_assignment_target_pattern(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_assignment_target(&mut *node, ctx);
+}
+
+unsafe fn walk_simple_assignment_target<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut SimpleAssignmentTarget<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_simple_assignment_target(&mut *node, ctx);
+    match &mut *node {
+        SimpleAssignmentTarget::AssignmentTargetIdentifier(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        SimpleAssignmentTarget::TSAsExpression(node) => {
+            walk_ts_as_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        SimpleAssignmentTarget::TSSatisfiesExpression(node) => {
+            walk_ts_satisfies_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        SimpleAssignmentTarget::TSNonNullExpression(node) => {
+            walk_ts_non_null_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        SimpleAssignmentTarget::TSTypeAssertion(node) => {
+            walk_ts_type_assertion(traverser, (&mut **node) as *mut _, ctx)
+        }
+        SimpleAssignmentTarget::ComputedMemberExpression(_)
+        | SimpleAssignmentTarget::StaticMemberExpression(_)
+        | SimpleAssignmentTarget::PrivateFieldExpression(_) => {
+            walk_member_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_simple_assignment_target(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_pattern<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetPattern<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_pattern(&mut *node, ctx);
+    match &mut *node {
+        AssignmentTargetPattern::ArrayAssignmentTarget(node) => {
+            walk_array_assignment_target(traverser, (&mut **node) as *mut _, ctx)
+        }
+        AssignmentTargetPattern::ObjectAssignmentTarget(node) => {
+            walk_object_assignment_target(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_assignment_target_pattern(&mut *node, ctx);
+}
+
+unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ArrayAssignmentTarget<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_array_assignment_target(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ArrayAssignmentTargetElements(
+        ancestor::ArrayAssignmentTargetWithoutElements(node, PhantomData),
+    ));
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
+        as *mut Vec<Option<AssignmentTargetMaybeDefault>>))
+        .iter_mut()
+        .flatten()
+    {
+        walk_assignment_target_maybe_default(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
+        as *mut Option<Box<AssignmentTargetRest>>)
+    {
+        ctx.retag_stack(AncestorType::ArrayAssignmentTargetRest);
+        walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_array_assignment_target(&mut *node, ctx);
+}
+
+unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ObjectAssignmentTarget<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_object_assignment_target(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ObjectAssignmentTargetProperties(
+        ancestor::ObjectAssignmentTargetWithoutProperties(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
+        as *mut Vec<AssignmentTargetProperty>)
+    {
+        walk_assignment_target_property(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
+        as *mut Option<Box<AssignmentTargetRest>>)
+    {
+        ctx.retag_stack(AncestorType::ObjectAssignmentTargetRest);
+        walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_object_assignment_target(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_rest<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetRest<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_rest(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentTargetRestTarget(
+        ancestor::AssignmentTargetRestWithoutTarget(node, PhantomData),
+    ));
+    walk_assignment_target(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_REST_TARGET)
+            as *mut AssignmentTarget,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_target_rest(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetMaybeDefault<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_maybe_default(&mut *node, ctx);
+    match &mut *node {
+        AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(node) => {
+            walk_assignment_target_with_default(traverser, (&mut **node) as *mut _, ctx)
+        }
+        AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(_)
+        | AssignmentTargetMaybeDefault::TSAsExpression(_)
+        | AssignmentTargetMaybeDefault::TSSatisfiesExpression(_)
+        | AssignmentTargetMaybeDefault::TSNonNullExpression(_)
+        | AssignmentTargetMaybeDefault::TSTypeAssertion(_)
+        | AssignmentTargetMaybeDefault::ArrayAssignmentTarget(_)
+        | AssignmentTargetMaybeDefault::ObjectAssignmentTarget(_)
+        | AssignmentTargetMaybeDefault::ComputedMemberExpression(_)
+        | AssignmentTargetMaybeDefault::StaticMemberExpression(_)
+        | AssignmentTargetMaybeDefault::PrivateFieldExpression(_) => {
+            walk_assignment_target(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_assignment_target_maybe_default(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_with_default<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetWithDefault<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_with_default(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentTargetWithDefaultBinding(
+        ancestor::AssignmentTargetWithDefaultWithoutBinding(node, PhantomData),
+    ));
+    walk_assignment_target(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_BINDING)
+            as *mut AssignmentTarget,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::AssignmentTargetWithDefaultInit);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_WITH_DEFAULT_INIT)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_target_with_default(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_property(&mut *node, ctx);
+    match &mut *node {
+        AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(node) => {
+            walk_assignment_target_property_identifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        AssignmentTargetProperty::AssignmentTargetPropertyProperty(node) => {
+            walk_assignment_target_property_property(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_assignment_target_property(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_property_identifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetPropertyIdentifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_property_identifier(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentTargetPropertyIdentifierBinding(
+        ancestor::AssignmentTargetPropertyIdentifierWithoutBinding(node, PhantomData),
+    ));
+    walk_identifier_reference(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_BINDING)
+            as *mut IdentifierReference,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_IDENTIFIER_INIT)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::AssignmentTargetPropertyIdentifierInit);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_target_property_identifier(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_target_property_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentTargetPropertyProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_target_property_property(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentTargetPropertyPropertyName(
+        ancestor::AssignmentTargetPropertyPropertyWithoutName(node, PhantomData),
+    ));
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_NAME)
+            as *mut PropertyKey,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::AssignmentTargetPropertyPropertyBinding);
+    walk_assignment_target_maybe_default(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_TARGET_PROPERTY_PROPERTY_BINDING)
+            as *mut AssignmentTargetMaybeDefault,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_target_property_property(&mut *node, ctx);
+}
+
+unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut SequenceExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_sequence_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::SequenceExpressionExpressions(
+        ancestor::SequenceExpressionWithoutExpressions(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS)
+        as *mut Vec<Expression>)
+    {
+        walk_expression(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_sequence_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_super<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Super,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_super(&mut *node, ctx);
+    traverser.exit_super(&mut *node, ctx);
+}
+
+unsafe fn walk_await_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AwaitExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_await_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AwaitExpressionArgument(
+        ancestor::AwaitExpressionWithoutArgument(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_AWAIT_EXPRESSION_ARGUMENT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_await_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_chain_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ChainExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_chain_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ChainExpressionExpression(
+        ancestor::ChainExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_chain_element(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CHAIN_EXPRESSION_EXPRESSION) as *mut ChainElement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_chain_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_chain_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ChainElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_chain_element(&mut *node, ctx);
+    match &mut *node {
+        ChainElement::CallExpression(node) => {
+            walk_call_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ChainElement::TSNonNullExpression(node) => {
+            walk_ts_non_null_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ChainElement::ComputedMemberExpression(_)
+        | ChainElement::StaticMemberExpression(_)
+        | ChainElement::PrivateFieldExpression(_) => {
+            walk_member_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_chain_element(&mut *node, ctx);
+}
+
+unsafe fn walk_parenthesized_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ParenthesizedExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_parenthesized_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ParenthesizedExpressionExpression(
+        ancestor::ParenthesizedExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PARENTHESIZED_EXPRESSION_EXPRESSION)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_parenthesized_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Statement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_statement(&mut *node, ctx);
+    match &mut *node {
+        Statement::BlockStatement(node) => {
+            walk_block_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::BreakStatement(node) => {
+            walk_break_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ContinueStatement(node) => {
+            walk_continue_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::DebuggerStatement(node) => {
+            walk_debugger_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::DoWhileStatement(node) => {
+            walk_do_while_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::EmptyStatement(node) => {
+            walk_empty_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ExpressionStatement(node) => {
+            walk_expression_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ForInStatement(node) => {
+            walk_for_in_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ForOfStatement(node) => {
+            walk_for_of_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ForStatement(node) => {
+            walk_for_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::IfStatement(node) => walk_if_statement(traverser, (&mut **node) as *mut _, ctx),
+        Statement::LabeledStatement(node) => {
+            walk_labeled_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ReturnStatement(node) => {
+            walk_return_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::SwitchStatement(node) => {
+            walk_switch_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::ThrowStatement(node) => {
+            walk_throw_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::TryStatement(node) => {
+            walk_try_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::WhileStatement(node) => {
+            walk_while_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::WithStatement(node) => {
+            walk_with_statement(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Statement::VariableDeclaration(_)
+        | Statement::FunctionDeclaration(_)
+        | Statement::ClassDeclaration(_)
+        | Statement::TSTypeAliasDeclaration(_)
+        | Statement::TSInterfaceDeclaration(_)
+        | Statement::TSEnumDeclaration(_)
+        | Statement::TSModuleDeclaration(_)
+        | Statement::TSGlobalDeclaration(_)
+        | Statement::TSImportEqualsDeclaration(_) => {
+            walk_declaration(traverser, node as *mut _, ctx)
+        }
+        Statement::ImportDeclaration(_)
+        | Statement::ExportAllDeclaration(_)
+        | Statement::ExportDefaultDeclaration(_)
+        | Statement::ExportNamedDeclaration(_)
+        | Statement::TSExportAssignment(_)
+        | Statement::TSNamespaceExportDeclaration(_) => {
+            walk_module_declaration(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_directive<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Directive<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_directive(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::DirectiveExpression(
+        ancestor::DirectiveWithoutExpression(node, PhantomData),
+    ));
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_DIRECTIVE_EXPRESSION) as *mut StringLiteral,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_directive(&mut *node, ctx);
+}
+
+unsafe fn walk_hashbang<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Hashbang<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_hashbang(&mut *node, ctx);
+    traverser.exit_hashbang(&mut *node, ctx);
+}
+
+unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BlockStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_block_statement(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::BlockStatementBody(
+        ancestor::BlockStatementWithoutBody(node, PhantomData),
+    ));
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_block_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Declaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_declaration(&mut *node, ctx);
+    match &mut *node {
+        Declaration::VariableDeclaration(node) => {
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::FunctionDeclaration(node) => {
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::ClassDeclaration(node) => walk_class(traverser, (&mut **node) as *mut _, ctx),
+        Declaration::TSTypeAliasDeclaration(node) => {
+            walk_ts_type_alias_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::TSInterfaceDeclaration(node) => {
+            walk_ts_interface_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::TSEnumDeclaration(node) => {
+            walk_ts_enum_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::TSModuleDeclaration(node) => {
+            walk_ts_module_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::TSGlobalDeclaration(node) => {
+            walk_ts_global_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        Declaration::TSImportEqualsDeclaration(node) => {
+            walk_ts_import_equals_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut VariableDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_variable_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::VariableDeclarationDeclarations(
+        ancestor::VariableDeclarationWithoutDeclarations(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATION_DECLARATIONS)
+        as *mut Vec<VariableDeclarator>)
+    {
+        walk_variable_declarator(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_variable_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut VariableDeclarator<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_variable_declarator(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::VariableDeclaratorId(
+        ancestor::VariableDeclaratorWithoutId(node, PhantomData),
+    ));
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATOR_ID) as *mut BindingPattern,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::VariableDeclaratorTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATOR_INIT)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::VariableDeclaratorInit);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_variable_declarator(&mut *node, ctx);
+}
+
+unsafe fn walk_empty_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut EmptyStatement,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_empty_statement(&mut *node, ctx);
+    traverser.exit_empty_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_expression_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExpressionStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_expression_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ExpressionStatementExpression(
+        ancestor::ExpressionStatementWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPRESSION_STATEMENT_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_expression_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_if_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut IfStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_if_statement(&mut *node, ctx);
+    let pop_token = ctx
+        .push_stack(Ancestor::IfStatementTest(ancestor::IfStatementWithoutTest(node, PhantomData)));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_TEST) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::IfStatementConsequent);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_CONSEQUENT) as *mut Statement,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_IF_STATEMENT_ALTERNATE)
+        as *mut Option<Statement>)
+    {
+        ctx.retag_stack(AncestorType::IfStatementAlternate);
+        walk_statement(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_if_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_do_while_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut DoWhileStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_do_while_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::DoWhileStatementBody(
+        ancestor::DoWhileStatementWithoutBody(node, PhantomData),
+    ));
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_DO_WHILE_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::DoWhileStatementTest);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_DO_WHILE_STATEMENT_TEST) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_do_while_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_while_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut WhileStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_while_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::WhileStatementTest(
+        ancestor::WhileStatementWithoutTest(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_WHILE_STATEMENT_TEST) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::WhileStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_WHILE_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_while_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ForStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_for_statement(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::ForStatementInit(ancestor::ForStatementWithoutInit(
+        node,
+        PhantomData,
+    )));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_INIT)
+        as *mut Option<ForStatementInit>)
+    {
+        walk_for_statement_init(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_TEST)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::ForStatementTest);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_UPDATE)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::ForStatementUpdate);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ForStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_for_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ForStatementInit<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_for_statement_init(&mut *node, ctx);
+    match &mut *node {
+        ForStatementInit::VariableDeclaration(node) => {
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ForStatementInit::BooleanLiteral(_)
+        | ForStatementInit::NullLiteral(_)
+        | ForStatementInit::NumericLiteral(_)
+        | ForStatementInit::BigIntLiteral(_)
+        | ForStatementInit::RegExpLiteral(_)
+        | ForStatementInit::StringLiteral(_)
+        | ForStatementInit::TemplateLiteral(_)
+        | ForStatementInit::Identifier(_)
+        | ForStatementInit::MetaProperty(_)
+        | ForStatementInit::Super(_)
+        | ForStatementInit::ArrayExpression(_)
+        | ForStatementInit::ArrowFunctionExpression(_)
+        | ForStatementInit::AssignmentExpression(_)
+        | ForStatementInit::AwaitExpression(_)
+        | ForStatementInit::BinaryExpression(_)
+        | ForStatementInit::CallExpression(_)
+        | ForStatementInit::ChainExpression(_)
+        | ForStatementInit::ClassExpression(_)
+        | ForStatementInit::ConditionalExpression(_)
+        | ForStatementInit::FunctionExpression(_)
+        | ForStatementInit::ImportExpression(_)
+        | ForStatementInit::LogicalExpression(_)
+        | ForStatementInit::NewExpression(_)
+        | ForStatementInit::ObjectExpression(_)
+        | ForStatementInit::ParenthesizedExpression(_)
+        | ForStatementInit::SequenceExpression(_)
+        | ForStatementInit::TaggedTemplateExpression(_)
+        | ForStatementInit::ThisExpression(_)
+        | ForStatementInit::UnaryExpression(_)
+        | ForStatementInit::UpdateExpression(_)
+        | ForStatementInit::YieldExpression(_)
+        | ForStatementInit::PrivateInExpression(_)
+        | ForStatementInit::JSXElement(_)
+        | ForStatementInit::JSXFragment(_)
+        | ForStatementInit::TSAsExpression(_)
+        | ForStatementInit::TSSatisfiesExpression(_)
+        | ForStatementInit::TSTypeAssertion(_)
+        | ForStatementInit::TSNonNullExpression(_)
+        | ForStatementInit::TSInstantiationExpression(_)
+        | ForStatementInit::V8IntrinsicExpression(_)
+        | ForStatementInit::ComputedMemberExpression(_)
+        | ForStatementInit::StaticMemberExpression(_)
+        | ForStatementInit::PrivateFieldExpression(_) => {
+            walk_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_for_statement_init(&mut *node, ctx);
+}
+
+unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ForInStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_for_in_statement(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::ForInStatementLeft(
+        ancestor::ForInStatementWithoutLeft(node, PhantomData),
+    ));
+    walk_for_statement_left(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_LEFT) as *mut ForStatementLeft,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ForInStatementRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ForInStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_IN_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_for_in_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ForStatementLeft<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_for_statement_left(&mut *node, ctx);
+    match &mut *node {
+        ForStatementLeft::VariableDeclaration(node) => {
+            walk_variable_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ForStatementLeft::AssignmentTargetIdentifier(_)
+        | ForStatementLeft::TSAsExpression(_)
+        | ForStatementLeft::TSSatisfiesExpression(_)
+        | ForStatementLeft::TSNonNullExpression(_)
+        | ForStatementLeft::TSTypeAssertion(_)
+        | ForStatementLeft::ArrayAssignmentTarget(_)
+        | ForStatementLeft::ObjectAssignmentTarget(_)
+        | ForStatementLeft::ComputedMemberExpression(_)
+        | ForStatementLeft::StaticMemberExpression(_)
+        | ForStatementLeft::PrivateFieldExpression(_) => {
+            walk_assignment_target(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_for_statement_left(&mut *node, ctx);
+}
+
+unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ForOfStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_for_of_statement(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::ForOfStatementLeft(
+        ancestor::ForOfStatementWithoutLeft(node, PhantomData),
+    ));
+    walk_for_statement_left(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_LEFT) as *mut ForStatementLeft,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ForOfStatementRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ForOfStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FOR_OF_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_for_of_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_continue_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ContinueStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_continue_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ContinueStatementLabel(
+        ancestor::ContinueStatementWithoutLabel(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CONTINUE_STATEMENT_LABEL)
+        as *mut Option<LabelIdentifier>)
+    {
+        walk_label_identifier(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_continue_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_break_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BreakStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_break_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::BreakStatementLabel(
+        ancestor::BreakStatementWithoutLabel(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_BREAK_STATEMENT_LABEL)
+        as *mut Option<LabelIdentifier>)
+    {
+        walk_label_identifier(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_break_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_return_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ReturnStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_return_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ReturnStatementArgument(
+        ancestor::ReturnStatementWithoutArgument(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_RETURN_STATEMENT_ARGUMENT)
+        as *mut Option<Expression>)
+    {
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_return_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_with_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut WithStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_with_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::WithStatementObject(
+        ancestor::WithStatementWithoutObject(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_WITH_STATEMENT_OBJECT) as *mut Expression,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_WITH_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    ctx.retag_stack(AncestorType::WithStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_WITH_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_with_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut SwitchStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_switch_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::SwitchStatementDiscriminant(
+        ancestor::SwitchStatementWithoutDiscriminant(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_DISCRIMINANT) as *mut Expression,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    ctx.retag_stack(AncestorType::SwitchStatementCases);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
+        as *mut Vec<SwitchCase>)
+    {
+        walk_switch_case(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_switch_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut SwitchCase<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_switch_case(&mut *node, ctx);
+    let pop_token = ctx
+        .push_stack(Ancestor::SwitchCaseTest(ancestor::SwitchCaseWithoutTest(node, PhantomData)));
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_TEST) as *mut Option<Expression>)
+    {
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::SwitchCaseConsequent);
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_switch_case(&mut *node, ctx);
+}
+
+unsafe fn walk_labeled_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut LabeledStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_labeled_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::LabeledStatementLabel(
+        ancestor::LabeledStatementWithoutLabel(node, PhantomData),
+    ));
+    walk_label_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_LABELED_STATEMENT_LABEL) as *mut LabelIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::LabeledStatementBody);
+    walk_statement(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_LABELED_STATEMENT_BODY) as *mut Statement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_labeled_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_throw_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ThrowStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_throw_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ThrowStatementArgument(
+        ancestor::ThrowStatementWithoutArgument(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_THROW_STATEMENT_ARGUMENT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_throw_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TryStatement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_try_statement(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TryStatementBlock(
+        ancestor::TryStatementWithoutBlock(node, PhantomData),
+    ));
+    walk_block_statement(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_BLOCK)
+            as *mut Box<BlockStatement>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_HANDLER)
+        as *mut Option<Box<CatchClause>>)
+    {
+        ctx.retag_stack(AncestorType::TryStatementHandler);
+        walk_catch_clause(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_FINALIZER)
+        as *mut Option<Box<BlockStatement>>)
+    {
+        ctx.retag_stack(AncestorType::TryStatementFinalizer);
+        walk_block_statement(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_try_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut CatchClause<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_catch_clause(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::CatchClauseParam(ancestor::CatchClauseWithoutParam(
+        node,
+        PhantomData,
+    )));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_PARAM)
+        as *mut Option<CatchParameter>)
+    {
+        walk_catch_parameter(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::CatchClauseBody);
+    walk_block_statement(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_BODY)
+            as *mut Box<BlockStatement>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_catch_clause(&mut *node, ctx);
+}
+
+unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut CatchParameter<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_catch_parameter(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::CatchParameterPattern(
+        ancestor::CatchParameterWithoutPattern(node, PhantomData),
+    ));
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_CATCH_PARAMETER_PATTERN) as *mut BindingPattern,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_CATCH_PARAMETER_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::CatchParameterTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_catch_parameter(&mut *node, ctx);
+}
+
+unsafe fn walk_debugger_statement<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut DebuggerStatement,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_debugger_statement(&mut *node, ctx);
+    traverser.exit_debugger_statement(&mut *node, ctx);
+}
+
+unsafe fn walk_binding_pattern<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BindingPattern<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_binding_pattern(&mut *node, ctx);
+    match &mut *node {
+        BindingPattern::BindingIdentifier(node) => {
+            walk_binding_identifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        BindingPattern::ObjectPattern(node) => {
+            walk_object_pattern(traverser, (&mut **node) as *mut _, ctx)
+        }
+        BindingPattern::ArrayPattern(node) => {
+            walk_array_pattern(traverser, (&mut **node) as *mut _, ctx)
+        }
+        BindingPattern::AssignmentPattern(node) => {
+            walk_assignment_pattern(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_binding_pattern(&mut *node, ctx);
+}
+
+unsafe fn walk_assignment_pattern<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AssignmentPattern<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_assignment_pattern(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AssignmentPatternLeft(
+        ancestor::AssignmentPatternWithoutLeft(node, PhantomData),
+    ));
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_PATTERN_LEFT) as *mut BindingPattern,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::AssignmentPatternRight);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ASSIGNMENT_PATTERN_RIGHT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_assignment_pattern(&mut *node, ctx);
+}
+
+unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ObjectPattern<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_object_pattern(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ObjectPatternProperties(
+        ancestor::ObjectPatternWithoutProperties(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_PROPERTIES)
+        as *mut Vec<BindingProperty>)
+    {
+        walk_binding_property(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_REST)
+        as *mut Option<Box<BindingRestElement>>)
+    {
+        ctx.retag_stack(AncestorType::ObjectPatternRest);
+        walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_object_pattern(&mut *node, ctx);
+}
+
+unsafe fn walk_binding_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BindingProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_binding_property(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::BindingPropertyKey(
+        ancestor::BindingPropertyWithoutKey(node, PhantomData),
+    ));
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_PROPERTY_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::BindingPropertyValue);
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_PROPERTY_VALUE) as *mut BindingPattern,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_binding_property(&mut *node, ctx);
+}
+
+unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ArrayPattern<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_array_pattern(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ArrayPatternElements(
+        ancestor::ArrayPatternWithoutElements(node, PhantomData),
+    ));
+    for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_ELEMENTS)
+        as *mut Vec<Option<BindingPattern>>))
+        .iter_mut()
+        .flatten()
+    {
+        walk_binding_pattern(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_REST)
+        as *mut Option<Box<BindingRestElement>>)
+    {
+        ctx.retag_stack(AncestorType::ArrayPatternRest);
+        walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_array_pattern(&mut *node, ctx);
+}
+
+unsafe fn walk_binding_rest_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BindingRestElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_binding_rest_element(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::BindingRestElementArgument(
+        ancestor::BindingRestElementWithoutArgument(node, PhantomData),
+    ));
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_BINDING_REST_ELEMENT_ARGUMENT)
+            as *mut BindingPattern,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_binding_rest_element(&mut *node, ctx);
+}
+
+unsafe fn walk_function<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Function<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_function(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_FUNCTION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token =
+        ctx.push_stack(Ancestor::FunctionId(ancestor::FunctionWithoutId(node, PhantomData)));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_ID)
+        as *mut Option<BindingIdentifier>)
+    {
+        walk_binding_identifier(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::FunctionTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
+    {
+        ctx.retag_stack(AncestorType::FunctionThisParam);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::FunctionParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_FUNCTION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::FunctionReturnType);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
+        as *mut Option<Box<FunctionBody>>)
+    {
+        ctx.retag_stack(AncestorType::FunctionBody);
+        walk_function_body(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_function(&mut *node, ctx);
+}
+
+unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut FormalParameters<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_formal_parameters(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::FormalParametersItems(
+        ancestor::FormalParametersWithoutItems(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_ITEMS)
+        as *mut Vec<FormalParameter>)
+    {
+        walk_formal_parameter(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_REST)
+        as *mut Option<Box<FormalParameterRest>>)
+    {
+        ctx.retag_stack(AncestorType::FormalParametersRest);
+        walk_formal_parameter_rest(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_formal_parameters(&mut *node, ctx);
+}
+
+unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut FormalParameter<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_formal_parameter(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::FormalParameterDecorators(
+        ancestor::FormalParameterWithoutDecorators(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_DECORATORS)
+        as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::FormalParameterPattern);
+    walk_binding_pattern(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_PATTERN) as *mut BindingPattern,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::FormalParameterTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_INITIALIZER)
+        as *mut Option<Box<Expression>>)
+    {
+        ctx.retag_stack(AncestorType::FormalParameterInitializer);
+        walk_expression(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_formal_parameter(&mut *node, ctx);
+}
+
+unsafe fn walk_formal_parameter_rest<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut FormalParameterRest<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_formal_parameter_rest(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::FormalParameterRestDecorators(
+        ancestor::FormalParameterRestWithoutDecorators(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
+        as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::FormalParameterRestRest);
+    walk_binding_rest_element(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_REST_REST)
+            as *mut BindingRestElement,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::FormalParameterRestTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_formal_parameter_rest(&mut *node, ctx);
+}
+
+unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut FunctionBody<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_function_body(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::FunctionBodyDirectives(
+        ancestor::FunctionBodyWithoutDirectives(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
+        as *mut Vec<Directive>)
+    {
+        walk_directive(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::FunctionBodyStatements);
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_function_body(&mut *node, ctx);
+}
+
+unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ArrowFunctionExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_arrow_function_expression(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8)
+        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::ArrowFunctionExpressionTypeParameters(
+        ancestor::ArrowFunctionExpressionWithoutTypeParameters(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ArrowFunctionExpressionParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ArrowFunctionExpressionBody);
+    walk_function_body(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
+            as *mut Box<FunctionBody>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_arrow_function_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut YieldExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_yield_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::YieldExpressionArgument(
+        ancestor::YieldExpressionWithoutArgument(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_YIELD_EXPRESSION_ARGUMENT)
+        as *mut Option<Expression>)
+    {
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_yield_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_class<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Class<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_class(&mut *node, ctx);
+    let pop_token = ctx
+        .push_stack(Ancestor::ClassDecorators(ancestor::ClassWithoutDecorators(node, PhantomData)));
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_ID) as *mut Option<BindingIdentifier>)
+    {
+        ctx.retag_stack(AncestorType::ClassId);
+        walk_binding_identifier(traverser, field as *mut _, ctx);
+    }
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_CLASS_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::ClassTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) =
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_CLASS) as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::ClassSuperClass);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::ClassSuperTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ClassImplements);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_IMPLEMENTS)
+        as *mut Vec<TSClassImplements>)
+    {
+        walk_ts_class_implements(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ClassBody);
+    walk_class_body(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut Box<ClassBody>))
+            as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_class(&mut *node, ctx);
+}
+
+unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ClassBody<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_class_body(&mut *node, ctx);
+    let pop_token =
+        ctx.push_stack(Ancestor::ClassBodyBody(ancestor::ClassBodyWithoutBody(node, PhantomData)));
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY) as *mut Vec<ClassElement>)
+    {
+        walk_class_element(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_class_body(&mut *node, ctx);
+}
+
+unsafe fn walk_class_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ClassElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_class_element(&mut *node, ctx);
+    match &mut *node {
+        ClassElement::StaticBlock(node) => {
+            walk_static_block(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ClassElement::MethodDefinition(node) => {
+            walk_method_definition(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ClassElement::PropertyDefinition(node) => {
+            walk_property_definition(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ClassElement::AccessorProperty(node) => {
+            walk_accessor_property(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ClassElement::TSIndexSignature(node) => {
+            walk_ts_index_signature(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_class_element(&mut *node, ctx);
+}
+
+unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut MethodDefinition<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_method_definition(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::MethodDefinitionDecorators(
+        ancestor::MethodDefinitionWithoutDecorators(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_DECORATORS)
+        as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::MethodDefinitionKey);
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::MethodDefinitionValue);
+    walk_function(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
+            as *mut Box<Function>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_method_definition(&mut *node, ctx);
+}
+
+unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut PropertyDefinition<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_property_definition(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::PropertyDefinitionDecorators(
+        ancestor::PropertyDefinitionWithoutDecorators(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_DECORATORS)
+        as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::PropertyDefinitionKey);
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::PropertyDefinitionTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_VALUE)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::PropertyDefinitionValue);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_property_definition(&mut *node, ctx);
+}
+
+unsafe fn walk_private_identifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut PrivateIdentifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_private_identifier(&mut *node, ctx);
+    traverser.exit_private_identifier(&mut *node, ctx);
+}
+
+unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut StaticBlock<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_static_block(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token = ctx
+        .push_stack(Ancestor::StaticBlockBody(ancestor::StaticBlockWithoutBody(node, PhantomData)));
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_static_block(&mut *node, ctx);
+}
+
+unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ModuleDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_module_declaration(&mut *node, ctx);
+    match &mut *node {
+        ModuleDeclaration::ImportDeclaration(node) => {
+            walk_import_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ModuleDeclaration::ExportAllDeclaration(node) => {
+            walk_export_all_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ModuleDeclaration::ExportDefaultDeclaration(node) => {
+            walk_export_default_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ModuleDeclaration::ExportNamedDeclaration(node) => {
+            walk_export_named_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ModuleDeclaration::TSExportAssignment(node) => {
+            walk_ts_export_assignment(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ModuleDeclaration::TSNamespaceExportDeclaration(node) => {
+            walk_ts_namespace_export_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_module_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut AccessorProperty<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_accessor_property(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::AccessorPropertyDecorators(
+        ancestor::AccessorPropertyWithoutDecorators(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_DECORATORS)
+        as *mut Vec<Decorator>)
+    {
+        walk_decorator(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::AccessorPropertyKey);
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::AccessorPropertyTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_VALUE)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::AccessorPropertyValue);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_accessor_property(&mut *node, ctx);
+}
+
+unsafe fn walk_import_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportExpressionSource(
+        ancestor::ImportExpressionWithoutSource(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_EXPRESSION_SOURCE) as *mut Expression,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_IMPORT_EXPRESSION_OPTIONS)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::ImportExpressionOptions);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportDeclarationSpecifiers(
+        ancestor::ImportDeclarationWithoutSpecifiers(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_IMPORT_DECLARATION_SPECIFIERS)
+        as *mut Option<Vec<ImportDeclarationSpecifier>>)
+    {
+        for item in field.iter_mut() {
+            walk_import_declaration_specifier(traverser, item as *mut _, ctx);
+        }
+    }
+    ctx.retag_stack(AncestorType::ImportDeclarationSource);
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_DECLARATION_SOURCE) as *mut StringLiteral,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
+        as *mut Option<Box<WithClause>>)
+    {
+        ctx.retag_stack(AncestorType::ImportDeclarationWithClause);
+        walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_import_declaration_specifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportDeclarationSpecifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_declaration_specifier(&mut *node, ctx);
+    match &mut *node {
+        ImportDeclarationSpecifier::ImportSpecifier(node) => {
+            walk_import_specifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ImportDeclarationSpecifier::ImportDefaultSpecifier(node) => {
+            walk_import_default_specifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ImportDeclarationSpecifier::ImportNamespaceSpecifier(node) => {
+            walk_import_namespace_specifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_import_declaration_specifier(&mut *node, ctx);
+}
+
+unsafe fn walk_import_specifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportSpecifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_specifier(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportSpecifierImported(
+        ancestor::ImportSpecifierWithoutImported(node, PhantomData),
+    ));
+    walk_module_export_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_SPECIFIER_IMPORTED) as *mut ModuleExportName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ImportSpecifierLocal);
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_SPECIFIER_LOCAL) as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_specifier(&mut *node, ctx);
+}
+
+unsafe fn walk_import_default_specifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportDefaultSpecifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_default_specifier(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportDefaultSpecifierLocal(
+        ancestor::ImportDefaultSpecifierWithoutLocal(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_DEFAULT_SPECIFIER_LOCAL)
+            as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_default_specifier(&mut *node, ctx);
+}
+
+unsafe fn walk_import_namespace_specifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportNamespaceSpecifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_namespace_specifier(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportNamespaceSpecifierLocal(
+        ancestor::ImportNamespaceSpecifierWithoutLocal(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_NAMESPACE_SPECIFIER_LOCAL)
+            as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_namespace_specifier(&mut *node, ctx);
+}
+
+unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut WithClause<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_with_clause(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::WithClauseWithEntries(
+        ancestor::WithClauseWithoutWithEntries(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_WITH_CLAUSE_WITH_ENTRIES)
+        as *mut Vec<ImportAttribute>)
+    {
+        walk_import_attribute(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_with_clause(&mut *node, ctx);
+}
+
+unsafe fn walk_import_attribute<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportAttribute<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_attribute(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ImportAttributeKey(
+        ancestor::ImportAttributeWithoutKey(node, PhantomData),
+    ));
+    walk_import_attribute_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_ATTRIBUTE_KEY) as *mut ImportAttributeKey,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ImportAttributeValue);
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_IMPORT_ATTRIBUTE_VALUE) as *mut StringLiteral,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_import_attribute(&mut *node, ctx);
+}
+
+unsafe fn walk_import_attribute_key<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ImportAttributeKey<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_import_attribute_key(&mut *node, ctx);
+    match &mut *node {
+        ImportAttributeKey::Identifier(node) => {
+            walk_identifier_name(traverser, node as *mut _, ctx)
+        }
+        ImportAttributeKey::StringLiteral(node) => {
+            walk_string_literal(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_import_attribute_key(&mut *node, ctx);
+}
+
+unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExportNamedDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_export_named_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ExportNamedDeclarationDeclaration(
+        ancestor::ExportNamedDeclarationWithoutDeclaration(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_DECLARATION)
+        as *mut Option<Declaration>)
+    {
+        walk_declaration(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ExportNamedDeclarationSpecifiers);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
+        as *mut Vec<ExportSpecifier>)
+    {
+        walk_export_specifier(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SOURCE)
+        as *mut Option<StringLiteral>)
+    {
+        ctx.retag_stack(AncestorType::ExportNamedDeclarationSource);
+        walk_string_literal(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
+        as *mut Option<Box<WithClause>>)
+    {
+        ctx.retag_stack(AncestorType::ExportNamedDeclarationWithClause);
+        walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_export_named_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExportDefaultDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_export_default_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationDeclaration(
+        ancestor::ExportDefaultDeclarationWithoutDeclaration(node, PhantomData),
+    ));
+    walk_export_default_declaration_kind(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
+            as *mut ExportDefaultDeclarationKind,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_export_default_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExportAllDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_export_all_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ExportAllDeclarationExported(
+        ancestor::ExportAllDeclarationWithoutExported(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_EXPORTED)
+        as *mut Option<ModuleExportName>)
+    {
+        walk_module_export_name(traverser, field as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::ExportAllDeclarationSource);
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_SOURCE) as *mut StringLiteral,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
+        as *mut Option<Box<WithClause>>)
+    {
+        ctx.retag_stack(AncestorType::ExportAllDeclarationWithClause);
+        walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_export_all_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_export_specifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExportSpecifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_export_specifier(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::ExportSpecifierLocal(
+        ancestor::ExportSpecifierWithoutLocal(node, PhantomData),
+    ));
+    walk_module_export_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_SPECIFIER_LOCAL) as *mut ModuleExportName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ExportSpecifierExported);
+    walk_module_export_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_SPECIFIER_EXPORTED) as *mut ModuleExportName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_export_specifier(&mut *node, ctx);
+}
+
+unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ExportDefaultDeclarationKind<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_export_default_declaration_kind(&mut *node, ctx);
+    match &mut *node {
+        ExportDefaultDeclarationKind::FunctionDeclaration(node) => {
+            walk_function(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ExportDefaultDeclarationKind::ClassDeclaration(node) => {
+            walk_class(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ExportDefaultDeclarationKind::TSInterfaceDeclaration(node) => {
+            walk_ts_interface_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        ExportDefaultDeclarationKind::BooleanLiteral(_)
+        | ExportDefaultDeclarationKind::NullLiteral(_)
+        | ExportDefaultDeclarationKind::NumericLiteral(_)
+        | ExportDefaultDeclarationKind::BigIntLiteral(_)
+        | ExportDefaultDeclarationKind::RegExpLiteral(_)
+        | ExportDefaultDeclarationKind::StringLiteral(_)
+        | ExportDefaultDeclarationKind::TemplateLiteral(_)
+        | ExportDefaultDeclarationKind::Identifier(_)
+        | ExportDefaultDeclarationKind::MetaProperty(_)
+        | ExportDefaultDeclarationKind::Super(_)
+        | ExportDefaultDeclarationKind::ArrayExpression(_)
+        | ExportDefaultDeclarationKind::ArrowFunctionExpression(_)
+        | ExportDefaultDeclarationKind::AssignmentExpression(_)
+        | ExportDefaultDeclarationKind::AwaitExpression(_)
+        | ExportDefaultDeclarationKind::BinaryExpression(_)
+        | ExportDefaultDeclarationKind::CallExpression(_)
+        | ExportDefaultDeclarationKind::ChainExpression(_)
+        | ExportDefaultDeclarationKind::ClassExpression(_)
+        | ExportDefaultDeclarationKind::ConditionalExpression(_)
+        | ExportDefaultDeclarationKind::FunctionExpression(_)
+        | ExportDefaultDeclarationKind::ImportExpression(_)
+        | ExportDefaultDeclarationKind::LogicalExpression(_)
+        | ExportDefaultDeclarationKind::NewExpression(_)
+        | ExportDefaultDeclarationKind::ObjectExpression(_)
+        | ExportDefaultDeclarationKind::ParenthesizedExpression(_)
+        | ExportDefaultDeclarationKind::SequenceExpression(_)
+        | ExportDefaultDeclarationKind::TaggedTemplateExpression(_)
+        | ExportDefaultDeclarationKind::ThisExpression(_)
+        | ExportDefaultDeclarationKind::UnaryExpression(_)
+        | ExportDefaultDeclarationKind::UpdateExpression(_)
+        | ExportDefaultDeclarationKind::YieldExpression(_)
+        | ExportDefaultDeclarationKind::PrivateInExpression(_)
+        | ExportDefaultDeclarationKind::JSXElement(_)
+        | ExportDefaultDeclarationKind::JSXFragment(_)
+        | ExportDefaultDeclarationKind::TSAsExpression(_)
+        | ExportDefaultDeclarationKind::TSSatisfiesExpression(_)
+        | ExportDefaultDeclarationKind::TSTypeAssertion(_)
+        | ExportDefaultDeclarationKind::TSNonNullExpression(_)
+        | ExportDefaultDeclarationKind::TSInstantiationExpression(_)
+        | ExportDefaultDeclarationKind::V8IntrinsicExpression(_)
+        | ExportDefaultDeclarationKind::ComputedMemberExpression(_)
+        | ExportDefaultDeclarationKind::StaticMemberExpression(_)
+        | ExportDefaultDeclarationKind::PrivateFieldExpression(_) => {
+            walk_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_export_default_declaration_kind(&mut *node, ctx);
+}
+
+unsafe fn walk_module_export_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut ModuleExportName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_module_export_name(&mut *node, ctx);
+    match &mut *node {
+        ModuleExportName::IdentifierName(node) => {
+            walk_identifier_name(traverser, node as *mut _, ctx)
+        }
+        ModuleExportName::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, node as *mut _, ctx)
+        }
+        ModuleExportName::StringLiteral(node) => {
+            walk_string_literal(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_module_export_name(&mut *node, ctx);
+}
+
+unsafe fn walk_v8_intrinsic_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut V8IntrinsicExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_v8_intrinsic_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::V8IntrinsicExpressionName(
+        ancestor::V8IntrinsicExpressionWithoutName(node, PhantomData),
+    ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_V8_INTRINSIC_EXPRESSION_NAME) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::V8IntrinsicExpressionArguments);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_V8_INTRINSIC_EXPRESSION_ARGUMENTS)
+        as *mut Vec<Argument>)
+    {
+        walk_argument(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_v8_intrinsic_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_boolean_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BooleanLiteral,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_boolean_literal(&mut *node, ctx);
+    traverser.exit_boolean_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_null_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut NullLiteral,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_null_literal(&mut *node, ctx);
+    traverser.exit_null_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_numeric_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut NumericLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_numeric_literal(&mut *node, ctx);
+    traverser.exit_numeric_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut StringLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_string_literal(&mut *node, ctx);
+    traverser.exit_string_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_big_int_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut BigIntLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_big_int_literal(&mut *node, ctx);
+    traverser.exit_big_int_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_reg_exp_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut RegExpLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_reg_exp_literal(&mut *node, ctx);
+    traverser.exit_reg_exp_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_element(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXElementOpeningElement(
+        ancestor::JSXElementWithoutOpeningElement(node, PhantomData),
+    ));
+    walk_jsx_opening_element(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
+            as *mut Box<JSXOpeningElement>)) as *mut _,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXElementChildren);
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN) as *mut Vec<JSXChild>)
+    {
+        walk_jsx_child(traverser, item as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
+        as *mut Option<Box<JSXClosingElement>>)
+    {
+        ctx.retag_stack(AncestorType::JSXElementClosingElement);
+        walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_element(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXOpeningElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_opening_element(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXOpeningElementName(
+        ancestor::JSXOpeningElementWithoutName(node, PhantomData),
+    ));
+    walk_jsx_element_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_NAME) as *mut JSXElementName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::JSXOpeningElementTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
+        as *mut Vec<JSXAttributeItem>)
+    {
+        walk_jsx_attribute_item(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_opening_element(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_closing_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXClosingElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_closing_element(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXClosingElementName(
+        ancestor::JSXClosingElementWithoutName(node, PhantomData),
+    ));
+    walk_jsx_element_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_CLOSING_ELEMENT_NAME) as *mut JSXElementName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_closing_element(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXFragment<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_fragment(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXFragmentOpeningFragment(
+        ancestor::JSXFragmentWithoutOpeningFragment(node, PhantomData),
+    ));
+    walk_jsx_opening_fragment(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT)
+            as *mut JSXOpeningFragment,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXFragmentChildren);
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
+    {
+        walk_jsx_child(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::JSXFragmentClosingFragment);
+    walk_jsx_closing_fragment(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT)
+            as *mut JSXClosingFragment,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_fragment(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_opening_fragment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXOpeningFragment,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_opening_fragment(&mut *node, ctx);
+    traverser.exit_jsx_opening_fragment(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_closing_fragment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXClosingFragment,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_closing_fragment(&mut *node, ctx);
+    traverser.exit_jsx_closing_fragment(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXElementName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_element_name(&mut *node, ctx);
+    match &mut *node {
+        JSXElementName::Identifier(node) => {
+            walk_jsx_identifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXElementName::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXElementName::NamespacedName(node) => {
+            walk_jsx_namespaced_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXElementName::MemberExpression(node) => {
+            walk_jsx_member_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXElementName::ThisExpression(node) => {
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_element_name(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXNamespacedName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_namespaced_name(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXNamespacedNameNamespace(
+        ancestor::JSXNamespacedNameWithoutNamespace(node, PhantomData),
+    ));
+    walk_jsx_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAMESPACE) as *mut JSXIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXNamespacedNameName);
+    walk_jsx_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAME) as *mut JSXIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_namespaced_name(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_member_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXMemberExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_member_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXMemberExpressionObject(
+        ancestor::JSXMemberExpressionWithoutObject(node, PhantomData),
+    ));
+    walk_jsx_member_expression_object(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_OBJECT)
+            as *mut JSXMemberExpressionObject,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXMemberExpressionProperty);
+    walk_jsx_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_MEMBER_EXPRESSION_PROPERTY)
+            as *mut JSXIdentifier,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_member_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXMemberExpressionObject<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_member_expression_object(&mut *node, ctx);
+    match &mut *node {
+        JSXMemberExpressionObject::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXMemberExpressionObject::MemberExpression(node) => {
+            walk_jsx_member_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXMemberExpressionObject::ThisExpression(node) => {
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_member_expression_object(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_expression_container<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXExpressionContainer<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_expression_container(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXExpressionContainerExpression(
+        ancestor::JSXExpressionContainerWithoutExpression(node, PhantomData),
+    ));
+    walk_jsx_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_EXPRESSION_CONTAINER_EXPRESSION)
+            as *mut JSXExpression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_expression_container(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_expression(&mut *node, ctx);
+    match &mut *node {
+        JSXExpression::EmptyExpression(node) => {
+            walk_jsx_empty_expression(traverser, node as *mut _, ctx)
+        }
+        JSXExpression::BooleanLiteral(_)
+        | JSXExpression::NullLiteral(_)
+        | JSXExpression::NumericLiteral(_)
+        | JSXExpression::BigIntLiteral(_)
+        | JSXExpression::RegExpLiteral(_)
+        | JSXExpression::StringLiteral(_)
+        | JSXExpression::TemplateLiteral(_)
+        | JSXExpression::Identifier(_)
+        | JSXExpression::MetaProperty(_)
+        | JSXExpression::Super(_)
+        | JSXExpression::ArrayExpression(_)
+        | JSXExpression::ArrowFunctionExpression(_)
+        | JSXExpression::AssignmentExpression(_)
+        | JSXExpression::AwaitExpression(_)
+        | JSXExpression::BinaryExpression(_)
+        | JSXExpression::CallExpression(_)
+        | JSXExpression::ChainExpression(_)
+        | JSXExpression::ClassExpression(_)
+        | JSXExpression::ConditionalExpression(_)
+        | JSXExpression::FunctionExpression(_)
+        | JSXExpression::ImportExpression(_)
+        | JSXExpression::LogicalExpression(_)
+        | JSXExpression::NewExpression(_)
+        | JSXExpression::ObjectExpression(_)
+        | JSXExpression::ParenthesizedExpression(_)
+        | JSXExpression::SequenceExpression(_)
+        | JSXExpression::TaggedTemplateExpression(_)
+        | JSXExpression::ThisExpression(_)
+        | JSXExpression::UnaryExpression(_)
+        | JSXExpression::UpdateExpression(_)
+        | JSXExpression::YieldExpression(_)
+        | JSXExpression::PrivateInExpression(_)
+        | JSXExpression::JSXElement(_)
+        | JSXExpression::JSXFragment(_)
+        | JSXExpression::TSAsExpression(_)
+        | JSXExpression::TSSatisfiesExpression(_)
+        | JSXExpression::TSTypeAssertion(_)
+        | JSXExpression::TSNonNullExpression(_)
+        | JSXExpression::TSInstantiationExpression(_)
+        | JSXExpression::V8IntrinsicExpression(_)
+        | JSXExpression::ComputedMemberExpression(_)
+        | JSXExpression::StaticMemberExpression(_)
+        | JSXExpression::PrivateFieldExpression(_) => {
+            walk_expression(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_empty_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXEmptyExpression,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_empty_expression(&mut *node, ctx);
+    traverser.exit_jsx_empty_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_attribute_item<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXAttributeItem<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_attribute_item(&mut *node, ctx);
+    match &mut *node {
+        JSXAttributeItem::Attribute(node) => {
+            walk_jsx_attribute(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXAttributeItem::SpreadAttribute(node) => {
+            walk_jsx_spread_attribute(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_attribute_item(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_attribute<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXAttribute<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_attribute(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXAttributeName(ancestor::JSXAttributeWithoutName(
+        node,
+        PhantomData,
+    )));
+    walk_jsx_attribute_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_ATTRIBUTE_NAME) as *mut JSXAttributeName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ATTRIBUTE_VALUE)
+        as *mut Option<JSXAttributeValue>)
+    {
+        ctx.retag_stack(AncestorType::JSXAttributeValue);
+        walk_jsx_attribute_value(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_attribute(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_spread_attribute<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXSpreadAttribute<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_spread_attribute(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXSpreadAttributeArgument(
+        ancestor::JSXSpreadAttributeWithoutArgument(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_SPREAD_ATTRIBUTE_ARGUMENT) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_spread_attribute(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_attribute_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXAttributeName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_attribute_name(&mut *node, ctx);
+    match &mut *node {
+        JSXAttributeName::Identifier(node) => {
+            walk_jsx_identifier(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXAttributeName::NamespacedName(node) => {
+            walk_jsx_namespaced_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_attribute_name(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_attribute_value<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXAttributeValue<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_attribute_value(&mut *node, ctx);
+    match &mut *node {
+        JSXAttributeValue::StringLiteral(node) => {
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXAttributeValue::ExpressionContainer(node) => {
+            walk_jsx_expression_container(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXAttributeValue::Element(node) => {
+            walk_jsx_element(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXAttributeValue::Fragment(node) => {
+            walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_jsx_attribute_value(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_identifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXIdentifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_identifier(&mut *node, ctx);
+    traverser.exit_jsx_identifier(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_child<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXChild<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_child(&mut *node, ctx);
+    match &mut *node {
+        JSXChild::Text(node) => walk_jsx_text(traverser, (&mut **node) as *mut _, ctx),
+        JSXChild::Element(node) => walk_jsx_element(traverser, (&mut **node) as *mut _, ctx),
+        JSXChild::Fragment(node) => walk_jsx_fragment(traverser, (&mut **node) as *mut _, ctx),
+        JSXChild::ExpressionContainer(node) => {
+            walk_jsx_expression_container(traverser, (&mut **node) as *mut _, ctx)
+        }
+        JSXChild::Spread(node) => walk_jsx_spread_child(traverser, (&mut **node) as *mut _, ctx),
+    }
+    traverser.exit_jsx_child(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_spread_child<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXSpreadChild<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_spread_child(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSXSpreadChildExpression(
+        ancestor::JSXSpreadChildWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_SPREAD_CHILD_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_jsx_spread_child(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_text<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXText<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_text(&mut *node, ctx);
+    traverser.exit_jsx_text(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSThisParameter<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_this_parameter(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSThisParameterTypeAnnotation(
+        ancestor::TSThisParameterWithoutTypeAnnotation(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_this_parameter(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSEnumDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_enum_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSEnumDeclarationId(
+        ancestor::TSEnumDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_ID) as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSEnumDeclarationBody);
+    walk_ts_enum_body(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_DECLARATION_BODY) as *mut TSEnumBody,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_enum_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_enum_body<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSEnumBody<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_enum_body(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_BODY_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSEnumBodyMembers(
+        ancestor::TSEnumBodyWithoutMembers(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_BODY_MEMBERS)
+        as *mut Vec<TSEnumMember>)
+    {
+        walk_ts_enum_member(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_enum_body(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSEnumMember<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_enum_member(&mut *node, ctx);
+    let pop_token = ctx
+        .push_stack(Ancestor::TSEnumMemberId(ancestor::TSEnumMemberWithoutId(node, PhantomData)));
+    walk_ts_enum_member_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_ENUM_MEMBER_ID) as *mut TSEnumMemberName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_MEMBER_INITIALIZER)
+        as *mut Option<Expression>)
+    {
+        ctx.retag_stack(AncestorType::TSEnumMemberInitializer);
+        walk_expression(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_enum_member(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSEnumMemberName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_enum_member_name(&mut *node, ctx);
+    match &mut *node {
+        TSEnumMemberName::Identifier(node) => {
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSEnumMemberName::String(node) => {
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSEnumMemberName::ComputedString(node) => {
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSEnumMemberName::ComputedTemplateString(node) => {
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_enum_member_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_annotation<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeAnnotation<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_annotation(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeAnnotationTypeAnnotation(
+        ancestor::TSTypeAnnotationWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ANNOTATION_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_annotation(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_literal_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSLiteralType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_literal_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSLiteralTypeLiteral(
+        ancestor::TSLiteralTypeWithoutLiteral(node, PhantomData),
+    ));
+    walk_ts_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_LITERAL_TYPE_LITERAL) as *mut TSLiteral,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_literal_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_literal(&mut *node, ctx);
+    match &mut *node {
+        TSLiteral::BooleanLiteral(node) => {
+            walk_boolean_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSLiteral::NumericLiteral(node) => {
+            walk_numeric_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSLiteral::BigIntLiteral(node) => {
+            walk_big_int_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSLiteral::StringLiteral(node) => {
+            walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSLiteral::TemplateLiteral(node) => {
+            walk_template_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSLiteral::UnaryExpression(node) => {
+            walk_unary_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type(&mut *node, ctx);
+    match &mut *node {
+        TSType::TSAnyKeyword(node) => walk_ts_any_keyword(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSBigIntKeyword(node) => {
+            walk_ts_big_int_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSBooleanKeyword(node) => {
+            walk_ts_boolean_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSIntrinsicKeyword(node) => {
+            walk_ts_intrinsic_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSNeverKeyword(node) => {
+            walk_ts_never_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSNullKeyword(node) => {
+            walk_ts_null_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSNumberKeyword(node) => {
+            walk_ts_number_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSObjectKeyword(node) => {
+            walk_ts_object_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSStringKeyword(node) => {
+            walk_ts_string_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSSymbolKeyword(node) => {
+            walk_ts_symbol_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSUndefinedKeyword(node) => {
+            walk_ts_undefined_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSUnknownKeyword(node) => {
+            walk_ts_unknown_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSVoidKeyword(node) => {
+            walk_ts_void_keyword(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSArrayType(node) => walk_ts_array_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSConditionalType(node) => {
+            walk_ts_conditional_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSConstructorType(node) => {
+            walk_ts_constructor_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSFunctionType(node) => {
+            walk_ts_function_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSImportType(node) => walk_ts_import_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSIndexedAccessType(node) => {
+            walk_ts_indexed_access_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSInferType(node) => walk_ts_infer_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSIntersectionType(node) => {
+            walk_ts_intersection_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSLiteralType(node) => {
+            walk_ts_literal_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSMappedType(node) => walk_ts_mapped_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSNamedTupleMember(node) => {
+            walk_ts_named_tuple_member(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSTemplateLiteralType(node) => {
+            walk_ts_template_literal_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSThisType(node) => walk_ts_this_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSTupleType(node) => walk_ts_tuple_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSTypeLiteral(node) => {
+            walk_ts_type_literal(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSTypeOperatorType(node) => {
+            walk_ts_type_operator(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSTypePredicate(node) => {
+            walk_ts_type_predicate(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSTypeQuery(node) => walk_ts_type_query(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSTypeReference(node) => {
+            walk_ts_type_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::TSUnionType(node) => walk_ts_union_type(traverser, (&mut **node) as *mut _, ctx),
+        TSType::TSParenthesizedType(node) => {
+            walk_ts_parenthesized_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::JSDocNullableType(node) => {
+            walk_js_doc_nullable_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::JSDocNonNullableType(node) => {
+            walk_js_doc_non_nullable_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSType::JSDocUnknownType(node) => {
+            walk_js_doc_unknown_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_conditional_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSConditionalType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_conditional_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSConditionalTypeCheckType(
+        ancestor::TSConditionalTypeWithoutCheckType(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_CHECK_TYPE) as *mut TSType,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    ctx.retag_stack(AncestorType::TSConditionalTypeExtendsType);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_EXTENDS_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSConditionalTypeTrueType);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_TRUE_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.retag_stack(AncestorType::TSConditionalTypeFalseType);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_CONDITIONAL_TYPE_FALSE_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_conditional_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSUnionType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_union_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSUnionTypeTypes(ancestor::TSUnionTypeWithoutTypes(
+        node,
+        PhantomData,
+    )));
+    for item in
+        &mut *((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut Vec<TSType>)
+    {
+        walk_ts_type(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_union_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSIntersectionType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_intersection_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSIntersectionTypeTypes(
+        ancestor::TSIntersectionTypeWithoutTypes(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERSECTION_TYPE_TYPES)
+        as *mut Vec<TSType>)
+    {
+        walk_ts_type(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_intersection_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_parenthesized_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSParenthesizedType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_parenthesized_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSParenthesizedTypeTypeAnnotation(
+        ancestor::TSParenthesizedTypeWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_PARENTHESIZED_TYPE_TYPE_ANNOTATION)
+            as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_parenthesized_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_operator<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeOperator<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_operator(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeOperatorTypeAnnotation(
+        ancestor::TSTypeOperatorWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_OPERATOR_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_operator(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_array_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSArrayType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_array_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSArrayTypeElementType(
+        ancestor::TSArrayTypeWithoutElementType(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_ARRAY_TYPE_ELEMENT_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_array_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_indexed_access_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSIndexedAccessType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_indexed_access_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSIndexedAccessTypeObjectType(
+        ancestor::TSIndexedAccessTypeWithoutObjectType(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_OBJECT_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSIndexedAccessTypeIndexType);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEXED_ACCESS_TYPE_INDEX_TYPE) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_indexed_access_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTupleType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_tuple_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTupleTypeElementTypes(
+        ancestor::TSTupleTypeWithoutElementTypes(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES)
+        as *mut Vec<TSTupleElement>)
+    {
+        walk_ts_tuple_element(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_tuple_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNamedTupleMember<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_named_tuple_member(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSNamedTupleMemberLabel(
+        ancestor::TSNamedTupleMemberWithoutLabel(node, PhantomData),
+    ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_LABEL) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSNamedTupleMemberElementType);
+    walk_ts_tuple_element(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMED_TUPLE_MEMBER_ELEMENT_TYPE)
+            as *mut TSTupleElement,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_named_tuple_member(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_optional_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSOptionalType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_optional_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSOptionalTypeTypeAnnotation(
+        ancestor::TSOptionalTypeWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_OPTIONAL_TYPE_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_optional_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_rest_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSRestType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_rest_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSRestTypeTypeAnnotation(
+        ancestor::TSRestTypeWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_REST_TYPE_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_rest_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTupleElement<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_tuple_element(&mut *node, ctx);
+    match &mut *node {
+        TSTupleElement::TSOptionalType(node) => {
+            walk_ts_optional_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTupleElement::TSRestType(node) => {
+            walk_ts_rest_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTupleElement::TSAnyKeyword(_)
+        | TSTupleElement::TSBigIntKeyword(_)
+        | TSTupleElement::TSBooleanKeyword(_)
+        | TSTupleElement::TSIntrinsicKeyword(_)
+        | TSTupleElement::TSNeverKeyword(_)
+        | TSTupleElement::TSNullKeyword(_)
+        | TSTupleElement::TSNumberKeyword(_)
+        | TSTupleElement::TSObjectKeyword(_)
+        | TSTupleElement::TSStringKeyword(_)
+        | TSTupleElement::TSSymbolKeyword(_)
+        | TSTupleElement::TSUndefinedKeyword(_)
+        | TSTupleElement::TSUnknownKeyword(_)
+        | TSTupleElement::TSVoidKeyword(_)
+        | TSTupleElement::TSArrayType(_)
+        | TSTupleElement::TSConditionalType(_)
+        | TSTupleElement::TSConstructorType(_)
+        | TSTupleElement::TSFunctionType(_)
+        | TSTupleElement::TSImportType(_)
+        | TSTupleElement::TSIndexedAccessType(_)
+        | TSTupleElement::TSInferType(_)
+        | TSTupleElement::TSIntersectionType(_)
+        | TSTupleElement::TSLiteralType(_)
+        | TSTupleElement::TSMappedType(_)
+        | TSTupleElement::TSNamedTupleMember(_)
+        | TSTupleElement::TSTemplateLiteralType(_)
+        | TSTupleElement::TSThisType(_)
+        | TSTupleElement::TSTupleType(_)
+        | TSTupleElement::TSTypeLiteral(_)
+        | TSTupleElement::TSTypeOperatorType(_)
+        | TSTupleElement::TSTypePredicate(_)
+        | TSTupleElement::TSTypeQuery(_)
+        | TSTupleElement::TSTypeReference(_)
+        | TSTupleElement::TSUnionType(_)
+        | TSTupleElement::TSParenthesizedType(_)
+        | TSTupleElement::JSDocNullableType(_)
+        | TSTupleElement::JSDocNonNullableType(_)
+        | TSTupleElement::JSDocUnknownType(_) => walk_ts_type(traverser, node as *mut _, ctx),
+    }
+    traverser.exit_ts_tuple_element(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_any_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSAnyKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_any_keyword(&mut *node, ctx);
+    traverser.exit_ts_any_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_string_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSStringKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_string_keyword(&mut *node, ctx);
+    traverser.exit_ts_string_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_boolean_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSBooleanKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_boolean_keyword(&mut *node, ctx);
+    traverser.exit_ts_boolean_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_number_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNumberKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_number_keyword(&mut *node, ctx);
+    traverser.exit_ts_number_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_never_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNeverKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_never_keyword(&mut *node, ctx);
+    traverser.exit_ts_never_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_intrinsic_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSIntrinsicKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_intrinsic_keyword(&mut *node, ctx);
+    traverser.exit_ts_intrinsic_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_unknown_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSUnknownKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_unknown_keyword(&mut *node, ctx);
+    traverser.exit_ts_unknown_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_null_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNullKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_null_keyword(&mut *node, ctx);
+    traverser.exit_ts_null_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_undefined_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSUndefinedKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_undefined_keyword(&mut *node, ctx);
+    traverser.exit_ts_undefined_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_void_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSVoidKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_void_keyword(&mut *node, ctx);
+    traverser.exit_ts_void_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_symbol_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSSymbolKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_symbol_keyword(&mut *node, ctx);
+    traverser.exit_ts_symbol_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_this_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSThisType,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_this_type(&mut *node, ctx);
+    traverser.exit_ts_this_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_object_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSObjectKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_object_keyword(&mut *node, ctx);
+    traverser.exit_ts_object_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_big_int_keyword<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSBigIntKeyword,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_big_int_keyword(&mut *node, ctx);
+    traverser.exit_ts_big_int_keyword(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeReference<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_reference(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeReferenceTypeName(
+        ancestor::TSTypeReferenceWithoutTypeName(node, PhantomData),
+    ));
+    walk_ts_type_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_NAME) as *mut TSTypeName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TSTypeReferenceTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_reference(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_name(&mut *node, ctx);
+    match &mut *node {
+        TSTypeName::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTypeName::QualifiedName(node) => {
+            walk_ts_qualified_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTypeName::ThisExpression(node) => {
+            walk_this_expression(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_type_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_qualified_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSQualifiedName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_qualified_name(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSQualifiedNameLeft(
+        ancestor::TSQualifiedNameWithoutLeft(node, PhantomData),
+    ));
+    walk_ts_type_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_QUALIFIED_NAME_LEFT) as *mut TSTypeName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSQualifiedNameRight);
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_QUALIFIED_NAME_RIGHT) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_qualified_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeParameterInstantiation<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_parameter_instantiation(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeParameterInstantiationParams(
+        ancestor::TSTypeParameterInstantiationWithoutParams(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_PARAMS)
+        as *mut Vec<TSType>)
+    {
+        walk_ts_type(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_parameter_instantiation(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeParameter<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_parameter(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeParameterName(
+        ancestor::TSTypeParameterWithoutName(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_NAME) as *mut BindingIdentifier,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_CONSTRAINT)
+        as *mut Option<TSType>)
+    {
+        ctx.retag_stack(AncestorType::TSTypeParameterConstraint);
+        walk_ts_type(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DEFAULT)
+        as *mut Option<TSType>)
+    {
+        ctx.retag_stack(AncestorType::TSTypeParameterDefault);
+        walk_ts_type(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_parameter(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeParameterDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_parameter_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeParameterDeclarationParams(
+        ancestor::TSTypeParameterDeclarationWithoutParams(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS)
+        as *mut Vec<TSTypeParameter>)
+    {
+        walk_ts_type_parameter(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_parameter_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeAliasDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_alias_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeAliasDeclarationId(
+        ancestor::TSTypeAliasDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_ID)
+            as *mut BindingIdentifier,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8)
+        .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeAnnotation);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_ANNOTATION)
+            as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_type_alias_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSClassImplements<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_class_implements(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSClassImplementsExpression(
+        ancestor::TSClassImplementsWithoutExpression(node, PhantomData),
+    ));
+    walk_ts_type_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION) as *mut TSTypeName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TSClassImplementsTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_class_implements(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSInterfaceDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_interface_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSInterfaceDeclarationId(
+        ancestor::TSInterfaceDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_ID)
+            as *mut BindingIdentifier,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8)
+        .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::TSInterfaceDeclarationTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
+        as *mut Vec<TSInterfaceHeritage>)
+    {
+        walk_ts_interface_heritage(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSInterfaceDeclarationBody);
+    walk_ts_interface_body(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_BODY)
+            as *mut Box<TSInterfaceBody>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_interface_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSInterfaceBody<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_interface_body(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSInterfaceBodyBody(
+        ancestor::TSInterfaceBodyWithoutBody(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_BODY_BODY)
+        as *mut Vec<TSSignature>)
+    {
+        walk_ts_signature(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_interface_body(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSPropertySignature<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_property_signature(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSPropertySignatureKey(
+        ancestor::TSPropertySignatureWithoutKey(node, PhantomData),
+    ));
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::TSPropertySignatureTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_property_signature(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_signature<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSSignature<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_signature(&mut *node, ctx);
+    match &mut *node {
+        TSSignature::TSIndexSignature(node) => {
+            walk_ts_index_signature(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSSignature::TSPropertySignature(node) => {
+            walk_ts_property_signature(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSSignature::TSCallSignatureDeclaration(node) => {
+            walk_ts_call_signature_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSSignature::TSConstructSignatureDeclaration(node) => {
+            walk_ts_construct_signature_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSSignature::TSMethodSignature(node) => {
+            walk_ts_method_signature(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_signature(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSIndexSignature<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_index_signature(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureParameters(
+        ancestor::TSIndexSignatureWithoutParameters(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
+        as *mut Vec<TSIndexSignatureName>)
+    {
+        walk_ts_index_signature_name(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSIndexSignatureTypeAnnotation);
+    walk_ts_type_annotation(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_index_signature(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSCallSignatureDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_call_signature_declaration(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSCallSignatureDeclarationTypeParameters(
+        ancestor::TSCallSignatureDeclarationWithoutTypeParameters(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
+    {
+        ctx.retag_stack(AncestorType::TSCallSignatureDeclarationThisParam);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSCallSignatureDeclarationParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::TSCallSignatureDeclarationReturnType);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_call_signature_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSMethodSignature<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_method_signature(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSMethodSignatureKey(
+        ancestor::TSMethodSignatureWithoutKey(node, PhantomData),
+    ));
+    walk_property_key(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_KEY) as *mut PropertyKey,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
+    {
+        ctx.retag_stack(AncestorType::TSMethodSignatureThisParam);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSMethodSignatureParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::TSMethodSignatureReturnType);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_method_signature(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSConstructSignatureDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_construct_signature_declaration(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSConstructSignatureDeclarationTypeParameters(
+        ancestor::TSConstructSignatureDeclarationWithoutTypeParameters(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationReturnType);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_construct_signature_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSIndexSignatureName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_index_signature_name(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureNameTypeAnnotation(
+        ancestor::TSIndexSignatureNameWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type_annotation(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_index_signature_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSInterfaceHeritage<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_interface_heritage(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSInterfaceHeritageExpression(
+        ancestor::TSInterfaceHeritageWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_interface_heritage(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypePredicate<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_predicate(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypePredicateParameterName(
+        ancestor::TSTypePredicateWithoutParameterName(node, PhantomData),
+    ));
+    walk_ts_type_predicate_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PREDICATE_PARAMETER_NAME)
+            as *mut TSTypePredicateName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
+        as *mut Option<Box<TSTypeAnnotation>>)
+    {
+        ctx.retag_stack(AncestorType::TSTypePredicateTypeAnnotation);
+        walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_predicate(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypePredicateName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_predicate_name(&mut *node, ctx);
+    match &mut *node {
+        TSTypePredicateName::Identifier(node) => {
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTypePredicateName::This(node) => walk_ts_this_type(traverser, node as *mut _, ctx),
+    }
+    traverser.exit_ts_type_predicate_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_module_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSModuleDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_module_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSModuleDeclarationId(
+        ancestor::TSModuleDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_ts_module_declaration_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_ID)
+            as *mut TSModuleDeclarationName,
+        ctx,
+    );
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id =
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_DECLARATION_BODY)
+        as *mut Option<TSModuleDeclarationBody>)
+    {
+        ctx.retag_stack(AncestorType::TSModuleDeclarationBody);
+        walk_ts_module_declaration_body(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_ts_module_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_module_declaration_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSModuleDeclarationName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_module_declaration_name(&mut *node, ctx);
+    match &mut *node {
+        TSModuleDeclarationName::Identifier(node) => {
+            walk_binding_identifier(traverser, node as *mut _, ctx)
+        }
+        TSModuleDeclarationName::StringLiteral(node) => {
+            walk_string_literal(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_module_declaration_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_module_declaration_body<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSModuleDeclarationBody<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_module_declaration_body(&mut *node, ctx);
+    match &mut *node {
+        TSModuleDeclarationBody::TSModuleDeclaration(node) => {
+            walk_ts_module_declaration(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSModuleDeclarationBody::TSModuleBlock(node) => {
+            walk_ts_module_block(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_module_declaration_body(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_global_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSGlobalDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_global_declaration(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id =
+        (*((node as *mut u8).add(ancestor::OFFSET_TS_GLOBAL_DECLARATION_SCOPE_ID)
+            as *mut Cell<Option<ScopeId>>))
+            .get()
+            .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let previous_hoist_scope_id = ctx.current_hoist_scope_id();
+    ctx.set_current_hoist_scope_id(current_scope_id);
+    let previous_block_scope_id = ctx.current_block_scope_id();
+    ctx.set_current_block_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSGlobalDeclarationBody(
+        ancestor::TSGlobalDeclarationWithoutBody(node, PhantomData),
+    ));
+    walk_ts_module_block(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_GLOBAL_DECLARATION_BODY) as *mut TSModuleBlock,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    ctx.set_current_hoist_scope_id(previous_hoist_scope_id);
+    ctx.set_current_block_scope_id(previous_block_scope_id);
+    traverser.exit_ts_global_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSModuleBlock<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_module_block(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSModuleBlockDirectives(
+        ancestor::TSModuleBlockWithoutDirectives(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
+        as *mut Vec<Directive>)
+    {
+        walk_directive(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSModuleBlockBody);
+    walk_statements(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut Vec<Statement>,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_module_block(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeLiteral<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_literal(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeLiteralMembers(
+        ancestor::TSTypeLiteralWithoutMembers(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_LITERAL_MEMBERS)
+        as *mut Vec<TSSignature>)
+    {
+        walk_ts_signature(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_literal(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSInferType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_infer_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSInferTypeTypeParameter(
+        ancestor::TSInferTypeWithoutTypeParameter(node, PhantomData),
+    ));
+    walk_ts_type_parameter(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INFER_TYPE_TYPE_PARAMETER)
+            as *mut Box<TSTypeParameter>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_infer_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeQuery<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_query(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeQueryExprName(
+        ancestor::TSTypeQueryWithoutExprName(node, PhantomData),
+    ));
+    walk_ts_type_query_expr_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_EXPR_NAME) as *mut TSTypeQueryExprName,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TSTypeQueryTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_query(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_query_expr_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeQueryExprName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_query_expr_name(&mut *node, ctx);
+    match &mut *node {
+        TSTypeQueryExprName::TSImportType(node) => {
+            walk_ts_import_type(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSTypeQueryExprName::IdentifierReference(_)
+        | TSTypeQueryExprName::QualifiedName(_)
+        | TSTypeQueryExprName::ThisExpression(_) => {
+            walk_ts_type_name(traverser, node as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_type_query_expr_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSImportType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_import_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSImportTypeSource(
+        ancestor::TSImportTypeWithoutSource(node, PhantomData),
+    ));
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_SOURCE) as *mut StringLiteral,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_OPTIONS)
+        as *mut Option<Box<ObjectExpression>>)
+    {
+        ctx.retag_stack(AncestorType::TSImportTypeOptions);
+        walk_object_expression(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIER)
+        as *mut Option<TSImportTypeQualifier>)
+    {
+        ctx.retag_stack(AncestorType::TSImportTypeQualifier);
+        walk_ts_import_type_qualifier(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
+        as *mut Option<Box<TSTypeParameterInstantiation>>)
+    {
+        ctx.retag_stack(AncestorType::TSImportTypeTypeArguments);
+        walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_import_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_import_type_qualifier<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSImportTypeQualifier<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_import_type_qualifier(&mut *node, ctx);
+    match &mut *node {
+        TSImportTypeQualifier::Identifier(node) => {
+            walk_identifier_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSImportTypeQualifier::QualifiedName(node) => {
+            walk_ts_import_type_qualified_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_import_type_qualifier(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_import_type_qualified_name<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSImportTypeQualifiedName<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_import_type_qualified_name(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSImportTypeQualifiedNameLeft(
+        ancestor::TSImportTypeQualifiedNameWithoutLeft(node, PhantomData),
+    ));
+    walk_ts_import_type_qualifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIED_NAME_LEFT)
+            as *mut TSImportTypeQualifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSImportTypeQualifiedNameRight);
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIED_NAME_RIGHT)
+            as *mut IdentifierName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_import_type_qualified_name(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSFunctionType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_function_type(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSFunctionTypeTypeParameters(
+        ancestor::TSFunctionTypeWithoutTypeParameters(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
+        as *mut Option<Box<TSThisParameter>>)
+    {
+        ctx.retag_stack(AncestorType::TSFunctionTypeThisParam);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSFunctionTypeParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSFunctionTypeReturnType);
+    walk_ts_type_annotation(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_function_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSConstructorType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_constructor_type(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx.push_stack(Ancestor::TSConstructorTypeTypeParameters(
+        ancestor::TSConstructorTypeWithoutTypeParameters(node, PhantomData),
+    ));
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
+        as *mut Option<Box<TSTypeParameterDeclaration>>)
+    {
+        walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSConstructorTypeParams);
+    walk_formal_parameters(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
+            as *mut Box<FormalParameters>)) as *mut _,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSConstructorTypeReturnType);
+    walk_ts_type_annotation(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
+            as *mut Box<TSTypeAnnotation>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_constructor_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_mapped_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSMappedType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_mapped_type(&mut *node, ctx);
+    let previous_scope_id = ctx.current_scope_id();
+    let current_scope_id = (*((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_SCOPE_ID)
+        as *mut Cell<Option<ScopeId>>))
+        .get()
+        .unwrap();
+    ctx.set_current_scope_id(current_scope_id);
+    let pop_token = ctx
+        .push_stack(Ancestor::TSMappedTypeKey(ancestor::TSMappedTypeWithoutKey(node, PhantomData)));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_KEY) as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSMappedTypeConstraint);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_CONSTRAINT) as *mut TSType,
+        ctx,
+    );
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MAPPED_TYPE_NAME_TYPE)
+        as *mut Option<TSType>)
+    {
+        ctx.retag_stack(AncestorType::TSMappedTypeNameType);
+        walk_ts_type(traverser, field as *mut _, ctx);
+    }
+    if let Some(field) = &mut *((node as *mut u8)
+        .add(ancestor::OFFSET_TS_MAPPED_TYPE_TYPE_ANNOTATION)
+        as *mut Option<TSType>)
+    {
+        ctx.retag_stack(AncestorType::TSMappedTypeTypeAnnotation);
+        walk_ts_type(traverser, field as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    ctx.set_current_scope_id(previous_scope_id);
+    traverser.exit_ts_mapped_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTemplateLiteralType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_template_literal_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTemplateLiteralTypeQuasis(
+        ancestor::TSTemplateLiteralTypeWithoutQuasis(node, PhantomData),
+    ));
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
+        as *mut Vec<TemplateElement>)
+    {
+        walk_template_element(traverser, item as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSTemplateLiteralTypeTypes);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
+        as *mut Vec<TSType>)
+    {
+        walk_ts_type(traverser, item as *mut _, ctx);
+    }
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_template_literal_type(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_as_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSAsExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_as_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSAsExpressionExpression(
+        ancestor::TSAsExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_AS_EXPRESSION_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSAsExpressionTypeAnnotation);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_AS_EXPRESSION_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_as_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_satisfies_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSSatisfiesExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_satisfies_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSSatisfiesExpressionExpression(
+        ancestor::TSSatisfiesExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_EXPRESSION)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSSatisfiesExpressionTypeAnnotation);
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_SATISFIES_EXPRESSION_TYPE_ANNOTATION)
+            as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_satisfies_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSTypeAssertion<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_type_assertion(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSTypeAssertionTypeAnnotation(
+        ancestor::TSTypeAssertionWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSTypeAssertionExpression);
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_ASSERTION_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_type_assertion(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_import_equals_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSImportEqualsDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_import_equals_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSImportEqualsDeclarationId(
+        ancestor::TSImportEqualsDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_binding_identifier(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_ID)
+            as *mut BindingIdentifier,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSImportEqualsDeclarationModuleReference);
+    walk_ts_module_reference(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_EQUALS_DECLARATION_MODULE_REFERENCE)
+            as *mut TSModuleReference,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_import_equals_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_module_reference<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSModuleReference<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_module_reference(&mut *node, ctx);
+    match &mut *node {
+        TSModuleReference::ExternalModuleReference(node) => {
+            walk_ts_external_module_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSModuleReference::IdentifierReference(node) => {
+            walk_identifier_reference(traverser, (&mut **node) as *mut _, ctx)
+        }
+        TSModuleReference::QualifiedName(node) => {
+            walk_ts_qualified_name(traverser, (&mut **node) as *mut _, ctx)
+        }
+    }
+    traverser.exit_ts_module_reference(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_external_module_reference<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSExternalModuleReference<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_external_module_reference(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSExternalModuleReferenceExpression(
+        ancestor::TSExternalModuleReferenceWithoutExpression(node, PhantomData),
+    ));
+    walk_string_literal(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_EXTERNAL_MODULE_REFERENCE_EXPRESSION)
+            as *mut StringLiteral,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_external_module_reference(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_non_null_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNonNullExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_non_null_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSNonNullExpressionExpression(
+        ancestor::TSNonNullExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_NON_NULL_EXPRESSION_EXPRESSION)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_non_null_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_decorator<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut Decorator<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_decorator(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::DecoratorExpression(
+        ancestor::DecoratorWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_DECORATOR_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_decorator(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_export_assignment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSExportAssignment<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_export_assignment(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSExportAssignmentExpression(
+        ancestor::TSExportAssignmentWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_EXPORT_ASSIGNMENT_EXPRESSION) as *mut Expression,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_export_assignment(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_namespace_export_declaration<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSNamespaceExportDeclaration<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_namespace_export_declaration(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSNamespaceExportDeclarationId(
+        ancestor::TSNamespaceExportDeclarationWithoutId(node, PhantomData),
+    ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_NAMESPACE_EXPORT_DECLARATION_ID)
+            as *mut IdentifierName,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_namespace_export_declaration(&mut *node, ctx);
+}
+
+unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut TSInstantiationExpression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_ts_instantiation_expression(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::TSInstantiationExpressionExpression(
+        ancestor::TSInstantiationExpressionWithoutExpression(node, PhantomData),
+    ));
+    walk_expression(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_EXPRESSION)
+            as *mut Expression,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSInstantiationExpressionTypeArguments);
+    walk_ts_type_parameter_instantiation(
+        traverser,
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
+            as *mut Box<TSTypeParameterInstantiation>)) as *mut _,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_ts_instantiation_expression(&mut *node, ctx);
+}
+
+unsafe fn walk_js_doc_nullable_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSDocNullableType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_js_doc_nullable_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSDocNullableTypeTypeAnnotation(
+        ancestor::JSDocNullableTypeWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JS_DOC_NULLABLE_TYPE_TYPE_ANNOTATION) as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_js_doc_nullable_type(&mut *node, ctx);
+}
+
+unsafe fn walk_js_doc_non_nullable_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSDocNonNullableType<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_js_doc_non_nullable_type(&mut *node, ctx);
+    let pop_token = ctx.push_stack(Ancestor::JSDocNonNullableTypeTypeAnnotation(
+        ancestor::JSDocNonNullableTypeWithoutTypeAnnotation(node, PhantomData),
+    ));
+    walk_ts_type(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JS_DOC_NON_NULLABLE_TYPE_TYPE_ANNOTATION)
+            as *mut TSType,
+        ctx,
+    );
+    ctx.pop_stack(pop_token);
+    traverser.exit_js_doc_non_nullable_type(&mut *node, ctx);
+}
+
+unsafe fn walk_js_doc_unknown_type<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSDocUnknownType,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_js_doc_unknown_type(&mut *node, ctx);
+    traverser.exit_js_doc_unknown_type(&mut *node, ctx);
+}
+
+unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    stmts: *mut Vec<'a, Statement<'a>>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_statements(&mut *stmts, ctx);
+    for stmt in &mut *stmts {
+        walk_statement(traverser, stmt, ctx);
+    }
+    traverser.exit_statements(&mut *stmts, ctx);
+}

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -45,12 +45,14 @@
 //! See the [crate documentation](https://github.com/oxc-project/oxc/tree/main/crates/oxc_minifier) for more details.
 
 mod compressor;
-mod ctx;
+pub(crate) mod generated;
 mod keep_var;
+mod minifier_traverse;
 mod options;
 mod peephole;
 mod state;
 mod symbol_value;
+mod traverse_context;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
@@ -63,6 +65,10 @@ use rustc_hash::FxHashMap;
 
 pub use oxc_mangler::{MangleOptions, MangleOptionsKeepNames};
 
+pub(crate) use crate::generated::traverse::Traverse;
+#[doc(hidden)]
+pub(crate) use crate::traverse_context::MinifierTraverseCtx as TraverseCtx;
+pub(crate) use crate::traverse_context::ReusableMinifierTraverseCtx as ReusableTraverseCtx;
 pub use crate::{compressor::Compressor, options::*};
 
 #[derive(Debug, Clone)]

--- a/crates/oxc_minifier/src/minifier_traverse.rs
+++ b/crates/oxc_minifier/src/minifier_traverse.rs
@@ -1,0 +1,26 @@
+use std::ptr;
+
+use oxc_ast::ast::Program;
+
+use crate::{
+    ReusableTraverseCtx, Traverse,
+    generated::{ancestor::Ancestor, walk::walk_ast},
+};
+
+pub fn traverse_mut_with_ctx<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    program: &mut Program<'a>,
+    ctx: &mut ReusableTraverseCtx<'a>,
+) {
+    let program = ptr::from_mut(program);
+    let ctx = ctx.get_mut();
+
+    debug_assert!(ctx.ancestors_depth() == 1);
+    debug_assert!(matches!(ctx.parent(), Ancestor::None));
+
+    // SAFETY: `program` originates from `&mut Program<'a>` and context stack invariants are checked.
+    unsafe { walk_ast(traverser, program, ctx) };
+
+    debug_assert!(ctx.ancestors_depth() == 1);
+    debug_assert!(matches!(ctx.parent(), Ancestor::None));
+}

--- a/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
+++ b/crates/oxc_minifier/src/peephole/convert_to_dotted_properties.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
@@ -13,10 +13,10 @@ impl<'a> PeepholeOptimizations {
     ///
     /// `foo['bar']` -> `foo.bar`
     /// `foo?.['bar']` -> `foo?.bar`
-    pub fn convert_to_dotted_properties(expr: &mut MemberExpression<'a>, ctx: &Ctx<'a, '_>) {
+    pub fn convert_to_dotted_properties(expr: &mut MemberExpression<'a>, ctx: &TraverseCtx<'a>) {
         let MemberExpression::ComputedMemberExpression(e) = expr else { return };
         let Expression::StringLiteral(s) = &e.expression else { return };
-        if Ctx::is_identifier_name_patched(&s.value) {
+        if TraverseCtx::is_identifier_name_patched(&s.value) {
             let property = ctx.ast.identifier_name(s.span, s.value);
             *expr =
                 MemberExpression::StaticMemberExpression(ctx.ast.alloc_static_member_expression(
@@ -31,7 +31,7 @@ impl<'a> PeepholeOptimizations {
         if e.optional {
             return;
         }
-        if let Some(n) = Ctx::string_to_equivalent_number_value(v) {
+        if let Some(n) = TraverseCtx::string_to_equivalent_number_value(v) {
             e.expression = ctx.ast.expression_numeric_literal(s.span, n, None, NumberBase::Decimal);
         }
     }

--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -1,14 +1,14 @@
+use crate::generated::ancestor::Ancestor;
 use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue};
 use oxc_span::GetSpan;
-use oxc_traverse::Ancestor;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
-    pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
         let BindingPattern::BindingIdentifier(ident) = &decl.id else { return };
         let Some(symbol_id) = ident.symbol_id.get() else { return };
         let value = if decl.kind.is_var() || Self::is_for_statement_init(ctx) {
@@ -21,11 +21,11 @@ impl<'a> PeepholeOptimizations {
         ctx.init_value(symbol_id, value);
     }
 
-    fn is_for_statement_init(ctx: &Ctx<'a, '_>) -> bool {
+    fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {
         ctx.ancestors().nth(1).is_some_and(Ancestor::is_parent_of_for_statement_left)
     }
 
-    pub fn inline_identifier_reference(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn inline_identifier_reference(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::Identifier(ident) = expr else { return };
         let reference_id = ident.reference_id();
         let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else { return };

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -1,4 +1,4 @@
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
@@ -16,7 +16,7 @@ impl<'a> PeepholeOptimizations {
         test: Expression<'a>,
         consequent: Expression<'a>,
         alternate: Expression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let mut cond_expr = ctx.ast.conditional_expression(span, test, consequent, alternate);
         Self::minimize_conditional_expression(&mut cond_expr, ctx)
@@ -26,7 +26,7 @@ impl<'a> PeepholeOptimizations {
     /// `MangleIfExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2745>
     pub fn minimize_conditional_expression(
         expr: &mut ConditionalExpression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         match &mut expr.test {
             // "(a, b) ? c : d" => "a, b ? c : d"
@@ -416,7 +416,7 @@ impl<'a> PeepholeOptimizations {
     /// - `x ? a = 0 : a = 1` -> `a = x ? 0 : 1`
     fn try_merge_conditional_expression_inside(
         expr: &mut ConditionalExpression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         let (
             Expression::AssignmentExpression(consequent),
@@ -461,7 +461,7 @@ impl<'a> PeepholeOptimizations {
         target_id_name: &str,
         expr_to_inject: &mut Expression<'a>,
         expr: &mut Expression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> bool {
         if Self::inject_optional_chaining_if_matched_inner(
             target_id_name,
@@ -486,7 +486,7 @@ impl<'a> PeepholeOptimizations {
         target_id_name: &str,
         expr_to_inject: &mut Expression<'a>,
         expr: &mut Expression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> bool {
         match expr {
             Expression::StaticMemberExpression(e) => {

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, IsInt32OrUint32};
 use oxc_span::GetSpan;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
@@ -13,7 +13,7 @@ impl<'a> PeepholeOptimizations {
     /// `SimplifyBooleanExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L2059>
     pub fn minimize_expression_in_boolean_context(
         expr: &mut Expression<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
         match expr {
             // "!!a" => "a"

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -2,13 +2,13 @@ use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     /// `mangleFor`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L9801>
-    pub fn minimize_for_statement(for_stmt: &mut ForStatement<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn minimize_for_statement(for_stmt: &mut ForStatement<'a>, ctx: &mut TraverseCtx<'a>) {
         // Get the first statement in the loop
         let mut first = &for_stmt.body;
         if let Statement::BlockStatement(block_stmt) = first {
@@ -106,7 +106,7 @@ impl<'a> PeepholeOptimizations {
         span: Span,
         body: Option<Statement<'a>>,
         replace: Option<Statement<'a>>,
-        ctx: &Ctx<'a, '_>,
+        ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
         match body {
             Some(Statement::BlockStatement(mut block_stmt)) if !block_stmt.body.is_empty() => {

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -4,7 +4,7 @@ use oxc_ast::ast::*;
 use oxc_semantic::ScopeFlags;
 use oxc_span::GetSpan;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
@@ -12,7 +12,7 @@ impl<'a> PeepholeOptimizations {
     /// `MangleIf`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_parser/js_parser.go#L9860>
     pub fn try_minimize_if(
         if_stmt: &mut IfStatement<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Option<Statement<'a>> {
         Self::wrap_to_avoid_ambiguous_else(if_stmt, ctx);
         if let Statement::ExpressionStatement(expr_stmt) = &mut if_stmt.consequent {
@@ -126,7 +126,7 @@ impl<'a> PeepholeOptimizations {
 
     /// Wrap to avoid ambiguous else.
     /// `if (foo) if (bar) baz else quaz` ->  `if (foo) { if (bar) baz else quaz }`
-    fn wrap_to_avoid_ambiguous_else(if_stmt: &mut IfStatement<'a>, ctx: &mut Ctx<'a, '_>) {
+    fn wrap_to_avoid_ambiguous_else(if_stmt: &mut IfStatement<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Statement::IfStatement(if2) = &mut if_stmt.consequent
             && if2.consequent.is_jump_statement()
             && if2.alternate.is_some()

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -3,19 +3,23 @@ use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::DetermineValueType;
 use oxc_span::GetSpan;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
-    pub fn minimize_not(span: Span, expr: Expression<'a>, ctx: &mut Ctx<'a, '_>) -> Expression<'a> {
+    pub fn minimize_not(
+        span: Span,
+        expr: Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Expression<'a> {
         let mut unary = ctx.ast.expression_unary(span, UnaryOperator::LogicalNot, expr);
         Self::minimize_unary(&mut unary, ctx);
         unary
     }
 
     /// `MaybeSimplifyNot`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L73>
-    pub fn minimize_unary(expr: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn minimize_unary(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::UnaryExpression(e) = expr else { return };
         if !e.operator.is_not() {
             return;

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use crate::{CompressOptionsUnused, ctx::Ctx};
+use crate::{CompressOptionsUnused, TraverseCtx};
 use oxc_allocator::{TakeIn, Vec};
 use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
@@ -14,7 +14,7 @@ use super::PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
     /// `SimplifyUnusedExpr`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_ast_helpers.go#L534>
-    pub fn remove_unused_expression(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    pub fn remove_unused_expression(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         match e {
             Expression::ArrayExpression(_) => Self::remove_unused_array_expr(e, ctx),
             Expression::AssignmentExpression(_) => Self::remove_unused_assignment_expr(e, ctx),
@@ -32,7 +32,7 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    fn remove_unused_unary_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_unary_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::UnaryExpression(unary_expr) = e else { return false };
         match unary_expr.operator {
             UnaryOperator::Void | UnaryOperator::LogicalNot => {
@@ -53,7 +53,7 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    fn remove_unused_sequence_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_sequence_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::SequenceExpression(sequence_expr) = e else { return false };
         let old_len = sequence_expr.expressions.len();
         sequence_expr.expressions.retain_mut(|e| !Self::remove_unused_expression(e, ctx));
@@ -63,7 +63,7 @@ impl<'a> PeepholeOptimizations {
         sequence_expr.expressions.is_empty()
     }
 
-    fn remove_unused_logical_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_logical_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         if !e.may_have_side_effects(ctx) {
             return true;
         }
@@ -175,7 +175,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     // `([1,2,3, foo()])` -> `foo()`
-    fn remove_unused_array_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_array_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::ArrayExpression(array_expr) = e else {
             return false;
         };
@@ -225,7 +225,7 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
-    fn remove_unused_new_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_new_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::NewExpression(new_expr) = e else { return false };
         if (new_expr.pure && ctx.annotations()) || ctx.manual_pure_functions(&new_expr.callee) {
             let mut exprs =
@@ -245,7 +245,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     // "`${1}2${foo()}3`" -> "`${foo()}`"
-    fn remove_unused_template_literal(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_template_literal(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::TemplateLiteral(temp_lit) = e else { return false };
         if temp_lit.expressions.is_empty() {
             return true;
@@ -327,7 +327,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     // `({ 1: 1, [foo()]: bar() })` -> `foo(), bar()`
-    fn remove_unused_object_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_object_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::ObjectExpression(object_expr) = e else {
             return false;
         };
@@ -392,7 +392,7 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
-    fn remove_unused_conditional_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_conditional_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         if !e.may_have_side_effects(ctx) {
             return true;
         }
@@ -443,7 +443,7 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
-    fn remove_unused_binary_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_binary_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::BinaryExpression(binary_expr) = e else {
             return false;
         };
@@ -493,7 +493,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// returns whether the passed expression is a string
-    fn fold_string_addition_chain(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn fold_string_addition_chain(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::BinaryExpression(binary_expr) = e else {
             return e.to_primitive(ctx).is_string() == Some(true);
         };
@@ -536,7 +536,7 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
-    fn remove_unused_call_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_call_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::CallExpression(call_expr) = e else { return false };
 
         let is_pure = {
@@ -572,7 +572,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn fold_arguments_into_needed_expressions(
         args: &mut Vec<'a, Argument<'a>>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Vec<'a, Expression<'a>> {
         ctx.ast.vec_from_iter(args.drain(..).filter_map(|arg| {
             let mut expr = match arg {
@@ -586,7 +586,10 @@ impl<'a> PeepholeOptimizations {
         }))
     }
 
-    pub fn remove_unused_assignment_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    pub fn remove_unused_assignment_expr(
+        e: &mut Expression<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> bool {
         let Expression::AssignmentExpression(assign_expr) = e else { return false };
         if matches!(
             ctx.state.options.unused,
@@ -627,7 +630,7 @@ impl<'a> PeepholeOptimizations {
         false
     }
 
-    fn remove_unused_class_expr(e: &mut Expression<'a>, ctx: &mut Ctx<'a, '_>) -> bool {
+    fn remove_unused_class_expr(e: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         let Expression::ClassExpression(c) = e else { return false };
         if let Some(exprs) = Self::remove_unused_class(c, ctx) {
             if exprs.is_empty() {
@@ -640,7 +643,7 @@ impl<'a> PeepholeOptimizations {
 
     pub fn remove_unused_class(
         c: &mut Class<'a>,
-        ctx: &mut Ctx<'a, '_>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Option<Vec<'a, Expression<'a>>> {
         // TypeError `class C extends (() => {}) {}`
         if c.super_class

--- a/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
@@ -1,7 +1,7 @@
 use oxc_ast::ast::*;
 use oxc_ecmascript::side_effects::MayHaveSideEffects;
 
-use crate::ctx::Ctx;
+use crate::TraverseCtx;
 
 use super::PeepholeOptimizations;
 
@@ -10,7 +10,7 @@ impl<'a> PeepholeOptimizations {
     ///
     /// This function uses the private member usage collected during the main traverse
     /// to remove unused private fields and methods from the class body.
-    pub fn remove_unused_private_members(body: &mut ClassBody<'a>, ctx: &mut Ctx<'a, '_>) {
+    pub fn remove_unused_private_members(body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
         if ctx.current_scope_flags().contains_direct_eval() {
             return;
         }

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -15,7 +15,6 @@ pub struct SymbolValue<'a> {
     pub read_references_count: u32,
     pub write_references_count: u32,
 
-    #[expect(unused)]
     pub scope_id: ScopeId,
 }
 

--- a/crates/oxc_minifier/src/traverse_context/ancestry.rs
+++ b/crates/oxc_minifier/src/traverse_context/ancestry.rs
@@ -1,0 +1,207 @@
+use std::mem::transmute;
+
+use oxc_data_structures::stack::NonEmptyStack;
+
+use crate::generated::ancestor::{Ancestor, AncestorType};
+
+const INITIAL_STACK_CAPACITY: usize = 64; // 64 entries = 1 KiB
+
+/// Traverse ancestry context.
+///
+/// Contains a stack of `Ancestor`s, and provides methods to get parent/ancestor of current node.
+///
+/// `walk_*` methods push/pop `Ancestor`s to `stack` when entering/exiting nodes.
+///
+/// `Ancestor<'a, 't>` is an owned type.
+/// * `'a` is lifetime of AST nodes.
+/// * `'t` is lifetime of the `Ancestor` (derived from `&'t TraverseAncestry`).
+///
+/// `'t` is constrained in `parent`, `ancestor` and `ancestors` methods to only live as long as
+/// the `&'t TraverseAncestry` passed to the method.
+/// i.e. `Ancestor`s can only live as long as `enter_*` or `exit_*` method in which they're obtained,
+/// and cannot "escape" those methods.
+/// This is required for soundness. If an `Ancestor` could be retained longer, the references that
+/// can be got from it could alias a `&mut` reference to the same AST node.
+///
+/// # SAFETY
+/// This type MUST NOT be mutable by consumer.
+///
+/// The safety scheme is entirely reliant on `stack` being in sync with the traversal,
+/// to prevent consumer from accessing fields of nodes which traversal has passed through,
+/// so as to not violate Rust's aliasing rules.
+/// If consumer could alter `stack` in any way, they could break the safety invariants and cause UB.
+///
+/// We prevent this in 3 ways:
+/// 1. `TraverseAncestry`'s `stack` field is private.
+/// 2. Public methods of `TraverseAncestry` provide no means for mutating `stack`.
+/// 3. Visitors receive a `&mut TraverseCtx`, but cannot overwrite its `ancestry` field because they:
+///    a. cannot create a new `TraverseAncestry`
+///       - `TraverseAncestry::new` and `TraverseCtx::new` are private.
+///         b. cannot obtain an owned `TraverseAncestry` from a `&TraverseAncestry`
+///       - `TraverseAncestry` is not `Clone`.
+///
+/// ## Soundness hole
+///
+/// Strictly speaking, there is still room to abuse the API and cause UB as follows:
+///
+/// * Initiate a 2nd traversal of a different AST inside a `Traverse` visitor method.
+/// * `mem::swap` the 2 x `&mut TraverseCtx`s from the 2 different traversals.
+///
+/// The 2 ASTs would have to be different, but borrowed for same lifetime, so I (@overlookmotel) don't
+/// think it's possible by this method to produce aliasing violations, or to over-extend AST node
+/// lifetimes to cause a use-after-free.
+/// But it *could* produce buffer underrun in `pop_stack`, when it tries to pop from a stack which
+/// is already empty.
+///
+/// In practice, this would be a completely bizarre thing to do, and would basically require you to
+/// write malicious code specifically designed to cause UB. So it's not a particularly real risk.
+///
+/// To close this hole and make the API 100% sound, we'd need branded lifetimes so that all
+/// `TraverseCtx`s have unique lifetimes, and so cannot be swapped for any other without
+/// the borrow-checker complaining.
+pub struct TraverseAncestry<'a> {
+    stack: NonEmptyStack<Ancestor<'a, 'static>>,
+}
+
+// Public methods
+impl<'a> TraverseAncestry<'a> {
+    /// Get parent of current node.
+    #[inline]
+    pub fn parent<'t>(&'t self) -> Ancestor<'a, 't> {
+        let ancestor = *self.stack.last();
+        // Shrink `Ancestor`'s `'t` lifetime to lifetime of `&'t self`.
+        // SAFETY: The `Ancestor` is guaranteed valid for `'t`. It is not possible to obtain
+        // a `&mut` ref to any AST node which this `Ancestor` gives access to during `'t`.
+        unsafe { transmute::<Ancestor<'a, '_>, Ancestor<'a, 't>>(ancestor) }
+    }
+
+    /// Get ancestor of current node.
+    ///
+    /// `level` is number of levels above parent.
+    /// `ancestor(0)` is equivalent to `parent()` (but better to use `parent()` as it's more efficient).
+    ///
+    /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
+    #[inline]
+    pub fn ancestor<'t>(&'t self, level: usize) -> Ancestor<'a, 't> {
+        // Behavior with different values:
+        // `len = 1, level = 0` -> return `Ancestor::None` from else branch
+        // `len = 1, level = 1` -> return `Ancestor::None` from else branch (out of bounds)
+        // `len = 3, level = 0` -> return parent (index 2)
+        // `len = 3, level = 1` -> return grandparent (index 1)
+        // `len = 3, level = 2` -> return `Ancestor::None` from else branch
+        // `len = 3, level = 3` -> return `Ancestor::None` from else branch (out of bounds)
+
+        // `self.stack.len()` is always at least 1, so `self.stack.len() - 1` cannot wrap around.
+        // `level <= last_index` would also work here, but `level < last_index` avoids a read from memory
+        // when that read would just get `Ancestor::None` anyway.
+        let last_index = self.stack.len() - 1;
+        if level < last_index {
+            // SAFETY: We just checked that `level < last_index` so `last_index - level` cannot wrap around,
+            // and `last_index - level` must be a valid index
+            let ancestor = unsafe { *self.stack.get_unchecked(last_index - level) };
+
+            // Shrink `Ancestor`'s `'t` lifetime to lifetime of `&'t self`.
+            // SAFETY: The `Ancestor` is guaranteed valid for `'t`. It is not possible to obtain
+            // a `&mut` ref to any AST node which this `Ancestor` gives access to during `'t`.
+            unsafe { transmute::<Ancestor<'a, '_>, Ancestor<'a, 't>>(ancestor) }
+        } else {
+            Ancestor::None
+        }
+    }
+
+    /// Get iterator over ancestors, starting with parent and working up.
+    ///
+    /// Last `Ancestor` returned will be `Program`. `Ancestor::None` is not included in iteration.
+    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+        // SAFETY: Stack always has at least 1 entry
+        let stack_without_first = unsafe { self.stack.get_unchecked(1..) };
+        stack_without_first.iter().rev().map(|&ancestor| {
+            // Shrink `Ancestor`'s `'t` lifetime to lifetime of `&'t self`.
+            // SAFETY: The `Ancestor` is guaranteed valid for `'t`. It is not possible to obtain
+            // a `&mut` ref to any AST node which this `Ancestor` gives access to during `'t`.
+            unsafe { transmute::<Ancestor<'a, '_>, Ancestor<'a, 't>>(ancestor) }
+        })
+    }
+
+    /// Get depth in the AST.
+    ///
+    /// Count includes current node. i.e. in `Program`, depth is 1.
+    #[inline]
+    pub fn ancestors_depth(&self) -> usize {
+        self.stack.len()
+    }
+}
+
+// Methods used internally within crate.
+impl<'a> TraverseAncestry<'a> {
+    /// Create new `TraverseAncestry`.
+    ///
+    /// # SAFETY
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    pub(super) fn new() -> Self {
+        Self { stack: NonEmptyStack::with_capacity(INITIAL_STACK_CAPACITY, Ancestor::None) }
+    }
+
+    /// Push item onto ancestry stack.
+    ///
+    /// # SAFETY
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    #[must_use] // `PopToken` must be passed to `pop_stack` to pop this entry off the stack again
+    pub(crate) fn push_stack(&mut self, ancestor: Ancestor<'a, 'static>) -> PopToken {
+        self.stack.push(ancestor);
+
+        // Return `PopToken` which can be used to pop this entry off again
+        PopToken(())
+    }
+
+    /// Pop last item off ancestry stack.
+    ///
+    /// # SAFETY
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    #[expect(unused_variables, clippy::needless_pass_by_value)]
+    pub(crate) fn pop_stack(&mut self, token: PopToken) {
+        // SAFETY: `PopToken`s are only created in `push_stack`, so the fact that caller provides one
+        // guarantees that a push has happened. This method consumes the token which guarantees another
+        // pop hasn't occurred already corresponding to that push.
+        // Therefore the stack cannot by empty.
+        // The stack starts with 1 entry, so also it cannot be left empty after this pop.
+        unsafe { self.stack.pop_unchecked() };
+    }
+
+    /// Retag last item on ancestry stack.
+    ///
+    /// i.e. Alter discriminant of `Ancestor` enum, without changing the "payload" it contains
+    /// of pointer to the ancestor node.
+    ///
+    /// This is purely a performance optimization. If the last item on stack already contains the
+    /// correct pointer, then `ctx.retag_stack(AncestorType::ProgramBody)` is equivalent to:
+    ///
+    /// ```nocompile
+    /// ctx.pop_stack();
+    /// ctx.push_stack(Ancestor::ProgramBody(ProgramWithoutBody(node_ptr)));
+    /// ```
+    ///
+    /// `retag_stack` is only a single 2-byte write operation.
+    ///
+    /// # SAFETY
+    /// * Stack must have length of at least 2 (so we are not retagging dummy root `Ancestor`).
+    /// * Last item on stack must contain pointer to type corresponding to provided `AncestorType`.
+    ///
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    #[expect(clippy::ptr_as_ptr, clippy::ref_as_ptr)]
+    pub(crate) unsafe fn retag_stack(&mut self, ty: AncestorType) {
+        debug_assert!(self.stack.len() >= 2);
+        // SAFETY: Caller must uphold the safety invariants
+        unsafe { *(self.stack.last_mut() as *mut _ as *mut AncestorType) = ty };
+    }
+}
+
+/// Zero sized token which allows popping from stack. Used to ensure push and pop always correspond.
+/// Inner field is private to this module so can only be created by methods in this file.
+/// It is not `Clone` or `Copy`, so no way to obtain one except in this file.
+/// Only method which generates a `PopToken` is `push_stack`, and `pop_stack` consumes one,
+/// which guarantees you can't have more pops than pushes.
+pub struct PopToken(());

--- a/crates/oxc_minifier/src/traverse_context/bound_identifier.rs
+++ b/crates/oxc_minifier/src/traverse_context/bound_identifier.rs
@@ -1,0 +1,345 @@
+use oxc_ast::ast::{
+    AssignmentTarget, BindingIdentifier, BindingPattern, Expression, IdentifierReference,
+    SimpleAssignmentTarget,
+};
+use oxc_span::{SPAN, Span};
+use oxc_str::Ident;
+use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
+
+use super::TraverseCtx;
+
+use super::MaybeBoundIdentifier;
+
+/// Info about a binding, from which one can create a `BindingIdentifier` or `IdentifierReference`s.
+///
+/// Typical usage:
+///
+/// ```rs
+/// // Generate a UID for a top-level var
+/// let binding = ctx.generate_uid_in_current_scope("foo", SymbolFlags::FunctionScopedVariable);
+///
+/// // Generate `IdentifierReference`s and insert them into AST
+/// some_node.id = binding.create_read_reference(ctx);
+/// some_other_node.id = binding.create_read_reference(ctx);
+///
+/// // Store details of the binding for later
+/// self.foo_binding = binding;
+///
+/// // Later on in `exit_program`
+/// let id = self.foo_binding.create_binding_identifier(ctx);
+/// // Insert `var <id> = something;` into `program.body`
+/// ```
+///
+/// Notes:
+///
+/// * `BoundIdentifier` is smaller than `BindingIdentifier`, so takes less memory when you store
+///   it for later use.
+/// * `BoundIdentifier` is `Clone` (unlike `BindingIdentifier`).
+/// * `BoundIdentifier` re-uses the same `Ident` for all `BindingIdentifier` / `IdentifierReference`s
+///   created from it.
+#[derive(Debug, Clone)]
+pub struct BoundIdentifier<'a> {
+    pub name: Ident<'a>,
+    pub symbol_id: SymbolId,
+}
+
+impl<'a> BoundIdentifier<'a> {
+    /// Create `BoundIdentifier` for `name` and `symbol_id`
+    pub fn new(name: Ident<'a>, symbol_id: SymbolId) -> Self {
+        Self { name, symbol_id }
+    }
+
+    /// Create `BoundIdentifier` from a `BindingIdentifier`
+    pub fn from_binding_ident(ident: &BindingIdentifier<'a>) -> Self {
+        Self { name: ident.name, symbol_id: ident.symbol_id() }
+    }
+
+    /// Convert `BoundIdentifier` to `MaybeBoundIdentifier`
+    pub fn to_maybe_bound_identifier(&self) -> MaybeBoundIdentifier<'a> {
+        MaybeBoundIdentifier::new(self.name, Some(self.symbol_id))
+    }
+
+    /// Create `BindingIdentifier` for this binding
+    pub fn create_binding_identifier<State>(
+        &self,
+        ctx: &TraverseCtx<'a, State>,
+    ) -> BindingIdentifier<'a> {
+        ctx.ast.binding_identifier_with_symbol_id(SPAN, self.name, self.symbol_id)
+    }
+
+    /// Create `BindingPattern` for this binding
+    pub fn create_binding_pattern<State>(
+        &self,
+        ctx: &TraverseCtx<'a, State>,
+    ) -> BindingPattern<'a> {
+        let ident = self.create_binding_identifier(ctx);
+        BindingPattern::BindingIdentifier(ctx.alloc(ident))
+    }
+
+    // --- Read only ---
+
+    /// Create `IdentifierReference` referencing this binding, which is read from, with dummy `Span`
+    pub fn create_read_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_read_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from, with dummy `Span`
+    pub fn create_read_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_read_expression(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from, with specified `Span`
+    pub fn create_spanned_read_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Read, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from, with specified `Span`
+    pub fn create_spanned_read_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Read, ctx)
+    }
+
+    // --- Write only ---
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_write_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_write_expression(SPAN, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_write_target(SPAN, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_simple_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_write_simple_target(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_simple_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(span, ReferenceFlags::Write, ctx)
+    }
+
+    // --- Read and write ---
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_read_write_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_read_write_expression(SPAN, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_read_write_target(SPAN, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_simple_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_read_write_simple_target(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_simple_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    // --- Specified ReferenceFlags ---
+
+    /// Create `IdentifierReference` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_reference<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(SPAN, flags, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_expression<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(SPAN, flags, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_target<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(SPAN, flags, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_simple_target<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(SPAN, flags, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_reference<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        ctx.create_bound_ident_reference(span, self.name, self.symbol_id, flags)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_expression<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        Expression::Identifier(ctx.alloc(ident))
+    }
+
+    /// Create `AssignmentTarget::AssignmentTargetIdentifier` referencing this binding,
+    /// with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_target<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident))
+    }
+
+    /// Create `SimpleAssignmentTarget::AssignmentTargetIdentifier` referencing this binding,
+    /// with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_simple_target<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        SimpleAssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident))
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/maybe_bound_identifier.rs
+++ b/crates/oxc_minifier/src/traverse_context/maybe_bound_identifier.rs
@@ -1,0 +1,325 @@
+use oxc_ast::ast::{AssignmentTarget, Expression, IdentifierReference, SimpleAssignmentTarget};
+use oxc_span::{SPAN, Span};
+use oxc_str::Ident;
+use oxc_syntax::{reference::ReferenceFlags, symbol::SymbolId};
+
+use super::TraverseCtx;
+
+use super::BoundIdentifier;
+
+/// A factory for generating `IdentifierReference`s.
+///
+/// Typical usage:
+///
+/// ```rs
+/// // Create `MaybeBoundIdentifier` from an existing `IdentifierReference`
+/// let binding = MaybeBoundIdentifier::from_identifier_reference(ident, ctx);
+///
+/// // Generate `IdentifierReference`s and insert them into AST
+/// assign_expr.left = binding.create_write_target(ctx);
+/// assign_expr.right = binding.create_read_expression(ctx);
+/// ```
+///
+/// Notes:
+///
+/// * The original `IdentifierReference` must also be used in the AST, or it'll be a dangling reference.
+/// * `MaybeBoundIdentifier` is smaller than `IdentifierReference`, so takes less memory when you store
+///   it for later use.
+/// * `MaybeBoundIdentifier` re-uses the same `Ident` for all `BindingIdentifier` / `IdentifierReference`s
+///   created from it.
+/// * `MaybeBoundIdentifier` looks up the `SymbolId` for the reference only once.
+#[derive(Debug, Clone)]
+pub struct MaybeBoundIdentifier<'a> {
+    pub name: Ident<'a>,
+    pub symbol_id: Option<SymbolId>,
+}
+
+impl<'a> MaybeBoundIdentifier<'a> {
+    /// Create `MaybeBoundIdentifier` for `name` and `Option<SymbolId>`
+    pub fn new(name: Ident<'a>, symbol_id: Option<SymbolId>) -> Self {
+        Self { name, symbol_id }
+    }
+
+    /// Create `MaybeBoundIdentifier` from an `IdentifierReference`
+    pub fn from_identifier_reference<State>(
+        ident: &IdentifierReference<'a>,
+        ctx: &TraverseCtx<'a, State>,
+    ) -> Self {
+        let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id();
+        Self { name: ident.name, symbol_id }
+    }
+
+    /// Convert `MaybeBoundIdentifier` to `BoundIdentifier`.
+    ///
+    /// Returns `None` if symbol is not bound.
+    pub fn to_bound_identifier(&self) -> Option<BoundIdentifier<'a>> {
+        self.symbol_id.map(|symbol_id| BoundIdentifier::new(self.name, symbol_id))
+    }
+
+    // --- Read only ---
+
+    /// Create `IdentifierReference` referencing this binding, which is read from, with dummy `Span`
+    pub fn create_read_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_read_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from, with dummy `Span`
+    pub fn create_read_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_read_expression(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from, with specified `Span`
+    pub fn create_spanned_read_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Read, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from, with specified `Span`
+    pub fn create_spanned_read_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Read, ctx)
+    }
+
+    // --- Write only ---
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_write_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_write_expression(SPAN, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_write_target(SPAN, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is written to, with dummy `Span`
+    pub fn create_write_simple_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_write_simple_target(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(span, ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is written to, with specified `Span`
+    pub fn create_spanned_write_simple_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(span, ReferenceFlags::Write, ctx)
+    }
+
+    // --- Read and write ---
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_reference<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_read_write_reference(SPAN, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_expression<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_read_write_expression(SPAN, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_read_write_target(SPAN, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is read from + written to,
+    /// with dummy `Span`
+    pub fn create_read_write_simple_target<State>(
+        &self,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_read_write_simple_target(SPAN, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_reference<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_expression<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, which is read from + written to,
+    /// with specified `Span`
+    pub fn create_spanned_read_write_simple_target<State>(
+        &self,
+        span: Span,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(span, ReferenceFlags::Read | ReferenceFlags::Write, ctx)
+    }
+
+    // --- Specified ReferenceFlags ---
+
+    /// Create `IdentifierReference` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_reference<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        self.create_spanned_reference(SPAN, flags, ctx)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_expression<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        self.create_spanned_expression(SPAN, flags, ctx)
+    }
+
+    /// Create `AssignmentTarget` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_target<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        self.create_spanned_target(SPAN, flags, ctx)
+    }
+
+    /// Create `SimpleAssignmentTarget` referencing this binding, with specified `ReferenceFlags`
+    pub fn create_simple_target<State>(
+        &self,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        self.create_spanned_simple_target(SPAN, flags, ctx)
+    }
+
+    /// Create `IdentifierReference` referencing this binding, with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_reference<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> IdentifierReference<'a> {
+        ctx.create_ident_reference(span, self.name, self.symbol_id, flags)
+    }
+
+    /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_expression<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> Expression<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        Expression::Identifier(ctx.alloc(ident))
+    }
+
+    /// Create `AssignmentTarget::AssignmentTargetIdentifier` referencing this binding,
+    /// with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_target<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> AssignmentTarget<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident))
+    }
+
+    /// Create `SimpleAssignmentTarget::AssignmentTargetIdentifier` referencing this binding,
+    /// with specified `Span` and `ReferenceFlags`
+    pub fn create_spanned_simple_target<State>(
+        &self,
+        span: Span,
+        flags: ReferenceFlags,
+        ctx: &mut TraverseCtx<'a, State>,
+    ) -> SimpleAssignmentTarget<'a> {
+        let ident = self.create_spanned_reference(span, flags, ctx);
+        SimpleAssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident))
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -1,0 +1,717 @@
+use oxc_allocator::{Allocator, Box as ArenaBox, Vec as ArenaVec};
+use oxc_ast::{
+    AstBuilder,
+    ast::{Expression, IdentifierReference, Statement},
+};
+use oxc_semantic::Scoping;
+use oxc_span::Span;
+use oxc_str::Ident;
+use oxc_syntax::{
+    reference::{ReferenceFlags, ReferenceId},
+    scope::{ScopeFlags, ScopeId},
+    symbol::{SymbolFlags, SymbolId},
+};
+use oxc_traverse::ast_operations::{GatherNodeParts, get_var_name_from_node};
+
+use crate::{
+    generated::ancestor::{Ancestor, AncestorType},
+    state::MinifierState,
+};
+
+mod ancestry;
+mod bound_identifier;
+mod ecma_context;
+mod maybe_bound_identifier;
+mod reusable;
+mod scopes_collector;
+mod scoping;
+mod uid;
+use ancestry::PopToken;
+pub use ancestry::TraverseAncestry;
+pub use bound_identifier::BoundIdentifier;
+pub use maybe_bound_identifier::MaybeBoundIdentifier;
+pub use reusable::ReusableTraverseCtx;
+pub use scoping::TraverseScoping;
+
+pub type MinifierTraverseCtx<'a> = TraverseCtx<'a, MinifierState<'a>>;
+pub type ReusableMinifierTraverseCtx<'a> = ReusableTraverseCtx<'a, MinifierState<'a>>;
+
+/// Traverse context.
+///
+/// Passed to all AST visitor functions.
+///
+/// Provides ability to:
+/// * Query parent/ancestor of current node via [`parent`], [`ancestor`], [`ancestors`].
+/// * Get scopes tree and symbols table via [`scoping`] and [`scoping_mut`],
+///   [`ancestor_scopes`].
+/// * Create AST nodes via AST builder [`ast`].
+/// * Allocate into arena via [`alloc`].
+///
+/// # Namespaced APIs
+///
+/// All APIs are provided via 2 routes:
+///
+/// 1. Directly on `TraverseCtx`.
+/// 2. Via "namespaces".
+///
+/// | Direct                   | Namespaced                       |
+/// |--------------------------|----------------------------------|
+/// | `ctx.parent()`           | `ctx.ancestry.parent()`          |
+/// | `ctx.current_scope_id()` | `ctx.scoping.current_scope_id()` |
+/// | `ctx.alloc(thing)`       | `ctx.ast.alloc(thing)`           |
+///
+/// Purpose of the "namespaces" is to support if you want to mutate scope tree or symbol table
+/// while holding an `&Ancestor`, or AST nodes obtained from an `&Ancestor`.
+///
+/// For example, this will not compile because it attempts to borrow `ctx`
+/// immutably and mutably at same time:
+///
+/// ```nocompile
+/// use oxc_ast::ast::*;
+/// use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+///
+/// struct MyTransform;
+/// impl<'a> Traverse<'a> for MyTransform {
+///     fn enter_unary_expression(&mut self, unary_expr: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
+///         // `right` is ultimately borrowed from `ctx`
+///         let right = match ctx.parent() {
+///             Ancestor::BinaryExpressionLeft(bin_expr) => bin_expr.right(),
+///             _ => return,
+///         };
+///
+///         // Won't compile! `ctx.scopes_mut()` attempts to mut borrow `ctx`
+///         // while it's already borrowed by `right`.
+///         let scope_tree_mut = ctx.scopes_mut();
+///
+///         // Use `right` later on
+///         dbg!(right);
+///     }
+/// }
+/// ```
+///
+/// You can fix this by using the "namespaced" methods instead.
+/// This works because you can borrow `ctx.ancestry` and `ctx.scoping` simultaneously:
+///
+/// ```
+/// use oxc_ast::ast::*;
+/// use oxc_traverse::{Ancestor, Traverse, TraverseCtx};
+///
+/// struct MyTransform;
+/// impl<'a> Traverse<'a, ()> for MyTransform {
+///     fn enter_unary_expression(&mut self, unary_expr: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a, ()>) {
+///         let right = match ctx.ancestry.parent() {
+///             Ancestor::BinaryExpressionLeft(bin_expr) => bin_expr.right(),
+///             _ => return,
+///         };
+///
+///         let scoping_mut = ctx.scoping.scoping_mut();
+///
+///         dbg!(right);
+///     }
+/// }
+/// ```
+///
+/// [`parent`]: `TraverseCtx::parent`
+/// [`ancestor`]: `TraverseCtx::ancestor`
+/// [`ancestors`]: `TraverseCtx::ancestors`
+/// [`scoping`]: `TraverseCtx::scoping`
+/// [`scoping_mut`]: `TraverseCtx::scoping_mut`
+/// [`ancestor_scopes`]: `TraverseCtx::ancestor_scopes`
+/// [`ast`]: `TraverseCtx::ast`
+/// [`alloc`]: `TraverseCtx::alloc`
+pub struct TraverseCtx<'a, State> {
+    pub state: State,
+    pub ancestry: TraverseAncestry<'a>,
+    pub scoping: TraverseScoping<'a>,
+    pub ast: AstBuilder<'a>,
+}
+
+// Public methods
+impl<'a, State> TraverseCtx<'a, State> {
+    /// Allocate a node in the arena.
+    ///
+    /// Returns a [`Box<'a, T>`](ArenaBox).
+    ///
+    /// Shortcut for `ctx.ast.alloc`.
+    #[inline]
+    pub fn alloc<T>(&self, node: T) -> ArenaBox<'a, T> {
+        self.ast.alloc(node)
+    }
+
+    /// Get parent of current node.
+    ///
+    /// Shortcut for `ctx.ancestry.parent`.
+    #[inline]
+    pub fn parent<'t>(&'t self) -> Ancestor<'a, 't> {
+        self.ancestry.parent()
+    }
+
+    /// Get ancestor of current node.
+    ///
+    /// `level` is number of levels above parent.
+    /// `ancestor(0)` is equivalent to `parent()` (but better to use `parent()` as it's more efficient).
+    ///
+    /// If `level` is out of bounds (above `Program`), returns `Ancestor::None`.
+    ///
+    /// Shortcut for `ctx.ancestry.ancestor`.
+    #[inline]
+    pub fn ancestor<'t>(&'t self, level: usize) -> Ancestor<'a, 't> {
+        self.ancestry.ancestor(level)
+    }
+
+    /// Get iterator over ancestors, starting with parent and working up.
+    ///
+    /// Last `Ancestor` returned will be `Program`. `Ancestor::None` is not included in iteration.
+    ///
+    /// Shortcut for `ctx.ancestry.ancestors`.
+    #[inline]
+    pub fn ancestors<'t>(&'t self) -> impl Iterator<Item = Ancestor<'a, 't>> {
+        self.ancestry.ancestors()
+    }
+
+    /// Get depth in the AST.
+    ///
+    /// Count includes current node. i.e. in `Program`, depth is 1.
+    ///
+    /// Shortcut for `self.ancestry.ancestors_depth`.
+    #[inline]
+    pub fn ancestors_depth(&self) -> usize {
+        self.ancestry.ancestors_depth()
+    }
+
+    /// Get current scope ID.
+    ///
+    /// Shortcut for `ctx.scoping.current_scope_id`.
+    #[inline]
+    pub fn current_scope_id(&self) -> ScopeId {
+        self.scoping.current_scope_id()
+    }
+
+    /// Get current var hoisting scope ID.
+    ///
+    /// Shortcut for `ctx.scoping.current_hoist_scope_id`.
+    #[inline]
+    pub fn current_hoist_scope_id(&self) -> ScopeId {
+        self.scoping.current_hoist_scope_id()
+    }
+
+    /// Get current block scope ID.
+    ///
+    /// Shortcut for `ctx.scoping.current_block_scope_id`.
+    #[inline]
+    pub fn current_block_scope_id(&self) -> ScopeId {
+        self.scoping.current_block_scope_id()
+    }
+
+    /// Get current scope flags.
+    ///
+    /// Shortcut for `ctx.scoping.current_scope_flags`.
+    #[inline]
+    pub fn current_scope_flags(&self) -> ScopeFlags {
+        self.scoping.current_scope_flags()
+    }
+
+    /// Get scopes tree.
+    ///
+    /// Shortcut for `ctx.scoping.scopes`.
+    #[inline]
+    pub fn scoping(&self) -> &Scoping {
+        self.scoping.scoping()
+    }
+
+    /// Get mutable scopes tree.
+    ///
+    /// Shortcut for `ctx.scoping.scopes_mut`.
+    #[inline]
+    pub fn scoping_mut(&mut self) -> &mut Scoping {
+        self.scoping.scoping_mut()
+    }
+
+    /// Get iterator over scopes, starting with current scope and working up.
+    ///
+    /// This is a shortcut for `ctx.scoping.parent_scopes`.
+    #[inline]
+    pub fn ancestor_scopes(&self) -> impl Iterator<Item = ScopeId> + '_ {
+        self.scoping.ancestor_scopes()
+    }
+
+    /// Create new scope as child of provided scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_child_scope`.
+    #[inline]
+    pub fn create_child_scope(&mut self, parent_id: ScopeId, flags: ScopeFlags) -> ScopeId {
+        self.scoping.create_child_scope(parent_id, flags)
+    }
+
+    /// Create new scope as child of current scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_child_scope_of_current`.
+    #[inline]
+    pub fn create_child_scope_of_current(&mut self, flags: ScopeFlags) -> ScopeId {
+        self.scoping.create_child_scope_of_current(flags)
+    }
+
+    /// Insert a scope into scope tree below a statement.
+    ///
+    /// Statement must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.insert_scope_below_statement`.
+    #[inline]
+    pub fn insert_scope_below_statement(&mut self, stmt: &Statement, flags: ScopeFlags) -> ScopeId {
+        self.scoping.insert_scope_below_statement(stmt, flags)
+    }
+
+    /// Insert a scope into scope tree below a statement.
+    ///
+    /// Statement must be in provided scope.
+    /// New scope is created as child of the provided scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.insert_scope_below_statement_from_scope_id`.
+    #[inline]
+    pub fn insert_scope_below_statement_from_scope_id(
+        &mut self,
+        stmt: &Statement,
+        scope_id: ScopeId,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        self.scoping.insert_scope_below_statement_from_scope_id(stmt, scope_id, flags)
+    }
+
+    /// Insert a scope into scope tree below an expression.
+    ///
+    /// Expression must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the expression are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.insert_scope_below_expression`.
+    #[inline]
+    pub fn insert_scope_below_expression(
+        &mut self,
+        expr: &Expression,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        self.scoping.insert_scope_below_expression(expr, flags)
+    }
+
+    /// Insert a scope into scope tree below a `Vec` of statements.
+    ///
+    /// Statements must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.insert_scope_below_statements`.
+    pub fn insert_scope_below_statements(
+        &mut self,
+        stmts: &ArenaVec<Statement>,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        self.scoping.insert_scope_below_statements(stmts, flags)
+    }
+
+    /// Insert a scope between a parent and a child scope.
+    ///
+    /// For example, given the following scopes
+    /// ```ts
+    /// parentScope1: {
+    ///     childScope: { }
+    ///     childScope2: { }
+    /// }
+    /// ```
+    /// and calling this function with `parentScope1` and `childScope`,
+    /// the resulting scopes will be:
+    /// ```ts
+    /// parentScope1: {
+    ///     newScope: {
+    ///         childScope: { }
+    ///     }
+    ///     childScope2: { }
+    /// }
+    /// ```
+    /// This is a shortcut for `ctx.scoping.insert_scope_between`.
+    pub fn insert_scope_between(
+        &mut self,
+        parent_id: ScopeId,
+        child_id: ScopeId,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        self.scoping.insert_scope_between(parent_id, child_id, flags)
+    }
+
+    /// Remove scope for an expression from the scope chain.
+    ///
+    /// Delete the scope and set parent of its child scopes to its parent scope.
+    /// e.g.:
+    /// * Starting scopes parentage `A -> B`, `B -> C`, `B -> D`.
+    /// * Remove scope `B` from chain.
+    /// * End result: scopes `A -> C`, `A -> D`.
+    ///
+    /// Use this when removing an expression which owns a scope, without removing its children.
+    /// For example when unwrapping `(() => foo)()` to just `foo`.
+    /// `foo` here could be an expression which itself contains scopes.
+    ///
+    /// This is a shortcut for `ctx.scoping.remove_scope_for_expression`.
+    pub fn remove_scope_for_expression(&mut self, scope_id: ScopeId, expr: &Expression) {
+        self.scoping.remove_scope_for_expression(scope_id, expr);
+    }
+
+    /// Generate binding.
+    ///
+    /// Creates a symbol with the provided name and flags and adds it to the specified scope.
+    ///
+    /// This is a shortcut for `ctx.scoping.generate_binding`.
+    pub fn generate_binding(
+        &mut self,
+        name: Ident<'a>,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.scoping.generate_binding(name, scope_id, flags)
+    }
+
+    /// Generate binding in current scope.
+    ///
+    /// Creates a symbol with the provided name and flags and adds it to the current scope.
+    ///
+    /// This is a shortcut for `ctx.scoping.generate_binding_in_current_scope`.
+    pub fn generate_binding_in_current_scope(
+        &mut self,
+        name: Ident<'a>,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.scoping.generate_binding_in_current_scope(name, flags)
+    }
+
+    /// Generate UID var name.
+    ///
+    /// Finds a unique variable name which does clash with any other variables used in the program.
+    ///
+    /// See [`TraverseScoping::generate_uid_name`] for important information on how UIDs are generated.
+    /// There are some potential "gotchas".
+    ///
+    /// This is a shortcut for `ctx.scoping.generate_uid_name`.
+    pub fn generate_uid_name(&mut self, name: &str) -> Ident<'a> {
+        self.scoping.generate_uid_name(name, self.ast.allocator)
+    }
+
+    /// Generate UID.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid(
+        &mut self,
+        name: &str,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        // Get name for UID
+        let name = self.generate_uid_name(name);
+        let symbol_id = self.scoping.add_binding(name, scope_id, flags);
+        BoundIdentifier::new(name, symbol_id)
+    }
+
+    /// Generate UID in current scope.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid_in_current_scope(
+        &mut self,
+        name: &str,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.generate_uid(name, self.current_scope_id(), flags)
+    }
+
+    /// Generate UID in root scope.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid_in_root_scope(
+        &mut self,
+        name: &str,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.generate_uid(name, self.scoping().root_scope_id(), flags)
+    }
+
+    /// Generate UID based on node.
+    ///
+    /// Recursively gathers the identifying names of a node, and joins them with `$`.
+    ///
+    /// Based on Babel's `scope.generateUidBasedOnNode` logic.
+    /// <https://github.com/babel/babel/blob/419644f27c5c59deb19e71aaabd417a3bc5483ca/packages/babel-traverse/src/scope/index.ts#L543>
+    #[inline]
+    pub fn generate_uid_based_on_node<N: GatherNodeParts<'a>>(
+        &mut self,
+        node: &N,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        let name = get_var_name_from_node(node);
+        self.generate_uid(&name, scope_id, flags)
+    }
+
+    /// Generate UID in current scope based on node.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid_in_current_scope_based_on_node<N: GatherNodeParts<'a>>(
+        &mut self,
+        node: &N,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.generate_uid_based_on_node(node, self.current_scope_id(), flags)
+    }
+
+    /// Generate UID in current hoist scope.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid_in_current_hoist_scope(&mut self, name: &str) -> BoundIdentifier<'a> {
+        self.generate_uid(name, self.current_hoist_scope_id(), SymbolFlags::FunctionScopedVariable)
+    }
+
+    /// Generate UID in current hoist scope based on node.
+    ///
+    /// See also comments on [`TraverseScoping::generate_uid_name`] for important information
+    /// on how UIDs are generated. There are some potential "gotchas".
+    #[inline]
+    pub fn generate_uid_in_current_hoist_scope_based_on_node<N: GatherNodeParts<'a>>(
+        &mut self,
+        node: &N,
+    ) -> BoundIdentifier<'a> {
+        let name = get_var_name_from_node(node);
+        self.generate_uid_in_current_hoist_scope(&name)
+    }
+
+    /// Create a reference bound to a `SymbolId`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_bound_reference`.
+    #[inline]
+    pub fn create_bound_reference(
+        &mut self,
+        symbol_id: SymbolId,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        self.scoping.create_bound_reference(symbol_id, flags)
+    }
+
+    /// Create an `IdentifierReference` bound to a `SymbolId`.
+    pub fn create_bound_ident_reference(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        symbol_id: SymbolId,
+        flags: ReferenceFlags,
+    ) -> IdentifierReference<'a> {
+        let reference_id = self.create_bound_reference(symbol_id, flags);
+        self.ast.identifier_reference_with_reference_id(span, name, reference_id)
+    }
+
+    /// Create an `Expression::Identifier` bound to a `SymbolId`.
+    pub fn create_bound_ident_expr(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        symbol_id: SymbolId,
+        flags: ReferenceFlags,
+    ) -> Expression<'a> {
+        let ident = self.create_bound_ident_reference(span, name, symbol_id, flags);
+        Expression::Identifier(self.ast.alloc(ident))
+    }
+
+    /// Create an unbound reference.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_unbound_reference`.
+    #[inline]
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        self.scoping.create_unbound_reference(name, flags)
+    }
+
+    /// Create an unbound `IdentifierReference`.
+    pub fn create_unbound_ident_reference(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        flags: ReferenceFlags,
+    ) -> IdentifierReference<'a> {
+        let reference_id = self.create_unbound_reference(name, flags);
+        self.ast.identifier_reference_with_reference_id(span, name, reference_id)
+    }
+
+    /// Create an unbound `Expression::Identifier`.
+    pub fn create_unbound_ident_expr(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        flags: ReferenceFlags,
+    ) -> Expression<'a> {
+        let ident = self.create_unbound_ident_reference(span, name, flags);
+        Expression::Identifier(self.ast.alloc(ident))
+    }
+
+    /// Create a reference optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_reference`
+    /// or `TraverseCtx::create_unbound_reference`.
+    ///
+    /// This is a shortcut for `ctx.scoping.create_reference`.
+    #[inline]
+    pub fn create_reference(
+        &mut self,
+        name: Ident<'_>,
+        symbol_id: Option<SymbolId>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        self.scoping.create_reference(name, symbol_id, flags)
+    }
+
+    /// Create an `IdentifierReference` optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_ident_reference`
+    /// or `TraverseCtx::create_unbound_ident_reference`.
+    pub fn create_ident_reference(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        symbol_id: Option<SymbolId>,
+        flags: ReferenceFlags,
+    ) -> IdentifierReference<'a> {
+        if let Some(symbol_id) = symbol_id {
+            self.create_bound_ident_reference(span, name, symbol_id, flags)
+        } else {
+            self.create_unbound_ident_reference(span, name, flags)
+        }
+    }
+
+    /// Create an `Expression::Identifier` optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_ident_expr`
+    /// or `TraverseCtx::create_unbound_ident_expr`.
+    pub fn create_ident_expr(
+        &mut self,
+        span: Span,
+        name: Ident<'a>,
+        symbol_id: Option<SymbolId>,
+        flags: ReferenceFlags,
+    ) -> Expression<'a> {
+        if let Some(symbol_id) = symbol_id {
+            self.create_bound_ident_expr(span, name, symbol_id, flags)
+        } else {
+            self.create_unbound_ident_expr(span, name, flags)
+        }
+    }
+
+    /// Create reference in current scope, looking up binding for `name`,
+    ///
+    /// This is a shortcut for `ctx.scoping.create_reference_in_current_scope`.
+    #[inline]
+    pub fn create_reference_in_current_scope(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        self.scoping.create_reference_in_current_scope(name, flags)
+    }
+
+    /// Delete a reference.
+    ///
+    /// Provided `name` must match `reference_id`.
+    ///
+    /// This is a shortcut for `ctx.scoping.delete_reference`.
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
+        self.scoping.delete_reference(reference_id, name);
+    }
+
+    /// Delete reference for an `IdentifierReference`.
+    ///
+    /// This is a shortcut for `ctx.scoping.delete_reference_for_identifier`.
+    pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
+        self.scoping.delete_reference_for_identifier(ident);
+    }
+}
+
+// Methods used internally within crate
+impl<'a, State> TraverseCtx<'a, State> {
+    /// Create new traversal context.
+    ///
+    /// # SAFETY
+    /// This function must not be public to maintain soundness of [`TraverseAncestry`].
+    pub(crate) fn new(state: State, scoping: Scoping, allocator: &'a Allocator) -> Self {
+        let ancestry = TraverseAncestry::new();
+        let scoping = TraverseScoping::new(scoping);
+        let ast = AstBuilder::new(allocator);
+        Self { state, ancestry, scoping, ast }
+    }
+
+    /// Shortcut for `self.ancestry.push_stack`, to make `walk_*` methods less verbose.
+    ///
+    /// # SAFETY
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    pub(crate) fn push_stack(&mut self, ancestor: Ancestor<'a, 'static>) -> PopToken {
+        self.ancestry.push_stack(ancestor)
+    }
+
+    /// Shortcut for `self.ancestry.pop_stack`, to make `walk_*` methods less verbose.
+    ///
+    /// # SAFETY
+    /// See safety constraints of `TraverseAncestry.pop_stack`.
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    pub(crate) unsafe fn pop_stack(&mut self, token: PopToken) {
+        self.ancestry.pop_stack(token);
+    }
+
+    /// Shortcut for `self.ancestry.retag_stack`, to make `walk_*` methods less verbose.
+    ///
+    /// # SAFETY
+    /// See safety constraints of `TraverseAncestry.retag_stack`.
+    /// This method must not be public outside this crate, or consumer could break safety invariants.
+    #[inline]
+    pub(crate) unsafe fn retag_stack(&mut self, ty: AncestorType) {
+        // SAFETY: Caller muct uphold safety constraints
+        unsafe { self.ancestry.retag_stack(ty) };
+    }
+
+    /// Shortcut for `ctx.scoping.set_current_scope_id`, to make `walk_*` methods less verbose.
+    #[inline]
+    pub(crate) fn set_current_scope_id(&mut self, scope_id: ScopeId) {
+        self.scoping.set_current_scope_id(scope_id);
+    }
+
+    /// Shortcut for `ctx.scoping.set_current_hoist_scope_id`, to make `walk_*` methods less verbose.
+    #[inline]
+    pub(crate) fn set_current_hoist_scope_id(&mut self, scope_id: ScopeId) {
+        self.scoping.set_current_hoist_scope_id(scope_id);
+    }
+
+    /// Shortcut for `ctx.scoping.set_current_block_scope_id`, to make `walk_*` methods less verbose.
+    #[inline]
+    pub(crate) fn set_current_block_scope_id(&mut self, scope_id: ScopeId) {
+        self.scoping.set_current_block_scope_id(scope_id);
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/scopes_collector.rs
+++ b/crates/oxc_minifier/src/traverse_context/scopes_collector.rs
@@ -1,0 +1,2027 @@
+// Auto-generated code, DO NOT EDIT DIRECTLY!
+// To edit this generated file you have to edit `tasks/ast_tools/src/generators/scopes_collector.rs`.
+
+#![expect(
+    unused_variables,
+    clippy::semicolon_if_nothing_returned,
+    clippy::match_wildcard_for_single_variants,
+    clippy::match_same_arms,
+    clippy::single_match_else
+)]
+
+use std::cell::Cell;
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_syntax::scope::{ScopeFlags, ScopeId};
+
+/// Visitor that locates all child scopes.
+///
+/// Note: Direct child scopes only, not grandchild scopes.
+/// Does not do full traversal - stops each time it hits a node with a scope.
+pub struct ChildScopeCollector {
+    pub(crate) scope_ids: Vec<ScopeId>,
+}
+
+impl ChildScopeCollector {
+    pub(crate) fn new() -> Self {
+        Self { scope_ids: vec![] }
+    }
+
+    pub(crate) fn add_scope(&mut self, scope_id: &Cell<Option<ScopeId>>) {
+        self.scope_ids.push(scope_id.get().unwrap());
+    }
+}
+
+impl<'a> Visit<'a> for ChildScopeCollector {
+    #[inline]
+    fn visit_program(&mut self, it: &Program<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    fn visit_expression(&mut self, it: &Expression<'a>) {
+        match it {
+            Expression::TemplateLiteral(it) => self.visit_template_literal(it),
+            Expression::ArrayExpression(it) => self.visit_array_expression(it),
+            Expression::ArrowFunctionExpression(it) => self.visit_arrow_function_expression(it),
+            Expression::AssignmentExpression(it) => self.visit_assignment_expression(it),
+            Expression::AwaitExpression(it) => self.visit_await_expression(it),
+            Expression::BinaryExpression(it) => self.visit_binary_expression(it),
+            Expression::CallExpression(it) => self.visit_call_expression(it),
+            Expression::ChainExpression(it) => self.visit_chain_expression(it),
+            Expression::ClassExpression(it) => self.visit_class(it),
+            Expression::ConditionalExpression(it) => self.visit_conditional_expression(it),
+            Expression::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            Expression::ImportExpression(it) => self.visit_import_expression(it),
+            Expression::LogicalExpression(it) => self.visit_logical_expression(it),
+            Expression::NewExpression(it) => self.visit_new_expression(it),
+            Expression::ObjectExpression(it) => self.visit_object_expression(it),
+            Expression::ParenthesizedExpression(it) => self.visit_parenthesized_expression(it),
+            Expression::SequenceExpression(it) => self.visit_sequence_expression(it),
+            Expression::TaggedTemplateExpression(it) => self.visit_tagged_template_expression(it),
+            Expression::UnaryExpression(it) => self.visit_unary_expression(it),
+            Expression::UpdateExpression(it) => self.visit_update_expression(it),
+            Expression::YieldExpression(it) => self.visit_yield_expression(it),
+            Expression::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            Expression::JSXElement(it) => self.visit_jsx_element(it),
+            Expression::JSXFragment(it) => self.visit_jsx_fragment(it),
+            Expression::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            Expression::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            Expression::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            Expression::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            Expression::TSInstantiationExpression(it) => self.visit_ts_instantiation_expression(it),
+            Expression::V8IntrinsicExpression(it) => self.visit_v8_intrinsic_expression(it),
+            Expression::ComputedMemberExpression(it) => self.visit_computed_member_expression(it),
+            Expression::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            Expression::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_identifier_name(&mut self, it: &IdentifierName<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_label_identifier(&mut self, it: &LabelIdentifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_this_expression(&mut self, it: &ThisExpression) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_array_expression(&mut self, it: &ArrayExpression<'a>) {
+        self.visit_array_expression_elements(&it.elements);
+    }
+
+    fn visit_array_expression_element(&mut self, it: &ArrayExpressionElement<'a>) {
+        match it {
+            ArrayExpressionElement::SpreadElement(it) => self.visit_spread_element(it),
+            ArrayExpressionElement::TemplateLiteral(it) => self.visit_template_literal(it),
+            ArrayExpressionElement::ArrayExpression(it) => self.visit_array_expression(it),
+            ArrayExpressionElement::ArrowFunctionExpression(it) => {
+                self.visit_arrow_function_expression(it)
+            }
+            ArrayExpressionElement::AssignmentExpression(it) => {
+                self.visit_assignment_expression(it)
+            }
+            ArrayExpressionElement::AwaitExpression(it) => self.visit_await_expression(it),
+            ArrayExpressionElement::BinaryExpression(it) => self.visit_binary_expression(it),
+            ArrayExpressionElement::CallExpression(it) => self.visit_call_expression(it),
+            ArrayExpressionElement::ChainExpression(it) => self.visit_chain_expression(it),
+            ArrayExpressionElement::ClassExpression(it) => self.visit_class(it),
+            ArrayExpressionElement::ConditionalExpression(it) => {
+                self.visit_conditional_expression(it)
+            }
+            ArrayExpressionElement::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            ArrayExpressionElement::ImportExpression(it) => self.visit_import_expression(it),
+            ArrayExpressionElement::LogicalExpression(it) => self.visit_logical_expression(it),
+            ArrayExpressionElement::NewExpression(it) => self.visit_new_expression(it),
+            ArrayExpressionElement::ObjectExpression(it) => self.visit_object_expression(it),
+            ArrayExpressionElement::ParenthesizedExpression(it) => {
+                self.visit_parenthesized_expression(it)
+            }
+            ArrayExpressionElement::SequenceExpression(it) => self.visit_sequence_expression(it),
+            ArrayExpressionElement::TaggedTemplateExpression(it) => {
+                self.visit_tagged_template_expression(it)
+            }
+            ArrayExpressionElement::UnaryExpression(it) => self.visit_unary_expression(it),
+            ArrayExpressionElement::UpdateExpression(it) => self.visit_update_expression(it),
+            ArrayExpressionElement::YieldExpression(it) => self.visit_yield_expression(it),
+            ArrayExpressionElement::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            ArrayExpressionElement::JSXElement(it) => self.visit_jsx_element(it),
+            ArrayExpressionElement::JSXFragment(it) => self.visit_jsx_fragment(it),
+            ArrayExpressionElement::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            ArrayExpressionElement::TSSatisfiesExpression(it) => {
+                self.visit_ts_satisfies_expression(it)
+            }
+            ArrayExpressionElement::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            ArrayExpressionElement::TSNonNullExpression(it) => {
+                self.visit_ts_non_null_expression(it)
+            }
+            ArrayExpressionElement::TSInstantiationExpression(it) => {
+                self.visit_ts_instantiation_expression(it)
+            }
+            ArrayExpressionElement::V8IntrinsicExpression(it) => {
+                self.visit_v8_intrinsic_expression(it)
+            }
+            ArrayExpressionElement::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            ArrayExpressionElement::StaticMemberExpression(it) => {
+                self.visit_static_member_expression(it)
+            }
+            ArrayExpressionElement::PrivateFieldExpression(it) => {
+                self.visit_private_field_expression(it)
+            }
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `Elision`
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_elision(&mut self, it: &Elision) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_object_expression(&mut self, it: &ObjectExpression<'a>) {
+        self.visit_object_property_kinds(&it.properties);
+    }
+
+    #[inline]
+    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
+        self.visit_property_key(&it.key);
+        self.visit_expression(&it.value);
+    }
+
+    fn visit_property_key(&mut self, it: &PropertyKey<'a>) {
+        match it {
+            PropertyKey::TemplateLiteral(it) => self.visit_template_literal(it),
+            PropertyKey::ArrayExpression(it) => self.visit_array_expression(it),
+            PropertyKey::ArrowFunctionExpression(it) => self.visit_arrow_function_expression(it),
+            PropertyKey::AssignmentExpression(it) => self.visit_assignment_expression(it),
+            PropertyKey::AwaitExpression(it) => self.visit_await_expression(it),
+            PropertyKey::BinaryExpression(it) => self.visit_binary_expression(it),
+            PropertyKey::CallExpression(it) => self.visit_call_expression(it),
+            PropertyKey::ChainExpression(it) => self.visit_chain_expression(it),
+            PropertyKey::ClassExpression(it) => self.visit_class(it),
+            PropertyKey::ConditionalExpression(it) => self.visit_conditional_expression(it),
+            PropertyKey::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            PropertyKey::ImportExpression(it) => self.visit_import_expression(it),
+            PropertyKey::LogicalExpression(it) => self.visit_logical_expression(it),
+            PropertyKey::NewExpression(it) => self.visit_new_expression(it),
+            PropertyKey::ObjectExpression(it) => self.visit_object_expression(it),
+            PropertyKey::ParenthesizedExpression(it) => self.visit_parenthesized_expression(it),
+            PropertyKey::SequenceExpression(it) => self.visit_sequence_expression(it),
+            PropertyKey::TaggedTemplateExpression(it) => self.visit_tagged_template_expression(it),
+            PropertyKey::UnaryExpression(it) => self.visit_unary_expression(it),
+            PropertyKey::UpdateExpression(it) => self.visit_update_expression(it),
+            PropertyKey::YieldExpression(it) => self.visit_yield_expression(it),
+            PropertyKey::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            PropertyKey::JSXElement(it) => self.visit_jsx_element(it),
+            PropertyKey::JSXFragment(it) => self.visit_jsx_fragment(it),
+            PropertyKey::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            PropertyKey::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            PropertyKey::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            PropertyKey::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            PropertyKey::TSInstantiationExpression(it) => {
+                self.visit_ts_instantiation_expression(it)
+            }
+            PropertyKey::V8IntrinsicExpression(it) => self.visit_v8_intrinsic_expression(it),
+            PropertyKey::ComputedMemberExpression(it) => self.visit_computed_member_expression(it),
+            PropertyKey::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            PropertyKey::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `StaticIdentifier`
+                // `PrivateIdentifier`
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {
+        self.visit_expressions(&it.expressions);
+    }
+
+    #[inline]
+    fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
+        self.visit_expression(&it.tag);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_template_literal(&it.quasi);
+    }
+
+    #[inline(always)]
+    fn visit_template_element(&mut self, it: &TemplateElement<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_computed_member_expression(&mut self, it: &ComputedMemberExpression<'a>) {
+        self.visit_expression(&it.object);
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        self.visit_expression(&it.object);
+    }
+
+    #[inline]
+    fn visit_private_field_expression(&mut self, it: &PrivateFieldExpression<'a>) {
+        self.visit_expression(&it.object);
+    }
+
+    #[inline]
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        self.visit_expression(&it.callee);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_arguments(&it.arguments);
+    }
+
+    #[inline]
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        self.visit_expression(&it.callee);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_arguments(&it.arguments);
+    }
+
+    #[inline(always)]
+    fn visit_meta_property(&mut self, it: &MetaProperty<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_spread_element(&mut self, it: &SpreadElement<'a>) {
+        self.visit_expression(&it.argument);
+    }
+
+    fn visit_argument(&mut self, it: &Argument<'a>) {
+        match it {
+            Argument::SpreadElement(it) => self.visit_spread_element(it),
+            Argument::TemplateLiteral(it) => self.visit_template_literal(it),
+            Argument::ArrayExpression(it) => self.visit_array_expression(it),
+            Argument::ArrowFunctionExpression(it) => self.visit_arrow_function_expression(it),
+            Argument::AssignmentExpression(it) => self.visit_assignment_expression(it),
+            Argument::AwaitExpression(it) => self.visit_await_expression(it),
+            Argument::BinaryExpression(it) => self.visit_binary_expression(it),
+            Argument::CallExpression(it) => self.visit_call_expression(it),
+            Argument::ChainExpression(it) => self.visit_chain_expression(it),
+            Argument::ClassExpression(it) => self.visit_class(it),
+            Argument::ConditionalExpression(it) => self.visit_conditional_expression(it),
+            Argument::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            Argument::ImportExpression(it) => self.visit_import_expression(it),
+            Argument::LogicalExpression(it) => self.visit_logical_expression(it),
+            Argument::NewExpression(it) => self.visit_new_expression(it),
+            Argument::ObjectExpression(it) => self.visit_object_expression(it),
+            Argument::ParenthesizedExpression(it) => self.visit_parenthesized_expression(it),
+            Argument::SequenceExpression(it) => self.visit_sequence_expression(it),
+            Argument::TaggedTemplateExpression(it) => self.visit_tagged_template_expression(it),
+            Argument::UnaryExpression(it) => self.visit_unary_expression(it),
+            Argument::UpdateExpression(it) => self.visit_update_expression(it),
+            Argument::YieldExpression(it) => self.visit_yield_expression(it),
+            Argument::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            Argument::JSXElement(it) => self.visit_jsx_element(it),
+            Argument::JSXFragment(it) => self.visit_jsx_fragment(it),
+            Argument::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            Argument::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            Argument::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            Argument::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            Argument::TSInstantiationExpression(it) => self.visit_ts_instantiation_expression(it),
+            Argument::V8IntrinsicExpression(it) => self.visit_v8_intrinsic_expression(it),
+            Argument::ComputedMemberExpression(it) => self.visit_computed_member_expression(it),
+            Argument::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            Argument::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
+        self.visit_simple_assignment_target(&it.argument);
+    }
+
+    #[inline]
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        self.visit_expression(&it.argument);
+    }
+
+    #[inline]
+    fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
+        self.visit_expression(&it.left);
+        self.visit_expression(&it.right);
+    }
+
+    #[inline]
+    fn visit_private_in_expression(&mut self, it: &PrivateInExpression<'a>) {
+        self.visit_expression(&it.right);
+    }
+
+    #[inline]
+    fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
+        self.visit_expression(&it.left);
+        self.visit_expression(&it.right);
+    }
+
+    #[inline]
+    fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
+        self.visit_expression(&it.test);
+        self.visit_expression(&it.consequent);
+        self.visit_expression(&it.alternate);
+    }
+
+    #[inline]
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        self.visit_assignment_target(&it.left);
+        self.visit_expression(&it.right);
+    }
+
+    fn visit_assignment_target(&mut self, it: &AssignmentTarget<'a>) {
+        match it {
+            AssignmentTarget::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            AssignmentTarget::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            AssignmentTarget::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            AssignmentTarget::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            AssignmentTarget::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            AssignmentTarget::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            AssignmentTarget::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            AssignmentTarget::ArrayAssignmentTarget(it) => self.visit_array_assignment_target(it),
+            AssignmentTarget::ObjectAssignmentTarget(it) => self.visit_object_assignment_target(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `AssignmentTargetIdentifier`
+            }
+        }
+    }
+
+    fn visit_simple_assignment_target(&mut self, it: &SimpleAssignmentTarget<'a>) {
+        match it {
+            SimpleAssignmentTarget::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            SimpleAssignmentTarget::TSSatisfiesExpression(it) => {
+                self.visit_ts_satisfies_expression(it)
+            }
+            SimpleAssignmentTarget::TSNonNullExpression(it) => {
+                self.visit_ts_non_null_expression(it)
+            }
+            SimpleAssignmentTarget::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            SimpleAssignmentTarget::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            SimpleAssignmentTarget::StaticMemberExpression(it) => {
+                self.visit_static_member_expression(it)
+            }
+            SimpleAssignmentTarget::PrivateFieldExpression(it) => {
+                self.visit_private_field_expression(it)
+            }
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `AssignmentTargetIdentifier`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_array_assignment_target(&mut self, it: &ArrayAssignmentTarget<'a>) {
+        for el in it.elements.iter().flatten() {
+            self.visit_assignment_target_maybe_default(el);
+        }
+        if let Some(rest) = &it.rest {
+            self.visit_assignment_target_rest(rest);
+        }
+    }
+
+    #[inline]
+    fn visit_object_assignment_target(&mut self, it: &ObjectAssignmentTarget<'a>) {
+        self.visit_assignment_target_properties(&it.properties);
+        if let Some(rest) = &it.rest {
+            self.visit_assignment_target_rest(rest);
+        }
+    }
+
+    #[inline]
+    fn visit_assignment_target_rest(&mut self, it: &AssignmentTargetRest<'a>) {
+        self.visit_assignment_target(&it.target);
+    }
+
+    fn visit_assignment_target_maybe_default(&mut self, it: &AssignmentTargetMaybeDefault<'a>) {
+        match it {
+            AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(it) => {
+                self.visit_assignment_target_with_default(it)
+            }
+            AssignmentTargetMaybeDefault::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            AssignmentTargetMaybeDefault::TSSatisfiesExpression(it) => {
+                self.visit_ts_satisfies_expression(it)
+            }
+            AssignmentTargetMaybeDefault::TSNonNullExpression(it) => {
+                self.visit_ts_non_null_expression(it)
+            }
+            AssignmentTargetMaybeDefault::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            AssignmentTargetMaybeDefault::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            AssignmentTargetMaybeDefault::StaticMemberExpression(it) => {
+                self.visit_static_member_expression(it)
+            }
+            AssignmentTargetMaybeDefault::PrivateFieldExpression(it) => {
+                self.visit_private_field_expression(it)
+            }
+            AssignmentTargetMaybeDefault::ArrayAssignmentTarget(it) => {
+                self.visit_array_assignment_target(it)
+            }
+            AssignmentTargetMaybeDefault::ObjectAssignmentTarget(it) => {
+                self.visit_object_assignment_target(it)
+            }
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `AssignmentTargetIdentifier`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_assignment_target_with_default(&mut self, it: &AssignmentTargetWithDefault<'a>) {
+        self.visit_assignment_target(&it.binding);
+        self.visit_expression(&it.init);
+    }
+
+    #[inline]
+    fn visit_assignment_target_property_identifier(
+        &mut self,
+        it: &AssignmentTargetPropertyIdentifier<'a>,
+    ) {
+        if let Some(init) = &it.init {
+            self.visit_expression(init);
+        }
+    }
+
+    #[inline]
+    fn visit_assignment_target_property_property(
+        &mut self,
+        it: &AssignmentTargetPropertyProperty<'a>,
+    ) {
+        self.visit_property_key(&it.name);
+        self.visit_assignment_target_maybe_default(&it.binding);
+    }
+
+    #[inline]
+    fn visit_sequence_expression(&mut self, it: &SequenceExpression<'a>) {
+        self.visit_expressions(&it.expressions);
+    }
+
+    #[inline(always)]
+    fn visit_super(&mut self, it: &Super) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_await_expression(&mut self, it: &AwaitExpression<'a>) {
+        self.visit_expression(&it.argument);
+    }
+
+    #[inline]
+    fn visit_chain_expression(&mut self, it: &ChainExpression<'a>) {
+        self.visit_chain_element(&it.expression);
+    }
+
+    #[inline]
+    fn visit_parenthesized_expression(&mut self, it: &ParenthesizedExpression<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        match it {
+            Statement::BlockStatement(it) => self.visit_block_statement(it),
+            Statement::DoWhileStatement(it) => self.visit_do_while_statement(it),
+            Statement::ExpressionStatement(it) => self.visit_expression_statement(it),
+            Statement::ForInStatement(it) => self.visit_for_in_statement(it),
+            Statement::ForOfStatement(it) => self.visit_for_of_statement(it),
+            Statement::ForStatement(it) => self.visit_for_statement(it),
+            Statement::IfStatement(it) => self.visit_if_statement(it),
+            Statement::LabeledStatement(it) => self.visit_labeled_statement(it),
+            Statement::ReturnStatement(it) => self.visit_return_statement(it),
+            Statement::SwitchStatement(it) => self.visit_switch_statement(it),
+            Statement::ThrowStatement(it) => self.visit_throw_statement(it),
+            Statement::TryStatement(it) => self.visit_try_statement(it),
+            Statement::WhileStatement(it) => self.visit_while_statement(it),
+            Statement::WithStatement(it) => self.visit_with_statement(it),
+            Statement::VariableDeclaration(it) => self.visit_variable_declaration(it),
+            Statement::FunctionDeclaration(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            Statement::ClassDeclaration(it) => self.visit_class(it),
+            Statement::TSTypeAliasDeclaration(it) => self.visit_ts_type_alias_declaration(it),
+            Statement::TSInterfaceDeclaration(it) => self.visit_ts_interface_declaration(it),
+            Statement::TSEnumDeclaration(it) => self.visit_ts_enum_declaration(it),
+            Statement::TSModuleDeclaration(it) => self.visit_ts_module_declaration(it),
+            Statement::TSGlobalDeclaration(it) => self.visit_ts_global_declaration(it),
+            Statement::ExportDefaultDeclaration(it) => self.visit_export_default_declaration(it),
+            Statement::ExportNamedDeclaration(it) => self.visit_export_named_declaration(it),
+            Statement::TSExportAssignment(it) => self.visit_ts_export_assignment(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BreakStatement`
+                // `ContinueStatement`
+                // `DebuggerStatement`
+                // `EmptyStatement`
+                // `TSImportEqualsDeclaration`
+                // `ImportDeclaration`
+                // `ExportAllDeclaration`
+                // `TSNamespaceExportDeclaration`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_directive(&mut self, it: &Directive<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_hashbang(&mut self, it: &Hashbang<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    fn visit_declaration(&mut self, it: &Declaration<'a>) {
+        match it {
+            Declaration::VariableDeclaration(it) => self.visit_variable_declaration(it),
+            Declaration::FunctionDeclaration(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            Declaration::ClassDeclaration(it) => self.visit_class(it),
+            Declaration::TSTypeAliasDeclaration(it) => self.visit_ts_type_alias_declaration(it),
+            Declaration::TSInterfaceDeclaration(it) => self.visit_ts_interface_declaration(it),
+            Declaration::TSEnumDeclaration(it) => self.visit_ts_enum_declaration(it),
+            Declaration::TSModuleDeclaration(it) => self.visit_ts_module_declaration(it),
+            Declaration::TSGlobalDeclaration(it) => self.visit_ts_global_declaration(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `TSImportEqualsDeclaration`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
+        self.visit_variable_declarators(&it.declarations);
+    }
+
+    #[inline]
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        self.visit_binding_pattern(&it.id);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(init) = &it.init {
+            self.visit_expression(init);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_empty_statement(&mut self, it: &EmptyStatement) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
+        self.visit_expression(&it.test);
+        self.visit_statement(&it.consequent);
+        if let Some(alternate) = &it.alternate {
+            self.visit_statement(alternate);
+        }
+    }
+
+    #[inline]
+    fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
+        self.visit_statement(&it.body);
+        self.visit_expression(&it.test);
+    }
+
+    #[inline]
+    fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
+        self.visit_expression(&it.test);
+        self.visit_statement(&it.body);
+    }
+
+    #[inline]
+    fn visit_for_statement(&mut self, it: &ForStatement<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    fn visit_for_statement_init(&mut self, it: &ForStatementInit<'a>) {
+        match it {
+            ForStatementInit::VariableDeclaration(it) => self.visit_variable_declaration(it),
+            ForStatementInit::TemplateLiteral(it) => self.visit_template_literal(it),
+            ForStatementInit::ArrayExpression(it) => self.visit_array_expression(it),
+            ForStatementInit::ArrowFunctionExpression(it) => {
+                self.visit_arrow_function_expression(it)
+            }
+            ForStatementInit::AssignmentExpression(it) => self.visit_assignment_expression(it),
+            ForStatementInit::AwaitExpression(it) => self.visit_await_expression(it),
+            ForStatementInit::BinaryExpression(it) => self.visit_binary_expression(it),
+            ForStatementInit::CallExpression(it) => self.visit_call_expression(it),
+            ForStatementInit::ChainExpression(it) => self.visit_chain_expression(it),
+            ForStatementInit::ClassExpression(it) => self.visit_class(it),
+            ForStatementInit::ConditionalExpression(it) => self.visit_conditional_expression(it),
+            ForStatementInit::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            ForStatementInit::ImportExpression(it) => self.visit_import_expression(it),
+            ForStatementInit::LogicalExpression(it) => self.visit_logical_expression(it),
+            ForStatementInit::NewExpression(it) => self.visit_new_expression(it),
+            ForStatementInit::ObjectExpression(it) => self.visit_object_expression(it),
+            ForStatementInit::ParenthesizedExpression(it) => {
+                self.visit_parenthesized_expression(it)
+            }
+            ForStatementInit::SequenceExpression(it) => self.visit_sequence_expression(it),
+            ForStatementInit::TaggedTemplateExpression(it) => {
+                self.visit_tagged_template_expression(it)
+            }
+            ForStatementInit::UnaryExpression(it) => self.visit_unary_expression(it),
+            ForStatementInit::UpdateExpression(it) => self.visit_update_expression(it),
+            ForStatementInit::YieldExpression(it) => self.visit_yield_expression(it),
+            ForStatementInit::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            ForStatementInit::JSXElement(it) => self.visit_jsx_element(it),
+            ForStatementInit::JSXFragment(it) => self.visit_jsx_fragment(it),
+            ForStatementInit::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            ForStatementInit::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            ForStatementInit::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            ForStatementInit::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            ForStatementInit::TSInstantiationExpression(it) => {
+                self.visit_ts_instantiation_expression(it)
+            }
+            ForStatementInit::V8IntrinsicExpression(it) => self.visit_v8_intrinsic_expression(it),
+            ForStatementInit::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            ForStatementInit::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            ForStatementInit::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    fn visit_for_statement_left(&mut self, it: &ForStatementLeft<'a>) {
+        match it {
+            ForStatementLeft::VariableDeclaration(it) => self.visit_variable_declaration(it),
+            ForStatementLeft::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            ForStatementLeft::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            ForStatementLeft::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            ForStatementLeft::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            ForStatementLeft::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            ForStatementLeft::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            ForStatementLeft::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            ForStatementLeft::ArrayAssignmentTarget(it) => self.visit_array_assignment_target(it),
+            ForStatementLeft::ObjectAssignmentTarget(it) => self.visit_object_assignment_target(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `AssignmentTargetIdentifier`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline(always)]
+    fn visit_continue_statement(&mut self, it: &ContinueStatement<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_break_statement(&mut self, it: &BreakStatement<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_return_statement(&mut self, it: &ReturnStatement<'a>) {
+        if let Some(argument) = &it.argument {
+            self.visit_expression(argument);
+        }
+    }
+
+    #[inline]
+    fn visit_with_statement(&mut self, it: &WithStatement<'a>) {
+        self.visit_expression(&it.object);
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
+        self.visit_expression(&it.discriminant);
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
+        if let Some(test) = &it.test {
+            self.visit_expression(test);
+        }
+        self.visit_statements(&it.consequent);
+    }
+
+    #[inline]
+    fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {
+        self.visit_statement(&it.body);
+    }
+
+    #[inline]
+    fn visit_throw_statement(&mut self, it: &ThrowStatement<'a>) {
+        self.visit_expression(&it.argument);
+    }
+
+    #[inline]
+    fn visit_try_statement(&mut self, it: &TryStatement<'a>) {
+        self.visit_block_statement(&it.block);
+        if let Some(handler) = &it.handler {
+            self.visit_catch_clause(handler);
+        }
+        if let Some(finalizer) = &it.finalizer {
+            self.visit_block_statement(finalizer);
+        }
+    }
+
+    #[inline]
+    fn visit_catch_clause(&mut self, it: &CatchClause<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_catch_parameter(&mut self, it: &CatchParameter<'a>) {
+        self.visit_binding_pattern(&it.pattern);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_debugger_statement(&mut self, it: &DebuggerStatement) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_binding_pattern(&mut self, it: &BindingPattern<'a>) {
+        match it {
+            BindingPattern::ObjectPattern(it) => self.visit_object_pattern(it),
+            BindingPattern::ArrayPattern(it) => self.visit_array_pattern(it),
+            BindingPattern::AssignmentPattern(it) => self.visit_assignment_pattern(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BindingIdentifier`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_assignment_pattern(&mut self, it: &AssignmentPattern<'a>) {
+        self.visit_binding_pattern(&it.left);
+        self.visit_expression(&it.right);
+    }
+
+    #[inline]
+    fn visit_object_pattern(&mut self, it: &ObjectPattern<'a>) {
+        self.visit_binding_properties(&it.properties);
+        if let Some(rest) = &it.rest {
+            self.visit_binding_rest_element(rest);
+        }
+    }
+
+    #[inline]
+    fn visit_binding_property(&mut self, it: &BindingProperty<'a>) {
+        self.visit_property_key(&it.key);
+        self.visit_binding_pattern(&it.value);
+    }
+
+    #[inline]
+    fn visit_array_pattern(&mut self, it: &ArrayPattern<'a>) {
+        for el in it.elements.iter().flatten() {
+            self.visit_binding_pattern(el);
+        }
+        if let Some(rest) = &it.rest {
+            self.visit_binding_rest_element(rest);
+        }
+    }
+
+    #[inline]
+    fn visit_binding_rest_element(&mut self, it: &BindingRestElement<'a>) {
+        self.visit_binding_pattern(&it.argument);
+    }
+
+    #[inline]
+    fn visit_function(&mut self, it: &Function<'a>, _: ScopeFlags) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
+        self.visit_formal_parameter_list(&it.items);
+        if let Some(rest) = &it.rest {
+            self.visit_formal_parameter_rest(rest);
+        }
+    }
+
+    #[inline]
+    fn visit_formal_parameter(&mut self, it: &FormalParameter<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.visit_binding_pattern(&it.pattern);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(initializer) = &it.initializer {
+            self.visit_expression(initializer);
+        }
+    }
+
+    #[inline]
+    fn visit_formal_parameter_rest(&mut self, it: &FormalParameterRest<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.visit_binding_rest_element(&it.rest);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
+        self.visit_statements(&it.statements);
+    }
+
+    #[inline]
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
+        if let Some(argument) = &it.argument {
+            self.visit_expression(argument);
+        }
+    }
+
+    #[inline]
+    fn visit_class(&mut self, it: &Class<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_class_body(&mut self, it: &ClassBody<'a>) {
+        self.visit_class_elements(&it.body);
+    }
+
+    #[inline]
+    fn visit_method_definition(&mut self, it: &MethodDefinition<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.visit_property_key(&it.key);
+        {
+            let flags = match it.kind {
+                MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
+                MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
+                MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
+                MethodDefinitionKind::Method => ScopeFlags::Function,
+            };
+            self.visit_function(&it.value, flags);
+        }
+    }
+
+    #[inline]
+    fn visit_property_definition(&mut self, it: &PropertyDefinition<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.visit_property_key(&it.key);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(value) = &it.value {
+            self.visit_expression(value);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_private_identifier(&mut self, it: &PrivateIdentifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_static_block(&mut self, it: &StaticBlock<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_module_declaration(&mut self, it: &ModuleDeclaration<'a>) {
+        match it {
+            ModuleDeclaration::ExportDefaultDeclaration(it) => {
+                self.visit_export_default_declaration(it)
+            }
+            ModuleDeclaration::ExportNamedDeclaration(it) => {
+                self.visit_export_named_declaration(it)
+            }
+            ModuleDeclaration::TSExportAssignment(it) => self.visit_ts_export_assignment(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `ImportDeclaration`
+                // `ExportAllDeclaration`
+                // `TSNamespaceExportDeclaration`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_accessor_property(&mut self, it: &AccessorProperty<'a>) {
+        self.visit_decorators(&it.decorators);
+        self.visit_property_key(&it.key);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+        if let Some(value) = &it.value {
+            self.visit_expression(value);
+        }
+    }
+
+    #[inline]
+    fn visit_import_expression(&mut self, it: &ImportExpression<'a>) {
+        self.visit_expression(&it.source);
+        if let Some(options) = &it.options {
+            self.visit_expression(options);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_declaration_specifier(&mut self, it: &ImportDeclarationSpecifier<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_specifier(&mut self, it: &ImportSpecifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_default_specifier(&mut self, it: &ImportDefaultSpecifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_namespace_specifier(&mut self, it: &ImportNamespaceSpecifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_with_clause(&mut self, it: &WithClause<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_attribute(&mut self, it: &ImportAttribute<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_import_attribute_key(&mut self, it: &ImportAttributeKey<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        if let Some(declaration) = &it.declaration {
+            self.visit_declaration(declaration);
+        }
+    }
+
+    #[inline]
+    fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
+        self.visit_export_default_declaration_kind(&it.declaration);
+    }
+
+    #[inline(always)]
+    fn visit_export_all_declaration(&mut self, it: &ExportAllDeclaration<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_export_specifier(&mut self, it: &ExportSpecifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    fn visit_export_default_declaration_kind(&mut self, it: &ExportDefaultDeclarationKind<'a>) {
+        match it {
+            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(it) => self.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                self.visit_ts_interface_declaration(it)
+            }
+            ExportDefaultDeclarationKind::TemplateLiteral(it) => self.visit_template_literal(it),
+            ExportDefaultDeclarationKind::ArrayExpression(it) => self.visit_array_expression(it),
+            ExportDefaultDeclarationKind::ArrowFunctionExpression(it) => {
+                self.visit_arrow_function_expression(it)
+            }
+            ExportDefaultDeclarationKind::AssignmentExpression(it) => {
+                self.visit_assignment_expression(it)
+            }
+            ExportDefaultDeclarationKind::AwaitExpression(it) => self.visit_await_expression(it),
+            ExportDefaultDeclarationKind::BinaryExpression(it) => self.visit_binary_expression(it),
+            ExportDefaultDeclarationKind::CallExpression(it) => self.visit_call_expression(it),
+            ExportDefaultDeclarationKind::ChainExpression(it) => self.visit_chain_expression(it),
+            ExportDefaultDeclarationKind::ClassExpression(it) => self.visit_class(it),
+            ExportDefaultDeclarationKind::ConditionalExpression(it) => {
+                self.visit_conditional_expression(it)
+            }
+            ExportDefaultDeclarationKind::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            ExportDefaultDeclarationKind::ImportExpression(it) => self.visit_import_expression(it),
+            ExportDefaultDeclarationKind::LogicalExpression(it) => {
+                self.visit_logical_expression(it)
+            }
+            ExportDefaultDeclarationKind::NewExpression(it) => self.visit_new_expression(it),
+            ExportDefaultDeclarationKind::ObjectExpression(it) => self.visit_object_expression(it),
+            ExportDefaultDeclarationKind::ParenthesizedExpression(it) => {
+                self.visit_parenthesized_expression(it)
+            }
+            ExportDefaultDeclarationKind::SequenceExpression(it) => {
+                self.visit_sequence_expression(it)
+            }
+            ExportDefaultDeclarationKind::TaggedTemplateExpression(it) => {
+                self.visit_tagged_template_expression(it)
+            }
+            ExportDefaultDeclarationKind::UnaryExpression(it) => self.visit_unary_expression(it),
+            ExportDefaultDeclarationKind::UpdateExpression(it) => self.visit_update_expression(it),
+            ExportDefaultDeclarationKind::YieldExpression(it) => self.visit_yield_expression(it),
+            ExportDefaultDeclarationKind::PrivateInExpression(it) => {
+                self.visit_private_in_expression(it)
+            }
+            ExportDefaultDeclarationKind::JSXElement(it) => self.visit_jsx_element(it),
+            ExportDefaultDeclarationKind::JSXFragment(it) => self.visit_jsx_fragment(it),
+            ExportDefaultDeclarationKind::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            ExportDefaultDeclarationKind::TSSatisfiesExpression(it) => {
+                self.visit_ts_satisfies_expression(it)
+            }
+            ExportDefaultDeclarationKind::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            ExportDefaultDeclarationKind::TSNonNullExpression(it) => {
+                self.visit_ts_non_null_expression(it)
+            }
+            ExportDefaultDeclarationKind::TSInstantiationExpression(it) => {
+                self.visit_ts_instantiation_expression(it)
+            }
+            ExportDefaultDeclarationKind::V8IntrinsicExpression(it) => {
+                self.visit_v8_intrinsic_expression(it)
+            }
+            ExportDefaultDeclarationKind::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            ExportDefaultDeclarationKind::StaticMemberExpression(it) => {
+                self.visit_static_member_expression(it)
+            }
+            ExportDefaultDeclarationKind::PrivateFieldExpression(it) => {
+                self.visit_private_field_expression(it)
+            }
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_module_export_name(&mut self, it: &ModuleExportName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_v8_intrinsic_expression(&mut self, it: &V8IntrinsicExpression<'a>) {
+        self.visit_arguments(&it.arguments);
+    }
+
+    #[inline(always)]
+    fn visit_boolean_literal(&mut self, it: &BooleanLiteral) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_null_literal(&mut self, it: &NullLiteral) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_numeric_literal(&mut self, it: &NumericLiteral<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_string_literal(&mut self, it: &StringLiteral<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_big_int_literal(&mut self, it: &BigIntLiteral<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        self.visit_jsx_opening_element(&it.opening_element);
+        self.visit_jsx_children(&it.children);
+    }
+
+    #[inline]
+    fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+        self.visit_jsx_attribute_items(&it.attributes);
+    }
+
+    #[inline(always)]
+    fn visit_jsx_closing_element(&mut self, it: &JSXClosingElement<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
+        self.visit_jsx_children(&it.children);
+    }
+
+    #[inline(always)]
+    fn visit_jsx_opening_fragment(&mut self, it: &JSXOpeningFragment) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_jsx_closing_fragment(&mut self, it: &JSXClosingFragment) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_jsx_namespaced_name(&mut self, it: &JSXNamespacedName<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_jsx_member_expression(&mut self, it: &JSXMemberExpression<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_jsx_member_expression_object(&mut self, it: &JSXMemberExpressionObject<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_expression_container(&mut self, it: &JSXExpressionContainer<'a>) {
+        self.visit_jsx_expression(&it.expression);
+    }
+
+    fn visit_jsx_expression(&mut self, it: &JSXExpression<'a>) {
+        match it {
+            JSXExpression::TemplateLiteral(it) => self.visit_template_literal(it),
+            JSXExpression::ArrayExpression(it) => self.visit_array_expression(it),
+            JSXExpression::ArrowFunctionExpression(it) => self.visit_arrow_function_expression(it),
+            JSXExpression::AssignmentExpression(it) => self.visit_assignment_expression(it),
+            JSXExpression::AwaitExpression(it) => self.visit_await_expression(it),
+            JSXExpression::BinaryExpression(it) => self.visit_binary_expression(it),
+            JSXExpression::CallExpression(it) => self.visit_call_expression(it),
+            JSXExpression::ChainExpression(it) => self.visit_chain_expression(it),
+            JSXExpression::ClassExpression(it) => self.visit_class(it),
+            JSXExpression::ConditionalExpression(it) => self.visit_conditional_expression(it),
+            JSXExpression::FunctionExpression(it) => {
+                let flags = ScopeFlags::Function;
+                self.visit_function(it, flags)
+            }
+            JSXExpression::ImportExpression(it) => self.visit_import_expression(it),
+            JSXExpression::LogicalExpression(it) => self.visit_logical_expression(it),
+            JSXExpression::NewExpression(it) => self.visit_new_expression(it),
+            JSXExpression::ObjectExpression(it) => self.visit_object_expression(it),
+            JSXExpression::ParenthesizedExpression(it) => self.visit_parenthesized_expression(it),
+            JSXExpression::SequenceExpression(it) => self.visit_sequence_expression(it),
+            JSXExpression::TaggedTemplateExpression(it) => {
+                self.visit_tagged_template_expression(it)
+            }
+            JSXExpression::UnaryExpression(it) => self.visit_unary_expression(it),
+            JSXExpression::UpdateExpression(it) => self.visit_update_expression(it),
+            JSXExpression::YieldExpression(it) => self.visit_yield_expression(it),
+            JSXExpression::PrivateInExpression(it) => self.visit_private_in_expression(it),
+            JSXExpression::JSXElement(it) => self.visit_jsx_element(it),
+            JSXExpression::JSXFragment(it) => self.visit_jsx_fragment(it),
+            JSXExpression::TSAsExpression(it) => self.visit_ts_as_expression(it),
+            JSXExpression::TSSatisfiesExpression(it) => self.visit_ts_satisfies_expression(it),
+            JSXExpression::TSTypeAssertion(it) => self.visit_ts_type_assertion(it),
+            JSXExpression::TSNonNullExpression(it) => self.visit_ts_non_null_expression(it),
+            JSXExpression::TSInstantiationExpression(it) => {
+                self.visit_ts_instantiation_expression(it)
+            }
+            JSXExpression::V8IntrinsicExpression(it) => self.visit_v8_intrinsic_expression(it),
+            JSXExpression::ComputedMemberExpression(it) => {
+                self.visit_computed_member_expression(it)
+            }
+            JSXExpression::StaticMemberExpression(it) => self.visit_static_member_expression(it),
+            JSXExpression::PrivateFieldExpression(it) => self.visit_private_field_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `EmptyExpression`
+                // `BooleanLiteral`
+                // `NullLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `RegExpLiteral`
+                // `StringLiteral`
+                // `Identifier`
+                // `MetaProperty`
+                // `Super`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_jsx_empty_expression(&mut self, it: &JSXEmptyExpression) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_attribute(&mut self, it: &JSXAttribute<'a>) {
+        if let Some(value) = &it.value {
+            self.visit_jsx_attribute_value(value);
+        }
+    }
+
+    #[inline]
+    fn visit_jsx_spread_attribute(&mut self, it: &JSXSpreadAttribute<'a>) {
+        self.visit_expression(&it.argument);
+    }
+
+    #[inline(always)]
+    fn visit_jsx_attribute_name(&mut self, it: &JSXAttributeName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_value(&mut self, it: &JSXAttributeValue<'a>) {
+        match it {
+            JSXAttributeValue::ExpressionContainer(it) => self.visit_jsx_expression_container(it),
+            JSXAttributeValue::Element(it) => self.visit_jsx_element(it),
+            JSXAttributeValue::Fragment(it) => self.visit_jsx_fragment(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `StringLiteral`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_jsx_identifier(&mut self, it: &JSXIdentifier<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
+        match it {
+            JSXChild::Element(it) => self.visit_jsx_element(it),
+            JSXChild::Fragment(it) => self.visit_jsx_fragment(it),
+            JSXChild::ExpressionContainer(it) => self.visit_jsx_expression_container(it),
+            JSXChild::Spread(it) => self.visit_jsx_spread_child(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `Text`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_jsx_spread_child(&mut self, it: &JSXSpreadChild<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline(always)]
+    fn visit_jsx_text(&mut self, it: &JSXText<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_this_parameter(&mut self, it: &TSThisParameter<'a>) {
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_enum_declaration(&mut self, it: &TSEnumDeclaration<'a>) {
+        self.visit_ts_enum_body(&it.body);
+    }
+
+    #[inline]
+    fn visit_ts_enum_body(&mut self, it: &TSEnumBody<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_enum_member(&mut self, it: &TSEnumMember<'a>) {
+        self.visit_ts_enum_member_name(&it.id);
+        if let Some(initializer) = &it.initializer {
+            self.visit_expression(initializer);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_enum_member_name(&mut self, it: &TSEnumMemberName<'a>) {
+        match it {
+            TSEnumMemberName::ComputedTemplateString(it) => self.visit_template_literal(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `Identifier`
+                // `String`
+                // `ComputedString`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_literal_type(&mut self, it: &TSLiteralType<'a>) {
+        self.visit_ts_literal(&it.literal);
+    }
+
+    #[inline]
+    fn visit_ts_literal(&mut self, it: &TSLiteral<'a>) {
+        match it {
+            TSLiteral::TemplateLiteral(it) => self.visit_template_literal(it),
+            TSLiteral::UnaryExpression(it) => self.visit_unary_expression(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `BooleanLiteral`
+                // `NumericLiteral`
+                // `BigIntLiteral`
+                // `StringLiteral`
+            }
+        }
+    }
+
+    fn visit_ts_type(&mut self, it: &TSType<'a>) {
+        match it {
+            TSType::TSArrayType(it) => self.visit_ts_array_type(it),
+            TSType::TSConditionalType(it) => self.visit_ts_conditional_type(it),
+            TSType::TSConstructorType(it) => self.visit_ts_constructor_type(it),
+            TSType::TSFunctionType(it) => self.visit_ts_function_type(it),
+            TSType::TSImportType(it) => self.visit_ts_import_type(it),
+            TSType::TSIndexedAccessType(it) => self.visit_ts_indexed_access_type(it),
+            TSType::TSInferType(it) => self.visit_ts_infer_type(it),
+            TSType::TSIntersectionType(it) => self.visit_ts_intersection_type(it),
+            TSType::TSLiteralType(it) => self.visit_ts_literal_type(it),
+            TSType::TSMappedType(it) => self.visit_ts_mapped_type(it),
+            TSType::TSNamedTupleMember(it) => self.visit_ts_named_tuple_member(it),
+            TSType::TSTemplateLiteralType(it) => self.visit_ts_template_literal_type(it),
+            TSType::TSTupleType(it) => self.visit_ts_tuple_type(it),
+            TSType::TSTypeLiteral(it) => self.visit_ts_type_literal(it),
+            TSType::TSTypeOperatorType(it) => self.visit_ts_type_operator(it),
+            TSType::TSTypePredicate(it) => self.visit_ts_type_predicate(it),
+            TSType::TSTypeQuery(it) => self.visit_ts_type_query(it),
+            TSType::TSTypeReference(it) => self.visit_ts_type_reference(it),
+            TSType::TSUnionType(it) => self.visit_ts_union_type(it),
+            TSType::TSParenthesizedType(it) => self.visit_ts_parenthesized_type(it),
+            TSType::JSDocNullableType(it) => self.visit_js_doc_nullable_type(it),
+            TSType::JSDocNonNullableType(it) => self.visit_js_doc_non_nullable_type(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `TSAnyKeyword`
+                // `TSBigIntKeyword`
+                // `TSBooleanKeyword`
+                // `TSIntrinsicKeyword`
+                // `TSNeverKeyword`
+                // `TSNullKeyword`
+                // `TSNumberKeyword`
+                // `TSObjectKeyword`
+                // `TSStringKeyword`
+                // `TSSymbolKeyword`
+                // `TSUndefinedKeyword`
+                // `TSUnknownKeyword`
+                // `TSVoidKeyword`
+                // `TSThisType`
+                // `JSDocUnknownType`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_ts_conditional_type(&mut self, it: &TSConditionalType<'a>) {
+        self.visit_ts_type(&it.check_type);
+        self.add_scope(&it.scope_id);
+        self.visit_ts_type(&it.false_type);
+    }
+
+    #[inline]
+    fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {
+        self.visit_ts_types(&it.types);
+    }
+
+    #[inline]
+    fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
+        self.visit_ts_types(&it.types);
+    }
+
+    #[inline]
+    fn visit_ts_parenthesized_type(&mut self, it: &TSParenthesizedType<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_type_operator(&mut self, it: &TSTypeOperator<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_array_type(&mut self, it: &TSArrayType<'a>) {
+        self.visit_ts_type(&it.element_type);
+    }
+
+    #[inline]
+    fn visit_ts_indexed_access_type(&mut self, it: &TSIndexedAccessType<'a>) {
+        self.visit_ts_type(&it.object_type);
+        self.visit_ts_type(&it.index_type);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_type(&mut self, it: &TSTupleType<'a>) {
+        self.visit_ts_tuple_elements(&it.element_types);
+    }
+
+    #[inline]
+    fn visit_ts_named_tuple_member(&mut self, it: &TSNamedTupleMember<'a>) {
+        self.visit_ts_tuple_element(&it.element_type);
+    }
+
+    #[inline]
+    fn visit_ts_optional_type(&mut self, it: &TSOptionalType<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_rest_type(&mut self, it: &TSRestType<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    fn visit_ts_tuple_element(&mut self, it: &TSTupleElement<'a>) {
+        match it {
+            TSTupleElement::TSOptionalType(it) => self.visit_ts_optional_type(it),
+            TSTupleElement::TSRestType(it) => self.visit_ts_rest_type(it),
+            TSTupleElement::TSArrayType(it) => self.visit_ts_array_type(it),
+            TSTupleElement::TSConditionalType(it) => self.visit_ts_conditional_type(it),
+            TSTupleElement::TSConstructorType(it) => self.visit_ts_constructor_type(it),
+            TSTupleElement::TSFunctionType(it) => self.visit_ts_function_type(it),
+            TSTupleElement::TSImportType(it) => self.visit_ts_import_type(it),
+            TSTupleElement::TSIndexedAccessType(it) => self.visit_ts_indexed_access_type(it),
+            TSTupleElement::TSInferType(it) => self.visit_ts_infer_type(it),
+            TSTupleElement::TSIntersectionType(it) => self.visit_ts_intersection_type(it),
+            TSTupleElement::TSLiteralType(it) => self.visit_ts_literal_type(it),
+            TSTupleElement::TSMappedType(it) => self.visit_ts_mapped_type(it),
+            TSTupleElement::TSNamedTupleMember(it) => self.visit_ts_named_tuple_member(it),
+            TSTupleElement::TSTemplateLiteralType(it) => self.visit_ts_template_literal_type(it),
+            TSTupleElement::TSTupleType(it) => self.visit_ts_tuple_type(it),
+            TSTupleElement::TSTypeLiteral(it) => self.visit_ts_type_literal(it),
+            TSTupleElement::TSTypeOperatorType(it) => self.visit_ts_type_operator(it),
+            TSTupleElement::TSTypePredicate(it) => self.visit_ts_type_predicate(it),
+            TSTupleElement::TSTypeQuery(it) => self.visit_ts_type_query(it),
+            TSTupleElement::TSTypeReference(it) => self.visit_ts_type_reference(it),
+            TSTupleElement::TSUnionType(it) => self.visit_ts_union_type(it),
+            TSTupleElement::TSParenthesizedType(it) => self.visit_ts_parenthesized_type(it),
+            TSTupleElement::JSDocNullableType(it) => self.visit_js_doc_nullable_type(it),
+            TSTupleElement::JSDocNonNullableType(it) => self.visit_js_doc_non_nullable_type(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `TSAnyKeyword`
+                // `TSBigIntKeyword`
+                // `TSBooleanKeyword`
+                // `TSIntrinsicKeyword`
+                // `TSNeverKeyword`
+                // `TSNullKeyword`
+                // `TSNumberKeyword`
+                // `TSObjectKeyword`
+                // `TSStringKeyword`
+                // `TSSymbolKeyword`
+                // `TSUndefinedKeyword`
+                // `TSUnknownKeyword`
+                // `TSVoidKeyword`
+                // `TSThisType`
+                // `JSDocUnknownType`
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn visit_ts_any_keyword(&mut self, it: &TSAnyKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_string_keyword(&mut self, it: &TSStringKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_boolean_keyword(&mut self, it: &TSBooleanKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_number_keyword(&mut self, it: &TSNumberKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_never_keyword(&mut self, it: &TSNeverKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_intrinsic_keyword(&mut self, it: &TSIntrinsicKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_unknown_keyword(&mut self, it: &TSUnknownKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_null_keyword(&mut self, it: &TSNullKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_undefined_keyword(&mut self, it: &TSUndefinedKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_void_keyword(&mut self, it: &TSVoidKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_symbol_keyword(&mut self, it: &TSSymbolKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_this_type(&mut self, it: &TSThisType) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_object_keyword(&mut self, it: &TSObjectKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_big_int_keyword(&mut self, it: &TSBigIntKeyword) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_type_reference(&mut self, it: &TSTypeReference<'a>) {
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_ts_type_name(&mut self, it: &TSTypeName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_qualified_name(&mut self, it: &TSQualifiedName<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
+        self.visit_ts_types(&it.params);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter(&mut self, it: &TSTypeParameter<'a>) {
+        if let Some(constraint) = &it.constraint {
+            self.visit_ts_type(constraint);
+        }
+        if let Some(default) = &it.default {
+            self.visit_ts_type(default);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
+        self.visit_ts_type_parameters(&it.params);
+    }
+
+    #[inline]
+    fn visit_ts_type_alias_declaration(&mut self, it: &TSTypeAliasDeclaration<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_class_implements(&mut self, it: &TSClassImplements<'a>) {
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_interface_declaration(&mut self, it: &TSInterfaceDeclaration<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_interface_body(&mut self, it: &TSInterfaceBody<'a>) {
+        self.visit_ts_signatures(&it.body);
+    }
+
+    #[inline]
+    fn visit_ts_property_signature(&mut self, it: &TSPropertySignature<'a>) {
+        self.visit_property_key(&it.key);
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_index_signature(&mut self, it: &TSIndexSignature<'a>) {
+        self.visit_ts_index_signature_names(&it.parameters);
+        self.visit_ts_type_annotation(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_call_signature_declaration(&mut self, it: &TSCallSignatureDeclaration<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_method_signature(&mut self, it: &TSMethodSignature<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_construct_signature_declaration(
+        &mut self,
+        it: &TSConstructSignatureDeclaration<'a>,
+    ) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature_name(&mut self, it: &TSIndexSignatureName<'a>) {
+        self.visit_ts_type_annotation(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_interface_heritage(&mut self, it: &TSInterfaceHeritage<'a>) {
+        self.visit_expression(&it.expression);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_type_predicate(&mut self, it: &TSTypePredicate<'a>) {
+        if let Some(type_annotation) = &it.type_annotation {
+            self.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_ts_type_predicate_name(&mut self, it: &TSTypePredicateName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_module_declaration(&mut self, it: &TSModuleDeclaration<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline(always)]
+    fn visit_ts_module_declaration_name(&mut self, it: &TSModuleDeclarationName<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_global_declaration(&mut self, it: &TSGlobalDeclaration<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_module_block(&mut self, it: &TSModuleBlock<'a>) {
+        self.visit_statements(&it.body);
+    }
+
+    #[inline]
+    fn visit_ts_type_literal(&mut self, it: &TSTypeLiteral<'a>) {
+        self.visit_ts_signatures(&it.members);
+    }
+
+    #[inline]
+    fn visit_ts_infer_type(&mut self, it: &TSInferType<'a>) {
+        self.visit_ts_type_parameter(&it.type_parameter);
+    }
+
+    #[inline]
+    fn visit_ts_type_query(&mut self, it: &TSTypeQuery<'a>) {
+        self.visit_ts_type_query_expr_name(&it.expr_name);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
+    #[inline]
+    fn visit_ts_type_query_expr_name(&mut self, it: &TSTypeQueryExprName<'a>) {
+        match it {
+            TSTypeQueryExprName::TSImportType(it) => self.visit_ts_import_type(it),
+            _ => {
+                // Remaining variants do not contain scopes:
+                // `IdentifierReference`
+                // `QualifiedName`
+                // `ThisExpression`
+            }
+        }
+    }
+
+    #[inline]
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        if let Some(options) = &it.options {
+            self.visit_object_expression(options);
+        }
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
+    #[inline(always)]
+    fn visit_ts_import_type_qualifier(&mut self, it: &TSImportTypeQualifier<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_import_type_qualified_name(&mut self, it: &TSImportTypeQualifiedName<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_function_type(&mut self, it: &TSFunctionType<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_constructor_type(&mut self, it: &TSConstructorType<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
+        self.add_scope(&it.scope_id);
+    }
+
+    #[inline]
+    fn visit_ts_template_literal_type(&mut self, it: &TSTemplateLiteralType<'a>) {
+        self.visit_ts_types(&it.types);
+    }
+
+    #[inline]
+    fn visit_ts_as_expression(&mut self, it: &TSAsExpression<'a>) {
+        self.visit_expression(&it.expression);
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_satisfies_expression(&mut self, it: &TSSatisfiesExpression<'a>) {
+        self.visit_expression(&it.expression);
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline(always)]
+    fn visit_ts_import_equals_declaration(&mut self, it: &TSImportEqualsDeclaration<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_module_reference(&mut self, it: &TSModuleReference<'a>) {
+        // Enum does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_ts_external_module_reference(&mut self, it: &TSExternalModuleReference<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_non_null_expression(&mut self, it: &TSNonNullExpression<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    fn visit_decorator(&mut self, it: &Decorator<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    fn visit_ts_export_assignment(&mut self, it: &TSExportAssignment<'a>) {
+        self.visit_expression(&it.expression);
+    }
+
+    #[inline(always)]
+    fn visit_ts_namespace_export_declaration(&mut self, it: &TSNamespaceExportDeclaration<'a>) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline]
+    fn visit_ts_instantiation_expression(&mut self, it: &TSInstantiationExpression<'a>) {
+        self.visit_expression(&it.expression);
+        self.visit_ts_type_parameter_instantiation(&it.type_arguments);
+    }
+
+    #[inline]
+    fn visit_js_doc_nullable_type(&mut self, it: &JSDocNullableType<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    fn visit_js_doc_non_nullable_type(&mut self, it: &JSDocNonNullableType<'a>) {
+        self.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline(always)]
+    fn visit_js_doc_unknown_type(&mut self, it: &JSDocUnknownType) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+
+    #[inline(always)]
+    fn visit_span(&mut self, it: &Span) {
+        // Struct does not contain a scope. Halt traversal.
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/scoping.rs
+++ b/crates/oxc_minifier/src/traverse_context/scoping.rs
@@ -1,0 +1,391 @@
+use std::str;
+
+use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_semantic::{NodeId, Reference, Scoping};
+use oxc_span::{Ident, SPAN};
+use oxc_syntax::{
+    reference::{ReferenceFlags, ReferenceId},
+    scope::{ScopeFlags, ScopeId},
+    symbol::{SymbolFlags, SymbolId},
+};
+
+use super::{
+    bound_identifier::BoundIdentifier, scopes_collector::ChildScopeCollector, uid::UidGenerator,
+};
+
+/// Traverse scope context.
+///
+/// Contains the scope tree and symbols table, and provides methods to access them.
+///
+/// `current_scope_id` is the ID of current scope during traversal.
+/// `walk_*` functions update this field when entering/exiting a scope.
+pub struct TraverseScoping<'a> {
+    scoping: Scoping,
+    uid_generator: Option<UidGenerator<'a>>,
+    current_scope_id: ScopeId,
+    current_hoist_scope_id: ScopeId,
+    current_block_scope_id: ScopeId,
+}
+
+// Public methods
+impl<'a> TraverseScoping<'a> {
+    /// Get current scope ID
+    #[inline]
+    pub fn current_scope_id(&self) -> ScopeId {
+        self.current_scope_id
+    }
+
+    /// Get current var hoisting scope ID
+    #[inline]
+    pub(crate) fn current_hoist_scope_id(&self) -> ScopeId {
+        self.current_hoist_scope_id
+    }
+
+    /// Get current block scope ID
+    #[inline]
+    pub(crate) fn current_block_scope_id(&self) -> ScopeId {
+        self.current_block_scope_id
+    }
+
+    /// Get current scope flags
+    #[inline]
+    pub fn current_scope_flags(&self) -> ScopeFlags {
+        self.scoping.scope_flags(self.current_scope_id)
+    }
+
+    /// Get scopes tree
+    #[inline]
+    pub fn scoping(&self) -> &Scoping {
+        &self.scoping
+    }
+
+    /// Get mutable scopes tree
+    #[inline]
+    pub fn scoping_mut(&mut self) -> &mut Scoping {
+        &mut self.scoping
+    }
+
+    /// Get iterator over scopes, starting with current scope and working up
+    pub fn ancestor_scopes(&self) -> impl Iterator<Item = ScopeId> + '_ {
+        self.scoping.scope_ancestors(self.current_scope_id)
+    }
+
+    /// Create new scope as child of provided scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn create_child_scope(&mut self, parent_id: ScopeId, flags: ScopeFlags) -> ScopeId {
+        let flags = self.scoping.get_new_scope_flags(flags, parent_id);
+        self.scoping.add_scope(Some(parent_id), NodeId::DUMMY, flags)
+    }
+
+    /// Create new scope as child of current scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn create_child_scope_of_current(&mut self, flags: ScopeFlags) -> ScopeId {
+        self.create_child_scope(self.current_scope_id, flags)
+    }
+
+    /// Insert a scope into scope tree below a statement.
+    ///
+    /// Statement must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn insert_scope_below_statement(&mut self, stmt: &Statement, flags: ScopeFlags) -> ScopeId {
+        self.insert_scope_below_statement_from_scope_id(stmt, self.current_scope_id, flags)
+    }
+
+    /// Insert a scope into scope tree below a statement.
+    ///
+    /// Statement must be in provided scope.
+    /// New scope is created as child of the provided scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn insert_scope_below_statement_from_scope_id(
+        &mut self,
+        stmt: &Statement,
+        scope_id: ScopeId,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        let mut collector = ChildScopeCollector::new();
+        collector.visit_statement(stmt);
+        self.insert_scope_below(scope_id, &collector.scope_ids, flags)
+    }
+
+    /// Insert a scope into scope tree below an expression.
+    ///
+    /// Expression must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the expression are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn insert_scope_below_expression(
+        &mut self,
+        expr: &Expression,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        let mut collector = ChildScopeCollector::new();
+        collector.visit_expression(expr);
+        self.insert_scope_below(self.current_scope_id, &collector.scope_ids, flags)
+    }
+
+    /// Insert a scope into scope tree below a `Vec` of statements.
+    ///
+    /// Statements must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    pub fn insert_scope_below_statements(
+        &mut self,
+        stmts: &ArenaVec<Statement>,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        let mut collector = ChildScopeCollector::new();
+        collector.visit_statements(stmts);
+        self.insert_scope_below(self.current_scope_id, &collector.scope_ids, flags)
+    }
+
+    fn insert_scope_below(
+        &mut self,
+        scope_id: ScopeId,
+        child_scope_ids: &[ScopeId],
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        // Create new scope as child of parent
+        let new_scope_id = self.create_child_scope(scope_id, flags);
+
+        // Set scopes as children of new scope instead
+        for &child_id in child_scope_ids {
+            self.scoping.set_scope_parent_id(child_id, Some(new_scope_id));
+        }
+
+        new_scope_id
+    }
+
+    /// Insert a scope between a parent and a child scope.
+    ///
+    /// For example, given the following scopes
+    /// ```ts
+    /// parentScope1: {
+    ///     childScope: { }
+    ///     childScope2: { }
+    /// }
+    /// ```
+    /// and calling this function with `parentScope1` and `childScope`,
+    /// the resulting scopes will be:
+    /// ```ts
+    /// parentScope1: {
+    ///     newScope: {
+    ///         childScope: { }
+    ///     }
+    ///     childScope2: { }
+    /// }
+    /// ```
+    pub fn insert_scope_between(
+        &mut self,
+        parent_id: ScopeId,
+        child_id: ScopeId,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        let scope_id = self.create_child_scope(parent_id, flags);
+
+        debug_assert_eq!(
+            self.scoping.scope_parent_id(child_id),
+            Some(parent_id),
+            "Child scope must be a child of parent scope"
+        );
+
+        self.scoping.set_scope_parent_id(child_id, Some(scope_id));
+        scope_id
+    }
+
+    /// Remove scope for an expression from the scope chain.
+    ///
+    /// Delete the scope and set parent of its child scopes to its parent scope.
+    /// e.g.:
+    /// * Starting scopes parentage `A -> B`, `B -> C`, `B -> D`.
+    /// * Remove scope `B` from chain.
+    /// * End result: scopes `A -> C`, `A -> D`.
+    ///
+    /// Use this when removing an expression which owns a scope, without removing its children.
+    /// For example when unwrapping `(() => foo)()` to just `foo`.
+    /// `foo` here could be an expression which itself contains scopes.
+    pub fn remove_scope_for_expression(&mut self, scope_id: ScopeId, expr: &Expression) {
+        let mut collector = ChildScopeCollector::new();
+        collector.visit_expression(expr);
+
+        let child_ids = collector.scope_ids;
+        if !child_ids.is_empty() {
+            let parent_id = self.scoping.scope_parent_id(scope_id);
+            for child_id in child_ids {
+                self.scoping.set_scope_parent_id(child_id, parent_id);
+            }
+        }
+    }
+
+    /// Add binding to `ScopeTree` and `SymbolTable`.
+    #[inline]
+    pub(crate) fn add_binding(
+        &mut self,
+        name: Ident<'_>,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> SymbolId {
+        let symbol_id = self.scoping.create_symbol(SPAN, name, flags, scope_id, NodeId::DUMMY);
+        self.scoping.add_binding(scope_id, name, symbol_id);
+
+        symbol_id
+    }
+
+    /// Generate binding.
+    ///
+    /// Creates a symbol with the provided name and flags and adds it to the specified scope.
+    pub fn generate_binding(
+        &mut self,
+        name: Ident<'a>,
+        scope_id: ScopeId,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        let symbol_id = self.add_binding(name, scope_id, flags);
+        BoundIdentifier::new(name, symbol_id)
+    }
+
+    /// Generate binding in current scope.
+    ///
+    /// Creates a symbol with the provided name and flags and adds it to the current scope.
+    pub fn generate_binding_in_current_scope(
+        &mut self,
+        name: Ident<'a>,
+        flags: SymbolFlags,
+    ) -> BoundIdentifier<'a> {
+        self.generate_binding(name, self.current_scope_id, flags)
+    }
+
+    /// Generate UID var name.
+    ///
+    /// Finds a unique variable name which does clash with any other variables used in the program.
+    ///
+    /// Caller must ensure `name` is a valid JS identifier, after a `_` is prepended on start.
+    /// The fact that a `_` will be prepended on start means providing an empty string or a string
+    /// starting with a digit (0-9) is fine.
+    ///
+    /// See comments on `UidGenerator` for further details.
+    pub fn generate_uid_name(&mut self, name: &str, allocator: &'a Allocator) -> Ident<'a> {
+        // If `uid_generator` is not already populated, initialize it
+        let uid_generator =
+            self.uid_generator.get_or_insert_with(|| UidGenerator::new(&self.scoping, allocator));
+        // Generate unique name
+        uid_generator.create(name)
+    }
+
+    /// Create a reference bound to a `SymbolId`
+    pub fn create_bound_reference(
+        &mut self,
+        symbol_id: SymbolId,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        let reference =
+            Reference::new_with_symbol_id(NodeId::DUMMY, symbol_id, self.current_scope_id, flags);
+        let reference_id = self.scoping.create_reference(reference);
+        self.scoping.add_resolved_reference(symbol_id, reference_id);
+        reference_id
+    }
+
+    /// Create an unbound reference
+    pub fn create_unbound_reference(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        let reference = Reference::new(NodeId::DUMMY, self.current_scope_id, flags);
+        let reference_id = self.scoping.create_reference(reference);
+        self.scoping.add_root_unresolved_reference(name, reference_id);
+        reference_id
+    }
+
+    /// Create a reference optionally bound to a `SymbolId`.
+    ///
+    /// If you know if there's a `SymbolId` or not, prefer `TraverseCtx::create_bound_reference`
+    /// or `TraverseCtx::create_unbound_reference`.
+    pub fn create_reference(
+        &mut self,
+        name: Ident<'_>,
+        symbol_id: Option<SymbolId>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        if let Some(symbol_id) = symbol_id {
+            self.create_bound_reference(symbol_id, flags)
+        } else {
+            self.create_unbound_reference(name, flags)
+        }
+    }
+
+    /// Create reference in current scope, looking up binding for `name`
+    pub fn create_reference_in_current_scope(
+        &mut self,
+        name: Ident<'_>,
+        flags: ReferenceFlags,
+    ) -> ReferenceId {
+        let symbol_id = self.scoping.find_binding(self.current_scope_id, name);
+        self.create_reference(name, symbol_id, flags)
+    }
+
+    /// Delete a reference.
+    ///
+    /// Provided `name` must match `reference_id`.
+    pub fn delete_reference(&mut self, reference_id: ReferenceId, name: Ident<'_>) {
+        let symbol_id = self.scoping.get_reference(reference_id).symbol_id();
+        if let Some(symbol_id) = symbol_id {
+            self.scoping.delete_resolved_reference(symbol_id, reference_id);
+        } else {
+            self.scoping.delete_root_unresolved_reference(name, reference_id);
+        }
+    }
+
+    /// Delete reference for an `IdentifierReference`.
+    pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
+        self.delete_reference(ident.reference_id(), ident.name);
+    }
+}
+
+// Methods used internally within crate
+impl TraverseScoping<'_> {
+    /// Create new `TraverseScoping`
+    pub(super) fn new(scoping: Scoping) -> Self {
+        Self {
+            scoping,
+            uid_generator: None,
+            // Dummy values. Both immediately overwritten in `walk_program`.
+            current_scope_id: ScopeId::new(0),
+            current_hoist_scope_id: ScopeId::new(0),
+            current_block_scope_id: ScopeId::new(0),
+        }
+    }
+
+    /// Set current scope ID
+    #[inline]
+    pub(crate) fn set_current_scope_id(&mut self, scope_id: ScopeId) {
+        self.current_scope_id = scope_id;
+    }
+
+    /// Set current hoist scope ID
+    #[inline]
+    pub(crate) fn set_current_hoist_scope_id(&mut self, scope_id: ScopeId) {
+        self.current_hoist_scope_id = scope_id;
+    }
+
+    /// Set current block scope ID
+    #[inline]
+    pub(crate) fn set_current_block_scope_id(&mut self, scope_id: ScopeId) {
+        self.current_block_scope_id = scope_id;
+    }
+
+    pub fn delete_typescript_bindings(&mut self) {
+        self.scoping.delete_typescript_bindings();
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/uid.rs
+++ b/crates/oxc_minifier/src/traverse_context/uid.rs
@@ -1,0 +1,374 @@
+use std::str;
+
+use itoa::Buffer as ItoaBuffer;
+use rustc_hash::FxHashMap;
+
+use oxc_allocator::{Allocator, StringBuilder as ArenaStringBuilder};
+use oxc_semantic::Scoping;
+use oxc_str::Ident;
+
+/// Unique identifier generator.
+///
+/// When initialized with [`UidGenerator::new`], creates a catalog of all symbols and unresolved references
+/// in the AST which begin with `_`.
+///
+/// [`UidGenerator::create`] uses that catalog to generate a unique identifier which does not clash with
+/// any existing name.
+///
+/// Such UIDs are based on the base name provided. They start with `_` and end with digits if required to
+/// maintain uniqueness. e.g. given base name of `foo`, UIDs will be `_foo`, `_foo2`, `_foo3` etc.
+///
+/// Roughly based on Babel's `scope.generateUid` logic, but with some differences (see below).
+/// <https://github.com/babel/babel/blob/3b1a3c0be9df65140260a316c1a21adcf948645d/packages/babel-traverse/src/scope/index.ts#L501-L523>
+///
+/// # Algorithm
+///
+/// UIDs are generated in series for each "base" name.
+/// "Base" name is the provided name with `_`s trimmed from the start, and digits trimmed from the end.
+///
+/// During cataloging of existing symbols, for each base name it's recorded:
+///
+/// 1. Largest number of leading `_`s.
+/// 2. Largest numeric postfix for that base name.
+///
+/// UIDs are generated for that base name with that number of leading underscores, and with ascending
+/// numeric postfix.
+///
+/// | Existing symbols | Generated UIDs                  |
+/// |------------------|---------------------------------|
+/// | (none)           | `_foo`, `_foo2`, `_foo3`        |
+/// | `_foo`           | `_foo2`, `_foo3`, `_foo4`       |
+/// | `_foo3`          | `_foo4`, `_foo5`, `_foo6`       |
+/// | `__foo`          | `__foo2`, `__foo3`, `__foo4`    |
+/// | `___foo5`        | `___foo6`, `___foo7`, `___foo8` |
+/// | `_foo8`, `__foo` | `__foo2`, `__foo3`, `__foo4`    |
+///
+/// This algorithm requires at most 1 hashmap lookup and 1 hashmap insert per UID generated.
+///
+/// # Differences from Babel
+///
+/// This implementation aims to replicate Babel's behavior, but differs from Babel
+/// in the following ways:
+///
+/// 1. Does not check that name provided as "base" for the UID is a valid JS identifier name.
+///    In most cases, we're creating a UID based on an existing variable name, in which case
+///    this check is redundant.
+///    Caller must ensure `name` is a valid JS identifier, after a `_` is prepended on start.
+///    The fact that a `_` will be prepended on start means providing an empty string or a string
+///    starting with a digit (0-9) is fine.
+///
+/// 2. Does not convert to camel case.
+///    This seems unimportant.
+///
+/// 3. Does not check var name against list of globals or "contextVariables"
+///    (which Babel does in `hasBinding`).
+///    No globals or "contextVariables" start with `_` anyway, so no need for this check.
+///
+/// 4. Does not check this name is unique if used as a named statement label,
+///    only that it's unique as an identifier.
+///
+/// 5. Uses a slightly different algorithm for generating names (see above).
+///    The resulting UIDs are similar enough to Babel's algorithm to fail only 1 of Babel's tests.
+///
+/// # Potential improvements
+///
+/// TODO(improve-on-babel):
+///
+/// UID generation is fairly expensive, because of the amount of string hashing required.
+///
+/// [`UidGenerator::new`] iterates through every binding and unresolved reference in the entire AST,
+/// and builds a hashmap of symbols which could clash with UIDs.
+/// Once that's built, [`UidGenerator::create`] has to do at a hashmap lookup when generating each UID.
+/// Hashing strings is a fairly expensive operation.
+///
+/// We could improve this in one of 3 ways:
+///
+/// ## 1. Build the hashmap in `SemanticBuilder`
+///
+/// Instead of iterating through all symbols again here.
+///
+/// ## 2. Use a simpler algorithm
+///
+/// * During initial semantic pass, check for any existing identifiers starting with `_`.
+/// * Calculate what is the highest postfix number on `_...` identifiers (e.g. `_foo1`, `_bar8`).
+/// * Store that highest number in a counter which is global across the whole program.
+/// * When creating a UID, increment the counter, and make the UID `_<name><counter>`.
+///
+/// i.e. if source contains identifiers `_foo1` and `_bar15`, create UIDs named `_qux16`,
+/// `_temp17` etc. They'll all be unique within the program.
+///
+/// Minimal cost in semantic, and generating UIDs extremely cheap.
+///
+/// The resulting UIDs would still be fairly readable.
+///
+/// This is a different method from Babel, and unfortunately produces UID names
+/// which differ from Babel for some of its test cases.
+///
+/// ## 3. Even simpler algorithm, but produces hard-to-read code
+///
+/// If output is being minified anyway, use a method which produces less debuggable output,
+/// but is even simpler:
+///
+/// * During initial semantic pass, check for any existing identifiers starting with `_`.
+/// * Find the highest number of leading `_`s for any existing symbol.
+/// * Generate UIDs with a counter starting at 0, prefixed with number of `_`s one greater than
+///   what was found in AST.
+///
+/// i.e. if source contains identifiers `_foo` and `__bar`, create UIDs names `___0`, `___1`,
+/// `___2` etc. They'll all be unique within the program.
+pub struct UidGenerator<'a> {
+    names: FxHashMap<&'a str, UidName>,
+    allocator: &'a Allocator,
+}
+
+/// Details of next UID for a base name.
+//
+// `#[repr(align(8))]` on 64-bit platforms so can fit in a single register.
+#[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+#[derive(Clone, Copy)]
+struct UidName {
+    /// Digits appended to end of name.
+    /// When generating a UID, increment this field and use that as the postfix.
+    /// This field is never 0, so postfix will be at least 2.
+    postfix: u32,
+    /// Number of underscores to prefix name with.
+    underscore_count: u32,
+}
+
+impl<'a> UidGenerator<'a> {
+    /// Create [`UidGenerator`].
+    pub(super) fn new(scoping: &Scoping, allocator: &'a Allocator) -> Self {
+        let mut generator = Self { names: FxHashMap::default(), allocator };
+
+        for name in scoping.symbol_names() {
+            generator.add(name);
+        }
+        for name in scoping.root_unresolved_references().keys() {
+            generator.add(name.as_str());
+        }
+
+        generator
+    }
+
+    /// Add a record to [`UidGenerator`].
+    fn add(&mut self, name: &str) {
+        // If `name` does not start with `_`, exit
+        if name.as_bytes().first() != Some(&b'_') {
+            return;
+        }
+
+        // Trim off underscores from start of `name`
+        let original_len = name.len();
+        // SAFETY: We just check first byte of `name` is `_`
+        let name = unsafe { name.get_unchecked(1..) };
+        let mut name = name.trim_start_matches('_');
+        #[expect(clippy::cast_possible_truncation)]
+        let underscore_count = (original_len - name.len()) as u32;
+        let mut uid_name = UidName { underscore_count, postfix: 1 };
+
+        // Find digits on end of `name`
+        let last_non_digit_index = name.as_bytes().iter().rposition(|&b| !b.is_ascii_digit());
+        let parts = match last_non_digit_index {
+            Some(last_non_digit_index) => {
+                if last_non_digit_index == name.len() - 1 {
+                    // No digits on end
+                    None
+                } else {
+                    // Name ends with digits
+                    let digit_index = last_non_digit_index + 1;
+                    debug_assert!(name.as_bytes().get(digit_index).is_some_and(u8::is_ascii_digit));
+                    // SAFETY: There's an ASCII digit at `digit_index`, so slicing `name` at that index
+                    // is guaranteed to yield 2 valid UTF-8 strings. `digit_index` cannot be out of bounds.
+                    unsafe {
+                        let without_digits = name.get_unchecked(..digit_index);
+                        let digits = name.get_unchecked(digit_index..);
+                        Some((without_digits, digits))
+                    }
+                }
+            }
+            None => {
+                if name.is_empty() {
+                    // Name consists purely of `_`s e.g. `_` or `___`
+                    None
+                } else {
+                    // Name consists of `_`s followed by digits e.g. `_123`
+                    Some(("", name))
+                }
+            }
+        };
+
+        if let Some((without_digits, digits)) = parts {
+            const U32_MAX_LEN: usize = "4294967295".len(); // 4294967295 = u32::MAX
+            // SAFETY: `digits` cannot be empty
+            let first_digit = unsafe { *digits.as_bytes().get_unchecked(0) };
+            if first_digit == b'0' || digits.len() > U32_MAX_LEN {
+                // We don't create UIDs with postfix starting with 0, or greater than `u32::MAX`,
+                // so can ignore this - can't clash
+                return;
+            }
+            if let Ok(n) = digits.parse::<u32>() {
+                if n == 1 {
+                    // We don't create UIDs with postfix of 1, so can ignore this - can't clash
+                    return;
+                }
+                name = without_digits;
+                uid_name.postfix = n;
+            } else {
+                // Digits represent a number greater than `u32::MAX`.
+                // We don't create UIDs with postfix over `u32::MAX` so can ignore this - can't clash.
+                return;
+            }
+        }
+
+        // Unfortunately can't use `Entry` API here because `name` doesn't have required lifetime `'a`,
+        // because it comes from `Semantic`'s arena, not the AST arena
+        if let Some(existing_uid_name) = self.names.get_mut(name) {
+            if uid_name.underscore_count > existing_uid_name.underscore_count
+                || (uid_name.underscore_count == existing_uid_name.underscore_count
+                    && uid_name.postfix > existing_uid_name.postfix)
+            {
+                *existing_uid_name = uid_name;
+            }
+        } else {
+            let name = self.allocator.alloc_str(name);
+            self.names.insert(name, uid_name);
+        }
+    }
+
+    /// Create a unique identifier.
+    ///
+    /// The UID returned will be added to the list of used identifiers, so this method will never
+    /// return the same UID twice.
+    ///
+    /// Caller must ensure `name` is a valid JS identifier, after a `_` is prepended on start.
+    /// The fact that a `_` will be prepended on start means providing an empty string or a string
+    /// starting with a digit (0-9) is fine.
+    ///
+    /// Please see docs for [`UidGenerator`] for further info.
+    pub(super) fn create(&mut self, name: &str) -> Ident<'a> {
+        // Get the base name, with `_`s trimmed from start, and digits trimmed from end.
+        // i.e. `__foo123` -> `foo`.
+        // Equivalent to `name.trim_start_matches('_').trim_end_matches(|c: char| c.is_ascii_digit())`
+        // but more efficient as operates on bytes not chars
+        let mut bytes = name.as_bytes();
+        while bytes.first() == Some(&b'_') {
+            bytes = &bytes[1..];
+        }
+        while matches!(bytes.last(), Some(b) if b.is_ascii_digit()) {
+            bytes = &bytes[0..bytes.len() - 1];
+        }
+        // SAFETY: We started with a valid UTF8 `&str` and have only trimmed off ASCII characters,
+        // so remainder must still be valid UTF8
+        let base = unsafe { str::from_utf8_unchecked(bytes) };
+
+        // Generate UID.
+        // Unfortunately can't use `Entry` API here as `name` doesn't have required lifetime `'a`.
+        if let Some(uid_name) = self.names.get_mut(base) {
+            // AST contains identifier(s) with this base already.
+            // Get next postfix.
+            if uid_name.postfix < u32::MAX {
+                // Increment `postfix`
+                uid_name.postfix += 1;
+            } else {
+                // Identifier `_<base>4294967295` was already used.
+                // Can't increment `postfix` as it would wrap around, so increment `underscore_count` instead.
+                // It shouldn't be possible for `underscore_count` to be `u32::MAX` too, because that
+                // would require an identifier comprising `u32::MAX` x underscores in source text.
+                // That's theoretically possible, but source text is limited to `u32::MAX` bytes,
+                // so it'd be the entirety of the source text. Therefore `postfix` would be 1.
+                uid_name.underscore_count += 1;
+                uid_name.postfix = 2;
+            }
+
+            // Format UID `_<base><postfix>`.
+            // If `underscore_count > 1`, add further underscores to the start.
+            let mut buffer = ItoaBuffer::new();
+            let digits = buffer.format(uid_name.postfix);
+
+            if uid_name.underscore_count == 1 {
+                Ident::from_strs_array_in(["_", base, digits], self.allocator)
+            } else {
+                let mut uid = ArenaStringBuilder::with_capacity_in(
+                    uid_name.underscore_count as usize + base.len() + digits.len(),
+                    self.allocator,
+                );
+                uid.push_ascii_byte_repeat(b'_', uid_name.underscore_count as usize);
+                uid.push_str(base);
+                uid.push_str(digits);
+                Ident::from(uid)
+            }
+        } else {
+            let uid = Ident::from_strs_array_in(["_", base], self.allocator);
+            // SAFETY: String starts with `_`, so trimming off that byte leaves a valid UTF-8 string
+            let base = unsafe { uid.as_str().get_unchecked(1..) };
+            self.names.insert(base, UidName { underscore_count: 1, postfix: 1 });
+            uid
+        }
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn uids() {
+    // (&[ initial, ... ], &[ (name, expected_uid), ... ])
+    #[expect(clippy::type_complexity)]
+    let cases: &[(&[&str], &[(&str, &str)])] = &[
+        (&[], &[("foo", "_foo"), ("foo", "_foo2"), ("foo", "_foo3")]),
+        (
+            &["foo", "foo0", "foo1", "foo2", "foo10", "_bar"],
+            &[("foo", "_foo"), ("foo", "_foo2"), ("foo", "_foo3")],
+        ),
+        (
+            &["_foo0", "_foo1", "__foo0", "____foo1", "_foo01", "_foo012345", "_foo000000"],
+            &[("foo", "_foo"), ("foo", "_foo2"), ("foo", "_foo3")],
+        ),
+        (&[], &[("_foo", "_foo"), ("__foo", "_foo2"), ("_____foo", "_foo3")]),
+        (&[], &[("_foo123", "_foo"), ("__foo456", "_foo2"), ("_____foo789", "_foo3")]),
+        (&["_foo"], &[("foo", "_foo2"), ("foo", "_foo3"), ("foo", "_foo4")]),
+        (&["_foo3"], &[("foo", "_foo4"), ("foo", "_foo5"), ("foo", "_foo6")]),
+        (&["__foo"], &[("foo", "__foo2"), ("foo", "__foo3"), ("foo", "__foo4")]),
+        (&["__foo8"], &[("foo", "__foo9"), ("foo", "__foo10"), ("foo", "__foo11")]),
+        (&["_foo999", "____foo"], &[("foo", "____foo2"), ("foo", "____foo3"), ("foo", "____foo4")]),
+        (
+            &["_foo4294967293"],
+            &[
+                ("foo", "_foo4294967294"),
+                ("foo", "_foo4294967295"),
+                ("foo", "__foo2"),
+                ("foo", "__foo3"),
+            ],
+        ),
+        (
+            &["___foo4294967293"],
+            &[
+                ("foo", "___foo4294967294"),
+                ("foo", "___foo4294967295"),
+                ("foo", "____foo2"),
+                ("foo", "____foo3"),
+            ],
+        ),
+        (&[], &[("_", "_"), ("_", "_2"), ("_", "_3")]),
+        (
+            &["_0", "_1", "__0", "____1", "_01", "_012345", "_000000"],
+            &[("_", "_"), ("_", "_2"), ("_", "_3")],
+        ),
+        (&[], &[("___", "_"), ("_____", "_2"), ("_____", "_3")]),
+        (&["_"], &[("_", "_2"), ("_", "_3"), ("_", "_4")]),
+        (&["_4"], &[("_", "_5"), ("_", "_6"), ("_", "_7")]),
+        (&["___"], &[("_", "___2"), ("_", "___3"), ("_", "___4")]),
+        (&["___99"], &[("_", "___100"), ("_", "___101"), ("_", "___102")]),
+        (&["_"], &[("_123", "_2"), ("__456", "_3"), ("___789", "_4")]),
+    ];
+
+    let allocator = Allocator::default();
+    for &(used_names, created) in cases {
+        let mut generator = UidGenerator { names: FxHashMap::default(), allocator: &allocator };
+        for &used_name in used_names {
+            generator.add(used_name);
+        }
+
+        for &(name, uid) in created {
+            assert_eq!(generator.create(name), uid);
+        }
+    }
+}

--- a/tasks/ast_tools/src/generators/minifier_traverse/mod.rs
+++ b/tasks/ast_tools/src/generators/minifier_traverse/mod.rs
@@ -1,0 +1,34 @@
+//! Generator for minifier-local traverse runtime.
+//!
+//! Generates 2 files in `oxc_minifier` crate:
+//! * `traverse.rs` - `MinifierTraverse` trait with `enter_*` / `exit_*` methods.
+//! * `walk.rs` - Unsafe `walk_*` functions for AST traversal.
+
+use super::traverse::{self, TraverseTraitConfig};
+use crate::{
+    Codegen, Generator, MINIFIER_CRATE_PATH,
+    output::{Output, output_path},
+    schema::Schema,
+};
+
+use super::define_generator;
+
+pub struct MinifierTraverseGenerator;
+
+define_generator!(MinifierTraverseGenerator);
+
+impl Generator for MinifierTraverseGenerator {
+    fn generate_many(&self, schema: &Schema, _codegen: &Codegen) -> Vec<Output> {
+        let config = TraverseTraitConfig::minifier();
+        vec![
+            Output::Rust {
+                path: output_path(MINIFIER_CRATE_PATH, "traverse.rs"),
+                tokens: traverse::generate_traverse_trait(schema, &config),
+            },
+            Output::Rust {
+                path: output_path(MINIFIER_CRATE_PATH, "walk.rs"),
+                tokens: traverse::generate_walk_minifier(schema),
+            },
+        ]
+    }
+}

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -11,6 +11,7 @@ mod ast_kind;
 mod estree_visit;
 mod formatter;
 mod get_id;
+mod minifier_traverse;
 #[cfg(feature = "generate-js")]
 mod oxlint_envs;
 #[cfg(feature = "generate-js")]
@@ -31,6 +32,7 @@ pub use ast_kind::AstKindGenerator;
 pub use estree_visit::ESTreeVisitGenerator;
 pub use formatter::{FormatterAstNodesGenerator, FormatterFormatGenerator};
 pub use get_id::GetIdGenerator;
+pub use minifier_traverse::MinifierTraverseGenerator;
 #[cfg(feature = "generate-js")]
 pub use oxlint_envs::OxlintEnvsGenerator;
 #[cfg(feature = "generate-js")]

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -253,6 +253,9 @@ const AST_MACROS_CRATE_PATH: &str = "crates/oxc_ast_macros";
 /// Path to `oxc_traverse` crate
 const TRAVERSE_CRATE_PATH: &str = "crates/oxc_traverse";
 
+/// Path to `oxc_minifier` crate
+const MINIFIER_CRATE_PATH: &str = "crates/oxc_minifier";
+
 /// Path to write TS type definitions to
 const TYPESCRIPT_DEFINITIONS_PATH: &str = "npm/oxc-types/types.d.ts";
 
@@ -300,6 +303,7 @@ const GENERATORS: &[&(dyn Generator + Sync)] = &[
     &generators::FormatterFormatGenerator,
     &generators::FormatterAstNodesGenerator,
     &generators::TraverseGenerator,
+    &generators::MinifierTraverseGenerator,
 ];
 
 /// Attributes on structs and enums (not including those defined by derives/generators)


### PR DESCRIPTION
## Summary
- generate a minifier-local traverse runtime in `oxc_minifier`
- introduce handwritten `MinifierTraverseCtx` and move prior `Ctx` functionality into it
- remove old `Ctx` usage and implement the needed traits on `MinifierTraverseCtx`
- wire minifier passes/compressor to use local traverse
- reuse `ancestor.rs` from `oxc_traverse` via path module in `oxc_minifier`

## Why
- avoids orphan-rule friction around implementing traits on the prior context type
- keeps minifier traversal concerns local to `oxc_minifier`

## Validation
- `just fmt`
- `cargo check -p oxc_ast_tools`
- `cargo check -p oxc_minifier`
- `cargo test -p oxc_minifier`
- `just lint`
