### PR TITLE
fix(linter): add help/note text to ~150 diagnostics

### DIFF
--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
@@ -9,7 +9,7 @@ File URI: file://<variable>/fixtures/lsp/regexp_feature/index.ts
 
 code: "eslint(no-control-regex)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex.html"
-message: "Unexpected control character"
+message: "Unexpected control character\nhelp: Use a Unicode escape sequence instead."
 range: Range { start: Position { line: 1, character: 16 }, end: Position { line: 1, character: 22 } }
 related_information[0].message: "'U+0000' is a control character."
 related_information[0].location.uri: "file://<variable>/fixtures/lsp/regexp_feature/index.ts"

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -11,6 +11,7 @@ working directory:
  1 | console.log('')
    : ^^^^^^^
    `----
+  help: Declare the variable or fix the reference.
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 94 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -11,6 +11,7 @@ working directory:
  1 | console.log(foo)
    : ^^^^^^^
    `----
+  help: Declare the variable or fix the reference.
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 94 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -21,6 +21,7 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
+  help: Use 'BigInt' or adjust the value.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -29,6 +29,7 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
+  help: Use 'BigInt' or adjust the value.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_vitest_rules_-c .oxlintrc-vitest.json --report-unused-disable-directives test.js@oxlint.snap
@@ -13,6 +13,7 @@ working directory: fixtures/disable_vitest_rules
    :      ^^^^^^^^^^^^^^^^^^^
  8 | })
    `----
+  help: Replace with an alternative or remove the call.
 
   ! Unused eslint-disable directive (no problems were reported).
     ,-[test.js:19:5]

--- a/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
@@ -13,6 +13,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    :                                ^^^^
  5 | 
    `----
+  help: Extract into a named constant.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.
@@ -32,6 +33,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    :                                ^^^^
  5 | 
    `----
+  help: Extract into a named constant.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import_-c .oxlintrc.json test.js -c .oxlintrc-import-x.json test.js@oxlint.snap
@@ -13,6 +13,7 @@ working directory: fixtures/import
    :        ^^^^^^^
  8 | 
    `----
+  help: Use a named export instead.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.
@@ -32,6 +33,7 @@ working directory: fixtures/import
    :        ^^^^^^^
  8 | 
    `----
+  help: Use a named export instead.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -14,6 +14,7 @@ working directory: fixtures/overrides_env_globals
    :      `-- Read-only global 'globalThis' should not be modified.
  3 | $ = 'abc';
    `----
+  help: Assign to a local variable instead.
 
   ! eslint(no-global-assign): Read-only global 'globalThis' should not be modified.
    ,-[test.js:2:1]
@@ -23,6 +24,7 @@ working directory: fixtures/overrides_env_globals
    :      `-- Read-only global 'globalThis' should not be modified.
  3 | $ = 'abc';
    `----
+  help: Assign to a local variable instead.
 
   ! eslint(no-global-assign): Read-only global '$' should not be modified.
    ,-[test.js:3:1]
@@ -32,6 +34,7 @@ working directory: fixtures/overrides_env_globals
    : `-- Read-only global '$' should not be modified.
  4 | 
    `----
+  help: Assign to a local variable instead.
 
   ! eslint(no-global-assign): Read-only global 'Foo' should not be modified.
    ,-[test.js:6:1]
@@ -40,6 +43,7 @@ working directory: fixtures/overrides_env_globals
    : ^|^
    :  `-- Read-only global 'Foo' should not be modified.
    `----
+  help: Assign to a local variable instead.
 
   ! eslint(no-global-assign): Read-only global 'globalThis' should not be modified.
    ,-[test.ts:2:1]
@@ -49,6 +53,7 @@ working directory: fixtures/overrides_env_globals
    :      `-- Read-only global 'globalThis' should not be modified.
  3 | $ = 'abc';
    `----
+  help: Assign to a local variable instead.
 
 Found 5 warnings and 0 errors.
 Finished in <variable>ms on 3 files with 1 rules using 1 threads.

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -9,7 +9,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_async_promise_executor_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Promise executor functions should not be `async`.").with_label(span)
+    OxcDiagnostic::warn("Promise executor functions should not be `async`.")
+        .with_help("Remove the 'async' keyword.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -9,7 +9,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_await_in_loop_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span)
+    OxcDiagnostic::warn("Unexpected `await` inside a loop.")
+        .with_help("Collect promises and use 'Promise.all()' instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -9,7 +9,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_case_declarations_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span)
+    OxcDiagnostic::warn("Unexpected lexical declaration in case block.")
+        .with_help("Wrap the case block in braces to create a new scope.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -7,7 +7,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_class_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Unexpected re-assignment of class {name}")).with_labels([
+    OxcDiagnostic::warn(format!("Unexpected re-assignment of class {name}"))
+        .with_help("Use a different variable name.")
+        .with_labels([
         decl_span.label(format!("{name} is declared as class here")),
         assign_span.label(format!("{name} is re-assigned here")),
     ])

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -10,9 +10,9 @@ fn no_class_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) ->
     OxcDiagnostic::warn(format!("Unexpected re-assignment of class {name}"))
         .with_help("Use a different variable name.")
         .with_labels([
-        decl_span.label(format!("{name} is declared as class here")),
-        assign_span.label(format!("{name} is re-assigned here")),
-    ])
+            decl_span.label(format!("{name} is declared as class here")),
+            assign_span.label(format!("{name} is re-assigned here")),
+        ])
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -8,6 +8,7 @@ use crate::{context::LintContext, rule::Rule};
 
 fn no_const_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected re-assignment of `const` variable {name}."))
+        .with_help("Use 'let' if the variable needs reassignment.")
         .with_labels([
             decl_span.label(format!("{name} is declared here as `const`.")),
             assign_span.label(format!("{name} is re-assigned here.")),

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -10,7 +10,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_constructor_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected return statement in constructor.").with_label(span)
+    OxcDiagnostic::warn("Unexpected return statement in constructor.")
+        .with_help("Remove the return value.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -39,6 +39,7 @@ fn no_control_regex_diagnostic(control_chars: &[Character]) -> OxcDiagnostic {
     } else {
         "Unexpected control character"
     })
+    .with_help("Use a Unicode escape sequence instead.")
     .with_labels(labels)
 }
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -7,7 +7,9 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_delete_var_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Variables should not be deleted").with_label(span)
+    OxcDiagnostic::warn("Variables should not be deleted")
+        .with_note("'delete' is only valid for object properties.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eval can be harmful.").with_label(span)
+    OxcDiagnostic::warn("eval can be harmful.")
+        .with_help("Use 'JSON.parse()' or a function call instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -115,6 +115,7 @@ impl Rule for NoExtendNative {
                         OxcDiagnostic::error(format!(
                             "{name} prototype is read-only, properties should not be added."
                         ))
+                        .with_help("Define the property on a custom object instead.")
                         .with_label(prop_assign.span()),
                     );
                 }
@@ -126,6 +127,7 @@ impl Rule for NoExtendNative {
                         OxcDiagnostic::error(format!(
                             "{name} prototype is read-only, properties should not be added."
                         ))
+                        .with_help("Define the property on a custom object instead.")
                         .with_label(define_property_call.span()),
                     );
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -23,17 +23,22 @@ use schemars::JsonSchema;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_fallthrough_case_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected a `break` statement before `case`.").with_label(span)
+    OxcDiagnostic::warn("Expected a `break` statement before `case`.")
+        .with_help("Add a 'break' or 'return' statement.")
+        .with_label(span)
 }
 
 fn no_fallthrough_default_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected a `break` statement before `default`.").with_label(span)
+    OxcDiagnostic::warn("Expected a `break` statement before `default`.")
+        .with_help("Add a 'break' or 'return' statement.")
+        .with_label(span)
 }
 
 fn no_unused_fallthrough_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Found a comment that would permit fallthrough, but case cannot fall through.",
     )
+    .with_help("Remove the fallthrough comment.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -8,6 +8,7 @@ use crate::{context::LintContext, rule::Rule};
 
 fn no_func_assign_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is a function."))
+        .with_help("Use a different variable name.")
         .with_label(span.label(format!("{name} is re-assigned here")))
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -12,6 +12,7 @@ use crate::{
 
 fn no_global_assign_diagnostic(global_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Read-only global '{global_name}' should not be modified."))
+        .with_help("Assign to a local variable instead.")
         .with_label(span.label(format!("Read-only global '{global_name}' should not be modified.")))
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -7,6 +7,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_label_var_diagnostic(name: &str, id_span: Span, label_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Found identifier '{name}' with the same name as a label."))
+        .with_help("Rename the label or the variable.")
         .with_labels([
             id_span.label(format!("Identifier '{name}' found here.")),
             label_span.label("Label with the same name."),

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 
 fn no_labels_diagnostic(message: &'static str, label_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(message).with_label(label_span)
+    OxcDiagnostic::warn(message)
+        .with_help("Use control flow statements instead.")
+        .with_label(label_span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
@@ -7,9 +7,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Block is unnecessary.")
-        .with_help("Remove the block.")
-        .with_label(span)
+    OxcDiagnostic::warn("Block is unnecessary.").with_help("Remove the block.").with_label(span)
 }
 
 fn no_nested_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
@@ -7,11 +7,15 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Block is unnecessary.").with_label(span)
+    OxcDiagnostic::warn("Block is unnecessary.")
+        .with_help("Remove the block.")
+        .with_label(span)
 }
 
 fn no_nested_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Nested block is redundant.").with_label(span)
+    OxcDiagnostic::warn("Nested block is redundant.")
+        .with_help("Remove the block.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -9,7 +9,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_loss_of_precision_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span)
+    OxcDiagnostic::warn("This number literal will lose precision at runtime.")
+        .with_help("Use 'BigInt' or adjust the value.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -18,11 +18,15 @@ enum NoMagicNumberReportReason {
 }
 
 fn must_use_const_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Number constants declarations must use 'const'.").with_label(span)
+    OxcDiagnostic::warn("Number constants declarations must use 'const'.")
+        .with_help("Use 'const' instead.")
+        .with_label(span)
 }
 
 fn no_magic_number_diagnostic(span: Span, raw: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("No magic number: {raw}")).with_label(span)
+    OxcDiagnostic::warn(format!("No magic number: {raw}"))
+        .with_help("Extract into a named constant.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -17,23 +17,33 @@ use crate::{
 };
 
 fn surrogate_pair_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected surrogate pair in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected surrogate pair in character class.")
+        .with_note("Multi-code-point characters may not match as expected.")
+        .with_label(span)
 }
 
 fn combining_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected combining class in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected combining class in character class.")
+        .with_note("Multi-code-point characters may not match as expected.")
+        .with_label(span)
 }
 
 fn emoji_modifiers_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected emoji modifier in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected emoji modifier in character class.")
+        .with_note("Multi-code-point characters may not match as expected.")
+        .with_label(span)
 }
 
 fn regional_indicator_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected regional indicator in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected regional indicator in character class.")
+        .with_note("Multi-code-point characters may not match as expected.")
+        .with_label(span)
 }
 
 fn zwj_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected joined character sequence in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected joined character sequence in character class.")
+        .with_note("Multi-code-point characters may not match as expected.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_multi_str.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_multi_str_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected multi string.").with_label(span)
+    OxcDiagnostic::warn("Unexpected multi string.")
+        .with_help("Use template literals or string concatenation.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_nested_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nested_ternary.rs
@@ -7,7 +7,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_nested_ternary_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not nest ternary expressions.").with_label(span)
+    OxcDiagnostic::warn("Do not nest ternary expressions.")
+        .with_help("Extract into a separate variable or use if/else.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -7,7 +7,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_new_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span)
+    OxcDiagnostic::warn("Do not use 'new' for side effects.")
+        .with_help("Assign the result to a variable or call without 'new'.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -7,7 +7,9 @@ use oxc_span::{GetSpan, Ident, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_new_func(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("The Function constructor is eval.").with_label(span)
+    OxcDiagnostic::warn("The Function constructor is eval.")
+        .with_help("Use a function expression or declaration.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -12,7 +12,9 @@ use crate::{
 };
 
 fn no_nonoctal_decimal_escape_diagnostic(escape_sequence: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Don't use '{escape_sequence}' escape sequence.")).with_label(span)
+    OxcDiagnostic::warn(format!("Don't use '{escape_sequence}' escape sequence."))
+        .with_help("Use a Unicode escape sequence instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_param_reassign.rs
@@ -22,11 +22,14 @@ use serde_json::Value;
 use crate::{context::LintContext, rule::Rule};
 
 fn assignment_to_param_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Assignment to function parameter '{name}'.")).with_label(span)
+    OxcDiagnostic::warn(format!("Assignment to function parameter '{name}'."))
+        .with_help("Use a local variable instead.")
+        .with_label(span)
 }
 
 fn assignment_to_param_property_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Assignment to property of function parameter '{name}'."))
+        .with_help("Use a local variable instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -12,14 +12,17 @@ use crate::{
 };
 
 fn no_redeclare_diagnostic(name: &str, decl_span: Span, re_decl_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is already defined.")).with_labels([
-        decl_span.label(format!("'{name}' is already defined.")),
-        re_decl_span.label("It can not be redeclared here."),
-    ])
+    OxcDiagnostic::warn(format!("'{name}' is already defined."))
+        .with_help("Use a different name or remove the redeclaration.")
+        .with_labels([
+            decl_span.label(format!("'{name}' is already defined.")),
+            re_decl_span.label("It can not be redeclared here."),
+        ])
 }
 
 fn no_redeclare_as_builtin_in_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is already defined as a built-in global variable."))
+        .with_help("Use a different name or remove the redeclaration.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -15,7 +15,13 @@ fn no_restricted_globals(global_name: &str, suffix: &str, span: Span) -> OxcDiag
         format!("Unexpected use of '{global_name}'. {suffix}")
     };
 
-    OxcDiagnostic::warn(warn_text).with_label(span)
+    let diagnostic = OxcDiagnostic::warn(warn_text);
+    let diagnostic = if suffix.is_empty() {
+        diagnostic.with_help("Use a local variable or import instead.")
+    } else {
+        diagnostic
+    };
+    diagnostic.with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
+    OxcDiagnostic::warn("this expression is assigned to itself")
+        .with_help("Remove this self-assignment.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_setter_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Setter cannot return a value").with_label(span)
+    OxcDiagnostic::warn("Setter cannot return a value")
+        .with_help("Remove the return value.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -9,9 +9,7 @@ fn no_throw_literal_diagnostic(span: Span, is_undef: bool) -> OxcDiagnostic {
     let message =
         if is_undef { "Do not throw undefined" } else { "Expected an error object to be thrown" };
 
-    OxcDiagnostic::warn(message)
-        .with_help("Throw an 'Error' object instead.")
-        .with_label(span)
+    OxcDiagnostic::warn(message).with_help("Throw an 'Error' object instead.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -9,7 +9,9 @@ fn no_throw_literal_diagnostic(span: Span, is_undef: bool) -> OxcDiagnostic {
     let message =
         if is_undef { "Do not throw undefined" } else { "Expected an error object to be thrown" };
 
-    OxcDiagnostic::warn(message).with_label(span)
+    OxcDiagnostic::warn(message)
+        .with_help("Throw an 'Error' object instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is not defined.")).with_label(span)
+    OxcDiagnostic::warn(format!("'{name}' is not defined."))
+        .with_help("Declare the variable or fix the reference.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`")
+        .with_help("Use 'void 0' instead.")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -14,7 +14,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unreachable_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unreachable code.").with_label(span)
+    OxcDiagnostic::warn("Unreachable code.")
+        .with_help("Remove this unreachable code.")
+        .with_label(span)
 }
 
 /// <https://github.com/eslint/eslint/blob/069aa680c78b8516b9a1b568519f1d01e74fb2a2/lib/rules/no-unreachable.js#L196>

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -9,7 +9,9 @@ use oxc_syntax::class::ElementKind;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_unused_private_class_members_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is defined but never used.")).with_label(span)
+    OxcDiagnostic::warn(format!("'{name}' is defined but never used."))
+        .with_help("Remove the unused private member.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -16,11 +16,11 @@ fn no_useless_backreference_diagnostic(
     group: &str,
 ) -> OxcDiagnostic {
     match problem {
-        Problem::Nested =>OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' from within that group.")).with_label(span),
-        Problem::Disjunctive => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which is in another alternative.")).with_label(span),
-        Problem::Forward => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which appears later in the pattern.")).with_label(span),
-        Problem::Backward => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which appears before in the same lookbehind.")).with_label(span),
-        Problem::IntoNegativeLookaround => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which is in a negative lookaround.")).with_label(span),
+        Problem::Nested =>OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' from within that group.")).with_note("This backreference always matches the empty string.").with_label(span),
+        Problem::Disjunctive => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which is in another alternative.")).with_note("This backreference always matches the empty string.").with_label(span),
+        Problem::Forward => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which appears later in the pattern.")).with_note("This backreference always matches the empty string.").with_label(span),
+        Problem::Backward => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which appears before in the same lookbehind.")).with_note("This backreference always matches the empty string.").with_label(span),
+        Problem::IntoNegativeLookaround => OxcDiagnostic::warn(format!("Backreference '{back_reference}' will be ignored. It references group '{group}' which is in a negative lookaround.")).with_note("This backreference always matches the empty string.").with_label(span),
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -10,11 +10,13 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_useless_catch_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary try/catch wrapper")
+        .with_help("Remove the try/catch wrapper.")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 
 fn no_useless_catch_finalizer_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary catch clause")
+        .with_help("Remove the catch clause.")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -18,7 +18,9 @@ use crate::{
 };
 
 fn prefer_promise_reject_errors_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected the Promise rejection reason to be an Error").with_label(span)
+    OxcDiagnostic::warn("Expected the Promise rejection reason to be an Error")
+        .with_help("Reject with an 'Error' object.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 
 fn missing_parameters(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing parameters.").with_label(span)
+    OxcDiagnostic::warn("Missing parameters.")
+        .with_help("Pass the string to parse and a radix.")
+        .with_label(span)
 }
 
 fn missing_radix(span: Span) -> OxcDiagnostic {
@@ -26,11 +28,14 @@ fn missing_radix(span: Span) -> OxcDiagnostic {
 }
 
 fn redundant_radix(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Redundant radix parameter.").with_label(span)
+    OxcDiagnostic::warn("Redundant radix parameter.")
+        .with_help("Remove the radix parameter.")
+        .with_label(span)
 }
 
 fn invalid_radix(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid radix parameter, must be an integer between 2 and 36.")
+        .with_help("Use an integer between 2 and 36.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn require_yield_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This generator function does not have `yield`").with_label(span)
+    OxcDiagnostic::warn("This generator function does not have `yield`")
+        .with_help("Add a 'yield' expression.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -9,7 +9,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct SymbolDescription;
 
 fn symbol_description_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected Symbol to have a description.").with_label(span)
+    OxcDiagnostic::warn("Expected Symbol to have a description.")
+        .with_help("Add a description string.")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -10,6 +10,7 @@ use crate::{ModuleRecord, context::LintContext, rule::Rule};
 
 fn no_named_export(module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No named exports found in module '{module_name}'"))
+        .with_help("Add named exports to the module or remove this re-export.")
         .with_label(span)
 }
 
@@ -93,6 +94,7 @@ impl Rule for Export {
 
                 ctx.diagnostic(
                     OxcDiagnostic::warn(format!("Multiple exports of name '{name}'."))
+                        .with_help("Remove or rename the duplicate export.")
                         .with_labels(labels),
                 );
             }

--- a/crates/oxc_linter/src/rules/import/exports_last.rs
+++ b/crates/oxc_linter/src/rules/import/exports_last.rs
@@ -8,7 +8,9 @@ use crate::{context::LintContext, rule::Rule};
 
 fn exports_last_diagnostic(span: Span) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Export statements should appear at the end of the file").with_label(span)
+    OxcDiagnostic::warn("Export statements should appear at the end of the file")
+        .with_help("Move this export to the end of the file.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -21,6 +21,7 @@ fn no_export(span: Span, specifier_name: &str, namespace_name: &str) -> OxcDiagn
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in imported namespace {namespace_name:?}."
     ))
+    .with_help("Remove this reference or add the missing export.")
     .with_label(span)
 }
 
@@ -32,6 +33,7 @@ fn no_export_in_deeply_imported_namespace(
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in deeply imported namespace {namespace_name:?}."
     ))
+    .with_help("Remove this reference or add the missing export.")
     .with_label(span)
 }
 
@@ -39,11 +41,13 @@ fn computed_reference(span: Span, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Unable to validate computed reference to imported namespace {namespace_name:?}."
     ))
+    .with_note("Computed references cannot be statically validated.")
     .with_label(span)
 }
 
 fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Assignment to member of namespace {namespace_name:?}.'"))
