### PR TITLE
refactor(linter): Enforce config options for various max-* rules.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -21,7 +21,7 @@ fn max_lines_diagnostic(count: usize, max: usize, span: Span) -> OxcDiagnostic {
 pub struct MaxLines(Box<MaxLinesConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxLinesConfig {
     /// Maximum number of lines allowed per file.
     max: usize,
@@ -77,9 +77,8 @@ impl Rule for MaxLines {
                 skip_blank_lines: false,
             })))
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -24,7 +24,7 @@ fn max_params_diagnostic(message: &str, span: Span) -> OxcDiagnostic {
 pub struct MaxParams(Box<MaxParamsConfig>);
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxParamsConfig {
     /// Maximum number of parameters allowed in function definitions.
     max: usize,
@@ -106,9 +106,8 @@ impl Rule for MaxParams {
         {
             Ok(Self(Box::new(MaxParamsConfig { max, count_void_this: false })))
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 


### PR DESCRIPTION
Updated these rules to use DefaultRuleConfig + deny_unknown_fields so they return validation errors if given invalid config options.