### PR TITLE
docs(linter): Fix invalid directive in example code for `import/no-nodejs-modules`.

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
     /// var foo = require('foo');
     /// var foo = require('./foo');
     ///
-    /// /* eslint import/no-nodejs-modules: ["error", {"allow": ["path"]}] */
+    /// /* import/no-nodejs-modules: ["error", {"allow": ["path"]}] */
     /// import path from 'path';
     /// ```
     NoNodejsModules,


### PR DESCRIPTION
Oxlint doesn't support inline config with actual settings like this, so remove the `eslint` part to avoid confusion with it being a directive.