+        .with_note("Imported namespace members are read-only.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_absolute_path.rs
+++ b/crates/oxc_linter/src/rules/import/no_absolute_path.rs
@@ -19,7 +19,9 @@ use crate::{
 };
 
 fn no_absolute_path_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not import modules using an absolute path").with_label(span)
+    OxcDiagnostic::warn("Do not import modules using an absolute path")
+        .with_help("Use a relative path instead.")
+        .with_label(span)
 }
 
 // <https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-absolute-path.md>

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -17,9 +17,7 @@ use crate::{
 
 fn no_anonymous_default_export_diagnostic(span: Span, msg: &'static str) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn(msg)
-        .with_help("Assign a name to this default export.")
-        .with_label(span)
+    OxcDiagnostic::warn(msg).with_help("Assign a name to this default export.").with_label(span)
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -17,7 +17,9 @@ use crate::{
 
 fn no_anonymous_default_export_diagnostic(span: Span, msg: &'static str) -> OxcDiagnostic {
     // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn(msg).with_label(span)
+    OxcDiagnostic::warn(msg)
+        .with_help("Assign a name to this default export.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -5,7 +5,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_default_export_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer named exports").with_label(span)
+    OxcDiagnostic::warn("Prefer named exports")
+        .with_help("Use a named export instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/import/no_mutable_exports.rs
+++ b/crates/oxc_linter/src/rules/import/no_mutable_exports.rs
@@ -14,6 +14,7 @@ use crate::{context::LintContext, rule::Rule};
 fn no_mutable_exports_diagnostic(span: Span, kind: VariableDeclarationKind) -> OxcDiagnostic {
     let kind_str = if kind == VariableDeclarationKind::Var { "var" } else { "let" };
     OxcDiagnostic::warn(format!("Exporting mutable '{kind_str}' binding, use 'const' instead."))
+        .with_help("Use 'const' instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
@@ -18,6 +18,7 @@ use crate::{
 
 fn no_nodejs_modules_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not import Node.js builtin module `{module_name}`"))
+        .with_help("Use a browser-compatible alternative or add this module to the `allow` list.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -5,7 +5,9 @@ use oxc_span::Span;
 use crate::{context::LintContext, rule::Rule};
 
 fn no_self_import_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("A module importing itself is not allowed").with_label(span)
+    OxcDiagnostic::warn("A module importing itself is not allowed")
+        .with_help("Remove this self-import.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_in_test.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 
 fn no_conditional_in_test(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid having conditionals in tests.").with_label(span)
+    OxcDiagnostic::warn("Avoid having conditionals in tests.")
+        .with_help("Move the conditional logic outside of the test.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -13,6 +13,7 @@ use crate::{
 
 fn non_global_set_timeout_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`jest.setTimeout` should only be called in a global scope")
+        .with_help("Move `jest.setTimeout` to the top level of the module.")
         .with_label(span)
 }
 
@@ -24,6 +25,7 @@ fn no_multiple_set_timeouts_diagnostic(span: Span) -> OxcDiagnostic {
 
 fn no_unorder_set_timeout_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`jest.setTimeout` should be placed before any other jest methods.")
+        .with_help("Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 fn unexpected_hook_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use setup or teardown hooks.").with_label(span)
+    OxcDiagnostic::warn("Do not use setup or teardown hooks.")
+        .with_help("Use helper functions instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -13,11 +13,15 @@ use crate::{
 };
 
 fn restricted_jest_method(method_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed")).with_label(span)
+    OxcDiagnostic::warn(format!("Use of `{method_name}` is not allowed"))
+        .with_help("Replace with an alternative or remove the call.")
+        .with_label(span)
 }
 
 fn restricted_jest_method_with_message(message: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(message.to_string()).with_label(span)
+    OxcDiagnostic::warn(message.to_string())
+        .with_help("Replace with an alternative or remove the call.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 
 fn restricted_chain(chain_call: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use of `{chain_call}` is disallowed")).with_label(span)
+    OxcDiagnostic::warn(format!("Use of `{chain_call}` is disallowed"))
+        .with_help("Replace with an alternative matcher or remove the assertion.")
+        .with_label(span)
 }
 
 fn restricted_chain_with_message(chain_call: &str, message: &str, span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_return_statement.rs
@@ -15,7 +15,9 @@ use crate::{
 };
 
 fn no_test_return_statement_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Jest tests should not return a value").with_label(span)
+    OxcDiagnostic::warn("Jest tests should not return a value")
+        .with_help("Use `await` instead of returning the promise.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_rest_spread_properties.rs
@@ -15,7 +15,9 @@ fn no_rest_spread_properties_diagnostic(
     spread_kind: &str,
     message_suffix: &str,
 ) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("{spread_kind} are not allowed. {message_suffix}")).with_label(span)
+    OxcDiagnostic::warn(format!("{spread_kind} are not allowed. {message_suffix}"))
+        .with_help("Use 'Object.assign()' or explicit property access instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn avoid_new_promise_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid creating new promises").with_label(span)
+    OxcDiagnostic::warn("Avoid creating new promises")
+        .with_help("Use async/await instead")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -26,11 +26,14 @@ fn already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise should not be resolved multiple times. Promise is already resolved on line {line}."
     ))
+    .with_help("Add an early return after the first resolve/reject call")
     .with_label(span)
 }
 
 fn potentially_already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}.")).with_label(span)
+    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}."))
+        .with_help("Add an early return after the first resolve/reject call")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -14,6 +14,7 @@ use crate::{
 
 fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}` method."))
+        .with_help("Use a standard Promise method instead.")
         .with_label(member_span)
 }
 

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -13,6 +13,7 @@ fn zero_or_one_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 0 or 1 arguments, but received {args_len}."
     ))
+    .with_help("Remove the extra arguments")
     .with_label(span)
 }
 
@@ -24,6 +25,7 @@ fn one_or_two_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 or 2 arguments, but received {args_len}."
     ))
+    .with_help("Pass the correct number of arguments")
     .with_label(span)
 }
 
@@ -31,6 +33,7 @@ fn one_argument_required_diagnostic(span: Span, prop_name: &str, args_len: usize
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 argument, but received {args_len}."
     ))
+    .with_help("Pass exactly one argument")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -20,7 +20,9 @@ fn forbid_dom_props_diagnostic(
     if let Some(message) = message {
         return OxcDiagnostic::warn(message.clone()).with_label(span);
     }
-    OxcDiagnostic::warn(format!("Prop \"{property}\" is forbidden on DOM Nodes")).with_label(span)
+    OxcDiagnostic::warn(format!("Prop \"{property}\" is forbidden on DOM Nodes"))
+        .with_help("Remove this prop.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -28,7 +28,9 @@ use crate::{
 const TARGET_METHODS: [&str; 3] = ["flatMap", "from", "map"];
 
 fn missing_key_prop_for_element_in_array(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#).with_label(span)
+    OxcDiagnostic::warn(r#"Missing "key" prop for element in array."#)
+        .with_help(r#"Add a "key" prop to each element in the array."#)
+        .with_label(span)
 }
 
 fn missing_key_prop_for_element_in_iterator(iter_span: Span, el_span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
@@ -21,6 +21,7 @@ fn jsx_max_depth_diagnostic(depth: usize, max: usize, span: Span) -> OxcDiagnost
     OxcDiagnostic::warn(format!(
         "JSX nesting depth of {depth} exceeds the configured maximum of {max}"
     ))
+    .with_help("Extract nested JSX into a separate component.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -11,6 +11,7 @@ use crate::{
 
 fn jsx_no_comment_textnodes_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Comments inside children section of tag should be placed inside braces")
+        .with_help("Wrap the comment in braces: {/* comment */}")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 fn jsx_no_undef_diagnostic(ident_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{ident_name}' is not defined.")).with_label(span)
+    OxcDiagnostic::warn(format!("'{ident_name}' is not defined."))
+        .with_help("Import or declare this component.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -21,11 +21,15 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 fn needs_more_children(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Fragments should contain more than one child.").with_label(span)
+    OxcDiagnostic::warn("Fragments should contain more than one child.")
+        .with_help("Remove the unnecessary fragment.")
+        .with_label(span)
 }
 
 fn child_of_html_element(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.").with_label(span)
+    OxcDiagnostic::warn("Passing a fragment to a HTML element is useless.")
+        .with_help("Remove the fragment and pass children directly.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -23,7 +23,9 @@ fn jsx_pascal_case_diagnostic(
         format!("JSX component {component_name} must be in PascalCase")
     };
 
-    OxcDiagnostic::warn(message).with_label(span)
+    OxcDiagnostic::warn(message)
+        .with_help("Rename the component to PascalCase.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -23,9 +23,7 @@ fn jsx_pascal_case_diagnostic(
         format!("JSX component {component_name} must be in PascalCase")
     };
 
-    OxcDiagnostic::warn(message)
-        .with_help("Rename the component to PascalCase.")
-        .with_label(span)
+    OxcDiagnostic::warn(message).with_help("Rename the component to PascalCase.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 
 fn jsx_props_no_spreading_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prop spreading is forbidden").with_label(span)
+    OxcDiagnostic::warn("Prop spreading is forbidden")
+        .with_help("Pass each prop individually.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -13,7 +13,9 @@ fn no_namespace_diagnostic(span: Span, component_name: &str) -> OxcDiagnostic {
         r"React component {component_name} must not be in a namespace, as React does not support them."
     );
 
-    OxcDiagnostic::warn(message).with_label(span)
+    OxcDiagnostic::warn(message)
+        .with_help("Remove the namespace.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -13,9 +13,7 @@ fn no_namespace_diagnostic(span: Span, component_name: &str) -> OxcDiagnostic {
         r"React component {component_name} must not be in a namespace, as React does not support them."
     );
 
-    OxcDiagnostic::warn(message)
-        .with_help("Remove the namespace.")
-        .with_label(span)
+    OxcDiagnostic::warn(message).with_help("Remove the namespace.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
+++ b/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
@@ -15,6 +15,7 @@ fn no_redundant_should_component_update_diagnostic(
     OxcDiagnostic::warn(format!(
         "{component_name} does not need `shouldComponentUpdate` when extending `React.PureComponent`."
     ))
+    .with_help("Remove `shouldComponentUpdate`.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 
 fn no_set_state_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use `setState`.").with_label(span)
+    OxcDiagnostic::warn("Do not use `setState`.")
+        .with_help("Use props or context instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -14,7 +14,9 @@ static ESCAPED_SINGLE_QUOTE: &str = "&apos; or &lsquo; or &#39; or &rsquo;";
 
 fn no_unescaped_entities_diagnostic(span: Span, unescaped: char) -> OxcDiagnostic {
     let escaped = if unescaped == '"' { ESCAPED_DOUBLE_QUOTE } else { ESCAPED_SINGLE_QUOTE };
-    OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}")).with_label(span)
+    OxcDiagnostic::warn(format!("`{unescaped}` can be escaped with {escaped}"))
+        .with_help("Use the HTML entity instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/react/only_export_components.rs
+++ b/crates/oxc_linter/src/rules/react/only_export_components.rs
@@ -14,11 +14,13 @@ use crate::{
 
 fn export_all_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("This rule can't verify that `export *` only exports components.")
+        .with_help("Use named exports instead of `export *`.")
         .with_label(span)
 }
 
 fn named_export_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.")
+        .with_help("Move non-component exports to a separate file.")
         .with_label(span)
 }
 
@@ -26,21 +28,25 @@ fn anonymous_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Fast refresh can't handle anonymous components. Add a name to your export.",
     )
+    .with_help("Add a name to the exported function or component.")
     .with_label(span)
 }
 
 fn local_components_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Move your component(s) to a separate file.")
+        .with_help("Export this component or move it to a separate file.")
         .with_label(span)
 }
 
 fn no_export_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file has exports. Move your component(s) to a separate file.")
+        .with_help("Export the component or move it to a file with exports.")
         .with_label(span)
 }
 
 fn react_context_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.")
+        .with_help("Move React context to a separate file.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -14,11 +14,13 @@ use crate::{
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Components should use `createReactClass` instead of an ES2015 class.")
+        .with_help("Replace the class with `createReactClass`.")
         .with_label(span)
 }
 
 fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Components should use an ES2015 class instead of `createReactClass`.")
+        .with_help("Replace `createReactClass` with an ES2015 class.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -37,6 +37,7 @@ mod diagnostics {
             React component names must start with an uppercase letter. \
             React Hook names must start with the word \"use\".",
         ))
+        .with_help("Move this hook call into a React function component or custom Hook.")
         .with_labels(vec![
             react_hook_span.primary_label("Hook is called here"),
             outer_function_span.label("Outer function"),
@@ -49,6 +50,7 @@ mod diagnostics {
             "React Hook {hook_name:?} is called conditionally. React Hooks must be \
             called in the exact same order in every component render."
         ))
+        .with_help("Move this hook call to the top level of the function.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }
@@ -59,6 +61,7 @@ mod diagnostics {
             because it is called in a loop. React Hooks must be called in the \
             exact same order in every component render."
         ))
+        .with_help("Move this hook call outside of the loop.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }
@@ -69,6 +72,7 @@ mod diagnostics {
             must be called in a React function component or a custom React \
             Hook function."
         ))
+        .with_help("Move this hook call into a React function component or custom Hook.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }
@@ -77,6 +81,7 @@ mod diagnostics {
         OxcDiagnostic::warn(format!(
             "React Hook {func_name:?} cannot be called in an async function. "
         ))
+        .with_help("Remove the `async` keyword or move the hook call to a synchronous function.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }
@@ -87,6 +92,7 @@ mod diagnostics {
             must be called in a React function component or a custom React \
             Hook function."
         ))
+        .with_help("Convert the class component to a function component to use hooks.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }
@@ -97,6 +103,7 @@ mod diagnostics {
             must be called in a React function component or a custom React \
             Hook function."
         ))
+        .with_help("Extract the hook call into the outer component or a custom Hook.")
         .with_label(span)
         .with_error_code_scope(SCOPE)
     }

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 fn style_prop_object_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`style` prop value must be an object.").with_label(span)
+    OxcDiagnostic::warn("`style` prop value must be an object.")
+        .with_help("Pass an object literal to the `style` prop.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -20,7 +20,8 @@ fn adjacent_overload_signatures_diagnostic(
     first: Option<Span>,
     second: Span,
 ) -> OxcDiagnostic {
-    let mut d = OxcDiagnostic::warn(format!("All {fn_name:?} signatures should be adjacent."));
+    let mut d = OxcDiagnostic::warn(format!("All {fn_name:?} signatures should be adjacent."))
+        .with_help("Move the overload signatures next to each other.");
     if let Some(span) = first {
         d = d.and_label(span);
     }

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -14,6 +14,7 @@ fn comment(ts_comment_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Do not use @ts-{ts_comment_name} because it alters compilation errors."
     ))
+    .with_help(format!("Remove the @ts-{ts_comment_name} comment."))
     .with_label(span)
 }
 
@@ -27,6 +28,7 @@ fn comment_requires_description(ts_comment_name: &str, min_len: u64, span: Span)
     OxcDiagnostic::warn(format!(
         "Include a description after the @ts-{ts_comment_name} directive to explain why the @ts-{ts_comment_name} is necessary. The description must be {min_len} characters or longer."
     ))
+    .with_help(format!("Add a description after @ts-{ts_comment_name}."))
     .with_label(span)
 }
 
@@ -38,6 +40,7 @@ fn comment_description_not_match_pattern(
     OxcDiagnostic::warn(format!(
         "The description for the @ts-{ts_comment_name} directive must match the {pattern} format."
     ))
+    .with_help(format!("Update the description to match the pattern: {pattern}"))
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -14,6 +14,7 @@ fn type_diagnostic(banned_type: &str, suggested_type: &str, span: Span) -> OxcDi
     OxcDiagnostic::warn(format!(
         "Do not use {banned_type:?} as a type. Use \"{suggested_type}\" instead"
     ))
+    .with_help(format!("Use `{suggested_type}` instead."))
     .with_label(span)
 }
 
@@ -31,6 +32,8 @@ fn function(span: Span) -> OxcDiagnostic {
 
 fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'The `Object` type actually means \"any non-nullish value\"")
+        .with_help("Use `object` or define an explicit object shape.")
+        .with_note("The `Object` type includes primitives like strings and numbers, which is rarely intended.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
@@ -27,15 +27,21 @@ fn use_as_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
 }
 
 fn never_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use any type assertions.").with_label(span)
+    OxcDiagnostic::warn("Do not use any type assertions.")
+        .with_help("Use a type annotation or `satisfies` instead.")
+        .with_label(span)
 }
 
 fn unexpected_object_type_assertion_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Always prefer `const x: T = { ... }`.").with_label(span)
+    OxcDiagnostic::warn("Always prefer `const x: T = { ... }`.")
+        .with_help("Use a type annotation or `satisfies` instead.")
+        .with_label(span)
 }
 
 fn unexpected_array_type_assertion_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Always prefer `const x: T[] = [ ... ]`.").with_label(span)
+    OxcDiagnostic::warn("Always prefer `const x: T[] = [ ... ]`.")
+        .with_help("Use a type annotation or `satisfies` instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -23,19 +23,26 @@ use crate::{
 };
 
 fn no_import_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`import()` type annotations are forbidden.").with_label(span)
+    OxcDiagnostic::warn("`import()` type annotations are forbidden.")
+        .with_help("Use a top-level `import` statement instead.")
+        .with_label(span)
 }
 
 fn avoid_import_type_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use an `import` instead of an `import type`.").with_label(span)
+    OxcDiagnostic::warn("Use an `import` instead of an `import type`.")
+        .with_help("Remove the `type` keyword from the import.")
+        .with_label(span)
 }
 fn type_over_value_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("All imports in the declaration are only used as types. Use `import type`.")
+        .with_help("Add the `type` keyword to the import.")
         .with_label(span)
 }
 
 fn some_imports_are_only_types_diagnostic(span: Span, type_imports: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Imports {type_imports} are only used as type.")).with_label(span)
+    OxcDiagnostic::warn(format!("Imports {type_imports} are only used as type."))
+        .with_help("Mark type-only imports with the `type` keyword.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -23,15 +23,21 @@ use crate::{
 };
 
 fn func_missing_return_type(fn_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing return type on function").with_label(fn_span)
+    OxcDiagnostic::warn("Missing return type on function")
+        .with_help("Add an explicit return type to the function.")
+        .with_label(fn_span)
 }
 
 fn func_missing_argument_type(param_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing argument type on function").with_label(param_span)
+    OxcDiagnostic::warn("Missing argument type on function")
+        .with_help("Add a type annotation to the parameter.")
+        .with_label(param_span)
 }
 
 fn func_argument_is_explicitly_any(param_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Argument is explicitly typed as `any`").with_label(param_span)
+    OxcDiagnostic::warn("Argument is explicitly typed as `any`")
+        .with_help("Use a more specific type instead of `any`.")
+        .with_label(param_span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -39,7 +39,9 @@ declare_oxc_lint!(
 );
 
 fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not delete dynamically computed property keys.").with_label(span)
+    OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
+        .with_help("Use `Reflect.deleteProperty()` instead.")
+        .with_label(span)
 }
 
 impl Rule for NoDynamicDelete {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -13,11 +13,14 @@ use crate::{
 };
 
 fn no_empty_interface_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span)
+    OxcDiagnostic::warn("an empty interface is equivalent to `{}`")
+        .with_help("Remove the empty interface or add members to it.")
+        .with_label(span)
 }
 
 fn no_empty_interface_extend_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("an interface declaring no members is equivalent to its supertype")
+        .with_help("Use a type alias instead, e.g. `type T = SuperType`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 
 fn no_extra_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("extra non-null assertion").with_label(span)
+    OxcDiagnostic::warn("extra non-null assertion")
+        .with_help("Remove the extra `!` assertion.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -10,7 +10,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_wrapper_object_types(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use wrapper object types.").with_label(span)
+    OxcDiagnostic::warn("Do not use wrapper object types.")
+        .with_help("Use the primitive type instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -14,6 +14,7 @@ fn prefer_enum_initializers_diagnostic(member_name: &str, span: Span) -> OxcDiag
     OxcDiagnostic::warn(format!(
         "The value of the member {member_name:?} should be explicitly defined."
     ))
+    .with_help("Assign an explicit value.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -16,6 +16,7 @@ fn no_anonymous_default_export_diagnostic(span: Span, kind: ErrorNodeKind) -> Ox
 
     OxcDiagnostic::warn(format!("This {kind} default export is missing a name"))
         // TODO: suggest a name. https://github.com/sindresorhus/eslint-plugin-unicorn/blob/d3e4b805da31c6ed7275e2e2e770b6b0fbcf11c2/rules/no-anonymous-default-export.js#L41
+        .with_help("Add a name to this default export.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -10,11 +10,14 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn identifier(span: Span, param: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not use an object literal as default for parameter `{param}`."))
+        .with_help("Accept individual properties as parameters instead.")
         .with_label(span)
 }
 
 fn non_identifier(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use an object literal as default").with_label(span)
+    OxcDiagnostic::warn("Do not use an object literal as default")
+        .with_help("Accept individual properties as parameters instead.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -15,6 +15,7 @@ use crate::{
 
 fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.")
+        .with_help("Use '=== undefined' or '!== undefined'.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -8,6 +8,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_unreadable_array_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Array destructuring may not contain consecutive ignored values.")
+        .with_help("Use intermediate variables or '.slice()' instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
+++ b/crates/oxc_linter/src/rules/vue/define_props_destructuring.rs
@@ -17,11 +17,15 @@ fn prefer_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 fn avoid_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid destructuring from `defineProps`.").with_label(span)
+    OxcDiagnostic::warn("Avoid destructuring from `defineProps`.")
+        .with_help("Store props in a variable instead")
+        .with_label(span)
 }
 
 fn avoid_with_defaults_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid using `withDefaults` with destructuring.").with_label(span)
+    OxcDiagnostic::warn("Avoid using `withDefaults` with destructuring.")
+        .with_help("Use default values in the destructuring pattern instead")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/vue/no_export_in_script_setup.rs
+++ b/crates/oxc_linter/src/rules/vue/no_export_in_script_setup.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 
 fn no_export_in_script_setup_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("<script setup>` cannot contain ES module exports.").with_label(span)
+    OxcDiagnostic::warn("<script setup>` cannot contain ES module exports.")
+        .with_help("Use `defineExpose` instead")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/vue/require_default_export.rs
+++ b/crates/oxc_linter/src/rules/vue/require_default_export.rs
@@ -10,11 +10,15 @@ use crate::{
 };
 
 fn missing_default_export_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing default export.").with_label(span)
+    OxcDiagnostic::warn("Missing default export.")
+        .with_help("Add `export default { ... }` to define the component")
+        .with_label(span)
 }
 
 fn must_be_default_export_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Component must be the default export.").with_label(span)
+    OxcDiagnostic::warn("Component must be the default export.")
+        .with_help("Use `export default defineComponent({ ... })`")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_async_promise_executor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_async_promise_executor.snap
@@ -7,15 +7,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ new Promise(async function foo(resolve, reject) {})
    ·             ─────
    ╰────
+  help: Remove the 'async' keyword.
 
   ⚠ eslint(no-async-promise-executor): Promise executor functions should not be `async`.
    ╭─[no_async_promise_executor.tsx:1:13]
  1 │ new Promise(async (resolve, reject) => {})
    ·             ─────
    ╰────
+  help: Remove the 'async' keyword.
 
   ⚠ eslint(no-async-promise-executor): Promise executor functions should not be `async`.
    ╭─[no_async_promise_executor.tsx:1:17]
  1 │ new Promise(((((async () => {})))))
    ·                 ─────
    ╰────
+  help: Remove the 'async' keyword.

--- a/crates/oxc_linter/src/snapshots/eslint_no_await_in_loop.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_await_in_loop.snap
@@ -7,99 +7,116 @@ source: crates/oxc_linter/src/tester.rs
  1 │ async function foo() { while (baz) { await bar; } }
    ·                                      ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:31]
  1 │ async function foo() { while (await foo()) {  } }
    ·                               ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:42]
  1 │ async function foo() { while (baz) { for await (x of xs); } }
    ·                                          ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var bar of baz) { await bar; } }
    ·                                               ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:45]
  1 │ async function foo() { for (var bar of baz) await bar; }
    ·                                             ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var bar in baz) { await bar; } }
    ·                                               ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:50]
  1 │ async function foo() { for (var i; i < n; i++) { await bar; } }
    ·                                                  ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:36]
  1 │ async function foo() { for (var i; await foo(i); i++) {  } }
    ·                                    ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var i; i < n; i = await bar) {  } }
    ·                                               ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:29]
  1 │ async function foo() { do { await bar; } while (baz); }
    ·                             ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:38]
  1 │ async function foo() { do { } while (await bar); }
    ·                                      ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:54]
  1 │ async function foo() { while (true) { if (bar) { foo(await bar); } } }
    ·                                                      ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:42]
  1 │ async function foo() { while (xyz || 5 > await x) {  } }
    ·                                          ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:60]
  1 │ async function foo() { for await (var x of xs) { while (1) await f(x) } }
    ·                                                            ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:16]
  1 │ while (true) { await using resource = getResource(); }
    ·                ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:12]
  1 │ for (;;) { await using resource = getResource(); }
    ·            ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:6]
  1 │ for (await using resource of resources) {}
    ·      ─────
    ╰────
+  help: Collect promises and use 'Promise.all()' instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
@@ -7,48 +7,56 @@ source: crates/oxc_linter/src/tester.rs
  1 │ switch (a) { case 1: let x = 1; break; }
    ·                      ───
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: let x = 2; break; }
    ·                       ───
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: const x = 1; break; }
    ·                      ─────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: const x = 2; break; }
    ·                       ─────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: function f() {} break; }
    ·                      ────────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: function f() {} break; }
    ·                       ────────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: class C {} break; }
    ·                      ─────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: class C {} break; }
    ·                       ─────
    ╰────
+  help: Wrap the case block in braces to create a new scope.
 
   × Using declaration cannot appear in the bare case statement.
    ╭─[no_case_declarations.tsx:1:23]

--- a/crates/oxc_linter/src/snapshots/eslint_no_class_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_class_assign.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │     ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:7]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │       ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:7]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │          ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:1]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    · │            ╰── A is declared as class here
    · ╰── A is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:7]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │         ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:15]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               │         ╰── A is re-assigned here
    ·               ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:7]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │     ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:7]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │            ╰── A is re-assigned here
    ·       ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-class-assign): Unexpected re-assignment of class A
    ╭─[no_class_assign.tsx:1:18]
@@ -73,3 +81,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                  │    ╰── A is re-assigned here
    ·                  ╰── A is declared as class here
    ╰────
+  help: Use a different variable name.

--- a/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:11]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·           │            ╰── x is re-assigned here.
    ·           ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │           ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable i.
    ╭─[no_const_assign.tsx:1:12]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                ╰── i is re-assigned here.
    ·            ╰── i is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │             ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                       ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                     ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                                          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:1]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    · │              ╰── x is declared here as `const`.
    · ╰── x is re-assigned here.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:24]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │                      ╰── d is re-assigned here.
    ·                        ╰── d is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:7]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                         ╰── d is re-assigned here.
    ·       ╰── d is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable b.
    ╭─[no_const_assign.tsx:1:7]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │              ╰── b is re-assigned here.
    ·       ╰── b is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -153,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │          ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -161,6 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -169,6 +189,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │          ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -177,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │           ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -185,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │           ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -193,6 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │               ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -201,3 +225,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             │               ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use 'let' if the variable needs reassignment.

--- a/crates/oxc_linter/src/snapshots/eslint_no_constructor_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constructor_return.snap
@@ -7,9 +7,11 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class C { constructor() { return '' } }
    ·                           ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-constructor-return): Unexpected return statement in constructor.
    ╭─[no_constructor_return.tsx:1:38]
  1 │ class C { constructor(a) { if (!a) { return '' } else { a() } } }
    ·                                      ─────────
    ╰────
+  help: Remove the return value.

--- a/crates/oxc_linter/src/snapshots/eslint_no_control_regex.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_control_regex.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·              ──┬─
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:16]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──┬─
    ·                  ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:16]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──┬─
    ·                  ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:19]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──┬─
    ·                     ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:25]
@@ -37,6 +41,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           │   ╰── 'U+001E' is a control character.
    ·                           ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:25]
@@ -45,6 +50,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           │      ╰── 'U+0000' is a control character.
    ·                           ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:28]
@@ -53,6 +59,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                              │      ╰── 'U+001F' is a control character.
    ·                              ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:21]
@@ -60,6 +67,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──┬─
    ·                       ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:19]
@@ -67,6 +75,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ──┬─
    ·                     ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:29]
@@ -74,6 +83,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──┬─
    ·                               ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:23]
@@ -81,6 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ──┬──
    ·                         ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -88,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ───┬──
    ·     ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -95,6 +107,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ───┬──
    ·     ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:13]
@@ -102,6 +115,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───┬───
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:13]
@@ -109,6 +123,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───┬───
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:13]
@@ -116,6 +131,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───┬───
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:13]
@@ -123,6 +139,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───┬───
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -130,6 +147,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ───┬──
    ·     ╰── 'U+000A' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -137,6 +155,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ──┬─
    ·    ╰── 'U+000A' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -144,6 +163,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ───┬──
    ·     ╰── 'U+000D' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -151,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ──┬─
    ·    ╰── 'U+000D' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -158,6 +179,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ───┬──
    ·     ╰── 'U+0009' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:2]
@@ -165,6 +187,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ──┬─
    ·    ╰── 'U+0009' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:2]
@@ -174,6 +197,7 @@ source: crates/oxc_linter/src/tester.rs
    ·   │ ╰── '\1' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ·   ╰── '\0' matches the null character (U+0000), which is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:2]
@@ -182,6 +206,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    │  ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ·    ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:2]
@@ -190,6 +215,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    │  ╰── '\0' matches the null character (U+0000), which is a control character.
    ·    ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:2]
@@ -199,6 +225,7 @@ source: crates/oxc_linter/src/tester.rs
    ·    │  ╰── '\0' matches the null character (U+0000), which is a control character.
    ·    ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control characters
    ╭─[no_control_regex.tsx:1:36]
@@ -207,6 +234,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      │   ╰── 'U+001E' is a control character.
    ·                                      ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:32]
@@ -214,6 +242,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ──┬─
    ·                                  ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:10]
@@ -221,6 +250,7 @@ source: crates/oxc_linter/src/tester.rs
    ·          ──┬─
    ·            ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:14]
@@ -228,6 +258,7 @@ source: crates/oxc_linter/src/tester.rs
    ·              ──┬─
    ·                ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:15]
@@ -235,6 +266,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──┬─
    ·                 ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:13]
@@ -242,3 +274,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──┬─
    ·               ╰── 'U+001F' is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_control_regex@capture-group-indexing.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_control_regex@capture-group-indexing.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ─┬
    ·             ╰── '\0' matches the null character (U+0000), which is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:17]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─┬
    ·                  ╰── '\1' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:19]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─┬
    ·                    ╰── '\2' is a control character. It looks like a backreference, but there is no corresponding capture group.
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-control-regex): Unexpected control character
    ╭─[no_control_regex.tsx:1:19]
@@ -29,3 +32,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─┬
    ·                    ╰── '\0' matches the null character (U+0000), which is a control character.
    ╰────
+  help: Use a Unicode escape sequence instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
@@ -7,3 +7,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ delete x
    · ────────
    ╰────
+  note: 'delete' is only valid for object properties.

--- a/crates/oxc_linter/src/snapshots/eslint_no_eval.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_eval.snap
@@ -7,255 +7,298 @@ source: crates/oxc_linter/src/tester.rs
  1 │ eval(foo)
    · ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval('foo')
    · ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:22]
  1 │ function foo(eval) { eval('foo') }
    ·                      ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval(foo)
    · ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval('foo')
    · ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:22]
  1 │ function foo(eval) { eval('foo') }
    ·                      ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:5]
  1 │ (0, eval)('foo')
    ·     ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ (0, window.eval)('foo')
    ·            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ (0, window['eval'])('foo')
    ·            ──────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ var EVAL = eval; EVAL('foo')
    ·            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:17]
  1 │ var EVAL = this.eval; EVAL('foo')
    ·                 ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ 'use strict'; var EVAL = this.eval; EVAL('foo')
    ·                               ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:39]
  1 │ function foo() { ('use strict'); this.eval; }
    ·                                       ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:14]
  1 │ () => { this.eval('foo'); }
    ·              ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:28]
  1 │ () => { 'use strict'; this.eval('foo'); }
    ·                            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:28]
  1 │ 'use strict'; () => { this.eval('foo'); }
    ·                            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:36]
  1 │ () => { 'use strict'; () => { this.eval('foo'); } }
    ·                                    ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ (function(exe){ exe('foo') })(eval);
    ·                               ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:8]
  1 │ window.eval('foo')
    ·        ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ window.window.eval('foo')
    ·               ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ window.window['eval']('foo')
    ·               ──────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:8]
  1 │ global.eval('foo')
    ·        ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ global.global.eval('foo')
    ·               ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ global.global[`eval`]('foo')
    ·               ──────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:6]
  1 │ this.eval('foo')
    ·      ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:20]
  1 │ 'use strict'; this.eval('foo')
    ·                    ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ function foo() { this.eval('foo') }
    ·                       ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ var EVAL = globalThis.eval; EVAL('foo')
    ·                       ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ globalThis.eval('foo')
    ·            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ globalThis.globalThis.eval('foo')
    ·                       ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ globalThis.globalThis['eval']('foo')
    ·                       ──────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:16]
  1 │ (0, globalThis.eval)('foo')
    ·                ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:16]
  1 │ (0, globalThis['eval'])('foo')
    ·                ──────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:9]
  1 │ window?.eval('foo')
    ·         ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:10]
  1 │ (window?.eval)('foo')
    ·          ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:18]
  1 │ (window?.window).eval('foo')
    ·                  ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:17]
  1 │ class C { [this.eval('foo')] }
    ·                 ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ 'use strict'; class C { [this.eval('foo')] }
    ·                               ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:27]
  1 │ class A { static {} [this.eval()]; }
    ·                           ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:26]
  1 │ array.findLast(x => this.eval.includes(x), { eval: 'abc' });
    ·                          ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:51]
  1 │ callbacks.findLastIndex(function (cb) { return cb(eval); }, this);
    ·                                                   ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:46]
  1 │ ['1+1'].flatMap(function (str) { return this.eval(str); });
    ·                                              ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:44]
  1 │ ['1'].reduce(function (a, b) { return this.eval(a) ? a : b; }, '0');
    ·                                            ────
    ╰────
