### PR TITLE
chore(oxlint,parser,e2e): explicitly set `strict: false` in tsconfigs

### DIFF
--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "target": "ESNext",
     "allowImportingTsExtensions": true,
+    "strict": false,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "skipLibCheck": true,

--- a/napi/parser/tsconfig.json
+++ b/napi/parser/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "target": "ESNext",
     "allowImportingTsExtensions": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strict": false
   }
 }

--- a/tasks/e2e/tsconfig.json
+++ b/tasks/e2e/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "module": "esnext",
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strict": false
   }
 }


### PR DESCRIPTION
fixes the failures seen in https://github.com/oxc-project/oxc/pull/19128