### PR TITLE
refactor(semantic): migrate temp semantic state to allocator scratch arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,6 @@ dependencies = [
  "rustc-hash",
  "self_cell",
  "serde_json",
- "smallvec",
 ]
 
 [[package]]

--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -181,7 +181,8 @@ unsafe fn parse_raw_impl(
         // Check for semantic errors.
         // If `ignore_non_fatal_errors` is `true`, skip running semantic, as any errors will be ignored anyway.
         if !parsing_failed && !ignore_non_fatal_errors {
-            let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(program);
+            let semantic_ret =
+                SemanticBuilder::new(&allocator).with_check_syntax_error(true).build(program);
             parsing_failed = !semantic_ret.errors.is_empty();
         }
 

--- a/crates/oxc/README.md
+++ b/crates/oxc/README.md
@@ -99,7 +99,7 @@ if panicked {
 let SemanticBuilderReturn {
     semantic,
     errors: semantic_errors,
-} = SemanticBuilder::new()
+} = SemanticBuilder::new(&allocator)
     .with_check_syntax_error(true) // Enable extra syntax error checking
     .with_cfg(true)                // Build a Control Flow Graph
     .build(&program);              // Produce the `Semantic`

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -136,7 +136,7 @@ pub trait CompilerInterface {
 
         /* Semantic */
 
-        let mut semantic_return = self.semantic(&program);
+        let mut semantic_return = self.semantic(&allocator, &program);
         if !semantic_return.errors.is_empty() {
             self.handle_errors(semantic_return.errors);
             return;
@@ -171,8 +171,11 @@ pub trait CompilerInterface {
 
         // Symbols and scopes are out of sync.
         if inject_options.is_some() || define_options.is_some() {
-            scoping =
-                SemanticBuilder::new().with_stats(stats).build(&program).semantic.into_scoping();
+            scoping = SemanticBuilder::new(&allocator)
+                .with_stats(stats)
+                .build(&program)
+                .semantic
+                .into_scoping();
         }
 
         if let Some(options) = inject_options {
@@ -220,8 +223,12 @@ pub trait CompilerInterface {
         Parser::new(allocator, source_text, source_type).with_options(self.parse_options()).parse()
     }
 
-    fn semantic<'a>(&self, program: &'a Program<'a>) -> SemanticBuilderReturn<'a> {
-        let mut builder = SemanticBuilder::new();
+    fn semantic<'a>(
+        &self,
+        allocator: &'a Allocator,
+        program: &'a Program<'a>,
+    ) -> SemanticBuilderReturn<'a> {
+        let mut builder = SemanticBuilder::new(allocator);
 
         if self.transform_options().is_some() {
             // Estimate transformer will triple scopes, symbols, references

--- a/crates/oxc_allocator/src/hash_map.rs
+++ b/crates/oxc_allocator/src/hash_map.rs
@@ -131,6 +131,15 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
         Self(ManuallyDrop::new(inner))
     }
 
+    /// Creates an empty [`HashMap`] with the given hasher in the allocator's scratch arena.
+    #[inline(always)]
+    pub fn with_hasher_in_scratch(hasher: S, allocator: &'alloc Allocator) -> Self {
+        const { Self::ASSERT_K_AND_V_ARE_NOT_DROP };
+
+        let inner = InnerHashMap::with_hasher_in(hasher, allocator.scratch_bump());
+        Self(ManuallyDrop::new(inner))
+    }
+
     /// Creates an empty [`HashMap`] with the specified capacity and hasher.
     /// It will be allocated with the given allocator.
     ///
@@ -145,6 +154,21 @@ impl<'alloc, K, V, S> HashMap<'alloc, K, V, S> {
         const { Self::ASSERT_K_AND_V_ARE_NOT_DROP };
 
         let inner = InnerHashMap::with_capacity_and_hasher_in(capacity, hasher, allocator.bump());
+        Self(ManuallyDrop::new(inner))
+    }
+
+    /// Creates an empty [`HashMap`] with the specified capacity and hasher in the
+    /// allocator's scratch arena.
+    #[inline(always)]
+    pub fn with_capacity_and_hasher_in_scratch(
+        capacity: usize,
+        hasher: S,
+        allocator: &'alloc Allocator,
+    ) -> Self {
+        const { Self::ASSERT_K_AND_V_ARE_NOT_DROP };
+
+        let inner =
+            InnerHashMap::with_capacity_and_hasher_in(capacity, hasher, allocator.scratch_bump());
         Self(ManuallyDrop::new(inner))
     }
 
@@ -195,6 +219,12 @@ impl<'alloc, K, V> HashMap<'alloc, K, V> {
         Self::with_hasher_in(FxBuildHasher, allocator)
     }
 
+    /// Creates an empty [`HashMap`] in the allocator's scratch arena.
+    #[inline(always)]
+    pub fn new_in_scratch(allocator: &'alloc Allocator) -> Self {
+        Self::with_hasher_in_scratch(FxBuildHasher, allocator)
+    }
+
     /// Creates an empty [`HashMap`] with the specified capacity. It will be allocated with the given allocator.
     ///
     /// The hash map will be able to hold at least capacity elements without reallocating.
@@ -202,6 +232,12 @@ impl<'alloc, K, V> HashMap<'alloc, K, V> {
     #[inline(always)]
     pub fn with_capacity_in(capacity: usize, allocator: &'alloc Allocator) -> Self {
         Self::with_capacity_and_hasher_in(capacity, FxBuildHasher, allocator)
+    }
+
+    /// Creates an empty [`HashMap`] with the specified capacity in the allocator's scratch arena.
+    #[inline(always)]
+    pub fn with_capacity_in_scratch(capacity: usize, allocator: &'alloc Allocator) -> Self {
+        Self::with_capacity_and_hasher_in_scratch(capacity, FxBuildHasher, allocator)
     }
 
     /// Create a new [`HashMap`] whose elements are taken from an iterator and

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -81,6 +81,16 @@ impl<'alloc, T> Vec<'alloc, T> {
         Self(InnerVec::new_in(allocator.bump()))
     }
 
+    /// Constructs a new, empty `Vec<T>` in the allocator's scratch arena.
+    ///
+    /// Data in the scratch arena is intended for temporary allocations.
+    #[inline(always)]
+    pub fn new_in_scratch(allocator: &'alloc Allocator) -> Self {
+        const { Self::ASSERT_T_IS_NOT_DROP };
+
+        Self(InnerVec::new_in(allocator.scratch_bump()))
+    }
+
     /// Constructs a new, empty `Vec<T>` with at least the specified capacity
     /// with the provided allocator.
     ///
@@ -132,6 +142,15 @@ impl<'alloc, T> Vec<'alloc, T> {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         Self(InnerVec::with_capacity_in(capacity, allocator.bump()))
+    }
+
+    /// Constructs a new, empty `Vec<T>` with at least the specified capacity in the
+    /// allocator's scratch arena.
+    #[inline(always)]
+    pub fn with_capacity_in_scratch(capacity: usize, allocator: &'alloc Allocator) -> Self {
+        const { Self::ASSERT_T_IS_NOT_DROP };
+
+        Self(InnerVec::with_capacity_in(capacity, allocator.scratch_bump()))
     }
 
     /// Create a new [`Vec`] whose elements are taken from an iterator and

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -35,7 +35,7 @@ fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     }
 
     // Using semantic analysis here only to get parent node
-    let semantic_ret = SemanticBuilder::new().build(&program);
+    let semantic_ret = SemanticBuilder::new(&allocator).build(&program);
     collector.collect(&program, &semantic_ret.semantic)
 }
 

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
     }
 
     // Build semantic model for AST analysis
-    let semantic_ret = SemanticBuilder::new().build(&ret.program);
+    let semantic_ret = SemanticBuilder::new(&allocator).build(&ret.program);
 
     let mut errors: Vec<OxcDiagnostic> = vec![];
 

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1093,7 +1093,8 @@ mod tests {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(allocator, source_text, source_type).parse();
         assert!(parser_ret.errors.is_empty());
-        let semantic_ret = SemanticBuilder::new().build(allocator.alloc(parser_ret.program));
+        let semantic_ret =
+            SemanticBuilder::new(allocator).build(allocator.alloc(parser_ret.program));
         semantic_ret.semantic
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1027,7 +1027,7 @@ impl Runtime {
             return Err(if ret.is_flow_language { vec![] } else { ret.errors });
         }
 
-        let semantic_ret = SemanticBuilder::new()
+        let semantic_ret = SemanticBuilder::new(allocator)
             .with_cfg(true)
             .with_check_syntax_error(check_syntax_errors)
             .build(allocator.alloc(ret.program));

--- a/crates/oxc_linter/src/utils/comment.rs
+++ b/crates/oxc_linter/src/utils/comment.rs
@@ -92,7 +92,7 @@ mod test {
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, source, source_type).parse();
             assert!(ret.errors.is_empty());
-            let semantic = SemanticBuilder::new().build(&ret.program).semantic;
+            let semantic = SemanticBuilder::new(&allocator).build(&ret.program).semantic;
             let comments = semantic.comments();
 
             assert_eq!(

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -330,7 +330,7 @@ mod test {
             let source_type = SourceType::default();
             let parser_ret = Parser::new(&allocator, "", source_type).parse();
             let program = allocator.alloc(parser_ret.program);
-            let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+            let semantic = SemanticBuilder::new(&allocator).with_cfg(true).build(program).semantic;
             Rc::new(ContextHost::new(
                 path,
                 vec![ContextSubHost::new(semantic, Arc::new(ModuleRecord::default()), 0)],

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -258,7 +258,7 @@ mod test {
         let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
         assert!(!ret.panicked, "{source_text}");
         assert!(ret.errors.is_empty(), "{source_text}");
-        let ret = SemanticBuilder::new().build(&ret.program);
+        let ret = SemanticBuilder::new(&allocator).build(&ret.program);
         assert!(ret.errors.is_empty(), "{source_text}");
         let semantic = ret.semantic;
         let symbols = collect_name_symbols(opts, &allocator, semantic.scoping(), semantic.nodes());

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -275,7 +275,10 @@ impl<'t> Mangler<'t> {
     /// Pass the symbol table to oxc_codegen to generate the mangled code.
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> ManglerReturn {
-        let mut semantic = SemanticBuilder::new().build(program).semantic;
+        let mut semantic = {
+            let temp_allocator = self.temp_allocator.as_ref();
+            SemanticBuilder::new(temp_allocator).build(program).semantic
+        };
         let class_private_mappings = self.build_with_semantic(&mut semantic, program);
         ManglerReturn { scoping: semantic.into_scoping(), class_private_mappings }
     }
@@ -284,7 +287,7 @@ impl<'t> Mangler<'t> {
     ///
     /// Panics if the child_ids does not exist in scope_tree.
     pub fn build_with_semantic(
-        self,
+        &self,
         semantic: &mut Semantic<'_>,
         program: &Program<'_>,
     ) -> IndexVec<ClassId, FxHashMap<String, CompactStr>> {
@@ -298,7 +301,7 @@ impl<'t> Mangler<'t> {
     }
 
     fn build_with_semantic_impl<const CAPACITY: usize, G: Fn(u32) -> InlineString<CAPACITY, u8>>(
-        self,
+        &self,
         semantic: &mut Semantic<'_>,
         program: &Program<'_>,
         generate_name: G,

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -19,7 +19,7 @@ impl<'a> Compressor<'a> {
     }
 
     pub fn build(self, program: &mut Program<'a>, options: CompressOptions) {
-        let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
+        let scoping = SemanticBuilder::new(self.allocator).build(program).semantic.into_scoping();
         self.build_with_scoping(program, scoping, options);
     }
 
@@ -43,7 +43,7 @@ impl<'a> Compressor<'a> {
     }
 
     pub fn dead_code_elimination(self, program: &mut Program<'a>, options: CompressOptions) -> u8 {
-        let scoping = SemanticBuilder::new().build(program).semantic.into_scoping();
+        let scoping = SemanticBuilder::new(self.allocator).build(program).semantic.into_scoping();
         self.dead_code_elimination_with_scoping(program, scoping, options)
     }
 

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -115,7 +115,7 @@ impl<'a> Minifier {
             .options
             .compress
             .map(|options| {
-                let semantic = SemanticBuilder::new().build(program).semantic;
+                let semantic = SemanticBuilder::new(allocator).build(program).semantic;
                 let stats = semantic.stats();
                 let scoping = semantic.into_scoping();
                 let compressor = Compressor::new(allocator);
@@ -136,7 +136,8 @@ impl<'a> Minifier {
             .options
             .mangle
             .map(|options| {
-                let mut semantic = SemanticBuilder::new().with_stats(stats).build(program).semantic;
+                let mut semantic =
+                    SemanticBuilder::new(allocator).with_stats(stats).build(program).semantic;
                 let class_private_mappings = Mangler::default()
                     .with_options(options)
                     .build_with_semantic(&mut semantic, program);

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -35,7 +35,6 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }
-smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -75,8 +75,10 @@ fn main() -> std::io::Result<()> {
     std::fs::write(ast_file_path, format!("{:#?}", &program))?;
     println!("Wrote AST to: {}", &ast_file_name);
 
-    let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).with_cfg(true).build(&program);
+    let semantic = SemanticBuilder::new(&allocator)
+        .with_check_syntax_error(true)
+        .with_cfg(true)
+        .build(&program);
 
     if !semantic.errors.is_empty() {
         let error_message: String = semantic

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -57,7 +57,7 @@ fn main() -> std::io::Result<()> {
     let program = parser_ret.program;
 
     // Build semantic model with syntax error checking
-    let semantic = SemanticBuilder::new()
+    let semantic = SemanticBuilder::new(&allocator)
         // Enable additional syntax checks not performed by the parser
         .with_check_syntax_error(true)
         .build(&program);

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -93,7 +93,14 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                 // Finally, add the variable to all hoisted scopes
                 // to support redeclaration checks when declaring variables with the same name later.
                 for &scope_id in &var_scope_ids {
-                    builder.hoisting_variables.entry(scope_id).or_default().insert(name, symbol_id);
+                    if let Some(symbols) = builder.hoisting_variables.get_mut(&scope_id) {
+                        symbols.insert(name, symbol_id);
+                    } else {
+                        let mut symbols =
+                            oxc_span::ArenaIdentHashMap::new_in_scratch(builder.allocator);
+                        symbols.insert(name, symbol_id);
+                        builder.hoisting_variables.insert(scope_id, symbols);
+                    }
                 }
             });
         }

--- a/crates/oxc_semantic/src/jsdoc/builder.rs
+++ b/crates/oxc_semantic/src/jsdoc/builder.rs
@@ -207,7 +207,7 @@ mod test {
     ) -> Semantic<'a> {
         let source_type = source_type.unwrap_or_default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::new(allocator).build(allocator.alloc(ret.program)).semantic
     }
 
     fn get_jsdocs<'a>(

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -45,7 +45,7 @@ mod test {
     fn build_semantic<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::new(allocator).build(allocator.alloc(ret.program)).semantic
     }
 
     #[test]

--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc_tag.rs
@@ -194,7 +194,7 @@ mod test {
     fn build_semantic<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::new(allocator).build(allocator.alloc(ret.program)).semantic
     }
 
     #[test]

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -269,7 +269,7 @@ mod tests {
     ) -> Semantic<'s> {
         let parse = oxc_parser::Parser::new(allocator, source, source_type).parse();
         assert!(parse.errors.is_empty());
-        let semantic = SemanticBuilder::new().build(allocator.alloc(parse.program));
+        let semantic = SemanticBuilder::new(allocator).build(allocator.alloc(parse.program));
         assert!(semantic.errors.is_empty(), "Parse error: {}", semantic.errors[0]);
         semantic.semantic
     }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -623,7 +623,7 @@ impl Scoping {
 
     pub(crate) fn set_root_unresolved_references<'a>(
         &mut self,
-        entries: impl Iterator<Item = (Ident<'a>, ReferenceIds)>,
+        entries: impl Iterator<Item = (Ident<'a>, ReferenceIds<'a>)>,
     ) {
         self.cell.with_dependent_mut(|allocator, cell| {
             for (k, v) in entries {

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -178,7 +178,7 @@ impl<'a> SemanticTester<'a> {
                 .collect::<String>()
         );
 
-        SemanticBuilder::new()
+        SemanticBuilder::new(&self.allocator)
             .with_check_syntax_error(true)
             .with_cfg(self.cfg)
             .build(self.allocator.alloc(parse.program))

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -127,7 +127,7 @@ fn analyze(
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&ret.program).semantic;
+        SemanticBuilder::new(&allocator).with_check_syntax_error(true).build(&ret.program).semantic;
     let ctx = TestContext { path, semantic };
     let scope_snapshot = run_scope_snapshot_test(&ctx);
     let conformance_snapshot = conformance_suite.run_on_source(&ctx);

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -62,7 +62,7 @@ fn main() {
 
     let mut program = ret.program;
 
-    let ret = SemanticBuilder::new()
+    let ret = SemanticBuilder::new(&allocator)
         // Estimate transformer will triple scopes, symbols, references
         .with_excess_capacity(2.0)
         .build(&program);

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -31,7 +31,7 @@ pub(crate) fn test(
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let ret = Transformer::new(&allocator, Path::new(""), options)
         .build_with_scoping(scoping, &mut program);
     if !ret.errors.is_empty() {

--- a/crates/oxc_transformer_plugins/examples/define.rs
+++ b/crates/oxc_transformer_plugins/examples/define.rs
@@ -40,7 +40,7 @@ fn main() -> std::io::Result<()> {
     let allocator = Allocator::default();
 
     let mut program = parse(&allocator, &source_text, source_type);
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let config = ReplaceGlobalDefinesConfig::new(&defines).unwrap();
     let _ = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
     let printed = codegen(&program, sourcemap);

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -872,7 +872,7 @@ mod test {
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let mut program = ret.program;
-        let mut scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let mut scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
         if is_jsx {
             let mut options = TransformOptions::default();
             options.jsx.runtime = JsxRuntime::Classic;

--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -18,7 +18,7 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty());
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let ret = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
     assert_eq!(ret.changed, source_text != expected);
     let result = Codegen::new()

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -16,7 +16,7 @@ pub fn test(source_text: &str, expected: &str, config: &ReplaceGlobalDefinesConf
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty());
     let mut program = ret.program;
-    let mut scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let mut scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let ret = ReplaceGlobalDefines::new(&allocator, config.clone()).build(scoping, &mut program);
     assert_eq!(ret.changed, source_text != expected);
     // Use the updated scoping, instead of recreating one.
@@ -282,7 +282,7 @@ log(__MEMBER__);
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(&allocator, c).build(scoping, &mut program);
     let result = Codegen::new()
         .with_options(CodegenOptions {

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -100,7 +100,8 @@ fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions)
     let mut diagnostics = ret.errors;
 
     if options.show_semantic_errors == Some(true) {
-        let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        let semantic_ret =
+            SemanticBuilder::new(&allocator).with_check_syntax_error(true).build(&program);
         diagnostics.extend(semantic_ret.errors);
     }
 

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -233,7 +233,8 @@ unsafe fn parse_raw_impl(
         // Note: Avoid calling `Error::from_diagnostics_in` unless there are some errors,
         // because it's fairly expensive (it copies whole of source text into a `String`).
         let mut errors = if options.show_semantic_errors == Some(true) {
-            let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+            let semantic_ret =
+                SemanticBuilder::new(&allocator).with_check_syntax_error(true).build(&program);
 
             if !ret.errors.is_empty() || !semantic_ret.errors.is_empty() {
                 Error::from_diagnostics_in(

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -1031,7 +1031,7 @@ fn module_runner_transform_impl(
     let mut program = parser_ret.program;
 
     let SemanticBuilderReturn { semantic, errors } =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        SemanticBuilder::new(&allocator).with_check_syntax_error(true).build(&program);
     parser_ret.errors.extend(errors);
 
     let scoping = semantic.into_scoping();

--- a/tasks/benchmark/benches/codegen.rs
+++ b/tasks/benchmark/benches/codegen.rs
@@ -19,7 +19,7 @@ fn bench_codegen(criterion: &mut Criterion) {
         assert!(parser_ret.errors.is_empty());
         let mut program = parser_ret.program;
 
-        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+        let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
 
         let transform_options = TransformOptions::enable_all();
         let transformer_ret =

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -31,7 +31,8 @@ fn bench_linter(criterion: &mut Criterion) {
 
                 let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
                 let path = Path::new("");
-                let semantic_ret = SemanticBuilder::new().with_cfg(true).build(&parser_ret.program);
+                let semantic_ret =
+                    SemanticBuilder::new(&allocator).with_cfg(true).build(&parser_ret.program);
                 let semantic = semantic_ret.semantic;
                 let module_record =
                     Arc::new(ModuleRecord::new(path, &parser_ret.module_record, &semantic));

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -29,7 +29,8 @@ fn bench_minifier(criterion: &mut Criterion) {
 
                 // Create fresh AST + semantic data for each iteration
                 let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+                let scoping =
+                    SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
 
                 // Minifier only works on esnext.
                 let transform_options = TransformOptions::from_target("esnext").unwrap();
@@ -37,7 +38,8 @@ fn bench_minifier(criterion: &mut Criterion) {
                     Transformer::new(&allocator, Path::new(&file.file_name), &transform_options)
                         .build_with_scoping(scoping, &mut program);
                 assert!(transformer_ret.errors.is_empty());
-                let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+                let scoping =
+                    SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
 
                 let options = CompressOptions::smallest();
                 runner.run(|| {
@@ -63,7 +65,7 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 temp_allocator.reset();
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                let mut semantic = SemanticBuilder::new(&allocator).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .build_with_semantic(&mut semantic, &program);
@@ -83,7 +85,7 @@ fn bench_mangler(criterion: &mut Criterion) {
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
                 let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                let mut semantic = SemanticBuilder::new(&allocator).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .with_options(MangleOptions {

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -41,7 +41,7 @@ fn bench_pipeline(criterion: &mut Criterion) {
                     let mut program = parser_ret.program;
 
                     // Semantic
-                    let scoping = SemanticBuilder::new()
+                    let scoping = SemanticBuilder::new(&allocator)
                         .with_excess_capacity(2.0)
                         .build(&program)
                         .semantic

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -29,7 +29,9 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
                     // but that's atypical, so don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+                    let ret = SemanticBuilder::new(&allocator)
+                        .with_check_syntax_error(true)
+                        .build(&program);
                     let ret = black_box(ret);
                     ret.errors
                 });

--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -33,7 +33,7 @@ fn bench_transformer(criterion: &mut Criterion) {
                 // Create fresh AST + semantic data for each iteration
                 let ParserReturn { mut program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
-                let scoping = SemanticBuilder::new()
+                let scoping = SemanticBuilder::new(&allocator)
                     // Estimate transformer will triple scopes, symbols, references
                     .with_excess_capacity(2.0)
                     .build(&program)

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -160,7 +160,7 @@ fn minify(source_text: &str, source_type: SourceType, options: Options) -> (Stri
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty());
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(
         &allocator,
         ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'development'")]).unwrap(),

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -149,7 +149,8 @@ pub fn run() -> Result<(), io::Error> {
         assert!(parsed.errors.is_empty());
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
-        let scoping = SemanticBuilder::new().build(&parsed.program).semantic.into_scoping();
+        let scoping =
+            SemanticBuilder::new(&allocator).build(&parsed.program).semantic.into_scoping();
         let transform_options = TransformOptions::from_target("esnext").unwrap();
         let _ =
             Transformer::new(&allocator, std::path::Path::new(&file.file_name), &transform_options)
@@ -181,7 +182,7 @@ pub fn run() -> Result<(), io::Error> {
         ));
 
         let (scoping, semantic_stats) = record_stats_in(&allocator, || {
-            SemanticBuilder::new().build(&parsed.program).semantic.into_scoping()
+            SemanticBuilder::new(&allocator).build(&parsed.program).semantic.into_scoping()
         });
 
         semantic_out.push_str(&format_table_row(

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -134,7 +134,7 @@ pub fn check_semantic_after_transform(
     // so the cloned AST will be "clean" of all semantic data, as if it had come fresh from the parser.
     let allocator = Allocator::default();
     let program = program.clone_in(&allocator);
-    let scoping_rebuilt = SemanticBuilder::new().build(&program).semantic.into_scoping();
+    let scoping_rebuilt = SemanticBuilder::new(&allocator).build(&program).semantic.into_scoping();
 
     let (scope_ids_rebuilt, symbol_ids_rebuilt, reference_ids_rebuilt, _) =
         SemanticIdsCollector::new(&mut errors).collect(&program);


### PR DESCRIPTION
## Summary
- add scratch-arena constructors for `oxc_allocator::Vec` and `oxc_allocator::HashMap`
- extend `Allocator` with internal scratch bump access and reset behavior
- migrate semantic temporary state (`module_instance_state_cache`, `hoisting_variables`, unresolved-reference stack) to scratch-backed arena containers
- update `SemanticBuilder::new` to take `&Allocator` and migrate all call sites across crates/apps/napi/tasks
- fix mangler semantic build helpers to borrow `self` when reusing temp allocator

## Related
- Implements option 3 from https://github.com/oxc-project/backlog/issues/121

## Validation
- `cargo fmt --all`
- `cargo check`
- `cargo test -p oxc_allocator`
- `cargo test -p oxc_allocator --features track_allocations`
- `cargo test -p oxc_allocator --features from_raw_parts`
- `cargo test -p oxc_semantic --lib --tests`
- `cargo test -p oxc_mangler --lib`

Note: `cargo test -p oxc_semantic` currently fails on `examples/cfg.rs` due missing `main` for that example target (pre-existing in this branch state).

## AI Disclosure
This PR was prepared with AI assistance (Codex/GPT-5). I reviewed the generated changes and ran the validation commands above.