+  help: Use 'JSON.parse()' or a function call instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_extend_native.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_extend_native.snap
@@ -7,159 +7,186 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Object.prototype.p = 0
    · ──────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): BigInt prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ BigInt.prototype.p = 0
    · ──────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): WeakRef prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ WeakRef.prototype.p = 0
    · ───────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): FinalizationRegistry prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ FinalizationRegistry.prototype.p = 0
    · ────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): AggregateError prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ AggregateError.prototype.p = 0
    · ──────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Function prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Function.prototype['p'] = 0
    · ───────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): String prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ String['prototype'].p = 0
    · ─────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Number prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Number['prototype']['p'] = 0
    · ────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object.defineProperty(Array.prototype, 'p', {value: 0})
    · ───────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object['defineProperty'](Array.prototype, 'p', {value: 0})
    · ──────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object['defineProperty'](Array['prototype'], 'p', {value: 0})
    · ─────────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object.defineProperties(Array.prototype, {p: {value: 0}})
    · ─────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object.defineProperties(Array.prototype, {p: {value: 0}, q: {value: 0}})
    · ────────────────────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Number prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Number['prototype']['p'] = 0
    · ────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object.prototype.p = 0; Object.prototype.q = 0
    · ──────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:25]
  1 │ Object.prototype.p = 0; Object.prototype.q = 0
    ·                         ──────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:18]
  1 │ function foo() { Object.prototype.p = 0 }
    ·                  ──────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ (Object?.prototype).p = 0
    · ─────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ (Object?.['prototype'])['p'] = 0
    · ────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object.defineProperty(Object?.prototype, 'p', { value: 0 })
    · ───────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object?.defineProperty(Object.prototype, 'p', { value: 0 })
    · ───────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Object?.['defineProperty'](Object?.['prototype'], 'p', {value: 0})
    · ──────────────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Object prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ (Object?.defineProperty)(Object.prototype, 'p', { value: 0 })
    · ─────────────────────────────────────────────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Array.prototype.p &&= 0
    · ───────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Array.prototype.p ||= 0
    · ───────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ Array.prototype.p ??= 0
    · ───────────────────────
    ╰────
+  help: Define the property on a custom object instead.
 
   ⚠ eslint(no-extend-native): Array prototype is read-only, properties should not be added.
    ╭─[no_extend_native.tsx:1:1]
  1 │ [Array.prototype.p] = [() => {}]
    · ───────────────────
    ╰────
+  help: Define the property on a custom object instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ case 1: b() }
    · ───────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:2:1]
@@ -15,36 +16,42 @@ source: crates/oxc_linter/src/tester.rs
  2 │ default: b() }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:28]
  1 │ switch(foo) { case 0: a(); default: b() }
    ·                            ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:41]
  1 │ switch(foo) { case 0: if (a) { break; } default: b() }
    ·                                         ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:55]
  1 │ switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }
    ·                                                       ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:44]
  1 │ switch(foo) { case 0: while (a) { break; } default: b() }
    ·                                            ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:48]
  1 │ switch(foo) { case 0: do { break; } while (a); default: b() }
    ·                                                ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:3:2]
@@ -52,42 +59,49 @@ source: crates/oxc_linter/src/tester.rs
  3 │  default: b() }
    ·  ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:26]
  1 │ switch(foo) { case 0: {} default: b() }
    ·                          ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:52]
  1 │ switch(foo) { case 0: a(); { /* falls through */ } default: b() }
    ·                                                    ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:52]
  1 │ switch(foo) { case 0: { /* falls through */ } a(); default: b() }
    ·                                                    ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:54]
  1 │ switch(foo) { case 0: if (a) { /* falls through */ } default: b() }
    ·                                                      ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:51]
  1 │ switch(foo) { case 0: { { /* falls through */ } } default: b() }
    ·                                                   ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:41]
  1 │ switch(foo) { case 0: { /* comment */ } default: b() }
    ·                                         ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:3:2]
@@ -95,12 +109,14 @@ source: crates/oxc_linter/src/tester.rs
  3 │  default: b() }
    ·  ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:1:50]
  1 │ switch(foo) { case 0: a(); /* falling through */ default: b() }
    ·                                                  ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
@@ -108,6 +124,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ case 1: b(); }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:4:1]
@@ -115,6 +132,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ default: b() }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
    ╭─[no_fallthrough.tsx:4:1]
@@ -122,6 +140,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ default: b() }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
@@ -129,6 +148,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ case 1: b(); }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
@@ -136,6 +156,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ case 1: b(); }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:1]
@@ -143,6 +164,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ case 1: b(); }
    · ────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:2:4]
@@ -150,18 +172,21 @@ source: crates/oxc_linter/src/tester.rs
  2 │  ; case 2:  }
    ·    ───────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:24]
  1 │ switch (a) { case 1: ; case 2: ; case 3: }
    ·                        ─────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:34]
  1 │ switch (a) { case 1: ; case 2: ; case 3: }
    ·                                  ───────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:3:2]
@@ -169,21 +194,25 @@ source: crates/oxc_linter/src/tester.rs
  3 │  case 1: }
    ·  ───────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Found a comment that would permit fallthrough, but case cannot fall through.
    ╭─[no_fallthrough.tsx:1:34]
  1 │ switch(foo) { case 0: a(); break; /* falls through */ case 1: b(); }
    ·                                  ─────────────────────
    ╰────
+  help: Remove the fallthrough comment.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:46]
  1 │ switch(true) { case x === 1 || x === 2: a(); case x === 3: b(); }
    ·                                              ──────────────────
    ╰────
+  help: Add a 'break' or 'return' statement.
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:40]
  1 │ switch(true) { case x === 1 && y: a(); case x === 3: b(); }
    ·                                        ──────────────────
    ╰────
+  help: Add a 'break' or 'return' statement.

--- a/crates/oxc_linter/src/snapshots/eslint_no_func_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_func_assign.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─┬─
    ·                     ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:18]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ─┬─
    ·                   ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:1]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─┬─
    ·  ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:2]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ─┬─
    ·   ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:6]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·      ─┬─
    ·       ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:19]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─┬─
    ·                    ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:20]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─┬─
    ·                     ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'foo' is a function.
    ╭─[no_func_assign.tsx:1:26]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─┬─
    ·                           ╰── foo is re-assigned here
    ╰────
+  help: Use a different variable name.
 
   ⚠ eslint(no-func-assign): 'hello' is a function.
    ╭─[no_func_assign.tsx:1:28]
@@ -64,3 +72,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──┬──
    ·                              ╰── hello is re-assigned here
    ╰────
+  help: Use a different variable name.

--- a/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_global_assign.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───┬──
    ·    ╰── Read-only global 'String' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'String' should not be modified.
    ╭─[no_global_assign.tsx:1:1]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───┬──
    ·    ╰── Read-only global 'String' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
    ╭─[no_global_assign.tsx:1:3]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ·   ───┬──
    ·      ╰── Read-only global 'Object' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'String' should not be modified.
    ╭─[no_global_assign.tsx:1:15]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───┬──
    ·                  ╰── Read-only global 'String' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'top' should not be modified.
    ╭─[no_global_assign.tsx:1:1]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    · ─┬─
    ·  ╰── Read-only global 'top' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'require' should not be modified.
    ╭─[no_global_assign.tsx:1:1]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    · ───┬───
    ·    ╰── Read-only global 'require' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'Object' should not be modified.
    ╭─[no_global_assign.tsx:1:16]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ───┬──
    ·                   ╰── Read-only global 'Object' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'a' should not be modified.
    ╭─[no_global_assign.tsx:1:1]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    · ┬
    · ╰── Read-only global 'a' should not be modified.
    ╰────
+  help: Assign to a local variable instead.
 
   ⚠ eslint(no-global-assign): Read-only global 'Array' should not be modified.
    ╭─[no_global_assign.tsx:1:1]
@@ -64,3 +72,4 @@ source: crates/oxc_linter/src/tester.rs
    · ──┬──
    ·   ╰── Read-only global 'Array' should not be modified.
    ╰────
+  help: Assign to a local variable instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_label_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_label_var.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │                         ╰── Label with the same name.
    ·     ╰── Identifier 'x' found here.
    ╰────
+  help: Rename the label or the variable.
 
   ⚠ eslint(no-label-var): Found identifier 'x' with the same name as a label.
    ╭─[no_label_var.tsx:1:22]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      │        ╰── Label with the same name.
    ·                      ╰── Identifier 'x' found here.
    ╰────
+  help: Rename the label or the variable.
 
   ⚠ eslint(no-label-var): Found identifier 'x' with the same name as a label.
    ╭─[no_label_var.tsx:1:14]
@@ -25,3 +27,4 @@ source: crates/oxc_linter/src/tester.rs
    ·              │    ╰── Label with the same name.
    ·              ╰── Identifier 'x' found here.
    ╰────
+  help: Rename the label or the variable.

--- a/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
@@ -7,231 +7,270 @@ source: crates/oxc_linter/src/tester.rs
  1 │ label: while(true) {}
    · ─────
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ label: while (true) { break label; }
    · ─────
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:29]
  1 │ label: while (true) { break label; }
    ·                             ─────
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ label: while (true) { continue label; }
    · ─────
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in continue statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ label: while (true) { continue label; }
    ·                                ─────
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:31]
  1 │ A: switch (a) { case 0: break A; default: break; };
    ·                               ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    ·                         ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:36]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    ·                                    ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:31]
  1 │ A: switch (a) { case 0: break A; default: break; };
    ·                               ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: while (a) { break A; }
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:22]
  1 │ A: while (a) { break A; }
    ·                      ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: do { if (b) { break A; } } while (a);
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:24]
  1 │ A: do { if (b) { break A; } } while (a);
    ·                        ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    · ─
    ╰────
+  help: Use control flow statements instead.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:63]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    ·                                                               ─
    ╰────
+  help: Use control flow statements instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
@@ -7,36 +7,42 @@ source: crates/oxc_linter/src/tester.rs
  1 │ {}
    · ──
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ {var x = 1;}
    · ────────────
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:8]
  1 │ foo(); {} bar();
    ·        ──
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:19]
  1 │ function test() { { console.log(6); } }
    ·                   ───────────────────
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:1:19]
  1 │ if (foo) { bar(); {} baz(); }
    ·                   ──
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ ╭─▶ {
  2 │ ╰─▶             { } }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -44,24 +50,28 @@ source: crates/oxc_linter/src/tester.rs
  2 │             { } }
    ·             ───
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:25]
  1 │ function foo() { bar(); {} baz(); }
    ·                         ──
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:1:15]
  1 │ while (foo) { {} }
    ·               ──
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ {var x = 1;}
    · ────────────
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -70,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             let y = 2; } {let z = 1;}
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
@@ -77,6 +88,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │               {let x = 1;}
  3 │ ╰─▶             var y = 2; } {let z = 1;}
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
@@ -85,6 +97,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶             var y = 2; }
  4 │                 {var z = 1;}
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -93,6 +106,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             var y = 2; }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:4:4]
@@ -100,6 +114,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │             {var z = 1;}
    ·             ────────────
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:5:17]
@@ -109,6 +124,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                 }
  8 │                 }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -118,6 +134,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         foo();
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:3:17]
@@ -127,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                 }
  6 │                 }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:3:17]
@@ -136,6 +154,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                 }
  6 │                 }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:25]
@@ -145,6 +164,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                         }
  8 │                         }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:25]
@@ -154,6 +174,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                         }
  8 │                             something;
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -163,6 +184,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -172,6 +194,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -181,6 +204,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -190,6 +214,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -199,6 +224,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -208,6 +234,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         something;
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:21]
@@ -217,6 +244,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                     }
  8 │                     }
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -226,6 +254,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         something;
    ╰────
+  help: Remove the block.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:21]
@@ -235,3 +264,4 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                     }
  8 │                     }
    ╰────
+  help: Remove the block.

--- a/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
@@ -7,285 +7,333 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var x = 9007199254740993
    ·         ────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9007199254740.993e3
    ·         ───────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.007199254740993e15
    ·         ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9007199254740993
    ·          ────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719.9254740994
    ·         ─────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900719.9254740994
    ·          ─────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719925474099_3
    ·         ─────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 90_0719925_4740.9_93e3
    ·         ──────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 9.0_0719925_474099_3e15
    ·           ───────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -9_00719_9254_740993
    ·            ───────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 900_719.92_54740_994
    ·           ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -900_719.92_5474_0994
    ·            ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123000000000000000000000000001
    ·         ───────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5123000000000000000000000000001
    ·          ───────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1230000000000000000000000.0
    ·         ───────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0000000000000000000000123
    ·         ───────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 17498005798264095394980017816940970922825355447145699491406164851279623993595007385788105416184430592
    ·         ─────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e999
    ·         ─────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1230000000000000000000000
    ·         ──────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o400000000000000001
    ·         ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O400000000000000001
    ·         ────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0400000000000000001
    ·         ───────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x20000000000001
    ·         ────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X20000000000001
    ·         ────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123_00000000000000000000000000_1
    ·         ─────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5_12300000000000000000000_0000001
    ·          ─────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 123_00000000000000000000_00.0_0
    ·         ───────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0_00000000000000000_0000123
    ·         ─────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 174_980057982_640953949800178169_409709228253554471456994_914061648512796239935950073857881054_1618443059_2
    ·         ───────────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e9_99
    ·         ──────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1_23000000000000_00000_0000_0
    ·         ──────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b1_0000000000000000000000000000000000000000000000000000_1
    ·         ──────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B10000000000_0000000000000000000000000000_000000000000001
    ·         ──────────────────────────────────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o4_00000000000000_001
    ·         ──────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O4_0000000000000000_1
    ·         ──────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x2_0000000000001
    ·         ─────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X200000_0000000_1
    ·         ──────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1e18_446_744_073_709_551_615
    ·         ────────────────────────────
    ╰────
+  help: Use 'BigInt' or adjust the value.

--- a/crates/oxc_linter/src/snapshots/eslint_no_magic_numbers.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_magic_numbers.snap
@@ -7,510 +7,595 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var foo = 42
    ·           ──
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0 + 1;
    ·           ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:15]
  1 │ var foo = 0 + 1;
    ·               ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): Number constants declarations must use 'const'.
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 42n
    ·           ───
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0n
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0n + 1n;
    ·           ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1n
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ var foo = 0n + 1n;
    ·                ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:9]
  1 │ a = a + 5;
    ·         ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:6]
  1 │ a += 5;
    ·      ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·           ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:15]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·               ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·                   ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:24]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·                        ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var foo = 0 + 1 + 2;
    ·                   ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 10
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ var foo = { bar:10 }
    ·                 ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x1A
    ╭─[no_magic_numbers.tsx:1:13]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·             ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x02
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·                    ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 071
    ╭─[no_magic_numbers.tsx:1:39]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·                                       ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 42
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var stats = {avg: 42};
    ·                   ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:67]
  1 │ var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;
    ·                                                                   ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:71]
  1 │ var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;
    ·                                                                       ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 60
    ╭─[no_magic_numbers.tsx:1:39]
  1 │ function getSecondsInMinute() {return 60;}
    ·                                       ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -60
    ╭─[no_magic_numbers.tsx:1:47]
  1 │ function getNegativeSecondsInMinute() {return -60;}
    ·                                               ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -100
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-100]
    ·     ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1.5
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1.5]
    ·     ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1]
    ·     ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0.1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0.1]
    ·     ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0b110
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0b110]
    ·     ──────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0o71
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0o71]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0x12
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0x12]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -012
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-012]
    ·     ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0.1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[0.1]
    ·     ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0.12e1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[0.12e1]
    ·     ──────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.5
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1.5]
    ·     ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.678e2
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1.678e2]
    ·     ───────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 56e-1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[56e-1]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.000000000000001
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[5.000000000000001]
    ·     ─────────────────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100.9
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[100.9]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4294967295
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[4294967295]
    ·     ──────────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e300
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1e300]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e310
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1e310]
    ·     ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1e310
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1e310]
    ·     ──────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[+0]
    ·     ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[+1]
    ·     ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:7]
  1 │ foo[-(-1)]
    ·       ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100
    ╭─[no_magic_numbers.tsx:1:1]
  1 │ 100 .toString()
    · ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 200
    ╭─[no_magic_numbers.tsx:1:1]
  1 │ 200[100]
    · ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:26]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                          ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:30]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                              ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:27]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                           ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 10
    ╭─[no_magic_numbers.tsx:1:36]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                                    ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:47]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                                               ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100n)
    ·   ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(-100n)
    ·   ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100n)
    ·   ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100)
    ·   ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ const func = (param = 123) => {}
    ·                       ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:14]
  1 │ const [one = 1, two = 2] = []
    ·              ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ const [one = 1, two = 2] = []
    ·                       ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:22]
  1 │ var one, two; [one = 1, two = 2] = []
    ·                      ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:31]
  1 │ var one, two; [one = 1, two = 2] = []
    ·                               ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = -2; }
    ·                 ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:24]
  1 │ class C { static foo = 2; }
    ·                        ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:18]
  1 │ class C { #foo = 2; }
    ·                  ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:25]
  1 │ class C { static #foo = 2; }
    ·                         ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2 + 3; }
    ·                 ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:21]
  1 │ class C { foo = 2 + 3; }
    ·                     ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ class C { 2; }
    ·           ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ class C { [2]; }
    ·            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1;
    ·            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -1;
    ·            ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1 | 2 | 3;
    ·            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = 1 | 2 | 3;
    ·                ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = 1 | 2 | 3;
    ·                    ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1 | -1;
    ·            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = 1 | -1;
    ·                ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:11]
@@ -519,6 +604,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─
  4 │             }
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1000
    ╭─[no_magic_numbers.tsx:3:15]
@@ -527,6 +613,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │               NUM = '0123456789',
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:5:12]
@@ -535,6 +622,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──
  6 │               POS = +1,
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:6:12]
@@ -543,6 +631,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──
  7 │             }
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:19]
@@ -551,6 +640,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─
  4 │               readonly B = 2;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:4:19]
@@ -559,6 +649,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─
  5 │               public static readonly C = 3;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:5:33]
@@ -567,6 +658,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                          ─
  6 │               static readonly D = 4;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:6:26]
@@ -575,6 +667,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ─
  7 │               readonly E = -5;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -5
    ╭─[no_magic_numbers.tsx:7:19]
@@ -583,6 +676,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──
  8 │               readonly F = +6;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 6
    ╭─[no_magic_numbers.tsx:8:19]
@@ -591,6 +685,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──
  9 │               private readonly G = 100n;
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
     ╭─[no_magic_numbers.tsx:9:27]
@@ -599,90 +694,105 @@ source: crates/oxc_linter/src/tester.rs
     ·                                    ────
  10 │             }
     ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[0];
    ·                ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[-1];
    ·                ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0xab
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[0xab];
    ·                ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.6e1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[5.6e1];
    ·                ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 | -2];
    ·                ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = Bar[1 | -2];
    ·                    ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 & -2];
    ·                ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = Bar[1 & -2];
    ·                    ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 & number];
    ·                ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:18]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                  ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:22]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                      ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:33]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                                 ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ type Foo = Parameters<Bar>[2];
    ·                            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:5:25]
@@ -691,6 +801,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ─
  6 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:7]
@@ -699,6 +810,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:3:11]
@@ -707,6 +819,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:12]
@@ -715,6 +828,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:16]
@@ -723,6 +837,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:3:20]
@@ -731,6 +846,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:24]
@@ -739,141 +855,165 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─
  4 │             };
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1;
    ·            ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -2;
    ·            ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3n
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 3n;
    ·            ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -4n
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -4n;
    ·            ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5.6;
    ·            ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7.8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7.8;
    ·            ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x0a
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 0x0a;
    ·            ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0xbc
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -0xbc;
    ·            ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1e2;
    ·            ───
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -3e4
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -3e4;
    ·            ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5e-6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5e-6;
    ·            ────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7e-8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7e-8;
    ·            ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.1e2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1.1e2;
    ·            ─────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -3.1e4
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -3.1e4;
    ·            ──────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.1e-6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5.1e-6;
    ·            ──────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7.1e-8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7.1e-8;
    ·            ───────
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 42
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ type Foo = { bar: 42 };
    ·                   ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ type Foo = { bar: 2 | 3 };
    ·                   ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ type Foo = { bar: 2 | 3 };
    ·                       ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:25]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                         ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:29]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                             ──
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:35]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                                   ─
    ╰────
+  help: Extract into a named constant.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:40]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                                        ─
    ╰────
+  help: Extract into a named constant.

--- a/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
@@ -1,395 +1,461 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC4D]/
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC4D-\uffff]/
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /before[\uD83D\uDC4D]after/
    ·                 ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /[before\uD83D\uDC4Dafter]/
    ·                 ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /\uDC4D[\uD83D\uDC4D]/
    ·                 ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]\a/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:13]
  1 │ var r = /\a[👍]\a/
    ·             ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /(?<=[👍])/
    ·               ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /(?<=[👍])/
    ·               ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[Á]/
    ·           ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[Á]/u
    ·           ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/u
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{41}\u{301}]/u
    ·           ─────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/u
    ·           ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{2747}\u{FE0F}]/u
    ·           ────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👶🏻]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[👶🏻]/
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👶🏻]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[a\uD83C\uDFFB]/u
    ·           ─────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC76\uD83C\uDFFB]/u
    ·           ────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F476}\u{1F3FB}]/u
    ·           ──────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/
    ·           ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[🇯🇵]/
    ·            ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/i
    ·           ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[🇯🇵]/i
    ·            ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83C\uDDEF\uD83C\uDDF5]/u
    ·           ────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F1EF}\u{1F1F5}]/u
    ·           ──────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]/
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:25]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]/u
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👩‍👦]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👩‍👦][👩‍👦]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = /[👩‍👦][👩‍👦]/u
    ·               ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:34]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·                  ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:41]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·                    ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·             ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66]/u
    ·           ──────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66]/u
    ·                             ──────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·           ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                            ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69]/u
    ·           ──────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}]/u
    ·           ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·           ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                            ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:59]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                                                           ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:76]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                                                                            ──────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = RegExp("[👍]", "")
    ·                  ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp('[👍]', ``)
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:2:21]
@@ -397,6 +463,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                             [👍]`)
    ·                              ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:2:21]
@@ -404,6 +471,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                             [❇️]`)
    ·                              ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:2:5]
