### PR TITLE
docs(linter/consistent-test-filename): escape file names fixes #19114

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_test_filename.rs
@@ -89,11 +89,11 @@ declare_oxc_lint!(
     ///
     /// An example of an **incorrect** file path for this rule configured as `{"allTestPattern": "__tests__",  "pattern": ".*\.spec\.ts$"}`:
     ///
-    /// __tests__/2.ts
+    /// `__tests__/2.ts`
     ///
     /// An example of a **correct** file path for this rule configured as `{"allTestPattern": "__tests__",  "pattern": ".*\.spec\.ts$"}`:
     ///
-    /// __tests__/2.spec.ts
+    /// `__tests__/2.spec.ts`
     ///
     ConsistentTestFilename,
     vitest,


### PR DESCRIPTION
fixes #19114