### PR TITLE
docs(linter): Improve docs for `import/max-dependencies` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -26,11 +26,17 @@ fn max_dependencies_diagnostic<S: Into<Cow<'static, str>>>(
 pub struct MaxDependencies(Box<MaxDependenciesConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxDependenciesConfig {
-    /// Maximum number of dependencies allowed in a module.
+    /// Maximum number of dependencies allowed in a file.
     max: usize,
     /// Whether to ignore type imports when counting dependencies.
+    ///
+    /// ```ts
+    /// // Neither of these count as dependencies if `ignoreTypeImports` is true:
+    /// import type { Foo } from './foo';
+    /// import { type Foo } from './foo';
+    /// ```
     ignore_type_imports: bool,
 }
 
@@ -51,7 +57,7 @@ impl Default for MaxDependenciesConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Forbid modules to have too many dependencies (import or require statements).
+    /// Forbid modules to have too many dependencies (`import` statements only).
     ///
     /// ### Why is this bad?
     ///
@@ -59,9 +65,13 @@ declare_oxc_lint!(
     /// and usually indicates the module is doing too much and/or should be broken up into
     /// smaller modules.
     ///
+    /// **NOTE**: This rule only counts `import` statements, and does not count dependencies from
+    /// CommonJS `require()` statements. This is a difference from the original
+    /// eslint-import-plugin rule.
+    ///
     /// ### Examples
     ///
-    /// Given `{"max": 2}`
+    /// Given `{ "max": 2 }`
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
@@ -82,6 +92,9 @@ declare_oxc_lint!(
 );
 
 impl Rule for MaxDependencies {
+    // TODO(breaking change): Remove support for the `["error", 3]`-style configuration
+    // option, as it is not actually supported in the original rule.
+    // Only the object configuration option should be supported in the future.
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
         if let Some(max) = value
             .get(0)
@@ -91,9 +104,8 @@ impl Rule for MaxDependencies {
         {
             Ok(Self(Box::new(MaxDependenciesConfig { max, ignore_type_imports: false })))
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 
@@ -156,7 +168,7 @@ fn test() {
         //      const a = require('./foo.js');
         //      const b = require('./bar.js');
         //     ",
-        //     Some(json!([{"max": 2}])),
+        //     Some(json!([{ "max": 2 }])),
         // ),
         (
             r"
@@ -174,33 +186,57 @@ fn test() {
         (
             r"
             import type { x } from './foo';
+            import { type z } from './foo';
+            import { y } from './foo';
+            ",
+            Some(json!([{ "max": 1, "ignoreTypeImports": true }])),
+        ),
+        (
+            r"
+            import { type x } from './foo';
+            import { type y } from './foo';
+            ",
+            Some(json!([{ "max": 1, "ignoreTypeImports": true }])),
+        ),
+        (
+            r"
+            import type { x } from './foo';
             import type { y } from './foo';
             ",
             Some(json!([2])),
         ),
+        // TODO: Fix this.
+        // (
+        //     r"
+        //     import { w } from './foo';
+        //     // This should only count as one dependency, because it's 3 named imports from the same place.
+        //     import { x, y, z } from './bar';
+        //     ",
+        //     Some(json!([{ "max": 2 }])),
+        // ),
     ];
 
     let fail = vec![
         (
             r"
             import { x } from './foo';
-            import { y } from './foo';
-            import { z } from './bar';
+            import { y } from './bar';
+            import { z } from './baz';
             ",
             Some(json!([1])),
         ),
         (
             r"
             import { x } from './foo';
-            import { y } from './foo';
-            import { z } from './bar';
+            import { y } from './bar';
+            import { z } from './baz';
             ",
             Some(json!([{ "max": 1 }])),
         ),
         (
             r"
             import { x } from './foo';
-            import { y } from './foo';
+            import { y } from './bar';
             import { z } from './baz';
             ",
             Some(json!([{ "max": 2 }])),
@@ -216,17 +252,50 @@ fn test() {
         (
             r"
             import type { x } from './foo';
-            import type { y } from './foo';
+            import type { y } from './bar';
             ",
             Some(json!([{ "max": 1 }])),
         ),
         (
             r"
             import type { x } from './foo';
-            import type { y } from './foo';
+            import type { y } from './bar';
             import type { z } from './baz';
             ",
             Some(json!([{ "max": 2, "ignoreTypeImports": false }])),
+        ),
+        (
+            r"
+            import type { x } from './foo';
+            import { type y } from './bar';
+            import { type z } from './baz';
+            ",
+            Some(json!([{ "max": 2, "ignoreTypeImports": false }])),
+        ),
+        (
+            r"
+            import { x } from './foo';
+            import { y } from './bar';
+            import { z } from './baz.json' with { type: 'json' };
+            ",
+            Some(json!([{ "max": 2 }])),
+        ),
+        (
+            r"
+            import { w } from './foo';
+            // This should still count, because only one is a type import
+            import { type x, y } from './bar';
+            import { z } from './baz';
+            ",
+            Some(json!([{ "max": 2, "ignoreTypeImports": true }])),
+        ),
+        (
+            r"
+            import { definePlugin } from '@oxlint/plugins';
+            import { fsSync } from 'node:fs';
+            import { path } from 'node:path';
+            ",
+            Some(json!([{ "max": 2 }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/import_max_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/import_max_dependencies.snap
@@ -5,24 +5,24 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 1.
    ╭─[index.ts:3:31]
  2 │             import { x } from './foo';
- 3 │             import { y } from './foo';
+ 3 │             import { y } from './bar';
    ·                               ───────
- 4 │             import { z } from './bar';
+ 4 │             import { z } from './baz';
    ╰────
   help: Reduce the number of dependencies in this file
 
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 1.
    ╭─[index.ts:3:31]
  2 │             import { x } from './foo';
- 3 │             import { y } from './foo';
+ 3 │             import { y } from './bar';
    ·                               ───────
- 4 │             import { z } from './bar';
+ 4 │             import { z } from './baz';
    ╰────
   help: Reduce the number of dependencies in this file
 
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
    ╭─[index.ts:4:31]
- 3 │             import { y } from './foo';
+ 3 │             import { y } from './bar';
  4 │             import { z } from './baz';
    ·                               ───────
  5 │             
@@ -32,7 +32,7 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (2). Maximum allowed is 1.
    ╭─[index.ts:3:36]
  2 │             import type { x } from './foo';
- 3 │             import type { y } from './foo';
+ 3 │             import type { y } from './bar';
    ·                                    ───────
  4 │             
    ╰────
@@ -40,9 +40,45 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
    ╭─[index.ts:4:36]
- 3 │             import type { y } from './foo';
+ 3 │             import type { y } from './bar';
  4 │             import type { z } from './baz';
    ·                                    ───────
+ 5 │             
+   ╰────
+  help: Reduce the number of dependencies in this file
+
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
+   ╭─[index.ts:4:36]
+ 3 │             import { type y } from './bar';
+ 4 │             import { type z } from './baz';
+   ·                                    ───────
+ 5 │             
+   ╰────
+  help: Reduce the number of dependencies in this file
+
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
+   ╭─[index.ts:4:31]
+ 3 │             import { y } from './bar';
+ 4 │             import { z } from './baz.json' with { type: 'json' };
+   ·                               ────────────
+ 5 │             
+   ╰────
+  help: Reduce the number of dependencies in this file
+
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
+   ╭─[index.ts:4:39]
+ 3 │             // This should still count, because only one is a type import
+ 4 │             import { type x, y } from './bar';
+   ·                                       ───────
+ 5 │             import { z } from './baz';
+   ╰────
+  help: Reduce the number of dependencies in this file
+
+  ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
+   ╭─[index.ts:4:34]
+ 3 │             import { fsSync } from 'node:fs';
+ 4 │             import { path } from 'node:path';
+   ·                                  ───────────
  5 │             
    ╰────
   help: Reduce the number of dependencies in this file


### PR DESCRIPTION
Also enforce the shape of the config object when using a config object.

Plus add a handful of additional tests to cover various cases. (inline type imports, JSON imports using `with`, imports of node builtins like `node:fs`, etc.).

I've updated the docs to give better examples, and also have a warning about the rule not supporting CommonJS `require` dependencies, which is a difference vs the original rule.

I also discovered an issue with the `import/max-dependencies` rule differing from the original rule's behavior in regards to multiple named imports from the same source counting as multiple dependencies. I opted not to fix it for now, and created #19120 for someone else to fix the problem.