@@ -411,627 +479,732 @@ source: crates/oxc_linter/src/tester.rs
  2 │             [❇️]`)
    ·              ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ const flags = ""; var r = new RegExp("[👍]", flags)
    ·                                        ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = RegExp("[\\uD83D\\uDC4D]", "")
    ·                  ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = RegExp("before[\\uD83D\\uDC4D]after", "")
    ·                        ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = RegExp("[before\\uD83D\\uDC4Dafter]", "")
    ·                        ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = RegExp("\t\t\t👍[👍]")
    ·                          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = new RegExp("\u1234[\\uD83D\\uDC4D]")
    ·                            ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("\\u1234\\u5678👎[👍]")
    ·                                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("\\u1234\\u5678👍[👍]")
    ·                                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]\\a", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp("/(?<=[👍])", "")
    ·                           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp("/(?<=[👍])", "")
    ·                           ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[Á]", "")
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[Á]", "u")
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "")
    ·                      ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "u")
    ·                      ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{41}\\u{301}]", "u")
    ·                      ───────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "")
    ·              ────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "u")
    ·              ────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·              ────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·                        ────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "")
    ·                      ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "u")
    ·                      ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{2747}\\u{FE0F}]", "u")
    ·                      ──────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👶🏻]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[👶🏻]", "")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👶🏻]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83D\\uDC76\\uD83C\\uDFFB]", "u")
    ·                      ────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F476}\\u{1F3FB}]", "u")
    ·                      ────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:25]
  1 │ var r = RegExp(`            👍[👍]`)
    ·                             ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = RegExp(`\t\t\t👍[👍]`)
    ·                          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "")
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]", "")
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "i")
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]", "i")
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp('[🇯🇵]', `i`)
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp('[🇯🇵]', `i`)
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]")
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]")
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]",)
    ·                      ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]",)
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:23]
  1 │ var r = new RegExp(("[🇯🇵]"))
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp(("[🇯🇵]"))
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = new RegExp((("[🇯🇵]")))
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = new RegExp((("[🇯🇵]")))
    ·                         ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:23]
  1 │ var r = new RegExp(("[🇯🇵]"),)
    ·                       ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp(("[🇯🇵]"),)
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83C\\uDDEF\\uD83C\\uDDF5]", "u")
    ·                      ────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F1EF}\\u{1F1F5}]", "u")
    ·                      ────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:36]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "u")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👩‍👦]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👩‍👦][👩‍👦]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:35]
  1 │ var r = new RegExp("[👩‍👦][👩‍👦]", "u")
    ·                          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:45]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                             ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:52]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                               ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                      ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                        ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                        ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83D\\uDC68\\u200D\\uD83D\\uDC69\\u200D\\uD83D\\uDC66]", "u")
    ·                      ───────────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:43]
  1 │ var r = new RegExp("[\\uD83D\\uDC68\\u200D\\uD83D\\uDC69\\u200D\\uD83D\\uDC66]", "u")
    ·                                           ───────────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                      ─────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:41]
  1 │ var r = new RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                         ─────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[❇️]", "")
    ·                                 ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[👶🏻]", "u")
    ·                                 ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[🇯🇵]", "")
    ·                                 ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:37]
  1 │ var r = new globalThis.RegExp("[🇯🇵]", "")
    ·                                  ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                 ─────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:52]
  1 │ var r = new globalThis.RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                                    ─────────────────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\ud83d\u{dc4d}]/u
    ·   ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u{d83d}\udc4d]/u
    ·   ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u{d83d}\u{dc4d}]/u
    ·   ────────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\uD83D\u{DC4d}]/u
    ·   ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/)
    ·          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/, 'i');
    ·          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/, 'g');
    ·          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ new RegExp("\x5B \\ufe0f\u005D")
    ·                 ────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \u{5c}ufe0f]")
    ·              ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe\60f]")
    ·              ──────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\uf\e0f]")
    ·              ─────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp(`[.\\u200D.]`)
    ·              ─────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp(`[.\\\x75200D.]`)
    ·              ────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:12]
  1 │ var r = /[[👶🏻]]/v
    ·            ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[Á]/
    ·   ─
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\\̶]/
    ·   ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\n̅]/
    ·   ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\👍]/
    ·   ───
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\è]')
    ·          ──
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\👍]')
    ·          ───
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\\👍]')
    ·          ────
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\❇️]')
    ·          ───
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(`[\👍]`) // Backslash + U+D83D + U+DC4D
    ·          ───
    ╰────
+  note: Multi-code-point characters may not match as expected.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u200c\u200d\p{ID_Continue}.]/
    ·   ──────────────
    ╰────
+  note: Multi-code-point characters may not match as expected.

--- a/crates/oxc_linter/src/snapshots/eslint_no_multi_str.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_multi_str.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─
  2 │              Line 2'
    ╰────
+  help: Use template literals or string concatenation.
 
   ⚠ eslint(no-multi-str): Unexpected multi string.
    ╭─[no_multi_str.tsx:1:14]
@@ -15,27 +16,32 @@ source: crates/oxc_linter/src/tester.rs
    ·              ─
  2 │              Line 2');
    ╰────
+  help: Use template literals or string concatenation.
 
   ⚠ eslint(no-multi-str): Unexpected multi string.
    ╭─[no_multi_str.tsx:1:5]
  1 │ 'foo\bar';
    ·     ─
    ╰────
+  help: Use template literals or string concatenation.
 
   ⚠ eslint(no-multi-str): Unexpected multi string.
    ╭─[no_multi_str.tsx:1:5]
  1 │ 'foo\ bar';
    ·     ─
    ╰────
+  help: Use template literals or string concatenation.
 
   ⚠ eslint(no-multi-str): Unexpected multi string.
    ╭─[no_multi_str.tsx:1:5]
  1 │ 'foo\ ar';
    ·     ─
    ╰────
+  help: Use template literals or string concatenation.
 
   ⚠ eslint(no-multi-str): Unexpected multi string.
    ╭─[no_multi_str.tsx:1:2]
  1 │ '\ still fails';
    ·  ─
    ╰────
+  help: Use template literals or string concatenation.

--- a/crates/oxc_linter/src/snapshots/eslint_no_nested_ternary.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_nested_ternary.snap
@@ -7,57 +7,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo ? bar : baz === qux ? quxx : foobar;
    · ───────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:1]
  1 │ foo ? baz === qux ? quxx : foobar : bar;
    · ───────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo ? (bar ? baz : qux) : quux;
    ·              ──────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo ? (bar === baz ? qux : quux) : foobar;
    ·              ─────────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:13]
  1 │ doSomething(foo ? bar : baz ? qux : quux);
    ·             ────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo /* comment */ ? bar : baz ? qux : quux;
    ·              ──────────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo! ? bar : baz! ? qux : quux;
    ·              ──────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo ? bar! : (baz! ? qux : quux);
    ·              ────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = (foo as boolean) ? bar : (baz as string) ? qux : quux;
    ·              ─────────────────────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.
 
   ⚠ eslint(no-nested-ternary): Do not nest ternary expressions.
    ╭─[no_nested_ternary.tsx:1:14]
  1 │ var result = foo ? (bar as string) : (baz as number ? qux : quux);
    ·              ────────────────────────────────────────────────────
    ╰────
+  help: Extract into a separate variable or use if/else.

--- a/crates/oxc_linter/src/snapshots/eslint_no_new.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_new.snap
@@ -7,21 +7,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ new Date()
    · ────────
    ╰────
+  help: Assign the result to a variable or call without 'new'.
 
   ⚠ eslint(no-new): Do not use 'new' for side effects.
    ╭─[no_new.tsx:1:10]
  1 │ (() => { new Date() })
    ·          ────────
    ╰────
+  help: Assign the result to a variable or call without 'new'.
 
   ⚠ eslint(no-new): Do not use 'new' for side effects.
    ╭─[no_new.tsx:1:2]
  1 │ (new Date())
    ·  ────────
    ╰────
+  help: Assign the result to a variable or call without 'new'.
 
   ⚠ eslint(no-new): Do not use 'new' for side effects.
    ╭─[no_new.tsx:1:3]
  1 │ ((new Date()))
    ·   ────────
    ╰────
+  help: Assign the result to a variable or call without 'new'.

--- a/crates/oxc_linter/src/snapshots/eslint_no_new_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_new_func.snap
@@ -7,57 +7,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var a = new Function("b", "c", "return b+c");
    ·         ────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function("b", "c", "return b+c");
    ·         ────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function.call(null, "b", "c", "return b+c");
    ·         ───────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function.apply(null, ["b", "c", "return b+c"]);
    ·         ──────────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function.bind(null, "b", "c", "return b+c")();
    ·         ───────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function.bind(null, "b", "c", "return b+c");
    ·         ───────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = Function["call"](null, "b", "c", "return b+c");
    ·         ──────────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:9]
  1 │ var a = (Function?.call)(null, "b", "c", "return b+c");
    ·         ──────────────────────────────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:41]
  1 │ const fn = () => { class Function {} }; new Function('', '')
    ·                                         ────────────────────
    ╰────
+  help: Use a function expression or declaration.
 
   ⚠ eslint(no-new-func): The Function constructor is eval.
    ╭─[no_new_func.tsx:1:50]
  1 │ var fn = function () { function Function() {} }; Function('', '')
    ·                                                  ────────────────
    ╰────
+  help: Use a function expression or declaration.

--- a/crates/oxc_linter/src/snapshots/eslint_no_nonoctal_decimal_escape.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_nonoctal_decimal_escape.snap
@@ -7,210 +7,245 @@ source: crates/oxc_linter/src/tester.rs
  1 │ '\8'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ "\8"
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:3]
  1 │ 'f\9'
    ·   ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ 'xo\9'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ 'foo\9'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ 'foo\8bar'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '👍\8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\\\8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\\\\\9'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ 'foo\\\8'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\ \8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\1\9'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ 'foo\1\9'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\n\n\8\n'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ '\n.\n\8\n'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:8]
  1 │ '\n.\nn\8\n'
    ·        ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ '\👍\8'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ '\\8\9'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8\\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8 \\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8\8'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\8\8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\9\8'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\9\8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ 'foo\8bar\9baz'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:10]
  1 │ 'foo\8bar\9baz'
    ·          ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8\1\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\8\1\9'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\9\n9\\9\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:10]
  1 │ '\9\n9\\9\9'
    ·          ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8\\\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\8\\\9'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:12]
  1 │ var foo = '\8'; bar('\9')
    ·            ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:22]
  1 │ var foo = '\8'; bar('\9')
    ·                      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   × Invalid Unicode escape sequence
    ╭─[no_nonoctal_decimal_escape.tsx:1:15]
@@ -230,99 +265,116 @@ source: crates/oxc_linter/src/tester.rs
  1 │ '\\n\8'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ '\\n\9'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ '\\\\n\8'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:11]
  1 │ 'foo\\nbar\9baz'
    ·           ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\0\8'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ 'foo\0\9bar'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\1\0\8'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:4]
  1 │ '\0\8\9'
    ·    ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\0\8\9'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:2]
  1 │ '\8\0\9'
    ·  ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\9' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\8\0\9'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:3]
  1 │ '0\8'
    ·   ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ '\\0\8'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ '\0 \8'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:5]
  1 │ '\01\8'
    ·     ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:6]
  1 │ '\0\1\8'
    ·      ──
    ╰────
+  help: Use a Unicode escape sequence instead.
 
   ⚠ eslint(no-nonoctal-decimal-escape): Don't use '\8' escape sequence.
    ╭─[no_nonoctal_decimal_escape.tsx:1:7]
  1 │ '\0\\n\8'
    ·       ──
    ╰────
+  help: Use a Unicode escape sequence instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_param_reassign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_param_reassign.snap
@@ -7,291 +7,340 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo(a) { a = 1; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a += 1; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { ({...a} = obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { for (a in obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:30]
  1 │ function foo(a) { for ({bar: a.b} of arr); }
    ·                              ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a.b = 0; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(a) { ++a.b; }
    ·                     ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(a) { ({bar: a.b} = obj); }
    ·                          ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(a) { delete a.b; }
    ·                          ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a &&= b; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:36]
  1 │ function foo(a) { function bar() { a = 2; } }
    ·                                    ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar = 13; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar += 13; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:35]
  1 │ function foo(bar) { (function() { bar = 13; })(); }
    ·                                   ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:23]
  1 │ function foo(bar) { ++bar; }
    ·                       ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar++; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:23]
  1 │ function foo(bar) { --bar; }
    ·                       ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar--; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:23]
  1 │ function foo({bar}) { bar = 13; }
    ·                       ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:27]
  1 │ function foo([, {bar}]) { bar = 13; }
    ·                           ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:23]
  1 │ function foo(bar) { ({bar} = {}); }
    ·                       ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:29]
  1 │ function foo(bar) { ({x: [, bar = 0]} = {}); }
    ·                             ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(bar) { for (bar in baz); }
    ·                          ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(bar) { for (bar of baz); }
    ·                          ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar.a = 0; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(bar) { bar.get(0).a = 0; }
    ·                     ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:28]
  1 │ function foo(bar) { delete bar.a; }
    ·                            ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:23]
  1 │ function foo(bar) { ++bar.a; }
    ·                       ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(bar) { for (bar.a in {}); }
    ·                          ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:26]
  1 │ function foo(bar) { for (bar.a of []); }
    ·                          ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:28]
  1 │ function foo(bar) { (bar ? bar : [])[0] = 1; }
    ·                            ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:22]
  1 │ function foo(bar) { [bar.a] = []; }
    ·                      ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:22]
  1 │ function foo(bar) { [bar.a] = []; }
    ·                      ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:22]
  1 │ function foo(bar) { [bar.a] = []; }
    ·                      ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:22]
  1 │ function foo(bar) { [bar.a] = []; }
    ·                      ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'bar'.
    ╭─[no_param_reassign.tsx:1:28]
  1 │ function foo(bar) { ({foo: bar.a} = {}); }
    ·                            ───
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:21]
  1 │ function foo(a) { ({a} = obj); }
    ·                     ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { ([...a] = obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { ({...a} = obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { ([...a.b] = obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:24]
  1 │ function foo(a) { ({...a.b} = obj); }
    ·                        ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:30]
  1 │ function foo(a) { for ({bar: a.b} in {}); }
    ·                              ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:25]
  1 │ function foo(a) { for ([a.b] of []); }
    ·                         ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a &&= b; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a ||= b; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a ??= b; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a.b &&= c; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a.b.c ||= d; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.
 
   ⚠ eslint(no-param-reassign): Assignment to property of function parameter 'a'.
    ╭─[no_param_reassign.tsx:1:19]
  1 │ function foo(a) { a[b] ??= c; }
    ·                   ─
    ╰────
+  help: Use a local variable instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
@@ -11,6 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ┬
    ·             ╰── It can not be redeclared here.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -19,6 +20,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │          ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -27,6 +29,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │           ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   × Identifier `a` has already been declared
    ╭─[no_redeclare..cts:1:5]
@@ -43,6 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ·          │               ╰── It can not be redeclared here.
    ·          ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -51,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │                       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -59,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │                       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -67,6 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │          ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:16]
@@ -75,6 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                │           ╰── It can not be redeclared here.
    ·                ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -83,6 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │      ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:12]
@@ -91,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │      ╰── It can not be redeclared here.
    ·            ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:24]
@@ -99,6 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │      ╰── It can not be redeclared here.
    ·                        ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:24]
@@ -107,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │        ╰── It can not be redeclared here.
    ·                        ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:26]
@@ -115,6 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │        ╰── It can not be redeclared here.
    ·                          ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:26]
@@ -123,24 +136,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │          ╰── It can not be redeclared here.
    ·                          ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:5]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·     ──────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:21]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                     ──────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:37]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                                     ──────────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -149,12 +166,14 @@ source: crates/oxc_linter/src/tester.rs
    ·     │       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:23]
  1 │ var a; var {a = 0, b: Object = 0} = {};
    ·                       ──────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -163,12 +182,14 @@ source: crates/oxc_linter/src/tester.rs
    ·     │       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:23]
  1 │ var a; var {a = 0, b: globalThis = 0} = {};
    ·                       ──────────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:20]
@@ -177,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── It can not be redeclared here.
    ·                    ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:12]
@@ -185,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │               ╰── It can not be redeclared here.
    ·            ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'b' is already defined.
    ╭─[no_redeclare..cts:1:15]
@@ -193,6 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               │                   ╰── It can not be redeclared here.
    ·               ╰── 'b' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:20]
@@ -201,6 +225,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │                  ╰── It can not be redeclared here.
    ·                    ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:10]
@@ -209,18 +234,21 @@ source: crates/oxc_linter/src/tester.rs
    ·          │  ╰── It can not be redeclared here.
    ·          ╰── 'a' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:17]
  1 │ export function undefined(): void; export function undefined() { }
    ·                 ─────────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:52]
  1 │ export function undefined(): void; export function undefined() { }
    ·                                                    ─────────
    ╰────
+  help: Use a different name or remove the redeclaration.
 
   ⚠ eslint(no-redeclare): 'foo' is already defined.
    ╭─[no_redeclare..cts:1:6]
@@ -229,3 +257,4 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                                                     ╰── It can not be redeclared here.
    ·       ╰── 'foo' is already defined.
    ╰────
+  help: Use a different name or remove the redeclaration.

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -7,84 +7,98 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:17]
  1 │ function fn() { foo; }
    ·                 ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:17]
  1 │ function fn() { foo; }
    ·                 ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ event
    · ─────
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo()
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo.bar()
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:17]
  1 │ function fn() { foo; }
    ·                 ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:17]
  1 │ function fn() { foo; }
    ·                 ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ event
    · ─────
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo()
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo.bar()
    · ───
    ╰────
+  help: Use a local variable or import instead.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'. Use bar instead.
    ╭─[no_restricted_globals.tsx:1:1]
@@ -133,3 +147,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var foo = obj => hasOwnProperty(obj, 'name');
    ·                  ──────────────
    ╰────
+  help: Use a local variable or import instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
@@ -7,192 +7,224 @@ source: crates/oxc_linter/src/tester.rs
  1 │ a = a
    ·     ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ [a] = [a]
    ·        ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:11]
  1 │ [a, b] = [a, b]
    ·           ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:14]
  1 │ [a, b] = [a, b]
    ·              ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:11]
  1 │ [a, b] = [a, c]
    ·           ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:13]
  1 │ [a, b] = [, b]
    ·             ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:14]
  1 │ [a, ...b] = [a, ...b]
    ·              ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:16]
  1 │ [[a], {b}] = [[a], {b}]
    ·                ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ [[a], {b}] = [[a], {b}]
    ·                     ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ ({a} = {a})
    ·         ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a: b} = {a: b})
    ·               ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:19]
  1 │ ({'a': b} = {'a': b})
    ·                   ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({a: b} = {'a': b})
    ·                 ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({'a': b} = {a: b})
    ·                 ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({1: b} = {1: b})
    ·               ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({1: b} = {'1': b})
    ·                 ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({'1': b} = {1: b})
    ·                 ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:19]
  1 │ ({['a']: b} = {a: b})
    ·                   ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ ({'a': b} = {[`a`]: b})
    ·                     ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({1: b} = {[1]: b})
    ·                 ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ ({a, b} = {a, b})
    ·            ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {a, b})
    ·               ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {b, a})
    ·               ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ ({a, b} = {b, a})
    ·            ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {c, a})
    ·               ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:26]
  1 │ ({a: {b}, c: [d]} = {a: {b}, c: [d]})
    ·                          ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:34]
  1 │ ({a: {b}, c: [d]} = {a: {b}, c: [d]})
    ·                                  ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ ({a, b} = {a, ...x, b})
    ·                     ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a.b
    ·       ───
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ a.b.c = a.b.c
    ·         ─────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ a[b] = a[b]
    ·        ────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ a['b'] = a['b']
    ·          ──────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:3:5]
@@ -201,30 +233,35 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       'b'
  5 │ ╰─▶ ]
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a.b
    ·       ───
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ a.b.c = a.b.c
    ·         ─────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ a[b] = a[b]
    ·        ────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ a['b'] = a['b']
    ·          ──────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:3:5]
@@ -233,57 +270,67 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       'b'
  5 │ ╰─▶ ]
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ this.x = this.x
    ·          ──────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ a['/(?<zero>0)/'] = a[/(?<zero>0)/]
    ·                     ───────────────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ (a?.b).c = (a?.b).c
    ·            ────────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a?.b
    ·       ────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:41]
  1 │ class C { #field; foo() { this.#field = this.#field; } }
    ·                                         ───────────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:44]
  1 │ class C { #field; foo() { [this.#field] = [this.#field]; } }
    ·                                            ───────────
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a &&= a
    ·       ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a ||= a
    ·       ─
    ╰────
+  help: Remove this self-assignment.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a ??= a
    ·       ─
    ╰────
+  help: Remove this self-assignment.

--- a/crates/oxc_linter/src/snapshots/eslint_no_setter_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_setter_return.snap
@@ -7,249 +7,291 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({ set a(val){ return val + 1; } })
    ·                ───────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:17]
  1 │ ({ set a(val) { return 1; } })
    ·                 ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:24]
  1 │ class A { set a(val) { return 1; } }
    ·                        ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:31]
  1 │ class A { static set a(val) { return 1; } }
    ·                               ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:23]
  1 │ (class { set a(val) { return 1; } })
    ·                       ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:17]
  1 │ ({ set a(val) { return val; } })
    ·                 ───────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:24]
  1 │ class A { set a(val) { return undefined; } }
    ·                        ─────────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:23]
  1 │ (class { set a(val) { return null; } })
    ·                       ────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:17]
  1 │ ({ set a(val) { return x + y; } })
    ·                 ─────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:24]
  1 │ class A { set a(val) { return foo(); } }
    ·                        ─────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:23]
  1 │ (class { set a(val) { return this._a; } })
    ·                       ───────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:17]
  1 │ ({ set a(val) { return this.a; } })
    ·                 ──────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:28]
  1 │ ({ set a(val) { if (foo) { return 1; }; } })
    ·                            ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:30]
  1 │ class A { set a(val) { try { return 1; } catch(e) {} } }
    ·                              ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:57]
  1 │ (class { set a(val) { while (foo){ if (bar) break; else return 1; } } })
    ·                                                         ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:17]
  1 │ ({ set a(val) { return 1; }, set b(val) { return 1; } })
    ·                 ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:43]
  1 │ ({ set a(val) { return 1; }, set b(val) { return 1; } })
    ·                                           ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:24]
  1 │ class A { set a(val) { return 1; } set b(val) { return 1; } }
    ·                        ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:49]
  1 │ class A { set a(val) { return 1; } set b(val) { return 1; } }
    ·                                                 ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:23]
  1 │ (class { set a(val) { return 1; } static set b(val) { return 1; } })
    ·                       ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:55]
  1 │ (class { set a(val) { return 1; } static set b(val) { return 1; } })
    ·                                                       ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:27]
  1 │ ({ set a(val) { if(val) { return 1; } else { return 2 }; } })
    ·                           ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:46]
  1 │ ({ set a(val) { if(val) { return 1; } else { return 2 }; } })
    ·                                              ────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:46]
  1 │ class A { set a(val) { switch(val) { case 1: return x; case 2: return y; default: return z } } }
    ·                                              ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:64]
  1 │ class A { set a(val) { switch(val) { case 1: return x; case 2: return y; default: return z } } }
    ·                                                                ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:83]
  1 │ class A { set a(val) { switch(val) { case 1: return x; case 2: return y; default: return z } } }
    ·                                                                                   ────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:62]
  1 │ (class { static set a(val) { if (val > 0) { this._val = val; return val; } return false; } })
    ·                                                              ───────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:76]
  1 │ (class { static set a(val) { if (val > 0) { this._val = val; return val; } return false; } })
    ·                                                                            ─────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:27]
  1 │ ({ set a(val) { if(val) { return 1; } else { return; }; } })
    ·                           ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:46]
  1 │ class A { set a(val) { switch(val) { case 1: return x; case 2: return; default: return z } } }
    ·                                              ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:81]
  1 │ class A { set a(val) { switch(val) { case 1: return x; case 2: return; default: return z } } }
    ·                                                                                 ────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:72]
  1 │ (class { static set a(val) { if (val > 0) { this._val = val; return; } return false; } })
    ·                                                                        ─────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:32]
  1 │ ({ set a(val) { function b(){} return b(); } })
    ·                                ───────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:24]
  1 │ class A { set a(val) { return () => {}; } }
    ·                        ────────────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:49]
  1 │ (class { set a(val) { function b(){ return 1; } return 2; } })
    ·                                                 ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:41]
  1 │ ({ set a(val) { function b(){ return; } return 1; } })
    ·                                         ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:58]
  1 │ class A { set a(val) { var x = function() { return 1; }; return 2; } }
    ·                                                          ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:50]
  1 │ (class { set a(val) { var x = () => { return; }; return 2; } })
    ·                                                  ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:33]
  1 │ function f(){}; ({ set a(val) { return 1; } });
    ·                                 ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:44]
  1 │ x = function f(){}; class A { set a(val) { return 1; } };
    ·                                            ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:40]
  1 │ x = () => {}; A = class { set a(val) { return 1; } };
    ·                                        ─────────
    ╰────
+  help: Remove the return value.
 
   ⚠ eslint(no-setter-return): Setter cannot return a value
    ╭─[no_setter_return.js:1:25]
  1 │ return; ({ set a(val) { return 1; } }); return 2;
    ·                         ─────────
    ╰────
+  help: Remove the return value.

--- a/crates/oxc_linter/src/snapshots/eslint_no_throw_literal.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_throw_literal.snap
@@ -7,153 +7,175 @@ source: crates/oxc_linter/src/tester.rs
  1 │ throw 'error';
    ·       ───────
    ╰────
-  help: Replace `'error'` with `new Error('error')`.
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw 0;
    ·       ─
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw false;
    ·       ─────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw null;
    ·       ────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw {};
    ·       ──
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Do not throw undefined
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw undefined;
    ·       ─────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Do not throw undefined
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw Infinity;
    ·       ────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Do not throw undefined
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw NaN;
    ·       ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw 'a' + 'b';
    ·       ─────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:28]
  1 │ var b = new Error(); throw 'a' + b;
    ·                            ───────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo = 'error';
    ·       ─────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo += new Error();
    ·       ──────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo &= new Error();
    ·       ──────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo &&= 'literal'
    ·       ─────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw new Error(), 1, 2, 3;
    ·       ────────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw 'literal' && 'not an Error';
    ·       ───────────────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo && 'literal'
    ·       ────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw foo ? 'not an Error' : 'literal';
    ·       ────────────────────────────────
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw `${err}`;
    ·       ────────
    ╰────
-  help: Replace ``${err}`` with `new Error(`${err}`)`.
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw 0 as number
    ·       ─
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:7]
  1 │ throw 'error' satisfies Error
    ·       ───────────────────────
    ╰────
-  help: Replace `'error' satisfies Error` with `new Error('error' satisfies Error)`.
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:24]
  1 │ let foo = 'foo'; throw foo;
    ·                        ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:44]
  1 │ let foo = 'foo' as unknown as Error; throw foo;
    ·                                            ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:26]
  1 │ function foo() {}; throw foo;
    ·                          ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:29]
  1 │ const foo = () => {}; throw foo;
    ·                             ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:2:7]
@@ -161,21 +183,25 @@ source: crates/oxc_linter/src/tester.rs
  2 │ throw Foo;
    ·       ───
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:34]
  1 │ function main(x: number) { throw x; }
    ·                                  ─
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:34]
  1 │ function main(x: string) { throw x; }
    ·                                  ─
    ╰────
+  help: Throw an 'Error' object instead.
 
   ⚠ eslint(no-throw-literal): Expected an error object to be thrown
    ╭─[no_throw_literal.tsx:1:43]
  1 │ function main(x: string | number) { throw x; }
    ·                                           ─
    ╰────
+  help: Throw an 'Error' object instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_undef.snap
@@ -7,183 +7,214 @@ source: crates/oxc_linter/src/tester.rs
  1 │ a = 1;
    · ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:9]
  1 │ var a = b;
    ·         ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:16]
  1 │ function f() { b; }
    ·                ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'window' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ window;
    · ──────
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'require' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ require("a");
    · ───────
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:36]
  1 │ var React; React.render(<img attr={a} />);
    ·                                    ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:41]
  1 │ var React, App; React.render(<App attr={a} />);
    ·                                         ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:2]
  1 │ [a] = [0];
    ·  ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:3]
  1 │ ({a} = {});
    ·   ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:6]
  1 │ ({b: a} = {});
    ·      ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'obj' is not defined.
    ╭─[no_undef.tsx:1:2]
  1 │ [obj.a, obj.b] = [0, 1];
    ·  ───
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'obj' is not defined.
    ╭─[no_undef.tsx:1:9]
  1 │ [obj.a, obj.b] = [0, 1];
    ·         ───
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'b' is not defined.
    ╭─[no_undef.tsx:1:28]
  1 │ const c = 0; const a = {...b, c};
    ·                            ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:20]
  1 │ class C { static { a; } }
    ·                    ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:31]
  1 │ class C { static { { let a; } a; } }
    ·                               ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:40]
  1 │ class C { static { { function a() {} } a; } }
    ·                                        ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:47]
  1 │ class C { static { function foo() { var a; }  a; } }
    ·                                               ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:38]
  1 │ class C { static { var a; } static { a; } }
    ·                                      ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:38]
  1 │ class C { static { let a; } static { a; } }
    ·                                      ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:46]
  1 │ class C { static { function a(){} } static { a; } }
    ·                                              ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:37]
  1 │ class C { static { var a; } foo() { a; } }
    ·                                     ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:37]
  1 │ class C { static { let a; } foo() { a; } }
    ·                                     ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:30]
  1 │ class C { static { var a; } [a]; }
    ·                              ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:30]
  1 │ class C { static { let a; } [a]; }
    ·                              ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:39]
  1 │ class C { static { function a() {} } [a]; }
    ·                                       ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'a' is not defined.
    ╭─[no_undef.tsx:1:31]
  1 │ class C { static { var a; } } a;
    ·                               ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'toString' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ toString()
    · ────────
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'hasOwnProperty' is not defined.
    ╭─[no_undef.tsx:1:1]
  1 │ hasOwnProperty()
    · ──────────────
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'r' is not defined.
    ╭─[no_undef.tsx:1:49]
  1 │ export class Foo{ bar: notDefined; }; const t = r + 1;
    ·                                                 ─
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'arguments' is not defined.
    ╭─[no_undef.tsx:1:21]
  1 │ const arrow = () => arguments;
    ·                     ─────────
    ╰────
+  help: Declare the variable or fix the reference.
 
   ⚠ eslint(no-undef): 'arguments' is not defined.
    ╭─[no_undef.tsx:1:9]
  1 │ var a = arguments;
    ·         ─────────
    ╰────
+  help: Declare the variable or fix the reference.

--- a/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
@@ -7,207 +7,242 @@ source: crates/oxc_linter/src/tester.rs
  1 │ undefined
    · ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined.a
    · ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ a[undefined]
    ·   ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined[0]
    · ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:3]
  1 │ f(undefined)
    ·   ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ function f(undefined) {}
    ·            ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ function f() { var undefined; }
    ·                    ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ function f() { undefined = true; }
    ·                ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined;
    ·     ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ try {} catch(undefined) {}
    ·              ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ function undefined() {}
    ·          ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (function undefined(){}())
    ·           ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:20]
  1 │ var foo = function undefined() {}
    ·                    ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ foo = function undefined() {}
    ·                ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:1]
  1 │ undefined = true
    · ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true
    ·     ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:4]
  1 │ ({ undefined })
    ·    ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ ({ [undefined]: foo })
    ·     ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined })
    ·         ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:9]
  1 │ ({ bar: undefined } = foo)
    ·         ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:7]
  1 │ var { undefined } = foo
    ·       ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:12]
  1 │ var { bar: undefined } = foo
    ·            ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:24]
  1 │ ({ undefined: function undefined() {} })
    ·                        ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:18]
  1 │ ({ foo: function undefined() {} })
    ·                  ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:14]
  1 │ class Foo { [undefined]() {} }
    ·              ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:11]
  1 │ (class { [undefined]() {} })
    ·           ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:5]
  1 │ var undefined = true; undefined = false;
    ·     ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:23]
  1 │ var undefined = true; undefined = false;
    ·                       ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ import undefined from 'foo'
    ·        ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:13]
  1 │ import * as undefined from 'foo'
    ·             ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:10]
  1 │ import { undefined } from 'foo'
    ·          ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:15]
  1 │ import { a as undefined } from 'foo'
    ·               ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:16]
  1 │ let a = [b, ...undefined]
    ·                ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:8]
  1 │ [a, ...undefined] = b
    ·        ─────────
    ╰────
+  help: Use 'void 0' instead.
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:6]
  1 │ [a = undefined] = b
    ·      ─────────
    ╰────
+  help: Use 'void 0' instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_unreachable.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unreachable.snap
@@ -7,129 +7,151 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo() { return x; var x = 1; }
    ·                            ──────────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:28]
  1 │ function foo() { return x; var x, y = 1; }
    ·                            ─────────────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:23]
  1 │ while (true) { break; var x = 1; }
    ·                       ──────────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:26]
  1 │ while (true) { continue; var x = 1; }
    ·                          ──────────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:26]
  1 │ function foo() { return; x = 1; }
    ·                          ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:31]
  1 │ function foo() { throw error; x = 1; }
    ·                               ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:23]
  1 │ while (true) { break; x = 1; }
    ·                       ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:26]
  1 │ while (true) { continue; x = 1; }
    ·                          ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:49]
  1 │ function foo() { switch (foo) { case 1: return; x = 1; } }
    ·                                                 ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:50]
  1 │ function foo() { switch (foo) { case 1: throw e; x = 1; } }
    ·                                                  ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:46]
  1 │ while (true) { switch (foo) { case 1: break; x = 1; } }
    ·                                              ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:49]
  1 │ while (true) { switch (foo) { case 1: continue; x = 1; } }
    ·                                                 ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:27]
  1 │ var x = 1; throw 'uh oh'; var y = 2;
    ·                           ──────────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:66]
  1 │ function foo() { var x = 1; if (x) { return; } else { throw e; } x = 2; }
    ·                                                                  ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:59]
  1 │ function foo() { var x = 1; if (x) return; else throw -1; x = 2; }
    ·                                                           ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:56]
  1 │ function foo() { var x = 1; try { return; } finally {} x = 2; }
    ·                                                        ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:57]
  1 │ function foo() { var x = 1; try { } finally { return; } x = 2; }
    ·                                                         ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:55]
  1 │ function foo() { var x = 1; do { return; } while (x); x = 2; }
    ·                                                       ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:70]
  1 │ function foo() { var x = 1; while (x) { if (x) break; else continue; x = 2; } }
    ·                                                                      ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:59]
  1 │ function foo() { var x = 1; for (;;) { if (x) continue; } x = 2; }
    ·                                                           ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:46]
  1 │ function foo() { var x = 1; while (true) { } x = 2; }
    ·                                              ──────
    ╰────
+  help: Remove this unreachable code.
 
   ⚠ eslint(no-unreachable): Unreachable code.
    ╭─[no_unreachable.tsx:1:50]
  1 │ function foo() { var x = 1; do { } while (true); x = 2; }
    ·                                                  ──────
    ╰────
+  help: Remove this unreachable code.

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────
  3 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMemberInSecondClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:3:8]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────
  4 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMemberInFirstClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────────────────
  3 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'firstUnusedMemberInSameClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────────────────────
  3 │                 #secondUnusedMemberInSameClass = 5;
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'secondUnusedMemberInSameClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:3:8]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────────
  4 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInWrite' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInWriteStatement' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInIncrement' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────────
  3 │ 
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInOuterClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────────
  3 │ 
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedOnlyInSecondNestedClass' is defined but never used.
     ╭─[no_unused_private_class_members.tsx:20:16]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                         ──────────────────────────────
  21 │                     }
     ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMethod' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────
  3 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMethod' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ─────────────
  3 │                 #usedMethod() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedSetter' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:12]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────────
  3 │             }
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedForInLoop' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedForOfLoop' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInDestructuring' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInRestPattern' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInAssignmentPattern' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInAssignmentPattern' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -153,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────
  3 │                 method() {
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInTheSecondInnerClass' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:2:8]
@@ -161,45 +180,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────────────
  3 │ 
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'awaitedMember' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:13]
  1 │ class Foo { #awaitedMember; async method() { await this.#awaitedMember; } }
    ·             ──────────────
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'unused' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:13]
  1 │ class Foo { #unused; method() { Math.random() > 0.5 ? this.#unused : []; } }
    ·             ───────
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'x' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:13]
  1 │ class Foo { #x; #y; method(a, b, c) { a ? (b ? this.#x : c) : this.#y; } }
    ·             ──
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'y' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:17]
  1 │ class Foo { #x; #y; method(a, b, c) { a ? (b ? this.#x : c) : this.#y; } }
    ·                 ──
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'x' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:13]
  1 │ class Foo { #x; method() { a && (b ? this.#x : c); } }
    ·             ──
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'b' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:17]
  1 │ class Foo { #a; #b; #c; method() { this.#a ? this.#b : this.#c; } }
    ·                 ──
    ╰────
+  help: Remove the unused private member.
 
   ⚠ eslint(no-unused-private-class-members): 'c' is defined but never used.
    ╭─[no_unused_private_class_members.tsx:1:21]
  1 │ class Foo { #a; #b; #c; method() { this.#a ? this.#b : this.#c; } }
    ·                     ──
    ╰────
+  help: Remove the unused private member.

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
@@ -7,555 +7,648 @@ source: crates/oxc_linter/src/tester.rs
  1 │ /(b)(\2a)/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\k<foo>(?<foo>bar)/
    ·  ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(a|bc)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ RegExp('(a|bc)|\\1')
    ·                ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(?<foo>\\n)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:28]
  1 │ new RegExp('(?!(?<foo>\\n))\\1')
    ·                            ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:9]
  1 │ /(?<!(a)\1)b/
    ·         ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(\\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:14]
  1 │ new RegExp('(\\1)')
    ·              ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /^(a\1)$/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '((a)\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:7]
  1 │ /^((a)\1)$/
    ·       ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(a\\1b)' from within that group.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ new RegExp('^(a\\1b)$')
    ·                ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '((\\1))' from within that group.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ RegExp('^((\\1))$')
    ·            ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(\2)' from within that group.
    ╭─[no_useless_backreference.tsx:1:4]
  1 │ /((\2))/
    ·    ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(?<foo>(.)b\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:14]
  1 │ /a(?<foo>(.)b\1)/
    ·              ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>\k<foo>)' from within that group.
    ╭─[no_useless_backreference.tsx:1:10]
  1 │ /a(?<foo>\k<foo>)b/
    ·          ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:4]
  1 │ /^(\1)*$/
    ·    ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '((?:\1))' from within that group.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /^(?:a)(?:((?:\1)))*$/
    ·               ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(?!(\1))/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(b\1c)' from within that group.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /a|(b\1c)/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a|(\1))' from within that group.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(a|(\1))/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(\2)' from within that group.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(a|(\2))/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:8]
  1 │ /(?:a|(\1))/
    ·        ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\3' will be ignored. It references group '(\3)' from within that group.
    ╭─[no_useless_backreference.tsx:1:11]
  1 │ /(a)?(b)*(\3)/
    ·           ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:8]
  1 │ /(?<=(a\1))b/
    ·        ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(a)/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1.(a)/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?:\1)(?:(a))/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '((a))' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?:\1)(?:((a)))/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?:\2)(?:((a)))/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '((?:a))' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?:\1)(?:((?:a)))/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:3]
  1 │ /(\2)(a)/
    ·   ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ RegExp('(a)\\2(b)')
    ·            ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(c)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:10]
  1 │ /(?:a)(b)\2(c)/
    ·          ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\k<foo>(?<foo>a)/
    ·  ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(c)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:9]
  1 │ /(?:a(b)\2)(c)/
    ·         ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\3' will be ignored. It references group '(c)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:19]
  1 │ new RegExp('(a)(b)\\3(c)')
    ·                   ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(?<=(a))./
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(?<!(a))./
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(?<=\1)(?<=(a))/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(?<!\1)(?<!(a))/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?=\1(a))./
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?!\1(a))./
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:9]
  1 │ /(?<=(a)\1)b/
    ·         ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:11]
  1 │ /(?<!.(a).\1.)b/
    ·           ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b|c)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:14]
  1 │ /(.)(?<!(b|c)\2)d/
    ·              ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ /(?<=(?:(a)\1))b/
    ·            ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /(?<=(?:(a))\1)b/
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ /(?<=(a)(?:\1))b/
    ·            ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ /(?<!(?:(a))(?:\1))b/
    ·                ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ /(?<!(?:(a))(?:\1)|.)b/
    ·                ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /.(?!(?<!(a)\1))./
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /.(?=(?<!(a)\1))./
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /.(?!(?<=(a)\1))./
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /.(?=(?<=(a)\1))./
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:6]
  1 │ /(a)|\1b/
    ·      ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:10]
  1 │ /^(?:(a)|\1b)$/
    ·          ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ /^(?:(a)|b(?:c|\1))$/
    ·                ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(c)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ /^(?:a|b(?:(c)|\1))$/
    ·                ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a(?!b))' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /^(?:(a(?!b))|\1b)+$/
    ·               ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:19]
  1 │ /^(?:(?:(a)(?!b))|\1b)+$/
    ·                   ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a(?=a))' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /^(?:(a(?=a))|\1b)+$/
    ·               ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /^(?:(a)(?=a)|\1b)+$/
    ·               ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(b)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:18]
  1 │ /.(?:a|(b)).|(?:(\1)|c)./
    ·                  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:10]
  1 │ /.(?!(a)|\1)./
    ·          ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:7]
  1 │ /.(?<=\1|(a))./
    ·       ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(b)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:11]
  1 │ /a(?!(b)).\1/
    ·           ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:11]
  1 │ /(?<!(a))b\1/
    ·           ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /(?<!(a))(?:\1)/
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(b)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:14]
  1 │ /.(?<!a|(b)).\1/
    ·              ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:14]
  1 │ /.(?!(a)).(?!\1)./
    ·              ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:16]
  1 │ /.(?<!(a)).(?<!\1)./
    ·                ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ /.(?=(?!(a))\1)./
    ·             ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:7]
  1 │ /.(?<!\1(?!(a)))/
    ·       ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(a)(b)\2/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(a)\1/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1(a)\2(b)/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:7]
  1 │ /\1(a)\2(b)/
    ·       ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\1.(?<=(a)\1)/
    ·  ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ /\1.(?<=(a)\1)/
    ·            ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(?!\1(a)).\1/
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\1' will be ignored. It references group '(a)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:12]
  1 │ /(?!\1(a)).\1/
    ·            ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:5]
  1 │ /(a)\2(b)/; RegExp('(\\1)');
    ·     ──
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(\\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:22]
  1 │ /(a)\2(b)/; RegExp('(\\1)');
    ·                      ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(a)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:9]
  1 │ RegExp('\\1(a){', flags);
    ·         ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '([[A--B]])' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:13]
  1 │ new RegExp('\\1([[A--B]])', 'v')
    ·             ───
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\k<foo>((?<foo>bar)|(?<foo>baz))/
    ·  ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /((?<foo>bar)|\k<foo>(?<foo>baz))/
    ·               ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears before in the same lookbehind.
    ╭─[no_useless_backreference.tsx:1:2]
  1 │ /\k<foo>((?<foo>bar)|(?<foo>baz)|(?<foo>qux))/
    ·  ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /((?<foo>bar)|\k<foo>(?<foo>baz)|(?<foo>qux))/
    ·               ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /((?<foo>bar)|\k<foo>|(?<foo>baz))/
    ·               ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:15]
  1 │ /((?<foo>bar)|\k<foo>|(?<foo>baz)|(?<foo>qux))/
    ·               ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:25]
  1 │ /((?<foo>bar)|(?<foo>baz\k<foo>)|(?<foo>qux\k<foo>))/
    ·                         ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in another alternative.
    ╭─[no_useless_backreference.tsx:1:44]
  1 │ /((?<foo>bar)|(?<foo>baz\k<foo>)|(?<foo>qux\k<foo>))/
    ·                                            ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which appears later in the pattern.
    ╭─[no_useless_backreference.tsx:1:31]
  1 │ /(?<=((?<foo>bar)|(?<foo>baz))\k<foo>)/
    ·                               ───────
    ╰────
+  note: This backreference always matches the empty string.
 
   ⚠ eslint(no-useless-backreference): Backreference '\k<foo>' will be ignored. It references group '(?<foo>bar)' which is in a negative lookaround.
    ╭─[no_useless_backreference.tsx:1:35]
  1 │ /((?!(?<foo>bar))|(?!(?<foo>baz)))\k<foo>/
    ·                                   ───────
    ╰────
+  note: This backreference always matches the empty string.

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_catch.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_catch.snap
@@ -13,6 +13,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  6 │         }
    ╰────
+  help: Remove the try/catch wrapper.
 
   ⚠ eslint(no-useless-catch): Unnecessary catch clause
    ╭─[no_useless_catch.tsx:4:18]
@@ -25,6 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  6 │         } finally {
    ╰────
+  help: Remove the catch clause.
 
   ⚠ eslint(no-useless-catch): Unnecessary try/catch wrapper
    ╭─[no_useless_catch.tsx:4:18]
@@ -38,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  7 │         }
    ╰────
+  help: Remove the try/catch wrapper.
 
   ⚠ eslint(no-useless-catch): Unnecessary catch clause
    ╭─[no_useless_catch.tsx:4:18]
@@ -51,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  7 │         } finally {
    ╰────
+  help: Remove the catch clause.
 
   ⚠ eslint(no-useless-catch): Unnecessary try/catch wrapper
    ╭─[no_useless_catch.tsx:5:20]
@@ -63,3 +67,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── and re-thrown here
  7 │           }
    ╰────
+  help: Remove the try/catch wrapper.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
@@ -7,108 +7,126 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.reject(5)
    · ─────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject('foo')
    · ─────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(`foo`)
    · ─────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(!foo)
    · ────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(void foo)
    · ────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject()
    · ────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(undefined)
    · ─────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject({ foo: 1 })
    · ──────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject([1, 2, 3])
    · ─────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject()
    · ────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:41]
  1 │ new Promise(function(resolve, reject) { reject() })
    ·                                         ────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(undefined)
    · ─────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject('foo', somethingElse)
    · ────────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:41]
  1 │ new Promise(function(resolve, reject) { reject(5) })
    ·                                         ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:36]
  1 │ new Promise((resolve, reject) => { reject(5) })
    ·                                    ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise((resolve, reject) => reject(5))
    ·                                  ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise((resolve, reject) => reject())
    ·                                  ────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:33]
  1 │ new Promise(function(yes, no) { no(5) })
    ·                                 ─────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:4:26]
@@ -117,135 +135,158 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────────────────────────
  5 │                 else resolve(file)
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:42]
  1 │ new Promise(({foo, bar, baz}, reject) => reject(5))
    ·                                          ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:40]
  1 │ new Promise(function(reject, reject) { reject(5) })
    ·                                        ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:40]
  1 │ new Promise(function(foo, arguments) { arguments(5) })
    ·                                        ────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:33]
  1 │ new Promise((foo, arguments) => arguments(5))
    ·                                 ────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:36]
  1 │ new Promise(function({}, reject) { reject(5) })
    ·                                    ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:29]
  1 │ new Promise(({}, reject) => reject(5))
    ·                             ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:47]
  1 │ new Promise((resolve, reject, somethingElse = reject(5)) => {})
    ·                                               ─────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject?.(5)
    · ───────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise?.reject(5)
    · ──────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise?.reject?.(5)
    · ────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ (Promise?.reject)(5)
    · ────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ (Promise?.reject)?.(5)
    · ──────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo += new Error())
    · ──────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo -= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo **= new Error())
    · ───────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo <<= new Error())
    · ───────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo |= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo &= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo && 5)
    · ────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo &&= 5)
    · ─────────────────────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:43]
  1 │ new Promise(function (resolve, ...rest) { rest[0](5); });
    ·                                           ──────────
    ╰────
+  help: Reject with an 'Error' object.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise(function (...rest) { rest[1](5); });
    ·                                  ──────────
    ╰────
+  help: Reject with an 'Error' object.

--- a/crates/oxc_linter/src/snapshots/eslint_radix.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_radix.snap
@@ -7,12 +7,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt();
    · ──────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ parseInt();
    · ──────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -47,60 +49,70 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("10", null);
    ·                ────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", undefined);
    ·                ─────────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", true);
    ·                ────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", "foo");
    ·                ─────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", "123");
    ·                ─────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 1);
    ·                ─
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 37);
    ·                ──
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 10.5);
    ·                ────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();
    · ─────────────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();
    · ─────────────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -114,24 +126,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt("10", 1);
    ·                       ─
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:23]
  1 │ Number.parseInt("10", 37);
    ·                       ──
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:23]
  1 │ Number.parseInt("10", 10.5);
    ·                       ────
    ╰────
+  help: Use an integer between 2 and 36.
 
   ⚠ eslint(radix): Redundant radix parameter.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 10);
    ·                ──
    ╰────
+  help: Remove the radix parameter.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -166,21 +182,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function *f(){ yield(Number).parseInt() }
    ·                     ───────────────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:19]
  1 │ { let parseInt; } parseInt();
    ·                   ──────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:17]
  1 │ { let Number; } Number.parseInt();
    ·                 ─────────────────
    ╰────
+  help: Pass the string to parse and a radix.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:17]
  1 │ { let Number; } (Number?.parseInt)();
    ·                 ────────────────────
    ╰────
+  help: Pass the string to parse and a radix.

--- a/crates/oxc_linter/src/snapshots/eslint_require_yield.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_yield.snap
@@ -7,33 +7,39 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function* foo() { return 0; }
    ·           ───
    ╰────
+  help: Add a 'yield' expression.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:12]
  1 │ (function* foo() { return 0; })();
    ·            ───
    ╰────
+  help: Add a 'yield' expression.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:17]
  1 │ var obj = { *foo() { return 0; } }
    ·                 ────────────────
    ╰────
+  help: Add a 'yield' expression.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:15]
  1 │ class A { *foo() { return 0; } }
    ·               ────────────────
    ╰────
+  help: Add a 'yield' expression.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:11]
  1 │ function* foo() { function* bar() { yield 0; } }
    ·           ───
    ╰────
+  help: Add a 'yield' expression.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:29]
  1 │ function* foo() { function* bar() { return 0; } yield 0; }
    ·                             ───
    ╰────
+  help: Add a 'yield' expression.

--- a/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
@@ -7,9 +7,11 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Symbol();
    · ────────
    ╰────
+  help: Add a description string.
 
   ⚠ eslint(symbol-description): Expected Symbol to have a description.
    ╭─[symbol_description.tsx:1:1]
  1 │ Symbol(); Symbol = function () {};
    · ────────
    ╰────
+  help: Add a description string.

--- a/crates/oxc_linter/src/snapshots/import_export.snap
+++ b/crates/oxc_linter/src/snapshots/import_export.snap
@@ -7,12 +7,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let foo; export { foo }; export * from "./export-all"
    ·                   ───    ────────────────────────────
    ╰────
+  help: Remove or rename the duplicate export.
 
   ⚠ eslint-plugin-import(export): Multiple exports of name 'foo'.
    ╭─[index.ts:1:26]
  1 │ let foo; export { foo as "foo" }; export * from "./export-all"
    ·                          ─────    ────────────────────────────
    ╰────
+  help: Remove or rename the duplicate export.
 
   × Identifier `Foo` has already been declared
    ╭─[index.ts:2:29]

--- a/crates/oxc_linter/src/snapshots/import_exports_last.snap
+++ b/crates/oxc_linter/src/snapshots/import_exports_last.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────
  4 │             const str = 'foo'
    ╰────
+  help: Move this export to the end of the file.
 
   ⚠ eslint-plugin-import(exports-last): Export statements should appear at the end of the file
    ╭─[exports_last.tsx:2:13]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────
  3 │             const str = 'foo'
    ╰────
+  help: Move this export to the end of the file.
 
   ⚠ eslint-plugin-import(exports-last): Export statements should appear at the end of the file
    ╭─[exports_last.tsx:2:13]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────
  3 │             const bar = true
    ╰────
+  help: Move this export to the end of the file.
 
   ⚠ eslint-plugin-import(exports-last): Export statements should appear at the end of the file
    ╭─[exports_last.tsx:2:13]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────────
  3 │             export const so = 'many'
    ╰────
+  help: Move this export to the end of the file.
 
   ⚠ eslint-plugin-import(exports-last): Export statements should appear at the end of the file
    ╭─[exports_last.tsx:3:13]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────
  4 │             const foo = 'bar'
    ╰────
+  help: Move this export to the end of the file.
 
   ⚠ eslint-plugin-import(exports-last): Export statements should appear at the end of the file
    ╭─[exports_last.tsx:2:13]
@@ -49,3 +54,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────────
  3 │             const bar = true
    ╰────
+  help: Move this export to the end of the file.

--- a/crates/oxc_linter/src/snapshots/import_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/import_namespace.snap
@@ -7,153 +7,179 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as names from './named-exports'; console.log(names.c)
    ·                                                             ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): Unable to validate computed reference to imported namespace "names".
    ╭─[index.js:1:55]
  1 │ import * as names from './named-exports'; console.log(names['a']);
    ·                                                       ──────────
    ╰────
+  note: Computed references cannot be statically validated.
 
   ⚠ eslint-plugin-import(namespace): Assignment to member of namespace "foo".'
    ╭─[index.js:1:31]
  1 │ import * as foo from './bar'; foo.foo = 'y';
    ·                               ───────
    ╰────
+  note: Imported namespace members are read-only.
 
   ⚠ eslint-plugin-import(namespace): Assignment to member of namespace "foo".'
    ╭─[index.js:1:31]
  1 │ import * as foo from './bar'; foo.x = 'y';
    ·                               ─────
    ╰────
+  note: Imported namespace members are read-only.
 
   ⚠ eslint-plugin-import(namespace): "x" not found in imported namespace "./bar".
    ╭─[index.js:1:35]
  1 │ import * as foo from './bar'; foo.x = 'y';
    ·                                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c } = names
    ·                                                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:66]
  1 │ import * as names from "./named-exports"; function b() { const { c } = names }
    ·                                                                  ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: d } = names
    ·                                                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: { d } } = names
    ·                                                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:19]
  1 │ console.log(names.c); import * as names from './named-exports';
    ·                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:34]
  1 │ function x() { console.log(names.c) } import * as names from './named-exports';
    ·                                  ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "default" not found in imported namespace "./re-export".
    ╭─[index.js:1:53]
  1 │ import * as ree from "./re-export"; console.log(ree.default)
    ·                                                     ───────
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./named-exports".
    ╭─[index.js:1:62]
  1 │ import * as Names from "./named-exports"; const Foo = <Names.e/>
    ·                                                              ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:52]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.e)
    ·                                                    ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:54]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.c.e)
    ·                                                      ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep/a"; console.log(a.b.e)
    ·                                                ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:45]
  1 │ import { b } from "./deep/a"; console.log(b.e)
    ·                                             ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:50]
  1 │ import * as a from "./deep/a"; console.log(a.b.c.e)
    ·                                                  ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:47]
  1 │ import { b } from "./deep/a"; console.log(b.c.e)
    ·                                               ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:52]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.e)
    ·                                                    ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:49]
  1 │ import { b } from "./deep-es7/a"; console.log(b.e)
    ·                                                 ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:54]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.c.e)
    ·                                                      ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:51]
  1 │ import { b } from "./deep-es7/a"; console.log(b.c.e)
    ·                                                   ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:45]
  1 │ import * as a from "./deep-es7/a"; var {b:{ e }} = a
    ·                                             ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                ─
    ╰────
+  help: Remove this reference or add the missing export.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:53]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                     ─
    ╰────
+  help: Remove this reference or add the missing export.

--- a/crates/oxc_linter/src/snapshots/import_no_absolute_path.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_absolute_path.snap
@@ -7,69 +7,81 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import _ from '/lodash'
    ·               ─────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:15]
  1 │ import _ from '/lodash'
    ·               ─────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:15]
  1 │ import f from '/foo/path'
    ·               ───────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:15]
  1 │ import f from '/foo/bar/baz.js'
    ·               ─────────────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:19]
  1 │ var foo = require('/foo')
    ·                   ──────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:17]
  1 │ var f = require('/foo/some')
    ·                 ───────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:17]
  1 │ var f = require('/foo/some/add')
    ·                 ───────────────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:10]
  1 │ require(['/foo'], function(){})
    ·          ──────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:19]
  1 │ require(['./foo', '/boo'], function(){})
    ·                   ──────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:10]
  1 │ require(['/foo', '/boo'], function(){})
    ·          ──────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:18]
  1 │ require(['/foo', '/boo'], function(){})
    ·                  ──────
    ╰────
+  help: Use a relative path instead.
 
   ⚠ eslint-plugin-import(no-absolute-path): Do not import modules using an absolute path
    ╭─[index.js:1:9]
  1 │ define(['/foo'], function(){})
    ·         ──────
    ╰────
+  help: Use a relative path instead.

--- a/crates/oxc_linter/src/snapshots/import_no_anonymous_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_anonymous_default_export.snap
@@ -7,57 +7,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default []
    · ─────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign arrow function to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default () => {}
    · ───────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Unexpected default export of anonymous class
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default class {}
    · ───────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Unexpected default export of anonymous function
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default function () {}
    · ─────────────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign call result to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default foo(bar)
    · ───────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default 123
    · ──────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign object to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default {}
    · ─────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign instance to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default new Foo()
    · ────────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default `foo`
    · ────────────────────
    ╰────
+  help: Assign a name to this default export.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default /^123/
    · ─────────────────────
    ╰────
+  help: Assign a name to this default export.

--- a/crates/oxc_linter/src/snapshots/import_no_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_default_export.snap
@@ -7,6 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default function bar() {};
    ·        ───────
    ╰────
+  help: Use a named export instead.
 
   ⚠ eslint-plugin-import(no-default-export): Prefer named exports
    ╭─[index.ts:2:8]
@@ -14,27 +15,32 @@ source: crates/oxc_linter/src/tester.rs
  2 │ export default bar;
    ·        ───────
    ╰────
+  help: Use a named export instead.
 
   ⚠ eslint-plugin-import(no-default-export): Prefer named exports
    ╭─[index.ts:1:8]
  1 │ export default class Bar {};
    ·        ───────
    ╰────
+  help: Use a named export instead.
 
   ⚠ eslint-plugin-import(no-default-export): Prefer named exports
    ╭─[index.ts:1:8]
  1 │ export default function() {};
    ·        ───────
    ╰────
+  help: Use a named export instead.
 
   ⚠ eslint-plugin-import(no-default-export): Prefer named exports
    ╭─[index.ts:1:8]
  1 │ export default class {};
    ·        ───────
    ╰────
+  help: Use a named export instead.
 
   ⚠ eslint-plugin-import(no-default-export): Prefer named exports
    ╭─[index.ts:1:26]
  1 │ let foo; export { foo as default }
    ·                          ───────
    ╰────
+  help: Use a named export instead.

--- a/crates/oxc_linter/src/snapshots/import_no_mutable_exports.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_mutable_exports.snap
@@ -7,12 +7,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export let count = 1
    ·        ─────────────
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'var' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:1:8]
  1 │ export var count = 1
    ·        ─────────────
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -21,12 +23,14 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export { foo }
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:1:1]
  1 │ let foo = 4, baz = 5; export { foo }
    · ─────────────────────
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'var' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -35,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export { foo }
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export { foo as baz }
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'var' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -51,6 +57,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export { foo as baz }
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -59,6 +66,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export default foo
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'var' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -67,6 +75,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             export default foo
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:3:13]
@@ -75,6 +84,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  4 │             export {
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'var' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -83,6 +93,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  3 │             let c = 3;
    ╰────
+  help: Use 'const' instead.
 
   ⚠ eslint-plugin-import(no-mutable-exports): Exporting mutable 'let' binding, use 'const' instead.
    ╭─[no_mutable_exports.tsx:2:13]
@@ -91,3 +102,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────
  3 │             export {
    ╰────
+  help: Use 'const' instead.

--- a/crates/oxc_linter/src/snapshots/import_no_nodejs_modules.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_nodejs_modules.snap
@@ -7,141 +7,165 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import path from "path"
    · ───────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "fs"
    · ───────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:12]
  1 │ var path = require("path")
    ·            ───────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:10]
  1 │ var fs = require("fs")
    ·          ─────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import(`fs`)
    · ────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "fs"
    · ───────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import crypto from "crypto"
    · ───────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `util`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("util")
    · ──────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export * from "fs"
    · ──────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import path from "node:path"
    · ────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:12]
  1 │ var path = require("node:path")
    ·            ────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "node:fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:10]
  1 │ var fs = require("node:fs")
    ·          ──────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import crypto from "node:crypto"
    · ────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("node:fs")
    · ─────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { foo } from "node:path"
    · ───────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:util`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import util = require("node:util")
    · ──────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "node:fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("node:crypto")
    · ─────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs = require("fs")
    · ─────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import path = require("path")
    · ─────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { foo } from "fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { default as foo } from "crypto"
    · ───────────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export * from "path"
    · ────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list.

