### PR TITLE
fix(linter): `no-misleading-character-class`: split sequences on all `CharacterSet`

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ var r = /[👍]/
@@ -774,4 +773,10 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_misleading_character_class.tsx:1:9]
  1 │ RegExp(`[\👍]`) // Backslash + U+D83D + U+DC4D
    ·         ─────
+   ╰────
+
+  ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
+   ╭─[no_misleading_character_class.tsx:1:2]
+ 1 │ /[\u200c\u200d\p{ID_Continue}.]/
+   ·  ──────────────────────────────
    ╰────


### PR DESCRIPTION
Oriented by the original rule code: 
https://github.com/eslint/eslint/blob/b69cfb32a16c5d5e9986390d484fae1d21e406f9/lib/rules/no-misleading-character-class.js#L44-L77

Other `CharacterClassContents` should start a new sequence too.  In ESLint they are under `CharacterSet`

- UnicodePropertyEscape: https://github.com/eslint-community/regexpp/blob/76b6a3aef2d53972e0a3ca5dd9e83f6bb6ec6e78/src/ast.ts#L308-L314
- NestedCharacterClass: was missing, see original rule
- CharacterClassEscape: https://github.com/eslint-community/regexpp/blob/76b6a3aef2d53972e0a3ca5dd9e83f6bb6ec6e78/src/ast.ts#L292-L306

fixes https://github.com/oxc-project/oxc/issues/19090