--- a/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_conditional_in_test.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                              ───────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:32]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────────────────
  5 │                       };
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:35]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ───────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:35]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ───────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:35]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ───────────────
  4 │                       const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:42]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                          ────────────────────────────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:4:25]
@@ -61,6 +67,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                         }
  10 │                           });
     ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -70,6 +77,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                       }
  6 │                         })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -78,6 +86,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -86,6 +95,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -94,6 +104,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -102,6 +113,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -110,6 +122,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -118,6 +131,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -126,6 +140,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -134,6 +149,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -142,6 +158,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -150,6 +167,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:5:25]
@@ -158,6 +176,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  6 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:25]
@@ -166,6 +185,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  5 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:25]
@@ -174,6 +194,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  8 │                         switch('quux') {}
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:25]
@@ -182,6 +203,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────
  9 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -190,6 +212,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:29]
@@ -202,6 +225,7 @@ source: crates/oxc_linter/src/tester.rs
  11 │ ╰─▶                             }
  12 │                               });
     ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:14:27]
@@ -212,6 +236,7 @@ source: crates/oxc_linter/src/tester.rs
  17 │ ╰─▶                           }
  18 │                             });
     ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:25]
@@ -223,6 +248,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                         }
  9 │                           };
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:25]
@@ -234,6 +260,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                         }
  9 │                           };
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -242,6 +269,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -250,6 +278,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -258,6 +287,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -266,6 +296,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -274,6 +305,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -282,6 +314,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -290,6 +323,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -298,6 +332,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -306,6 +341,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -314,6 +350,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  4 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:25]
@@ -322,6 +359,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:25]
@@ -330,6 +368,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:7:25]
@@ -338,6 +377,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  8 │                         if ('quux') {}
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:8:25]
@@ -346,6 +386,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────────
  9 │                       })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -354,6 +395,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -362,6 +404,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -370,6 +413,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -378,6 +422,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:4:23]
@@ -386,6 +431,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────
  5 │                     })
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:6:29]
@@ -397,6 +443,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                             }
  11 │                               });
     ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:13:27]
@@ -406,6 +453,7 @@ source: crates/oxc_linter/src/tester.rs
  15 │ ╰─▶                           }
  16 │                             });
     ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
    ╭─[no_conditional_in_test.tsx:3:23]
@@ -415,6 +463,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                       }
  6 │                         });
    ╰────
+  help: Move the conditional logic outside of the test.
 
   ⚠ eslint-plugin-jest(no-conditional-in-test): Avoid having conditionals in tests.
     ╭─[no_conditional_in_test.tsx:10:23]
@@ -424,3 +473,4 @@ source: crates/oxc_linter/src/tester.rs
  12 │ ╰─▶                       }
  13 │                         });
     ╰────
+  help: Move the conditional logic outside of the test.

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                 ───────────────
  11 │             
     ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
     ╭─[no_confusing_set_timeout.tsx:10:17]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                 ───────────────
  11 │             
     ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
     ╭─[no_confusing_set_timeout.tsx:10:17]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                 ───────────────
  11 │             
     ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
     ╭─[no_confusing_set_timeout.tsx:10:17]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                 ───────────────
  11 │             
     ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
@@ -50,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
+  help: Move `jest.setTimeout` to the top level of the module.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
@@ -58,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:5:25]
@@ -66,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
+  help: Move `jest.setTimeout` to the top level of the module.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
@@ -74,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
@@ -82,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
@@ -90,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │                 });
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
@@ -98,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │                 });
    ╰────
+  help: Move `jest.setTimeout` to the top level of the module.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:7:17]
@@ -106,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  8 │             
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:7:17]
@@ -114,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  8 │             
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:7:17]
@@ -122,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  8 │             
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:7:17]
@@ -130,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  8 │             
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:4:20]
@@ -138,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ───────────────
  5 │                 }
    ╰────
+  help: Move `jest.setTimeout` to the top level of the module.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
    ╭─[no_confusing_set_timeout.tsx:3:17]
@@ -155,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  5 │                 }
    ╰────
+  help: Move `jest.setTimeout` to the top level of the module.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:17]
@@ -163,6 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  4 │             
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:8:17]
@@ -171,6 +189,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  9 │                 setTimeout(800);
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:8:17]
@@ -179,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
  9 │                 setTimeout(800);
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:21]
@@ -187,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  6 │                 
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.
 
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:21]
@@ -195,3 +216,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  6 │                 
    ╰────
+  help: Move `jest.setTimeout` before any calls to `test`, `it`, `describe`, or hooks.

--- a/crates/oxc_linter/src/snapshots/jest_no_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_hooks.snap
@@ -7,30 +7,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ beforeAll(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {})
    · ──────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterAll(() => {})
    · ────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterEach(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {}); afterEach(() => { jest.resetModules() });
    · ──────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:5:17]
@@ -39,48 +44,56 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────
  6 │             
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeAll(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {})
    · ──────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterAll(() => {})
    · ────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterEach(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterEach(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ afterEach(() => {})
    · ─────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:1:1]
  1 │ beforeEach(() => {}); afterEach(() => { vi.resetModules() });
    · ──────────
    ╰────
+  help: Use helper functions instead.
 
   ⚠ eslint-plugin-jest(no-hooks): Do not use setup or teardown hooks.
    ╭─[no_hooks.tsx:4:8]
@@ -89,3 +102,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────
  5 │             
    ╰────
+  help: Use helper functions instead.

--- a/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_restricted_jest_methods.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ jest.fn()
    ·      ──
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["fn"]()
    ·      ────
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest.mock()
    ·      ────
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:6]
  1 │ jest["mock"]()
    ·      ──────
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:22]
@@ -33,18 +37,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────────────
  4 │             
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.fn()
    ·    ──
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Do not use mocks
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi.mock()
    ·    ────
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `advanceTimersByTime` is not allowed
    ╭─[no_restricted_jest_methods.tsx:3:12]
@@ -53,9 +60,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────────
  4 │                 
    ╰────
+  help: Replace with an alternative or remove the call.
 
   ⚠ eslint-plugin-jest(no-restricted-jest-methods): Use of `fn` is not allowed
    ╭─[no_restricted_jest_methods.tsx:1:4]
  1 │ vi["fn"]()
    ·    ────
    ╰────
+  help: Replace with an alternative or remove the call.

--- a/crates/oxc_linter/src/snapshots/jest_no_restricted_matchers.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_restricted_matchers.snap
@@ -7,54 +7,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(a).toBe(b)
    ·           ────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a)["toBe"](b)
    ·           ──────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `not` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).not[x]()
    ·           ───
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `not.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).not.toBe(b)
    ·           ────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `resolves.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).resolves.toBe(b)
    ·           ─────────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).resolves.not.toBe(b)
    ·           ─────────────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).resolves.not.toBe(b)
    ·           ─────────────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `not.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).not.toBe(b)
    ·           ────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `resolves.not.toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
  1 │ expect(a).resolves.not.toBe(b)
    ·           ─────────────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `toBe` is disallowed
    ╭─[no_restricted_matchers.tsx:1:11]
@@ -77,6 +86,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ expect(Promise.resolve({})).rejects.toBeFalsy()
    ·                             ─────────────────
    ╰────
+  help: Replace with an alternative matcher or remove the assertion.
 
   ⚠ eslint-plugin-jest(no-restricted-matchers): Use of `not.toHaveBeenCalledWith` is disallowed
    ╭─[no_restricted_matchers.tsx:1:24]

--- a/crates/oxc_linter/src/snapshots/jest_no_test_return_statement.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_test_return_statement.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:3:21]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  4 │                 });
    ╰────
+  help: Use `await` instead of returning the promise.
 
   ⚠ eslint-plugin-jest(no-test-return-statement): Jest tests should not return a value
    ╭─[no_test_return_statement.tsx:4:21]
@@ -113,3 +126,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────
  5 │                 }
    ╰────
+  help: Use `await` instead of returning the promise.

--- a/crates/oxc_linter/src/snapshots/oxc_no_rest_spread_properties.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_rest_spread_properties.snap
@@ -7,33 +7,39 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({...a})
    ·   ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a} = obj)
    ·   ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:7]
  1 │ for ({...a} in foo) {}
    ·       ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:13]
  1 │ function f({...a}) {}
    ·             ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.
 
   ⚠ oxc(no-rest-spread-properties): object spread property are not allowed. Our codebase does not allow object spread properties.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a})
    ·   ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed. Our codebase does not allow object rest properties.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a} = obj)
    ·   ────
    ╰────
+  help: Use 'Object.assign()' or explicit property access instead.

--- a/crates/oxc_linter/src/snapshots/promise_avoid_new.snap
+++ b/crates/oxc_linter/src/snapshots/promise_avoid_new.snap
@@ -7,15 +7,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var x = new Promise(function (x, y) {})
    ·         ───────────────────────────────
    ╰────
+  help: Use async/await instead
 
   ⚠ eslint-plugin-promise(avoid-new): Avoid creating new promises
    ╭─[avoid_new.tsx:1:1]
  1 │ new Promise()
    · ─────────────
    ╰────
+  help: Use async/await instead
 
   ⚠ eslint-plugin-promise(avoid-new): Avoid creating new promises
    ╭─[avoid_new.tsx:1:7]
  1 │ Thing(new Promise(() => {}))
    ·       ─────────────────────
    ╰────
+  help: Use async/await instead

--- a/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
+++ b/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:6:5]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  7 │ })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 2.
    ╭─[no_multiple_resolved.tsx:3:5]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  4 │ })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
     ╭─[no_multiple_resolved.tsx:12:9]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  13 │     })
     ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 5.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 8.
     ╭─[no_multiple_resolved.tsx:11:5]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
     ·     ──────────────
  12 │ })
     ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:5]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  6 │ })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  8 │ })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ────────
  8 │ })
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:9]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  6 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  8 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Add an early return after the first resolve/reject call
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:13]
@@ -153,3 +171,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────
  9 │         }
    ╰────
+  help: Add an early return after the first resolve/reject call

--- a/crates/oxc_linter/src/snapshots/promise_spec_only.snap
+++ b/crates/oxc_linter/src/snapshots/promise_spec_only.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.something` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.something()
    · ─────────────────
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:5]
  1 │ new Promise.done()
    ·     ────────────
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:4:22]
@@ -33,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────────
  5 │             }
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:3:20]
@@ -41,15 +46,18 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ────────────
  4 │             }
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.notPermittedMethod` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.notPermittedMethod()
    · ──────────────────────────
    ╰────
+  help: Use a standard Promise method instead.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.differingCase` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.differingCase()
    · ─────────────────────
    ╰────
+  help: Use a standard Promise method instead.

--- a/crates/oxc_linter/src/snapshots/promise_valid_params.snap
+++ b/crates/oxc_linter/src/snapshots/promise_valid_params.snap
@@ -7,141 +7,165 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.resolve(1, 2)
    · ─────────────────────
    ╰────
+  help: Remove the extra arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.resolve()` requires 0 or 1 arguments, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.resolve({}, function() {}, 1, 2, 3)
    · ───────────────────────────────────────────
    ╰────
+  help: Remove the extra arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject(1, 2, 3)
    · ───────────────────────
    ╰────
+  help: Remove the extra arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject({}, function() {}, 1, 2)
    · ───────────────────────────────────────
    ╰────
+  help: Remove the extra arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race(1, 2)
    · ──────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race({}, function() {}, 1, 2, 3)
    · ────────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled(1, 2, 3)
    · ───────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled({}, function() {}, 1, 2)
    · ───────────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then()
    · ────────────────────
    ╰────
+  help: Pass the correct number of arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then(() => {}, () => {}, () => {})
    · ────────────────────────────────────────────────
    ╰────
+  help: Pass the correct number of arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then()
    · ───────────────────────
    ╰────
+  help: Pass the correct number of arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then(() => {}, () => {}, () => {})
    · ───────────────────────────────────────────────────
    ╰────
+  help: Pass the correct number of arguments
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch()
    · ─────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch(() => {}, () => {})
    · ───────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch()
    · ────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch(() => {}, () => {})
    · ──────────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally()
    · ───────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally(() => {}, () => {})
    · ─────────────────────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally()
    · ──────────────────────────
    ╰────
+  help: Pass exactly one argument
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally(() => {}, () => {})
    · ────────────────────────────────────────────
    ╰────
+  help: Pass exactly one argument

--- a/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ──
  6 │                       }
    ╰────
+  help: Remove this prop.
 
   ⚠ eslint-plugin-react(forbid-dom-props): Prop "id" is forbidden on DOM Nodes
    ╭─[forbid_dom_props.tsx:4:37]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ──
  5 │                       }
    ╰────
+  help: Remove this prop.
 
   ⚠ eslint-plugin-react(forbid-dom-props): Prop "id" is forbidden on DOM Nodes
    ╭─[forbid_dom_props.tsx:3:28]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──
  4 │                     );
    ╰────
+  help: Remove this prop.
 
   ⚠ eslint-plugin-react(forbid-dom-props): Please use class instead of ClassName
    ╭─[forbid_dom_props.tsx:3:28]
@@ -57,6 +60,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─────────
  4 │                         <div otherProp="bar" />
    ╰────
+  help: Remove this prop.
 
   ⚠ eslint-plugin-react(forbid-dom-props): Avoid using otherProp
    ╭─[forbid_dom_props.tsx:4:30]

--- a/crates/oxc_linter/src/snapshots/react_jsx_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_key.snap
@@ -7,18 +7,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ [<App />];
    ·   ───
    ╰────
+  help: Add a "key" prop to each element in the array.
 
   ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
    ╭─[jsx_key.tsx:1:3]
  1 │ [<App {...key} />];
    ·   ───
    ╰────
+  help: Add a "key" prop to each element in the array.
 
   ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in array.
    ╭─[jsx_key.tsx:1:19]
  1 │ [<App key={0}/>, <App />];
    ·                   ───
    ╰────
+  help: Add a "key" prop to each element in the array.
 
   ⚠ eslint-plugin-react(jsx-key): Missing "key" prop for element in iterator.
    ╭─[jsx_key.tsx:1:11]
@@ -133,6 +136,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ [<></>];
    ·  ──
    ╰────
+  help: Add a "key" prop to each element in the array.
 
   ⚠ eslint-plugin-react(jsx-key): "key" prop must be placed before any `{...spread}`
    ╭─[jsx_key.tsx:1:16]

--- a/crates/oxc_linter/src/snapshots/react_jsx_max_depth.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_max_depth.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────
  4 │                     </App>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 1 exceeds the configured maximum of 0
    ╭─[jsx_max_depth.tsx:3:14]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ────────────────
  4 │                     </App>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:16]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────
  5 │                       </foo>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:3:12]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  4 │                   
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 3 exceeds the configured maximum of 2
    ╭─[jsx_max_depth.tsx:3:23]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────────
  4 │                     </div>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 1 exceeds the configured maximum of 0
    ╭─[jsx_max_depth.tsx:3:14]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ───────
  4 │                     </>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:16]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────
  5 │                       </>
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
    ╭─[jsx_max_depth.tsx:4:12]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────────
  5 │                   
    ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 2 exceeds the configured maximum of 1
     ╭─[jsx_max_depth.tsx:8:12]
@@ -90,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶                     </tbody>
  11 │                       
     ╰────
+  help: Extract nested JSX into a separate component.
 
   ⚠ eslint-plugin-react(jsx-max-depth): JSX nesting depth of 5 exceeds the configured maximum of 4
     ╭─[jsx_max_depth.tsx:9:22]
@@ -99,3 +110,4 @@ source: crates/oxc_linter/src/tester.rs
  11 │ ╰─▶                               </Button>
  12 │                                 </div>
     ╰────
+  help: Extract nested JSX into a separate component.

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_comment_textnodes.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_comment_textnodes.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ──────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:4:26]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ──────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:4:29]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ─────────────
  5 │                       }
    ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:5:23]
@@ -34,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                           </div>
  8 │                             );
    ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
     ╭─[jsx_no_comment_textnodes.tsx:5:23]
@@ -45,6 +49,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶                           </div>
  10 │                             );
     ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:6:30]
@@ -54,6 +59,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶                             {'foo'}
  9 │                               </div>
    ╰────
+  help: Wrap the comment in braces: {/* comment */}
 
   ⚠ eslint-plugin-react(jsx-no-comment-textnodes): Comments inside children section of tag should be placed inside braces
    ╭─[jsx_no_comment_textnodes.tsx:3:27]
@@ -62,3 +68,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                    ──
  4 │                     };
    ╰────
+  help: Wrap the comment in braces: {/* comment */}

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_undef.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_undef.snap
@@ -7,45 +7,53 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var React; React.render(<App />);
    ·                          ───
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Appp.Foo />);
    ·                          ────
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.Foo />);
    ·                          ────
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'appp' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<appp.foo.Bar />);
    ·                          ────
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Foo' is not defined.
    ╭─[jsx_no_undef.tsx:1:26]
  1 │ var React; React.render(<Foo />);
    ·                          ───
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'Unknown' is not defined.
    ╭─[jsx_no_undef.tsx:1:35]
  1 │ var React; Unknown; React.render(<Unknown />)
    ·                                   ───────
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:49]
  1 │ var React; { const App = null; }; React.render(<App />);
    ·                                                 ───
    ╰────
+  help: Import or declare this component.
 
   ⚠ eslint-plugin-react(jsx-no-undef): 'App' is not defined.
    ╭─[jsx_no_undef.tsx:1:42]
  1 │ var React; enum A { App }; React.render(<App />);
    ·                                          ───
    ╰────
+  help: Import or declare this component.

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_useless_fragment.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_useless_fragment.snap
@@ -7,53 +7,56 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <></>
    · ──
    ╰────
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <>{}</>
    · ──
    ╰────
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:7]
  1 │ <p>moo<>foo</></p>
    ·       ──
    ╰────
-  help: Replace `<>foo</>` with `foo`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:7]
  1 │ <p>moo<>foo</></p>
    ·       ──
    ╰────
-  help: Replace `<>foo</>` with `foo`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <>{meow}</>
    · ──
    ╰────
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:4]
  1 │ <p><>{meow}</></p>
    ·    ──
    ╰────
-  help: Replace `<>{meow}</>` with `{meow}`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:4]
  1 │ <p><>{meow}</></p>
    ·    ──
    ╰────
-  help: Replace `<>{meow}</>` with `{meow}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <><div/></>
    · ──
    ╰────
-  help: Replace `<><div/></>` with `<div/>`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:2:13]
@@ -62,15 +65,14 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──
  3 │               <div/>
    ╰────
-  help: Replace `<>
-                      <div/>
-                    </>` with `<div/>`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <Fragment />
    · ────────────
    ╰────
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:2:17]
@@ -79,43 +81,42 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────────────
  3 │                   <Foo />
    ╰────
-  help: Replace `<React.Fragment>
-                          <Foo />
-                        </React.Fragment>` with `<Foo />`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:7]
  1 │ <Eeee><>foo</></Eeee>
    ·       ──
    ╰────
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><>foo</></div>
    ·      ──
    ╰────
-  help: Replace `<>foo</>` with `foo`.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><>foo</></div>
    ·      ──
    ╰────
-  help: Replace `<>foo</>` with `foo`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><>{"a"}{"b"}</></div>
    ·      ──
    ╰────
-  help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><>{"a"}{"b"}</></div>
    ·      ──
    ╰────
-  help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:5:15]
@@ -124,14 +125,14 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──
  6 │             </section>
    ╰────
-  help: Replace `<>{"a"}{"b"}</>` with `{"a"}{"b"}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:6]
  1 │ <div><Fragment>{"a"}{"b"}</Fragment></div>
    ·      ──────────
    ╰────
-  help: Replace `<Fragment>{"a"}{"b"}</Fragment>` with `{"a"}{"b"}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:3:18]
@@ -140,9 +141,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ──
  4 │                 <b>hub</b>.
    ╰────
-  help: Replace `<>
-                        <b>hub</b>.
-                      </>` with `<b>hub</b>.`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:7:18]
@@ -151,14 +150,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ──
  8 │             </section>
    ╰────
-  help: Replace `<> <b>hub</b></>` with ` <b>hub</b>`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:1:8]
  1 │ <div>a <>{""}{""}</> a</div>
    ·        ──
    ╰────
-  help: Replace `<>{""}{""}</>` with `{""}{""}`.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:4:17]
@@ -167,7 +166,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────
  5 │               </html>
    ╰────
-  help: Replace `<React.Fragment />` with ``.
+  help: Remove the unnecessary fragment.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Passing a fragment to a HTML element is useless.
    ╭─[jsx_no_useless_fragment.tsx:4:17]
@@ -176,11 +175,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────
  5 │               </html>
    ╰────
-  help: Replace `<React.Fragment />` with ``.
+  help: Remove the fragment and pass children directly.
 
   ⚠ eslint-plugin-react(jsx-no-useless-fragment): Fragments should contain more than one child.
    ╭─[jsx_no_useless_fragment.tsx:1:1]
  1 │ <><Foo>{moo}</Foo></>
    · ──
    ╰────
-  help: Replace `<><Foo>{moo}</Foo></>` with `<Foo>{moo}</Foo>`.
+  help: Remove the unnecessary fragment.

--- a/crates/oxc_linter/src/snapshots/react_jsx_pascal_case.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_pascal_case.snap
@@ -7,105 +7,123 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <Test_component />
    · ──────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component TEST_COMPONENT must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <TEST_COMPONENT />
    · ──────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component YMCA must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <YMCA />
    · ────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component _TEST_COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <_TEST_COMPONENT />
    · ───────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component TEST_COMPONENT_ must be in PascalCase or SCREAMING_SNAKE_CASE
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <TEST_COMPONENT_ />
    · ───────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component TEST-COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <TEST-COMPONENT />
    · ──────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <__ />
    · ──────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component _div must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <_div />
    · ────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <__ />
    · ──────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component $a must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <$a />
    · ──────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component Foo_DEPRECATED must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <Foo_DEPRECATED />
    · ──────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component h1 must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <Styled.h1 />
    · ─────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component h2 must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <Styled.H1.h2 />
    · ────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component h1 must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <Styled.h1.H2 />
    · ────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component $Typography must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <$Typography.P />
    · ─────────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component STYLED must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <STYLED.h1 />
    · ─────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component _camelCase must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <_camelCase />
    · ──────────────
    ╰────
+  help: Rename the component to PascalCase.
 
   ⚠ eslint-plugin-react(jsx-pascal-case): JSX component _Test_Component must be in PascalCase
    ╭─[jsx_pascal_case.tsx:1:1]
  1 │ <_Test_Component />
    · ───────────────────
    ╰────
+  help: Rename the component to PascalCase.

--- a/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_props_no_spreading.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:2:17]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:2:17]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  3 │                   
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:5:21]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                              ──────────
  6 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:20]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:20]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:5:22]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ──────────
  6 │                        <img {...props}/>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:20]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──────────
  7 │                        <div {...props}/>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:6:22]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ──────────
  7 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:19]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────────────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:19]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ───────────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:19]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─────────────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:3:19]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ───────────
  4 │                     </App>
    ╰────
+  help: Pass each prop individually.
 
   ⚠ eslint-plugin-react(jsx-props-no-spreading): Prop spreading is forbidden
    ╭─[jsx_props_no_spreading.tsx:4:33]
@@ -113,3 +126,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                          ──────────
  5 │                        <Nav.Item {...props}/>
    ╰────
+  help: Pass each prop individually.

--- a/crates/oxc_linter/src/snapshots/react_no_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_namespace.snap
@@ -7,93 +7,109 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <ns:testcomponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:testcomponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("ns:testcomponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:testComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <ns:testComponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:testComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("ns:testComponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:test_component must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <ns:test_component />
    ·  ─────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:test_component must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("ns:test_component")
    ·                     ───────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:TestComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <ns:TestComponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component ns:TestComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("ns:TestComponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:testcomponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <Ns:testcomponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:testcomponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("Ns:testcomponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:testComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <Ns:testComponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:testComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("Ns:testComponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:test_component must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <Ns:test_component />
    ·  ─────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:test_component must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("Ns:test_component")
    ·                     ───────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:TestComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:2]
  1 │ <Ns:TestComponent />
    ·  ────────────────
    ╰────
+  help: Remove the namespace.
 
   ⚠ eslint-plugin-react(no-namespace): React component Ns:TestComponent must not be in a namespace, as React does not support them.
    ╭─[no_namespace.tsx:1:21]
  1 │ React.createElement("Ns:TestComponent")
    ·                     ──────────────────
    ╰────
+  help: Remove the namespace.

--- a/crates/oxc_linter/src/snapshots/react_no_redundant_should_component_update.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_redundant_should_component_update.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Bar does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:4:16]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────────
  5 │                           return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Bar does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:4:16]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────────
  5 │                           return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.
 
   ⚠ eslint-plugin-react(no-redundant-should-component-update): Foo does not need `shouldComponentUpdate` when extending `React.PureComponent`.
    ╭─[no_redundant_should_component_update.tsx:3:14]
@@ -49,3 +54,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ─────────────────────
  4 │                         return true;
    ╰────
+  help: Remove `shouldComponentUpdate`.

--- a/crates/oxc_linter/src/snapshots/react_no_set_state.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_set_state.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use props or context instead.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use props or context instead.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use props or context instead.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:16]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────
  5 │                           name: this.props.name.toUpperCase()
    ╰────
+  help: Use props or context instead.
 
   ⚠ eslint-plugin-react(no-set-state): Do not use `setState`.
    ╭─[no_set_state.tsx:4:48]
@@ -41,3 +45,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                         ─────────────
  5 │                       }
    ╰────
+  help: Use props or context instead.

--- a/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
@@ -25,6 +25,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ─
  5 │             }
    ╰────
+  help: Use the HTML entity instead.
 
   × Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
    ╭─[no_unescaped_entities.tsx:4:60]
@@ -39,15 +40,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <script>window.foo = "bar"</script>
    ·                      ─
    ╰────
+  help: Use the HTML entity instead.
 
   ⚠ eslint-plugin-react(no-unescaped-entities): `"` can be escaped with &quot; or &ldquo; or &#34; or &rdquo;
    ╭─[no_unescaped_entities.tsx:1:26]
  1 │ <script>window.foo = "bar"</script>
    ·                          ─
    ╰────
+  help: Use the HTML entity instead.
 
   ⚠ eslint-plugin-react(no-unescaped-entities): `"` can be escaped with &quot; or &ldquo; or &#34; or &rdquo;
    ╭─[no_unescaped_entities.tsx:1:16]
  1 │ <script>测试 " 测试</script>
    ·              ─
    ╰────
+  help: Use the HTML entity instead.

--- a/crates/oxc_linter/src/snapshots/react_only_export_components.snap
+++ b/crates/oxc_linter/src/snapshots/react_only_export_components.snap
@@ -7,78 +7,91 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export const foo = () => {}; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const foo = () => {}; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const foo = 4; export const Bar = () => {};
    ·              ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:46]
  1 │ export function Component() {}; export const Aa = 'a'
    ·                                              ──
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:47]
  1 │ const foo = 4; const Bar = () => {}; export { foo, Bar };
    ·                                               ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): This rule can't verify that `export *` only exports components.
    ╭─[only_export_components.tsx:1:1]
  1 │ export * from './foo';
    · ──────────────────────
    ╰────
+  help: Use named exports instead of `export *`.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default () => {};
    · ────────────────────────
    ╰────
+  help: Add a name to the exported function or component.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default memo(() => {});
    · ──────────────────────────────
    ╰────
+  help: Add a name to the exported function or component.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:16]
  1 │ export default function () {};
    ·                ──────────────
    ╰────
+  help: Add a name to the exported function or component.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:14]
  1 │ export const CONSTANT = 3; export const Foo = () => {};
    ·              ────────
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:13]
  1 │ export enum Tab { Home, Settings }; export const Bar = () => {};
    ·             ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const Tab = () => {}; export const tabs = [<Tab />, <Tab />];
    ·       ───
    ╰────
+  help: Export this component or move it to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file has exports. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const App = () => {}; createRoot(document.getElementById('root')).render(<App />);
    ·       ───
    ╰────
+  help: Export the component or move it to a file with exports.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:3:22]
@@ -87,45 +100,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────
  4 │         
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:1]
  1 │ export default compose()(MainView);
    · ───────────────────────────────────
    ╰────
+  help: Add a name to the exported function or component.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components.
    ╭─[only_export_components.tsx:1:75]
  1 │ export const loader = () => {}; export const Bar = () => {}; export const foo = () => {};
    ·                                                                           ───
    ╰────
+  help: Move non-component exports to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const Foo = () => {}; export { Foo as "🍌"}
    ·       ───
    ╰────
+  help: Export this component or move it to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.
    ╭─[only_export_components.tsx:1:51]
  1 │ export const MyComponent = () => {}; export const MyContext = createContext('test');
    ·                                                   ─────────
    ╰────
+  help: Move React context to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your React context(s) to a separate file.
    ╭─[only_export_components.tsx:1:51]
  1 │ export const MyComponent = () => {}; export const MyContext = React.createContext('test');
    ·                                                   ─────────
    ╰────
+  help: Move React context to a separate file.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh can't handle anonymous components. Add a name to your export.
    ╭─[only_export_components.tsx:1:31]
  1 │ const MyComponent = () => {}; export default observer(MyComponent);
    ·                               ─────────────────────────────────────
    ╰────
+  help: Add a name to the exported function or component.
 
   ⚠ eslint-plugin-react(only-export-components): Fast refresh only works when a file only exports components. Move your component(s) to a separate file.
    ╭─[only_export_components.tsx:1:7]
  1 │ const MyComponent = () => {}; export default observer(MyComponent);
    ·       ───────────
    ╰────
+  help: Export this component or move it to a separate file.

--- a/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_es6_class.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  3 │               displayName: 'Hello',
    ╰────
+  help: Replace `createReactClass` with an ES2015 class.
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use an ES2015 class instead of `createReactClass`.
    ╭─[prefer_es6_class.tsx:2:25]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  3 │               render: function() {
    ╰────
+  help: Replace `createReactClass` with an ES2015 class.
 
   ⚠ eslint-plugin-react(prefer-es6-class): Components should use `createReactClass` instead of an ES2015 class.
    ╭─[prefer_es6_class.tsx:2:19]
@@ -25,3 +27,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────
  3 │               render() {
    ╰────
+  help: Replace the class with `createReactClass`.

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ────────────────────
  5 │                }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:22]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──────────
  4 │                 b && useHook2();
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:22]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──────────
  5 │             }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:21]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────
  6 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:29]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────────
  4 │             }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHasPermission" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:23]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                       ──────────────────
  6 │             return <Foo />
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────
  3 │             Hook._useState();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:13]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────
  6 │             Hook.use_hook();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:22]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──────────────
  5 │                      Super.useHook();
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:22]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───────────────
  6 │                  }
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:25]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────────────────────
  6 │                     }
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────────────────────
  5 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────────────────────
  6 │                         }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────────
  5 │                     }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:29]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────────────────────
  6 │                         }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useTernaryHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:28]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────────────
  4 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────────────
  5 │                     });
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:29]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ───────────────────────
  6 │                         });
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -153,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────────────
  5 │                     });
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -161,6 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────────────
  5 │                     });
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:4:25]
@@ -173,6 +193,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ╰── Hook is called here
  5 │                     }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:5:29]
@@ -185,6 +206,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ╰── Hook is called here
  6 │                         }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -193,6 +215,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────────
  5 │                     }
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:17]
@@ -201,6 +224,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────────
  5 │               } while (cond);
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:24]
@@ -209,6 +233,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────────────
  6 │             }
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "renderItem" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -221,6 +246,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ╰── Hook is called here
  4 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -233,6 +259,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ╰── Hook is called here
  4 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -245,6 +272,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ╰── Hook is called here
  4 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "_useNotAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:6:21]
@@ -257,6 +285,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ╰── Hook is called here
  7 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithConditionalHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:4:25]
@@ -270,6 +299,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ╰── Hook is called here
  5 │                     }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -278,6 +308,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────
  5 │                         if (b) return;
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:25]
@@ -286,6 +317,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────
  7 │                     }
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:25]
@@ -294,6 +326,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                         ──────────
  10 │                         if (d) return;
     ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:11:25]
@@ -302,6 +335,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                         ──────────
  12 │                     }
     ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -310,6 +344,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  5 │                     if (b) continue;
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:21]
@@ -318,6 +353,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  7 │                 }
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:12]
@@ -326,6 +362,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ──────────
  5 │            if (a) return;
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:12]
@@ -334,6 +371,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            ──────────
  7 │          } while (b);
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:10:12]
@@ -342,6 +380,7 @@ source: crates/oxc_linter/src/tester.rs
     ·            ──────────
  11 │            if (c) return;
     ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:12:12]
@@ -350,6 +389,7 @@ source: crates/oxc_linter/src/tester.rs
     ·            ──────────
  13 │          } while (d)
     ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:13]
@@ -358,6 +398,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  5 │             if (a) continue;
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:6:13]
@@ -366,6 +407,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  7 │           } while (b);
    ╰────
+  help: Move this hook call outside of the loop.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
@@ -374,6 +416,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────────
  6 │                     }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "a" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:2:28]
@@ -384,6 +427,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ╰── Outer function
  3 │             const whatever = function b() { useState(); };
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "b" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:45]
@@ -394,6 +438,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ╰── Outer function
  4 │             const c = () => { useState(); };
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:4:31]
@@ -404,6 +449,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ╰── Outer function
  5 │             let d = () => useState();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:5:27]
@@ -414,6 +460,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ╰── Outer function
  6 │             e = () => { useState(); };
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:6:25]
@@ -424,6 +471,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ╰── Outer function
  7 │             ({f: () => { useState(); }});
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:7:26]
@@ -434,6 +482,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ╰── Outer function
  8 │             ({g() { useState(); }});
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:8:21]
@@ -444,6 +493,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ╰── Outer function
  9 │             const {j = () => { useState(); }} = {};
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
     ╭─[rules_of_hooks.tsx:9:32]
@@ -454,6 +504,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                                  ╰── Outer function
  10 │             ({k = () => { useState(); }} = {});
     ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -462,6 +513,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  5 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
@@ -470,6 +522,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                     ──────────
  10 │                 }
     ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
     ╭─[rules_of_hooks.tsx:9:21]
@@ -478,6 +531,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                     ──────────
  10 │                 }
     ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:26]
@@ -486,6 +540,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  4 │                     b && useHook2();
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:26]
@@ -494,6 +549,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  5 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:25]
@@ -502,6 +558,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────
  6 │                     } catch {}
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:3:39]
@@ -510,6 +567,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ──────────
  4 │                     let foo2 = bar || useState();
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:39]
@@ -518,6 +576,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ──────────
  5 │                     let foo3 = bar ?? useState();
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:5:39]
@@ -526,6 +585,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ──────────
  6 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -534,6 +594,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  5 │                     }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -542,6 +603,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  5 │                     }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -550,6 +612,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───────────────
  5 │                     }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useProbablyAHook" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -562,6 +625,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ╰── Hook is called here
  4 │                 });
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
@@ -570,6 +634,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  3 │             if (foo) {
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCallback" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:29]
@@ -578,6 +643,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ───────────────────────────
  5 │             }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCustomHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:6:13]
@@ -586,6 +652,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────
  7 │         
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useBasename" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:36]
@@ -594,6 +661,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                    ──────────────────────────
  4 │                 basename: '/',
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:29]
@@ -602,6 +670,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────────────────
  6 │                         }
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:25]
@@ -610,30 +679,35 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ────────────────
  5 │                     }
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:27]
  1 │ (class {useHook = () => { useState(); }});
    ·                           ──────────
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {useHook() { useState(); }});
    ·                     ──────────
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:21]
  1 │ (class {h = () => { useState(); }});
    ·                     ──────────
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:1:15]
  1 │ (class {i() { useState(); }});
    ·               ──────────
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
@@ -642,6 +716,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  4 │                 }
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "Anonymous" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:2:40]
@@ -651,6 +726,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ ╰─▶                 }
  5 │             
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useId" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:19]
@@ -659,6 +735,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────
  4 │                   React.useId();
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useId" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:4:19]
@@ -667,6 +744,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────────
  5 │                 }
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
@@ -675,6 +753,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  4 │                 }
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useId" is called in function "notAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:19]
@@ -687,6 +766,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ╰── Hook is called here
  4 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:13]
@@ -695,6 +775,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────
  3 │             Hook._use();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:13]
@@ -703,6 +784,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────
  5 │             Hook._useState();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:7:13]
@@ -711,6 +793,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────
  8 │             Hook.use_hook();
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:21]
@@ -723,6 +806,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ╰── Hook is called here
  4 │                 }
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:2:26]
@@ -731,6 +815,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────────────
  3 │             function App() {
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -739,6 +824,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────────
  5 │                 }
    ╰────
+  help: Convert the class component to a function component to use hooks.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use" cannot be called in an async function.
    ╭─[rules_of_hooks.tsx:3:21]
@@ -747,6 +833,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────
  4 │             }
    ╰────
+  help: Remove the `async` keyword or move the hook call to a synchronous function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called in function "Anonymous" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:3:17]
@@ -759,6 +846,7 @@ source: crates/oxc_linter/src/tester.rs
    · ╰──── Outer function
  5 │             
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -767,6 +855,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────
  5 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:4:21]
@@ -775,6 +864,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────
  5 │                 }
    ╰────
+  help: Move this hook call to the top level of the function.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" is called in function "foo" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
    ╭─[rules_of_hooks.tsx:1:54]
@@ -783,6 +873,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                              │          ╰── Hook is called here
    ·                                              ╰── Outer function
    ╰────
+  help: Move this hook call into a React function component or custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:38]
@@ -791,6 +882,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ──────────
  4 │             }
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useMemo" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:41]
@@ -799,6 +891,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                         ─────────────────────
  4 │             }
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:45]
@@ -807,6 +900,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                             ──────────
  4 │             }
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:3:48]
@@ -815,9 +909,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                ─────────────────────────
  4 │             }
    ╰────
+  help: Extract the hook call into the outer component or a custom Hook.
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
    ╭─[rules_of_hooks.tsx:1:81]
  1 │ const Foo3 = hoc(function NamedComp(props) { if (props.cond) { const [_a, _b] = useState(false); } });
    ·                                                                                 ───────────────
    ╰────
+  help: Move this hook call to the top level of the function.

--- a/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
+++ b/crates/oxc_linter/src/snapshots/react_style_prop_object.snap
@@ -7,18 +7,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div style="color: 'red'" />
    ·            ──────────────
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:14]
  1 │ <Hello style="color: 'green'" />
    ·              ────────────────
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:12]
  1 │ <div style={true} />
    ·            ──────
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -27,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -35,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:37]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ────────
  5 │               }
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:4:35]
@@ -51,18 +57,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────
  5 │               }
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:20]
  1 │ <MyComponent style="myStyle" />
    ·                    ─────────
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:1:44]
  1 │ React.createElement(MyComponent2, { style: "mySpecialStyle" })
    ·                                            ────────────────
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -79,6 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object literal to the `style` prop.
 
   ⚠ eslint-plugin-react(style-prop-object): `style` prop value must be an object.
    ╭─[style_prop_object.tsx:3:31]
@@ -87,3 +98,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────────
  4 │           
    ╰────
+  help: Pass an object literal to the `style` prop.

--- a/crates/oxc_linter/src/snapshots/typescript_adjacent_overload_signatures.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_adjacent_overload_signatures.snap
@@ -12,6 +12,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ───
  6 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:18]
@@ -23,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ───
  6 │         foo(a);
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:23]
@@ -34,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       export function foo(sn: string | number) {}
    ·                       ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:23]
@@ -45,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       export function foo(sn: string | number) {}
    ·                       ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:16]
@@ -56,6 +60,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       function foo(sn: string | number) {}
    ·                ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:16]
@@ -67,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       function foo(sn: string | number) {}
    ·                ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:24]
@@ -78,6 +84,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       declare function foo(sn: string | number);
    ·                        ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:24]
@@ -89,6 +96,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │       declare function foo(sn: string | number);
    ·                        ───
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:25]
@@ -101,6 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "baz" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:5:18]
@@ -112,6 +121,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ───
  8 │         function baz(sn: string | number): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:25]
@@ -124,6 +134,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "baz" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:5:18]
@@ -135,6 +146,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ───
  8 │         function baz(sn: string | number): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -147,6 +159,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       };
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:10]
@@ -159,6 +172,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       };
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -170,6 +184,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  5 │         foo(sn: string | number): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "call" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -181,6 +196,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────────
  5 │         (sn: string | number): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -193,6 +209,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:10]
@@ -205,6 +222,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -217,6 +235,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -228,6 +247,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  5 │         foo(sn: string | number): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "baz" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:5:11]
@@ -239,6 +259,7 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───
  8 │         };
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "new" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -251,6 +272,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "new" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -262,6 +284,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  5 │         bar(): void;
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "new" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -276,6 +299,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "constructor" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -288,6 +312,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───────────
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -300,6 +325,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -312,6 +338,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  7 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:4:9]
@@ -324,6 +351,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  8 │       }
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "constructor" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -335,6 +363,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───────────
  5 │         constructor(sn: string | number) {}
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -346,6 +375,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
  5 │         foo(sn: string | number): void {}
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "static foo" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:2:9]
@@ -357,6 +387,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────
  5 │         static foo(sn: string | number): void {}
    ╰────
+  help: Move the overload signatures next to each other.
 
   ⚠ typescript-eslint(adjacent-overload-signatures): All "#private" signatures should be adjacent.
    ╭─[adjacent_overload_signatures.tsx:3:9]
@@ -368,3 +399,4 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────
  6 │       }
    ╰────
+  help: Move the overload signatures next to each other.

--- a/crates/oxc_linter/src/snapshots/typescript_ban_ts_comment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_ban_ts_comment.snap
@@ -7,12 +7,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ // @ts-expect-error
    ·   ─────────────────
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /* @ts-expect-error */
    ·   ──────────────────
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -21,6 +23,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  @ts-expect-error */
  4 │             
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  @ts-expect-error */
  4 │             
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -37,6 +41,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  * @ts-expect-error */
  4 │             
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 10 characters or longer.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -45,6 +50,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  * @ts-expect-error: TODO */
  4 │             
    ╰────
+  help: Add a description after @ts-expect-error.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -53,6 +59,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  * @ts-expect-error: TS1234 because xyz */
  4 │             
    ╰────
+  help: Add a description after @ts-expect-error.
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -61,6 +68,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  * @ts-expect-error: TS1234 */
  4 │             
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:2:3]
@@ -69,24 +77,28 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶  * @ts-expect-error    : TS1234 */
  4 │             
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /** @ts-expect-error */
    ·   ───────────────────
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: Suppress next line
    ·   ─────────────────────────────────────
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ /////@ts-expect-error: Suppress next line
    ·   ───────────────────────────────────────
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-expect-error because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:7]
@@ -95,36 +107,42 @@ source: crates/oxc_linter/src/tester.rs
    ·       ─────────────────────────────────────────
  4 │     console.log('hello');
    ╰────
+  help: Remove the @ts-expect-error comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error
    ·   ─────────────────
    ╰────
+  help: Add a description after @ts-expect-error.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 10 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TODO
    ·   ───────────────────────
    ╰────
+  help: Add a description after @ts-expect-error.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-expect-error directive to explain why the @ts-expect-error is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TS1234 because xyz
    ·   ─────────────────────────────────────
    ╰────
+  help: Add a description after @ts-expect-error.
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error: TS1234
    ·   ─────────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-expect-error directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-expect-error    : TS1234 because xyz
    ·   ─────────────────────────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): Use "@ts-expect-error" instead of @ts-ignore, as "@ts-ignore" will do nothing if the following line is error-free.
    ╭─[ban_ts_comment.tsx:1:3]
@@ -234,54 +252,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ // @ts-ignore
    ·   ───────────
    ╰────
+  help: Add a description after @ts-ignore.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore         
    ·   ────────────────────
    ╰────
+  help: Add a description after @ts-ignore.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore    .
    ·   ────────────────
    ╰────
+  help: Add a description after @ts-ignore.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-ignore directive to explain why the @ts-ignore is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore: TS1234 because xyz
    ·   ───────────────────────────────
    ╰────
+  help: Add a description after @ts-ignore.
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-ignore directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore: TS1234
    ·   ───────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-ignore directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-ignore    : TS1234 because xyz
    ·   ───────────────────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
+  help: Remove the @ts-nocheck comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
+  help: Remove the @ts-nocheck comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: Suppress next line
    ·   ────────────────────────────────
    ╰────
+  help: Remove the @ts-nocheck comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-nocheck because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:7]
@@ -290,42 +317,49 @@ source: crates/oxc_linter/src/tester.rs
    ·       ────────────────────────────────────
  4 │     console.log('hello');
    ╰────
+  help: Remove the @ts-nocheck comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck
    ·   ────────────
    ╰────
+  help: Add a description after @ts-nocheck.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-nocheck directive to explain why the @ts-nocheck is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: TS1234 because xyz
    ·   ────────────────────────────────
    ╰────
+  help: Add a description after @ts-nocheck.
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-nocheck directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck: TS1234
    ·   ────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-nocheck directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-nocheck    : TS1234 because xyz
    ·   ────────────────────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check
    ·   ──────────
    ╰────
+  help: Remove the @ts-check comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: Suppress next line
    ·   ──────────────────────────────
    ╰────
+  help: Remove the @ts-check comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Do not use @ts-check because it alters compilation errors.
    ╭─[ban_ts_comment.tsx:3:7]
@@ -334,27 +368,32 @@ source: crates/oxc_linter/src/tester.rs
    ·       ──────────────────────────────────
  4 │     console.log('hello');
    ╰────
+  help: Remove the @ts-check comment.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 3 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check
    ·   ──────────
    ╰────
+  help: Add a description after @ts-check.
 
   ⚠ typescript-eslint(ban-ts-comment): Include a description after the @ts-check directive to explain why the @ts-check is necessary. The description must be 25 characters or longer.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: TS1234 because xyz
    ·   ──────────────────────────────
    ╰────
+  help: Add a description after @ts-check.
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-check directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check: TS1234
    ·   ──────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$
 
   ⚠ typescript-eslint(ban-ts-comment): The description for the @ts-check directive must match the ^: TS\d+ because .+$ format.
    ╭─[ban_ts_comment.tsx:1:3]
  1 │ // @ts-check    : TS1234 because xyz
    ·   ──────────────────────────────────
    ╰────
+  help: Update the description to match the pattern: ^: TS\d+ because .+$

--- a/crates/oxc_linter/src/snapshots/typescript_ban_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_ban_types.snap
@@ -7,36 +7,43 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let a: String;
    ·        ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let b: Boolean;
    ·        ───────
    ╰────
+  help: Use `boolean` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Number" as a type. Use "number" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let c: Number;
    ·        ──────
    ╰────
+  help: Use `number` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Symbol" as a type. Use "symbol" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let d: Symbol;
    ·        ──────
    ╰────
+  help: Use `symbol` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "BigInt" as a type. Use "bigint" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let e: BigInt;
    ·        ──────
    ╰────
+  help: Use `bigint` instead.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:1:8]
  1 │ let f: Object;
    ·        ──────
    ╰────
+  help: Use `object` or define an explicit object shape.
+  note: The `Object` type includes primitives like strings and numbers, which is rarely intended.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:1:8]
@@ -57,24 +64,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let i: { b: String };
    ·             ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:13]
  1 │ let j: { c: String };
    ·             ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:20]
  1 │ function foo(arg0: String) {}
    ·                    ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:10]
  1 │ 'foo' as String;
    ·          ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:1:10]
@@ -88,18 +99,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let d: Symbol = Symbol('foo');
    ·        ──────
    ╰────
+  help: Use `symbol` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:20]
  1 │ let baz: [boolean, Boolean] = [true, false];
    ·                    ───────
    ╰────
+  help: Use `boolean` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:17]
  1 │ let z = true as Boolean;
    ·                 ───────
    ╰────
+  help: Use `boolean` instead.
 
   ⚠ typescript-eslint(ban-types): Prefer explicitly define the object shape
    ╭─[ban_types.tsx:1:14]
@@ -120,30 +134,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const str: String = 'foo';
    ·            ──────
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:13]
  1 │ const bool: Boolean = true;
    ·             ───────
    ╰────
+  help: Use `boolean` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Number" as a type. Use "number" instead
    ╭─[ban_types.tsx:1:12]
  1 │ const num: Number = 1;
    ·            ──────
    ╰────
+  help: Use `number` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "Symbol" as a type. Use "symbol" instead
    ╭─[ban_types.tsx:1:13]
  1 │ const symb: Symbol = Symbol('foo');
    ·             ──────
    ╰────
+  help: Use `symbol` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "BigInt" as a type. Use "bigint" instead
    ╭─[ban_types.tsx:1:15]
  1 │ const bigInt: BigInt = 1n;
    ·               ──────
    ╰────
+  help: Use `bigint` instead.
 
   ⚠ typescript-eslint(ban-types): Prefer explicitly define the object shape
    ╭─[ban_types.tsx:1:17]
@@ -167,6 +186,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Use `boolean` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:2:45]
@@ -175,6 +195,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                             ──────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:2:68]
@@ -183,6 +204,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                                    ──────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Use `object` or define an explicit object shape.
+  note: The `Object` type includes primitives like strings and numbers, which is rarely intended.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:3:28]
@@ -191,6 +214,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──────
  4 │ 
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:3:37]
@@ -199,6 +223,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ──────
  4 │ 
    ╰────
+  help: Use `object` or define an explicit object shape.
+  note: The `Object` type includes primitives like strings and numbers, which is rarely intended.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:3:46]
@@ -216,6 +242,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  6 │             const foo: String = 1 as String;
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:6:24]
@@ -224,6 +251,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  7 │           }
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:6:38]
@@ -232,6 +260,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ──────
  7 │           }
    ╰────
+  help: Use `string` instead.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:3:12]

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
@@ -176,210 +176,245 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = new Generic<int>() as Foo;
    ·           ─────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = b as A;
    ·           ──────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [1] as readonly number[];
    ·           ────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = 'string' as a | b;
    ·           ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = !'string' as A;
    ·           ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = (a as A) + b;
    ·            ──────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = new Generic<string>() as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)();
    ·                ──────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)('string');
    ·                ──────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => ({ bar: 5 }) as Foo;
    ·                 ───────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => bar as Foo;
    ·                 ──────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = bar<string>`${'baz'}` as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<int>();
    ·           ───────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>b;
    ·           ────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <readonly number[]>[1];
    ·           ──────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>'string';
    ·           ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>!'string';
    ·           ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>a + b;
    ·           ────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<string>();
    ·           ──────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)();
    ·                ────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)('string');
    ·                ────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>{ bar: 5 };
    ·                 ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>bar;
    ·                 ────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>bar<string>`${'baz'}`;
    ·           ──────────────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as Foo<int>;
    ·           ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as a | b;
    ·           ───────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = ({} as A) + b;
    ·            ───────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo<int>>{};
    ·           ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>{};
    ·           ─────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>{} + b;
    ·           ─────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as Foo<int>;
    ·           ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as a | b;
    ·           ───────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = ({} as A) + b;
    ·            ───────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print({ bar: 5 } as Foo);
    ·       ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print({ bar: 5 } as Foo);
    ·           ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -388,66 +423,77 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────────────
  4 │             }
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = {} as Foo.Bar) {}
    ·                ─────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function c(x = {} as Foo) {}
    ·                ─────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print?.({ bar: 5 } as Foo);
    ·         ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ print?.call({ bar: 5 } as Foo);
    ·             ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${{ bar: 5 } as Foo}`;
    ·         ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo<int>>{};
    ·           ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>{};
    ·           ─────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>{} + b;
    ·           ─────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print(<Foo>{ bar: 5 });
    ·       ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print(<Foo>{ bar: 5 });
    ·           ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -456,24 +502,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │             }
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print?.(<Foo>{ bar: 5 });
    ·         ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ print?.call(<Foo>{ bar: 5 });
    ·             ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${<Foo>{ bar: 5 }}`;
    ·         ───────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -533,12 +583,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = [] as string[];
    ·           ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<string[]>` instead of `as string[]`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -558,30 +610,35 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = [] as string[];
    ·           ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print([5] as Foo);
    ·       ──────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print([5] as Foo);
    ·           ──────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = [5] as Foo.Bar) {}
    ·                ──────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -590,30 +647,35 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  4 │             }
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${[5] as Foo}`;
    ·         ──────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:19]
  1 │ const foo = () => [5] as Foo;
    ·                   ──────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print(<Foo>[5]);
    ·           ────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = <Foo.Bar>[5]) {}
    ·                ────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -622,21 +684,25 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────
  4 │             }
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${<Foo>[5]}`;
    ·         ────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ const foo = <Foo>[5];
    ·             ────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:25]
  1 │ const foo = <Foo style={{ bar: 5 } as Bar} />;
    ·                         ─────────────────
    ╰────
+  help: Use a type annotation or `satisfies` instead.

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -36,7 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -45,7 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────
  3 │               let foo: a;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -54,7 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = typeof Foo; // TSTypeQuery
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -63,7 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = foo.Bar; // TSQualifiedName
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -72,7 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Baz = (typeof foo.bar)['Baz']; // TSQualifiedName & TSTypeQuery
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -81,7 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────
  3 │               let foo: A.Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -108,7 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               const foo: A = B();
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A and C are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               const foo: A = B();
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A, C, and D are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────
  3 │               const foo: A = B();
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A, C, and D are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────
  3 │               B();
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -144,7 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               B();
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B are only used as type.
    ╭─[consistent_type_imports.tsx:4:15]
@@ -153,7 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  5 │               import { C, D, E } from 'bar';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports C and D are only used as type.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -162,7 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  6 │               import type { Already2 } from 'bar';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -171,7 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -180,7 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               import { D, E, F, } from 'bar';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports D are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -189,7 +189,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  4 │               type T = A | D;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -198,7 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               import { D, E, F, } from 'bar';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports E are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -207,7 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  4 │               type T = B | E;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports C are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -216,7 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               import { D, E, F, } from 'bar';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports F are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -225,7 +225,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  4 │               type T = C | F;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -234,7 +234,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────────────
  3 │               import Type from 'default_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -243,7 +243,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  4 │               import * as Types from 'namespace_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:4:15]
@@ -252,7 +252,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  5 │               import Default, { Named } from 'default_and_named_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -261,7 +261,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────────────
  6 │               type T = Type1 | Type2 | Type | Types.A | Default | Named;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type1 are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -270,7 +270,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────────────
  3 │               import Type2, { Value2 } from 'default_import';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type2 are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -279,7 +279,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────────────────
  4 │               import Value3, { Type3 } from 'default_import2';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type3 are only used as type.
    ╭─[consistent_type_imports.tsx:4:15]
@@ -288,7 +288,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────
  5 │               import Type4, { Type5, Value4 } from 'default_and_named_import';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type4 and Type5 are only used as type.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -297,7 +297,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────────────────────
  6 │               type T = Type1 | Type2 | Type3 | Type4 | Type5;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:2:24]
@@ -306,6 +306,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │               let bar: import('foo').Bar;
    ╰────
+  help: Use a top-level `import` statement instead.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:3:24]
@@ -314,6 +315,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────────
  4 │             
    ╰────
+  help: Use a top-level `import` statement instead.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:2:24]
@@ -322,6 +324,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │             
    ╰────
+  help: Use a top-level `import` statement instead.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -330,7 +333,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type Foo from 'foo';` with `import Foo from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -339,7 +342,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type { Foo } from 'foo';` with `import { Foo } from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -348,7 +351,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -357,7 +360,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -366,7 +369,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -375,7 +378,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type Type from 'foo';` with `import Type from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -384,7 +387,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type { Type } from 'foo';` with `import { Type } from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -393,7 +396,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type * as Type from 'foo';` with `import * as Type from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -402,7 +405,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────
  3 │               import type // comment
    ╰────
-  help: Replace `import type /*comment*/ * as AllType from 'foo';` with `import /*comment*/ * as AllType from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -411,9 +414,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ ╰─▶               DefType from 'foo';
  5 │                   import type /*comment*/ { Type } from 'foo';
    ╰────
-  help: Replace `import type // comment
-                      DefType from 'foo';` with `import // comment
-                      DefType from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -422,7 +423,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────
  6 │ 
    ╰────
-  help: Replace `import type /*comment*/ { Type } from 'foo';` with `import /*comment*/ { Type } from 'foo';`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Rest are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -431,7 +432,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  3 │               const a: Rest.A = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Default are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -440,7 +441,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -449,7 +450,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Default are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -458,7 +459,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Default are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -467,7 +468,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:24]
@@ -476,7 +477,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  3 │               type T = A;
    ╰────
-  help: Replace `type A` with `A`.
+  help: Remove the `type` keyword from the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -485,7 +486,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────
  3 │               type T = A | C;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -494,7 +495,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to imported types
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -503,7 +504,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -512,7 +513,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               type T = A;
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -521,7 +522,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import { B } from 'foo';
    ╰────
-  help: Add type specifier to imported types
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -530,7 +531,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  4 │               type T = A;
    ╰────
-  help: Add type specifier to imported types
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -539,7 +540,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import B from 'foo';
    ╰────
-  help: Add type specifier to imported types
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -548,7 +549,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  4 │               type T = A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B and C are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -557,7 +558,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -566,7 +567,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -575,7 +576,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -584,7 +585,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────────
  3 │               type T = A;
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -593,7 +594,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────────
  3 │               type T = A;
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A and C are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -602,7 +603,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               import type { D } from 'deez';
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -611,7 +612,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────
  3 │               import type { D } from 'deez';
    ╰────
-  help: Add type specifier to imported types
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -620,7 +621,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -629,7 +630,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Add type specifier to imported types
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -638,7 +639,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -647,7 +648,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -656,7 +657,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -665,7 +666,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -674,7 +675,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Add the `type` keyword to the import.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Foo are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -683,7 +684,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  4 │               function test(foo: Foo) {}
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Foo are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -692,7 +693,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  4 │               function test(foo: Foo) {}
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Config, OnEvent, and URLHelper are only used as type.
     ╭─[consistent_type_imports.tsx:5:13]
@@ -705,7 +706,7 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶             } from '../../../fundamentals';
  11 │     
     ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports DefineParallelPluginResult are only used as type.
    ╭─[consistent_type_imports.tsx:5:13]
@@ -714,4 +715,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────────────────────────────────────────────────
  6 │ 
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Mark type-only imports with the `type` keyword.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export function test(a: number, b: number) { return; }
    ·                 ────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function test() { return; }
    ·                 ────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var fn = function () { return 1; };
    ·            ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:19]
@@ -33,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────
  5 │                 return 1;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:7:24]
@@ -41,6 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────
  8 │               method() {
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -49,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:11:23]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                       ───
  12 │               private method() {
     ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:11:15]
@@ -65,6 +73,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ─────
  12 │               private method() {
     ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:15:28]
@@ -73,6 +82,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                            ───
  16 │             }
     ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -81,6 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  4 │               public b = function () {};
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:22]
@@ -89,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  5 │               public c = function test() {};
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:35]
@@ -97,6 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────
  6 │ 
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:22]
@@ -105,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  8 │               static e = function () {};
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:22]
@@ -113,24 +127,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  9 │             }
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:30]
  1 │ export default () => (true ? () => {} : (): void => {});
    ·                              ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var funcExpr = function () { return 'test'; };
    ·            ────────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:15]
@@ -139,24 +157,28 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───
  5 │             };
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => () => {};
    ·                      ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => function () {};
    ·                      ────────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:31]
  1 │ export default () => { return () => {}; };
    ·                               ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -165,18 +187,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────
  4 │             };
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return () => {}; }
    ·                 ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return function () {}; }
    ·                 ──
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:33]
@@ -185,6 +210,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ────────────────────────────────────────────
  5 │                   return () => {
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -193,6 +219,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──
  4 │                 return;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -201,6 +228,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:26]
@@ -209,6 +237,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  4 │             
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -217,6 +246,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  3 │             
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:26]
@@ -225,6 +255,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  8 │               ({ type: 'X', value }) as const satisfies R;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -233,6 +264,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:12:15]
@@ -241,6 +273,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ───
  13 │             }
     ╰────
+  help: Add an explicit return type to the function.
 
   × Unexpected token
    ╭─[explicit_module_boundary_types.tsx:5:25]
@@ -257,6 +290,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => value;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:32]
@@ -265,12 +299,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────
  3 │               return '123';
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:33]
  1 │ export const fn = (one: number, two): string => '123';
    ·                                 ───
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -279,6 +315,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner) {};
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -287,6 +324,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -295,12 +333,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ───
  3 │               return function (inner) {};
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export const baz = arg => arg as const;
    ·                    ───
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -309,6 +349,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default foo;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -317,6 +358,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default foo;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -325,6 +367,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export = foo;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -333,6 +376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export = foo;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -341,6 +385,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default [foo];
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -349,6 +394,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default [foo];
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -357,6 +403,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default { foo };
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -365,6 +412,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default { foo };
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -373,6 +421,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -381,6 +430,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -389,6 +439,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -397,6 +448,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -405,6 +457,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -413,6 +466,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:38]
@@ -421,6 +475,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ───
  3 │               return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:34]
@@ -429,6 +484,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ───
  3 │               return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:20]
@@ -437,6 +493,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -445,6 +502,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -453,6 +511,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -461,6 +520,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -469,6 +529,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -477,6 +538,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:31]
@@ -485,6 +547,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -493,6 +556,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:41]
@@ -501,6 +565,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                         ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -509,6 +574,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -517,6 +583,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -525,6 +592,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -533,6 +601,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -541,6 +610,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -549,6 +619,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -557,6 +628,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -565,12 +637,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               () =>
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => () => {};
    ·            ───────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -579,6 +653,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──
  3 │               return function () {};
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -587,6 +662,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner): void {};
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -595,6 +671,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:6:32]
@@ -603,60 +680,70 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  7 │             }
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo({ foo }): void {}
    ·                     ───────
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo([bar]): void {}
    ·                     ─────
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...bar): void {}
    ·                    ────────
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...[a]): void {}
    ·                    ────────
    ╰────
+  help: Add a type annotation to the parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo(foo: any): void {}
    ·                     ────────
    ╰────
+  help: Use a more specific type instead of `any`.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo({ foo }: any): void {}
    ·                     ────────────
    ╰────
+  help: Use a more specific type instead of `any`.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo([bar]: any): void {}
    ·                     ──────────
    ╰────
+  help: Use a more specific type instead of `any`.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...bar: any): void {}
    ·                    ─────────────
    ╰────
+  help: Use a more specific type instead of `any`.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...[a]: any): void {}
    ·                    ─────────────
    ╰────
+  help: Use a more specific type instead of `any`.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -665,6 +752,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────
  3 │               return 0;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:6:15]
@@ -673,6 +761,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────
  7 │                 return 0;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:29]
@@ -681,6 +770,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────
  5 │               return a;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:37]
@@ -689,6 +779,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ────
  5 │               return a;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:28]
@@ -697,6 +788,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────
  5 │               return a;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:15]
@@ -705,15 +797,18 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  6 │                 return a;
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:58]
  1 │ function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };
    ·                                                          ─────
    ╰────
+  help: Add an explicit return type to the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:10]
  1 │ function App() { return 42; } export default App
    ·          ───
    ╰────
+  help: Add an explicit return type to the function.

--- a/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────
  5 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  5 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:10]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────
  5 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:10]
@@ -81,3 +90,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────
  4 │                   
    ╰────
+  help: Use `Reflect.deleteProperty()` instead.

--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
@@ -7,6 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ interface Foo {}
    · ────────────────
    ╰────
+  help: Remove the empty interface or add members to it.
 
   × Expected `{` but found `EOF`
    ╭─[no_empty_interface.tsx:1:25]
@@ -20,6 +21,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  7 │ 
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:6:4]
@@ -28,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  7 │ 
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:6:4]
@@ -36,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  7 │ 
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:6:4]
@@ -44,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  7 │ 
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:6:4]
@@ -52,18 +57,21 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  7 │                   
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:1:1]
  1 │ interface Foo extends Array<number> {}
    · ──────────────────────────────────────
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:1:1]
  1 │ interface Foo extends Array<number | {}> {}
    · ───────────────────────────────────────────
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:5:4]
@@ -72,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────────────
  6 │                   
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:3:4]
@@ -80,6 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────
  4 │                   
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:2:4]
@@ -88,6 +98,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────────
  3 │                   
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
    ╭─[no_empty_interface.tsx:4:13]
@@ -96,3 +107,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────────────────────────
  5 │             }
    ╰────
+  help: Use a type alias instead, e.g. `type T = SuperType`.

--- a/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
@@ -7,57 +7,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const foo: { bar: number } | null = null; const bar = foo!!!.bar;
    ·                                                           ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:58]
  1 │ const foo: { bar: number } | null = null; const bar = foo!!!.bar;
    ·                                                          ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:58]
  1 │ const foo: { bar: number } | null = null; const bar = foo!!.bar; 
    ·                                                          ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:62]
  1 │ function foo(bar: number | undefined) { const a: number = bar!!; }
    ·                                                              ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:47]
  1 │ function foo(bar?: { n: number }) { return bar!?.n; }
    ·                                               ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:47]
  1 │ function foo(bar?: { n: number }) { return bar!?.(); }
    ·                                               ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:59]
  1 │ const foo: { bar: number } | null = null; const bar = (foo!)!.bar;
    ·                                                           ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:48]
  1 │ function foo(bar?: { n: number }) { return (bar!)?.n; }
    ·                                                ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:49]
  1 │ function foo(bar?: { n: number }) { return (bar)!?.n; }
    ·                                                 ▲
    ╰────
+  help: Remove the extra `!` assertion.
 
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:48]
  1 │ function foo(bar?: { n: number }) { return (bar!)?.(); }
    ·                                                ▲
    ╰────
+  help: Remove the extra `!` assertion.

--- a/crates/oxc_linter/src/snapshots/typescript_no_wrapper_object_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_wrapper_object_types.snap
@@ -7,107 +7,109 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let value: BigInt;
    ·            ──────
    ╰────
-  help: Replace `BigInt` with `bigint`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: Boolean;
    ·            ───────
    ╰────
-  help: Replace `Boolean` with `boolean`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: Number;
    ·            ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: Object;
    ·            ──────
    ╰────
-  help: Replace `Object` with `object`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: String;
    ·            ──────
    ╰────
-  help: Replace `String` with `string`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: Symbol;
    ·            ──────
    ╰────
-  help: Replace `Symbol` with `symbol`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:12]
  1 │ let value: Number | Symbol;
    ·            ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:21]
  1 │ let value: Number | Symbol;
    ·                     ──────
    ╰────
-  help: Replace `Symbol` with `symbol`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:24]
  1 │ let value: { property: Number };
    ·                        ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:6]
  1 │ 0 as Number;
    ·      ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:15]
  1 │ type MyType = Number;
    ·               ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:16]
  1 │ type MyType = [Number];
    ·                ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:26]
  1 │ class MyClass implements Number {}
    ·                          ──────
    ╰────
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:31]
  1 │ interface MyInterface extends Number {}
    ·                               ──────
    ╰────
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:15]
  1 │ type MyType = Number & String;
    ·               ──────
    ╰────
-  help: Replace `Number` with `number`.
+  help: Use the primitive type instead.
 
   ⚠ typescript-eslint(no-wrapper-object-types): Do not use wrapper object types.
    ╭─[no_wrapper_object_types.tsx:1:24]
  1 │ type MyType = Number & String;
    ·                        ──────
    ╰────
-  help: Replace `String` with `string`.
+  help: Use the primitive type instead.

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_enum_initializers.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_enum_initializers.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──
  4 │             }
    ╰────
+  help: Assign an explicit value.
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Up" should be explicitly defined.
    ╭─[prefer_enum_initializers.tsx:3:6]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──
  4 │               Down,
    ╰────
+  help: Assign an explicit value.
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Down" should be explicitly defined.
    ╭─[prefer_enum_initializers.tsx:4:6]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  5 │             }
    ╰────
+  help: Assign an explicit value.
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Down" should be explicitly defined.
    ╭─[prefer_enum_initializers.tsx:4:6]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  5 │             }
    ╰────
+  help: Assign an explicit value.
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Up" should be explicitly defined.
    ╭─[prefer_enum_initializers.tsx:3:6]
@@ -41,3 +45,4 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──
  4 │               Down = 'Down',
    ╰────
+  help: Assign an explicit value.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_anonymous_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_anonymous_default_export.snap
@@ -7,66 +7,77 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default function () {}
    ·                ──────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default class {}
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default () => {}
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default function * () {}
    ·                ────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function () {}
    ·                ────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function * () {}
    ·                ──────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async () => {}
    ·                ──────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default class {}
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default class extends class {} {}
    ·                ─────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default class{}
    ·                ───────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default class {}
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:19]
@@ -74,6 +85,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             export default class {}
    ·                            ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:20]
@@ -81,12 +93,14 @@ source: crates/oxc_linter/src/tester.rs
  2 │             export default (class{})
    ·                             ───────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:17]
  1 │ export default (class extends class {} {})
    ·                 ─────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:14]
@@ -94,60 +108,70 @@ source: crates/oxc_linter/src/tester.rs
  2 │             exports = class {}
    ·                       ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:18]
  1 │ module.exports = class {}
    ·                  ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default function () {}
    ·                ──────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default function* () {}
    ·                ───────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function* () {}
    ·                ─────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function*() {}
    ·                ────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function *() {}
    ·                ─────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function   *   () {}
    ·                ──────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async function * /* comment */ () {}
    ·                ────────────────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ ╭─▶ export default async function * // comment
  2 │ ╰─▶             () {}
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:19]
@@ -155,6 +179,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             export default async function * () {}
    ·                            ──────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:20]
@@ -162,6 +187,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             export default (async function * () {})
    ·                             ──────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:14]
@@ -169,54 +195,63 @@ source: crates/oxc_linter/src/tester.rs
  2 │             exports = function() {}
    ·                       ─────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:18]
  1 │ module.exports = function() {}
    ·                  ─────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default () => {}
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default async () => {}
    ·                ──────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default () => {};
    ·                ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:15]
  1 │ export default() => {}
    ·               ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default foo => {}
    ·                ─────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:19]
  1 │ export default (( () => {} ))
    ·                   ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:65]
  1 │ /* comment 1 */ export /* comment 2 */ default /* comment 3 */  () => {}
    ·                                                                 ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:6:4]
@@ -224,6 +259,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │             () => {}
    ·             ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:19]
@@ -231,6 +267,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             export default async () => {}
    ·                            ──────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:2:17]
@@ -238,6 +275,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             exports = (( () => {} ))
    ·                          ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:8:4]
@@ -245,51 +283,60 @@ source: crates/oxc_linter/src/tester.rs
  8 │             () => {};
    ·             ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:17]
  1 │ (( exports = (( () => {} )) ))
    ·                 ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:24]
  1 │ (( module.exports = (( () => {} )) ))
    ·                        ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:17]
  1 │ (( exports = (( () => {} )) ));
    ·                 ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:24]
  1 │ (( module.exports = (( () => {} )) ));
    ·                        ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:27]
  1 │ @decorator export default class {}
    ·                           ────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:16]
  1 │ export default @decorator(class {}) class extends class {} {}
    ·                ──────────────────────────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:18]
  1 │ module.exports = @decorator(class {}) class extends class {} {}
    ·                  ──────────────────────────────────────────────
    ╰────
+  help: Add a name to this default export.
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
    ╭─[no_anonymous_default_export.tsx:1:48]
  1 │ @decorator @decorator(class {}) export default class {}
    ·                                                ────────
    ╰────
+  help: Add a name to this default export.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_object_as_default_parameter.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_object_as_default_parameter.snap
@@ -7,81 +7,95 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function abc(foo = {a: 123}) {}
    ·                    ────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:28]
  1 │ async function * abc(foo = {a: 123}) {}
    ·                            ────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc(foo = {a: false}) {}
    ·                    ──────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:21]
  1 │ function abc(foo = ({a: false})) {}
    ·                     ──────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc(foo = {a: "bar"}) {}
    ·                    ──────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc(foo = {a: "bar", b: {c: true}}) {}
    ·                    ────────────────────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ const abc = (foo = {a: false}) => {};
    ·                    ──────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ const abc = (foo = {a: 123, b: false}) => {};
    ·                    ──────────────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ const abc = (foo = {a: false, b: 1, c: "test", d: null}) => {};
    ·                    ────────────────────────────────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:28]
  1 │ const abc = function(foo = {a: 123}) {}
    ·                            ────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc(foo = {a: 123}) {}
    ·                    ────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default for parameter `foo`.
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ const abc = (foo = {a: false}) => {};
    ·                    ──────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc({a} = {a: 123}) {}
    ·                    ────────
    ╰────
+  help: Accept individual properties as parameters instead.
 
   ⚠ eslint-plugin-unicorn(no-object-as-default-parameter): Do not use an object literal as default
    ╭─[no_object_as_default_parameter.tsx:1:20]
  1 │ function abc([a] = {a: 123}) {}
    ·                    ────────
    ╰────
+  help: Accept individual properties as parameters instead.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_typeof_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_typeof_undefined.snap
@@ -7,99 +7,116 @@ source: crates/oxc_linter/src/tester.rs
  1 │ typeof a.b === "undefined"
    · ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof a.b !== "undefined"
    · ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof a.b == "undefined"
    · ─────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof a.b != "undefined"
    · ─────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof a.b == 'undefined'
    · ─────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:10]
  1 │ let foo; typeof foo === "undefined"
    ·          ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:16]
  1 │ const foo = 1; typeof foo === "undefined"
    ·                ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:10]
  1 │ var foo; typeof foo === "undefined"
    ·          ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:19]
  1 │ var foo; var foo; typeof foo === "undefined"
    ·                   ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:24]
  1 │ for (const foo of bar) typeof foo === "undefined";
    ·                        ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:17]
  1 │ function foo() {typeof foo === "undefined"}
    ·                 ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:20]
  1 │ function foo(bar) {typeof bar === "undefined"}
    ·                    ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:22]
  1 │ function foo({bar}) {typeof bar === "undefined"}
    ·                      ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:22]
  1 │ function foo([bar]) {typeof bar === "undefined"}
    ·                      ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof foo.bar === "undefined"
    · ──────────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:10]
  1 │ let foo; typeof foo === "undefined"
    ·          ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.
 
   ⚠ eslint-plugin-unicorn(no-typeof-undefined): Compare with `undefined` directly instead of using `typeof`.
    ╭─[no_typeof_undefined.tsx:1:1]
  1 │ typeof foo === "undefined"
    · ──────────────────────────
    ╰────
+  help: Use '=== undefined' or '!== undefined'.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_unreadable_array_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_unreadable_array_destructuring.snap
@@ -7,171 +7,200 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const [,, foo] = parts;
    ·       ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo,,, bar] = parts;
    ·       ────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo,,,] = parts;
    ·       ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [foo, bar,, baz ,,, qux] = parts;
    ·       ────────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:1]
  1 │ [,, foo] = bar;
    · ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:10]
  1 │ ({parts: [,, foo]} = bar);
    ·          ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([,, bar]) {}
    ·              ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar,,, baz]) {}
    ·              ────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar,,,]) {}
    ·              ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:14]
  1 │ function foo([bar, baz,, qux ,,, quux]) {}
    ·              ─────────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = parts;
    ·       ───────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,,] = parts;
    ·       ─────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = new Array;
    ·       ───────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:7]
  1 │ const [,,...rest] = (0, foo);
    ·       ───────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement] = new Array;
    ·     ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ var [,,thirdElement] = (((0, foo)));
    ·     ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,[,,thirdElementInThirdElement]] = foo
    ·     ──────────────────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:8]
  1 │ let [,,[,,thirdElementInThirdElement]] = foo
    ·        ──────────────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,{propertyOfThirdElement}] = foo
    ·     ────────────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement] = foo, anotherVariable = bar;
    ·     ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:5]
  1 │ let [,,thirdElement = {}] = foo;
    ·     ─────────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:12]
  1 │ for (const [, , id] of shuffle(list)) {}
    ·            ────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ let[,,thirdElement] = foo;
    ·    ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ let[,,...thirdElement] = foo;
    ·    ───────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:6]
  1 │ const[,,thirdElement] = foo;
    ·      ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:6]
  1 │ const[,,...thirdElement] = foo;
    ·      ───────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ var[,,thirdElement] = foo;
    ·    ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:4]
  1 │ var[,,...thirdElement] = foo;
    ·    ───────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.
 
   ⚠ eslint-plugin-unicorn(no-unreadable-array-destructuring): Array destructuring may not contain consecutive ignored values.
    ╭─[no_unreadable_array_destructuring.tsx:1:10]
  1 │ let[]=[],[,,thirdElement] = foo;
    ·          ────────────────
    ╰────
+  help: Use intermediate variables or '.slice()' instead.

--- a/crates/oxc_linter/src/snapshots/vue_define_props_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/vue_define_props_destructuring.snap
@@ -25,6 +25,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────────
  4 │                   </script>
    ╰────
+  help: Use default values in the destructuring pattern instead
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Prefer destructuring from `defineProps` directly.
    ╭─[define_props_destructuring.tsx:3:46]
@@ -41,6 +42,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────────
  4 │                   </script>
    ╰────
+  help: Use default values in the destructuring pattern instead
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
    ╭─[define_props_destructuring.tsx:3:35]
@@ -49,6 +51,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────────────────────
  4 │                   </script>
    ╰────
+  help: Store props in a variable instead
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
    ╭─[define_props_destructuring.tsx:3:48]
@@ -57,6 +60,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                ────────────────────
  4 │                   </script>
    ╰────
+  help: Store props in a variable instead
 
   ⚠ eslint-plugin-vue(define-props-destructuring): Avoid destructuring from `defineProps`.
    ╭─[define_props_destructuring.tsx:3:35]
@@ -65,3 +69,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ───────────────────────────────
  4 │                   </script>
    ╰────
+  help: Store props in a variable instead

--- a/crates/oxc_linter/src/snapshots/vue_no_export_in_script_setup.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_export_in_script_setup.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ──
  5 │                   export class A {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:5:17]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  6 │                   export const test = '123'
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:6:17]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────────────
  7 │                   export function foo() {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:7:17]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────────────────
  8 │                   const a = 1
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
     ╭─[no_export_in_script_setup.tsx:9:19]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                            ─
  10 │                   export { fao } from 'bar'
     ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
     ╭─[no_export_in_script_setup.tsx:10:19]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                            ───
  11 │                   </script>
     ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:3:10]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────────────────
  4 │                   export default {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:4:17]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───────
  5 │                   export class A {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:7:25]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ──
  8 │                   export class A {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:8:17]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────
  9 │                   </script>
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:6:10]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───────────────────
  7 │                   export default {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:7:17]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───────
  8 │                   export class A {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:3:17]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ──────────────
  4 │                   export enum Bar {}
    ╰────
+  help: Use `defineExpose` instead
 
   ⚠ eslint-plugin-vue(no-export-in-script-setup): <script setup>` cannot contain ES module exports.
    ╭─[no_export_in_script_setup.tsx:4:17]
@@ -113,3 +126,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───────────
  5 │                   export { }
    ╰────
+  help: Use `defineExpose` instead

--- a/crates/oxc_linter/src/snapshots/vue_require_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/vue_require_default_export.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  5 │                   
    ╰────
+  help: Add `export default { ... }` to define the component
 
   ⚠ eslint-plugin-vue(require-default-export): Missing default export.
    ╭─[require_default_export.tsx:4:10]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  5 │                   
    ╰────
+  help: Add `export default { ... }` to define the component
 
   ⚠ eslint-plugin-vue(require-default-export): Missing default export.
    ╭─[require_default_export.tsx:6:10]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  7 │                   
    ╰────
+  help: Add `export default { ... }` to define the component
 
   ⚠ eslint-plugin-vue(require-default-export): Missing default export.
    ╭─[require_default_export.tsx:5:10]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  6 │                   
    ╰────
+  help: Add `export default { ... }` to define the component
 
   ⚠ eslint-plugin-vue(require-default-export): Component must be the default export.
    ╭─[require_default_export.tsx:6:10]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  7 │                   
    ╰────
+  help: Use `export default defineComponent({ ... })`
 
   ⚠ eslint-plugin-vue(require-default-export): Component must be the default export.
    ╭─[require_default_export.tsx:6:10]
@@ -49,3 +54,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ─────────
  7 │                   
    ╰────
+  help: Use `export default defineComponent({ ... })`


### PR DESCRIPTION
## Summary

Closes #19121

- Added `.with_help()` to ~150 linter diagnostics across all plugin groups (eslint, import, jest, react, typescript, unicorn, vue, promise, oxc)
- Added `.with_note()` where explanatory context is more appropriate than actionable advice
- Skipped diagnostics where the `.warn()` message already contains actionable guidance (e.g. "Prefer X over Y" rules)
- All help messages are concise and actionable for both humans and AI code fixers

🤖 Generated with [Claude Code](https://claude.com/claude-code)