### PR TITLE
perf(oxc_str): add precomputed hash to Ident for fast HashMap lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,6 @@ dependencies = [
  "oxc-schemars",
  "oxc_allocator",
  "oxc_estree",
- "rustc-hash",
  "serde",
 ]
 

--- a/crates/oxc_allocator/src/ident_hasher.rs
+++ b/crates/oxc_allocator/src/ident_hasher.rs
@@ -1,0 +1,348 @@
+//! A custom hasher for `Ident` keys with precomputed hashes.
+//!
+//! [`IdentBuildHasher`] creates [`IdentHasher`]s that handle two hash paths:
+//! * `Ident::hash()` — writes a precomputed `u64` via [`write_u64`](std::hash::Hasher::write_u64)
+//! * `str::hash()` — writes bytes via [`write`](std::hash::Hasher::write), then computes hash data
+//!
+//! Both paths are normalized to the same final state so `Equivalent<Ident> for str` lookups
+//! always match `Ident`-keyed inserts.
+
+use std::hash::{BuildHasher, Hasher};
+
+/// Read 4 bytes from `s` at `offset` as a little-endian `u32`.
+#[inline]
+const fn read_u32(s: &[u8], i: usize) -> u32 {
+    (s[i] as u32) | ((s[i + 1] as u32) << 8) | ((s[i + 2] as u32) << 16) | ((s[i + 3] as u32) << 24)
+}
+
+/// Fold two `u32` values into one via 64-bit multiply + XOR-fold.
+///
+/// This is the core mixer from wyhash/rapidhash. The 64-bit multiply is non-linear,
+/// so every input bit influences many output bits. The XOR-fold combines the upper
+/// and lower halves for full avalanche.
+#[inline]
+#[expect(clippy::cast_possible_truncation)]
+const fn mix(a: u32, b: u32) -> u32 {
+    let m = (a as u64).wrapping_mul(b as u64);
+    (m as u32) ^ ((m >> 32) as u32)
+}
+
+/// Compute a fast, high-quality hash of identifier bytes.
+///
+/// Design:
+/// - **Read all bytes** for short strings (≤8), sample head+middle+tail for longer
+/// - **wyhash-style mixing** — 64-bit multiply + XOR-fold provides non-linear
+///   combination where every input bit affects many output bits
+/// - **Asymmetric seeds** — XOR with different constants before mixing, so even
+///   when read windows overlap (e.g. 4-byte strings where head == tail), the two
+///   mixer inputs are always different
+/// - **`const fn`** — enables compile-time hashing for `ident!("await")` macros
+#[inline]
+pub const fn ident_hash(s: &[u8]) -> u32 {
+    // Seeds from murmur3 / splitmix
+    const SEED1: u32 = 0x9E37_79B9;
+    const SEED2: u32 = 0x85EB_CA6B;
+
+    let len = s.len();
+    if len == 0 {
+        return 0;
+    }
+
+    if len < 4 {
+        // 1-3 bytes: wyhash trick — read first, middle, last byte.
+        // Captures all bytes regardless of length (middle overlaps for len=1,2).
+        let packed = ((s[0] as u32) << 16) | ((s[len >> 1] as u32) << 8) | (s[len - 1] as u32);
+        mix(packed ^ SEED1, packed ^ SEED2)
+    } else if len <= 8 {
+        // 4-8 bytes: read first 4 + last 4 (covers all bytes, may overlap).
+        // XOR with different seeds so even when head == tail (len=4), the mix inputs differ.
+        let head = read_u32(s, 0);
+        let tail = read_u32(s, len - 4);
+        mix(head ^ SEED1, tail ^ SEED2)
+    } else if len <= 16 {
+        // 9-16 bytes: head + middle + tail (12 bytes sampled).
+        let head = read_u32(s, 0);
+        let mid = read_u32(s, (len >> 1) - 2);
+        let tail = read_u32(s, len - 4);
+        mix(head ^ mid ^ SEED1, tail ^ SEED2)
+    } else {
+        // 17+ bytes: 4 evenly-spaced samples (16 bytes total).
+        let head = read_u32(s, 0);
+        let mid1 = read_u32(s, len / 3);
+        let mid2 = read_u32(s, 2 * len / 3);
+        let tail = read_u32(s, len - 4);
+        mix(head ^ mid1 ^ SEED1, mid2 ^ tail ^ SEED2)
+    }
+}
+
+/// Pack length and hash into a single `u64`.
+///
+/// Lower 32 bits = length, upper 32 bits = hash.
+///
+/// This is used as compact precomputed data inside `Ident` and as the
+/// `Ident::hash()` payload passed into [`IdentHasher::write_u64`].
+#[inline]
+pub const fn pack_len_hash(len: u32, hash: u32) -> u64 {
+    (len as u64) | ((hash as u64) << 32)
+}
+
+/// Compose the final hash state used by hashbrown.
+///
+/// Keep upper bits derived from `hash` (for tag/SIMD filtering), while ensuring
+/// the low bits used for bucket index also contain hash entropy instead of being
+/// dominated by identifier length.
+#[inline]
+const fn hashbrown_state(len: u32, hash: u32) -> u64 {
+    let low = hash ^ len.rotate_left(16);
+    (low as u64) | ((hash as u64) << 32)
+}
+
+/// Unpack `len` (low 32 bits) and `hash` (high 32 bits) from packed `u64`.
+#[inline]
+const fn unpack_len_hash(packed: u64) -> (u32, u32) {
+    let bytes = packed.to_le_bytes();
+    let len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    let hash = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    (len, hash)
+}
+
+/// A [`BuildHasher`] for `Ident`-keyed hash maps.
+///
+/// Creates [`IdentHasher`]s that accept both precomputed `u64` hashes (from `Ident`)
+/// and raw byte slices (from `str` lookups).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IdentBuildHasher;
+
+impl BuildHasher for IdentBuildHasher {
+    type Hasher = IdentHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        IdentHasher { state: 0 }
+    }
+}
+
+/// A [`Hasher`] that handles both `Ident` (precomputed) and `str` (computed) hash paths.
+#[derive(Debug, Clone, Copy)]
+pub struct IdentHasher {
+    state: u64,
+}
+
+impl Hasher for IdentHasher {
+    /// `Ident::hash()` path: decode packed `len|hash` and normalize.
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        let (len, hash) = unpack_len_hash(i);
+        self.state = hashbrown_state(len, hash);
+    }
+
+    /// `str::hash()` path: compute `len` + hash from bytes, then normalize.
+    #[inline]
+    #[expect(clippy::cast_possible_truncation)] // Identifier strings are always < 4GB
+    fn write(&mut self, bytes: &[u8]) {
+        let hash = ident_hash(bytes);
+        self.state = hashbrown_state(bytes.len() as u32, hash);
+    }
+
+    /// `str::hash()` writes a 0xFF terminator byte after the string bytes. Ignore it.
+    #[inline]
+    fn write_u8(&mut self, _: u8) {}
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::hash::{BuildHasher, Hasher};
+
+    use super::{
+        IdentBuildHasher, IdentHasher, hashbrown_state, ident_hash, pack_len_hash, unpack_len_hash,
+    };
+
+    // ---- ident_hash quality tests ----
+
+    #[test]
+    fn hash_empty() {
+        assert_eq!(ident_hash(b""), 0);
+    }
+
+    #[test]
+    fn hash_nonzero_for_all_lengths() {
+        // Every non-empty string should produce a non-zero hash
+        for s in
+            &[b"x" as &[u8], b"ab", b"abc", b"abcd", b"hello", b"useState", b"longIdentifierName"]
+        {
+            assert_ne!(
+                ident_hash(s),
+                0,
+                "hash should be non-zero for {:?}",
+                std::str::from_utf8(s)
+            );
+        }
+    }
+
+    #[test]
+    fn hash_discriminates_similar_idents() {
+        // Same-length identifiers with small differences should hash differently
+        assert_ne!(ident_hash(b"null"), ident_hash(b"void"));
+        assert_ne!(ident_hash(b"this"), ident_hash(b"that"));
+        assert_ne!(ident_hash(b"abcd"), ident_hash(b"abce"));
+        assert_ne!(ident_hash(b"useState"), ident_hash(b"useEffect"));
+        assert_ne!(ident_hash(b"fooBar"), ident_hash(b"fooBaz"));
+        assert_ne!(ident_hash(b"a"), ident_hash(b"b"));
+        assert_ne!(ident_hash(b"ab"), ident_hash(b"ba")); // spellchecker:disable-line
+    }
+
+    #[test]
+    fn hash_four_byte_no_zero_collision() {
+        // The old hash had all 4-byte strings colliding to 0. Verify that's fixed.
+        let keywords = [b"null", b"void", b"this", b"that", b"true", b"else", b"case", b"from"];
+        for kw in &keywords {
+            assert_ne!(ident_hash(*kw), 0, "4-byte keyword {kw:?} should not hash to 0");
+        }
+        // Also verify they're all distinct
+        for (i, a) in keywords.iter().enumerate() {
+            for b in &keywords[i + 1..] {
+                assert_ne!(
+                    ident_hash(*a),
+                    ident_hash(*b),
+                    "{a:?} and {b:?} should have different hashes",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hash_long_strings_with_middle_differences() {
+        // Strings that differ only in the middle — the 17+ path must catch this
+        assert_ne!(
+            ident_hash(b"privateInterfaceWithPrivatePropertyTypes"),
+            ident_hash(b"privateInterfaceWithPrivateParmeterTypes"), // spellchecker:disable-line
+        );
+    }
+
+    // ---- pack_len_hash tests ----
+
+    #[test]
+    fn pack_round_trip() {
+        let len = 42u32;
+        let hash = 0xDEAD_BEEFu32;
+        let packed = pack_len_hash(len, hash);
+        assert_eq!((packed & 0xFFFF_FFFF) as u32, len);
+        assert_eq!((packed >> 32) as u32, hash);
+    }
+
+    // ---- IdentHasher tests ----
+
+    #[test]
+    fn hasher_write_u64_path() {
+        let mut hasher = IdentHasher { state: 0 };
+        let hash = ident_hash(b"hello");
+        let packed = pack_len_hash(5, hash);
+        hasher.write_u64(packed);
+        assert_eq!(hasher.finish(), hashbrown_state(5, hash));
+    }
+
+    #[test]
+    fn hasher_write_bytes_path() {
+        let mut hasher = IdentHasher { state: 0 };
+        hasher.write(b"hello");
+        let hash = ident_hash(b"hello");
+        let expected = hashbrown_state(5, hash);
+        assert_eq!(hasher.finish(), expected);
+    }
+
+    #[test]
+    fn str_hash_matches_ident_packed() {
+        // Simulate what str::hash() does: write bytes, then write_u8(0xFF)
+        let build_hasher = IdentBuildHasher;
+        let mut hasher = build_hasher.build_hasher();
+        hasher.write(b"fooBar");
+        hasher.write_u8(0xFF);
+        let str_hash = hasher.finish();
+
+        // Simulate what Ident::hash() does: write_u64 with packed value
+        let mut hasher2 = build_hasher.build_hasher();
+        let packed = pack_len_hash(6, ident_hash(b"fooBar"));
+        hasher2.write_u64(packed);
+        let ident_hash_val = hasher2.finish();
+
+        assert_eq!(str_hash, ident_hash_val);
+    }
+
+    #[test]
+    fn build_hasher_default() {
+        let bh = IdentBuildHasher;
+        let hasher = bh.build_hasher();
+        assert_eq!(hasher.finish(), 0);
+    }
+
+    /// Test that `str` hashing through standard `Hash` trait produces the same
+    /// result as our manual `write` path.
+    #[test]
+    fn std_str_hash_compatible() {
+        let build_hasher = IdentBuildHasher;
+        let std_hash = build_hasher.hash_one("hello");
+
+        let mut hasher2 = build_hasher.build_hasher();
+        hasher2.write(b"hello");
+        hasher2.write_u8(0xFF);
+        let manual_hash = hasher2.finish();
+
+        assert_eq!(std_hash, manual_hash);
+    }
+
+    /// Verify str and Ident hash paths agree across all length buckets.
+    #[test]
+    fn str_hash_matches_across_lengths() {
+        let test_cases = [
+            "x",                                        // 1 byte
+            "ab",                                       // 2 bytes
+            "foo",                                      // 3 bytes
+            "this",                                     // 4 bytes
+            "hello",                                    // 5 bytes
+            "fooBar",                                   // 6 bytes
+            "useState",                                 // 8 bytes
+            "useEffect",                                // 9 bytes
+            "myVariable123",                            // 13 bytes
+            "longIdentifierNm",                         // 17 bytes
+            "privateInterfaceWithPrivatePropertyTypes", // 40 bytes
+        ];
+
+        let build_hasher = IdentBuildHasher;
+        for s in &test_cases {
+            // str path
+            let str_hash = build_hasher.hash_one(*s);
+
+            // Ident path (precomputed)
+            let mut hasher = build_hasher.build_hasher();
+            #[expect(clippy::cast_possible_truncation)]
+            let packed = pack_len_hash(s.len() as u32, ident_hash(s.as_bytes()));
+            hasher.write_u64(packed);
+            let ident_hash_val = hasher.finish();
+
+            assert_eq!(str_hash, ident_hash_val, "hash mismatch for {s:?} (len={})", s.len());
+        }
+    }
+
+    #[test]
+    fn hashbrown_state_uses_hash_entropy_for_h1() {
+        let len = 6u32;
+        let hash1 = ident_hash(b"fooBar");
+        let hash2 = ident_hash(b"fooBaz");
+
+        let state1 = hashbrown_state(len, hash1);
+        let state2 = hashbrown_state(len, hash2);
+
+        // Keep tag bits tied to identifier hash.
+        assert_eq!((state1 >> 32) as u32, hash1);
+        assert_eq!((state2 >> 32) as u32, hash2);
+        // Ensure same-length identifiers don't collapse to same low bits.
+        let (low1, _) = unpack_len_hash(state1);
+        let (low2, _) = unpack_len_hash(state2);
+        assert_ne!(low1, low2);
+    }
+}

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -54,6 +54,7 @@ mod convert;
 mod from_raw_parts;
 pub mod hash_map;
 pub mod hash_set;
+pub mod ident_hasher;
 mod passthrough_hasher;
 #[cfg(feature = "pool")]
 mod pool;
@@ -74,6 +75,7 @@ pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
 pub use hash_map::HashMap;
 pub use hash_set::HashSet;
+pub use ident_hasher::{IdentBuildHasher, ident_hash, pack_len_hash};
 pub use passthrough_hasher::{PassthroughBuildHasher, PassthroughHasher};
 #[cfg(feature = "pool")]
 pub use pool::*;

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1648,27 +1648,27 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<Expression>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<IdentifierName>() == 16);
+    assert!(size_of::<IdentifierName>() == 20);
     assert!(align_of::<IdentifierName>() == 4);
     assert!(offset_of!(IdentifierName, span) == 0);
     assert!(offset_of!(IdentifierName, name) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<IdentifierReference>() == 20);
+    assert!(size_of::<IdentifierReference>() == 24);
     assert!(align_of::<IdentifierReference>() == 4);
     assert!(offset_of!(IdentifierReference, span) == 0);
     assert!(offset_of!(IdentifierReference, name) == 8);
-    assert!(offset_of!(IdentifierReference, reference_id) == 16);
+    assert!(offset_of!(IdentifierReference, reference_id) == 20);
 
     // Padding: 0 bytes
-    assert!(size_of::<BindingIdentifier>() == 20);
+    assert!(size_of::<BindingIdentifier>() == 24);
     assert!(align_of::<BindingIdentifier>() == 4);
     assert!(offset_of!(BindingIdentifier, span) == 0);
     assert!(offset_of!(BindingIdentifier, name) == 8);
-    assert!(offset_of!(BindingIdentifier, symbol_id) == 16);
+    assert!(offset_of!(BindingIdentifier, symbol_id) == 20);
 
     // Padding: 0 bytes
-    assert!(size_of::<LabelIdentifier>() == 16);
+    assert!(size_of::<LabelIdentifier>() == 20);
     assert!(align_of::<LabelIdentifier>() == 4);
     assert!(offset_of!(LabelIdentifier, span) == 0);
     assert!(offset_of!(LabelIdentifier, name) == 8);
@@ -1759,20 +1759,20 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ComputedMemberExpression, optional) == 24);
 
     // Padding: 3 bytes
-    assert!(size_of::<StaticMemberExpression>() == 36);
+    assert!(size_of::<StaticMemberExpression>() == 40);
     assert!(align_of::<StaticMemberExpression>() == 4);
     assert!(offset_of!(StaticMemberExpression, span) == 0);
     assert!(offset_of!(StaticMemberExpression, object) == 8);
     assert!(offset_of!(StaticMemberExpression, property) == 16);
-    assert!(offset_of!(StaticMemberExpression, optional) == 32);
+    assert!(offset_of!(StaticMemberExpression, optional) == 36);
 
     // Padding: 3 bytes
-    assert!(size_of::<PrivateFieldExpression>() == 36);
+    assert!(size_of::<PrivateFieldExpression>() == 40);
     assert!(align_of::<PrivateFieldExpression>() == 4);
     assert!(offset_of!(PrivateFieldExpression, span) == 0);
     assert!(offset_of!(PrivateFieldExpression, object) == 8);
     assert!(offset_of!(PrivateFieldExpression, field) == 16);
-    assert!(offset_of!(PrivateFieldExpression, optional) == 32);
+    assert!(offset_of!(PrivateFieldExpression, optional) == 36);
 
     // Padding: 2 bytes
     assert!(size_of::<CallExpression>() == 40);
@@ -1794,11 +1794,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(NewExpression, pure) == 36);
 
     // Padding: 0 bytes
-    assert!(size_of::<MetaProperty>() == 40);
+    assert!(size_of::<MetaProperty>() == 48);
     assert!(align_of::<MetaProperty>() == 4);
     assert!(offset_of!(MetaProperty, span) == 0);
     assert!(offset_of!(MetaProperty, meta) == 8);
-    assert!(offset_of!(MetaProperty, property) == 24);
+    assert!(offset_of!(MetaProperty, property) == 28);
 
     // Padding: 0 bytes
     assert!(size_of::<SpreadElement>() == 16);
@@ -1833,11 +1833,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(BinaryExpression, right) == 16);
 
     // Padding: 0 bytes
-    assert!(size_of::<PrivateInExpression>() == 32);
+    assert!(size_of::<PrivateInExpression>() == 36);
     assert!(align_of::<PrivateInExpression>() == 4);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
-    assert!(offset_of!(PrivateInExpression, right) == 24);
+    assert!(offset_of!(PrivateInExpression, right) == 28);
 
     // Padding: 3 bytes
     assert!(size_of::<LogicalExpression>() == 28);
@@ -1906,11 +1906,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<AssignmentTargetProperty>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 36);
+    assert!(size_of::<AssignmentTargetPropertyIdentifier>() == 40);
     assert!(align_of::<AssignmentTargetPropertyIdentifier>() == 4);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, span) == 0);
     assert!(offset_of!(AssignmentTargetPropertyIdentifier, binding) == 8);
-    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 28);
+    assert!(offset_of!(AssignmentTargetPropertyIdentifier, init) == 32);
 
     // Padding: 3 bytes
     assert!(size_of::<AssignmentTargetPropertyProperty>() == 28);
@@ -2068,13 +2068,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(ForOfStatement, scope_id) == 32);
 
     // Padding: 0 bytes
-    assert!(size_of::<ContinueStatement>() == 24);
+    assert!(size_of::<ContinueStatement>() == 28);
     assert!(align_of::<ContinueStatement>() == 4);
     assert!(offset_of!(ContinueStatement, span) == 0);
     assert!(offset_of!(ContinueStatement, label) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<BreakStatement>() == 24);
+    assert!(size_of::<BreakStatement>() == 28);
     assert!(align_of::<BreakStatement>() == 4);
     assert!(offset_of!(BreakStatement, span) == 0);
     assert!(offset_of!(BreakStatement, label) == 8);
@@ -2109,11 +2109,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(SwitchCase, consequent) == 16);
 
     // Padding: 0 bytes
-    assert!(size_of::<LabeledStatement>() == 32);
+    assert!(size_of::<LabeledStatement>() == 36);
     assert!(align_of::<LabeledStatement>() == 4);
     assert!(offset_of!(LabeledStatement, span) == 0);
     assert!(offset_of!(LabeledStatement, label) == 8);
-    assert!(offset_of!(LabeledStatement, body) == 24);
+    assert!(offset_of!(LabeledStatement, body) == 28);
 
     // Padding: 0 bytes
     assert!(size_of::<ThrowStatement>() == 16);
@@ -2189,22 +2189,22 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(BindingRestElement, argument) == 8);
 
     // Padding: 2 bytes
-    assert!(size_of::<Function>() == 60);
+    assert!(size_of::<Function>() == 64);
     assert!(align_of::<Function>() == 4);
     assert!(offset_of!(Function, span) == 0);
-    assert!(offset_of!(Function, r#type) == 52);
+    assert!(offset_of!(Function, r#type) == 56);
     assert!(offset_of!(Function, id) == 8);
-    assert!(offset_of!(Function, generator) == 53);
-    assert!(offset_of!(Function, r#async) == 54);
-    assert!(offset_of!(Function, declare) == 55);
-    assert!(offset_of!(Function, type_parameters) == 28);
-    assert!(offset_of!(Function, this_param) == 32);
-    assert!(offset_of!(Function, params) == 36);
-    assert!(offset_of!(Function, return_type) == 40);
-    assert!(offset_of!(Function, body) == 44);
-    assert!(offset_of!(Function, scope_id) == 48);
-    assert!(offset_of!(Function, pure) == 56);
-    assert!(offset_of!(Function, pife) == 57);
+    assert!(offset_of!(Function, generator) == 57);
+    assert!(offset_of!(Function, r#async) == 58);
+    assert!(offset_of!(Function, declare) == 59);
+    assert!(offset_of!(Function, type_parameters) == 32);
+    assert!(offset_of!(Function, this_param) == 36);
+    assert!(offset_of!(Function, params) == 40);
+    assert!(offset_of!(Function, return_type) == 44);
+    assert!(offset_of!(Function, body) == 48);
+    assert!(offset_of!(Function, scope_id) == 52);
+    assert!(offset_of!(Function, pure) == 60);
+    assert!(offset_of!(Function, pife) == 61);
 
     assert!(size_of::<FunctionType>() == 1);
     assert!(align_of::<FunctionType>() == 1);
@@ -2270,20 +2270,20 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(YieldExpression, argument) == 8);
 
     // Padding: 1 bytes
-    assert!(size_of::<Class>() == 88);
+    assert!(size_of::<Class>() == 92);
     assert!(align_of::<Class>() == 4);
     assert!(offset_of!(Class, span) == 0);
-    assert!(offset_of!(Class, r#type) == 84);
+    assert!(offset_of!(Class, r#type) == 88);
     assert!(offset_of!(Class, decorators) == 8);
     assert!(offset_of!(Class, id) == 24);
-    assert!(offset_of!(Class, type_parameters) == 44);
-    assert!(offset_of!(Class, super_class) == 48);
-    assert!(offset_of!(Class, super_type_arguments) == 56);
-    assert!(offset_of!(Class, implements) == 60);
-    assert!(offset_of!(Class, body) == 76);
-    assert!(offset_of!(Class, r#abstract) == 85);
-    assert!(offset_of!(Class, declare) == 86);
-    assert!(offset_of!(Class, scope_id) == 80);
+    assert!(offset_of!(Class, type_parameters) == 48);
+    assert!(offset_of!(Class, super_class) == 52);
+    assert!(offset_of!(Class, super_type_arguments) == 60);
+    assert!(offset_of!(Class, implements) == 64);
+    assert!(offset_of!(Class, body) == 80);
+    assert!(offset_of!(Class, r#abstract) == 89);
+    assert!(offset_of!(Class, declare) == 90);
+    assert!(offset_of!(Class, scope_id) == 84);
 
     assert!(size_of::<ClassType>() == 1);
     assert!(align_of::<ClassType>() == 1);
@@ -2340,7 +2340,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<MethodDefinitionKind>() == 1);
 
     // Padding: 0 bytes
-    assert!(size_of::<PrivateIdentifier>() == 16);
+    assert!(size_of::<PrivateIdentifier>() == 20);
     assert!(align_of::<PrivateIdentifier>() == 4);
     assert!(offset_of!(PrivateIdentifier, span) == 0);
     assert!(offset_of!(PrivateIdentifier, name) == 8);
@@ -2398,21 +2398,21 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<ImportDeclarationSpecifier>() == 4);
 
     // Padding: 3 bytes
-    assert!(size_of::<ImportSpecifier>() == 64);
+    assert!(size_of::<ImportSpecifier>() == 68);
     assert!(align_of::<ImportSpecifier>() == 4);
     assert!(offset_of!(ImportSpecifier, span) == 0);
     assert!(offset_of!(ImportSpecifier, imported) == 8);
     assert!(offset_of!(ImportSpecifier, local) == 40);
-    assert!(offset_of!(ImportSpecifier, import_kind) == 60);
+    assert!(offset_of!(ImportSpecifier, import_kind) == 64);
 
     // Padding: 0 bytes
-    assert!(size_of::<ImportDefaultSpecifier>() == 28);
+    assert!(size_of::<ImportDefaultSpecifier>() == 32);
     assert!(align_of::<ImportDefaultSpecifier>() == 4);
     assert!(offset_of!(ImportDefaultSpecifier, span) == 0);
     assert!(offset_of!(ImportDefaultSpecifier, local) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<ImportNamespaceSpecifier>() == 28);
+    assert!(size_of::<ImportNamespaceSpecifier>() == 32);
     assert!(align_of::<ImportNamespaceSpecifier>() == 4);
     assert!(offset_of!(ImportNamespaceSpecifier, span) == 0);
     assert!(offset_of!(ImportNamespaceSpecifier, local) == 8);
@@ -2477,11 +2477,11 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<ModuleExportName>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<V8IntrinsicExpression>() == 40);
+    assert!(size_of::<V8IntrinsicExpression>() == 44);
     assert!(align_of::<V8IntrinsicExpression>() == 4);
     assert!(offset_of!(V8IntrinsicExpression, span) == 0);
     assert!(offset_of!(V8IntrinsicExpression, name) == 8);
-    assert!(offset_of!(V8IntrinsicExpression, arguments) == 24);
+    assert!(offset_of!(V8IntrinsicExpression, arguments) == 28);
 
     // Padding: 3 bytes
     assert!(size_of::<BooleanLiteral>() == 12);
@@ -2667,13 +2667,13 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSThisParameter, type_annotation) == 16);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSEnumDeclaration>() == 60);
+    assert!(size_of::<TSEnumDeclaration>() == 64);
     assert!(align_of::<TSEnumDeclaration>() == 4);
     assert!(offset_of!(TSEnumDeclaration, span) == 0);
     assert!(offset_of!(TSEnumDeclaration, id) == 8);
-    assert!(offset_of!(TSEnumDeclaration, body) == 28);
-    assert!(offset_of!(TSEnumDeclaration, r#const) == 56);
-    assert!(offset_of!(TSEnumDeclaration, declare) == 57);
+    assert!(offset_of!(TSEnumDeclaration, body) == 32);
+    assert!(offset_of!(TSEnumDeclaration, r#const) == 60);
+    assert!(offset_of!(TSEnumDeclaration, declare) == 61);
 
     // Padding: 0 bytes
     assert!(size_of::<TSEnumBody>() == 28);
@@ -2768,12 +2768,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTupleType, element_types) == 8);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSNamedTupleMember>() == 36);
+    assert!(size_of::<TSNamedTupleMember>() == 40);
     assert!(align_of::<TSNamedTupleMember>() == 4);
     assert!(offset_of!(TSNamedTupleMember, span) == 0);
     assert!(offset_of!(TSNamedTupleMember, label) == 8);
-    assert!(offset_of!(TSNamedTupleMember, element_type) == 24);
-    assert!(offset_of!(TSNamedTupleMember, optional) == 32);
+    assert!(offset_of!(TSNamedTupleMember, element_type) == 28);
+    assert!(offset_of!(TSNamedTupleMember, optional) == 36);
 
     // Padding: 0 bytes
     assert!(size_of::<TSOptionalType>() == 16);
@@ -2871,7 +2871,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSTypeName>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSQualifiedName>() == 32);
+    assert!(size_of::<TSQualifiedName>() == 36);
     assert!(align_of::<TSQualifiedName>() == 4);
     assert!(offset_of!(TSQualifiedName, span) == 0);
     assert!(offset_of!(TSQualifiedName, left) == 8);
@@ -2884,15 +2884,15 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeParameterInstantiation, params) == 8);
 
     // Padding: 1 bytes
-    assert!(size_of::<TSTypeParameter>() == 48);
+    assert!(size_of::<TSTypeParameter>() == 52);
     assert!(align_of::<TSTypeParameter>() == 4);
     assert!(offset_of!(TSTypeParameter, span) == 0);
     assert!(offset_of!(TSTypeParameter, name) == 8);
-    assert!(offset_of!(TSTypeParameter, constraint) == 28);
-    assert!(offset_of!(TSTypeParameter, default) == 36);
-    assert!(offset_of!(TSTypeParameter, r#in) == 44);
-    assert!(offset_of!(TSTypeParameter, out) == 45);
-    assert!(offset_of!(TSTypeParameter, r#const) == 46);
+    assert!(offset_of!(TSTypeParameter, constraint) == 32);
+    assert!(offset_of!(TSTypeParameter, default) == 40);
+    assert!(offset_of!(TSTypeParameter, r#in) == 48);
+    assert!(offset_of!(TSTypeParameter, out) == 49);
+    assert!(offset_of!(TSTypeParameter, r#const) == 50);
 
     // Padding: 0 bytes
     assert!(size_of::<TSTypeParameterDeclaration>() == 24);
@@ -2901,14 +2901,14 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeParameterDeclaration, params) == 8);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSTypeAliasDeclaration>() == 48);
+    assert!(size_of::<TSTypeAliasDeclaration>() == 52);
     assert!(align_of::<TSTypeAliasDeclaration>() == 4);
     assert!(offset_of!(TSTypeAliasDeclaration, span) == 0);
     assert!(offset_of!(TSTypeAliasDeclaration, id) == 8);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 28);
-    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 32);
-    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 44);
-    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 40);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_parameters) == 32);
+    assert!(offset_of!(TSTypeAliasDeclaration, type_annotation) == 36);
+    assert!(offset_of!(TSTypeAliasDeclaration, declare) == 48);
+    assert!(offset_of!(TSTypeAliasDeclaration, scope_id) == 44);
 
     assert!(size_of::<TSAccessibility>() == 1);
     assert!(align_of::<TSAccessibility>() == 1);
@@ -2921,15 +2921,15 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSClassImplements, type_arguments) == 16);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSInterfaceDeclaration>() == 60);
+    assert!(size_of::<TSInterfaceDeclaration>() == 64);
     assert!(align_of::<TSInterfaceDeclaration>() == 4);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 28);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 32);
-    assert!(offset_of!(TSInterfaceDeclaration, body) == 48);
-    assert!(offset_of!(TSInterfaceDeclaration, declare) == 56);
-    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 52);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 32);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 36);
+    assert!(offset_of!(TSInterfaceDeclaration, body) == 52);
+    assert!(offset_of!(TSInterfaceDeclaration, declare) == 60);
+    assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56);
 
     // Padding: 0 bytes
     assert!(size_of::<TSInterfaceBody>() == 24);
@@ -3090,7 +3090,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(align_of::<TSImportTypeQualifier>() == 4);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSImportTypeQualifiedName>() == 32);
+    assert!(size_of::<TSImportTypeQualifiedName>() == 36);
     assert!(align_of::<TSImportTypeQualifiedName>() == 4);
     assert!(offset_of!(TSImportTypeQualifiedName, span) == 0);
     assert!(offset_of!(TSImportTypeQualifiedName, left) == 8);
@@ -3117,16 +3117,16 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSConstructorType, scope_id) == 20);
 
     // Padding: 2 bytes
-    assert!(size_of::<TSMappedType>() == 60);
+    assert!(size_of::<TSMappedType>() == 64);
     assert!(align_of::<TSMappedType>() == 4);
     assert!(offset_of!(TSMappedType, span) == 0);
     assert!(offset_of!(TSMappedType, key) == 8);
-    assert!(offset_of!(TSMappedType, constraint) == 28);
-    assert!(offset_of!(TSMappedType, name_type) == 36);
-    assert!(offset_of!(TSMappedType, type_annotation) == 44);
-    assert!(offset_of!(TSMappedType, optional) == 56);
-    assert!(offset_of!(TSMappedType, readonly) == 57);
-    assert!(offset_of!(TSMappedType, scope_id) == 52);
+    assert!(offset_of!(TSMappedType, constraint) == 32);
+    assert!(offset_of!(TSMappedType, name_type) == 40);
+    assert!(offset_of!(TSMappedType, type_annotation) == 48);
+    assert!(offset_of!(TSMappedType, optional) == 60);
+    assert!(offset_of!(TSMappedType, readonly) == 61);
+    assert!(offset_of!(TSMappedType, scope_id) == 56);
 
     assert!(size_of::<TSMappedTypeModifierOperator>() == 1);
     assert!(align_of::<TSMappedTypeModifierOperator>() == 1);
@@ -3160,12 +3160,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSTypeAssertion, expression) == 16);
 
     // Padding: 3 bytes
-    assert!(size_of::<TSImportEqualsDeclaration>() == 40);
+    assert!(size_of::<TSImportEqualsDeclaration>() == 44);
     assert!(align_of::<TSImportEqualsDeclaration>() == 4);
     assert!(offset_of!(TSImportEqualsDeclaration, span) == 0);
     assert!(offset_of!(TSImportEqualsDeclaration, id) == 8);
-    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 28);
-    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 36);
+    assert!(offset_of!(TSImportEqualsDeclaration, module_reference) == 32);
+    assert!(offset_of!(TSImportEqualsDeclaration, import_kind) == 40);
 
     assert!(size_of::<TSModuleReference>() == 8);
     assert!(align_of::<TSModuleReference>() == 4);
@@ -3195,7 +3195,7 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSExportAssignment, expression) == 8);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSNamespaceExportDeclaration>() == 24);
+    assert!(size_of::<TSNamespaceExportDeclaration>() == 28);
     assert!(align_of::<TSNamespaceExportDeclaration>() == 4);
     assert!(offset_of!(TSNamespaceExportDeclaration, span) == 0);
     assert!(offset_of!(TSNamespaceExportDeclaration, id) == 8);

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -224,9 +224,9 @@ impl<'a> Dummy<'a> for TemplateElementValue<'a> {
 impl<'a> Dummy<'a> for MemberExpression<'a> {
     /// Create a dummy [`MemberExpression`].
     ///
-    /// Has cost of making 2 allocations (64 bytes).
+    /// Has cost of making 3 allocations (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::StaticMemberExpression(Dummy::dummy(allocator))
+        Self::ComputedMemberExpression(Dummy::dummy(allocator))
     }
 }
 
@@ -1319,9 +1319,9 @@ impl<'a> Dummy<'a> for StaticBlock<'a> {
 impl<'a> Dummy<'a> for ModuleDeclaration<'a> {
     /// Create a dummy [`ModuleDeclaration`].
     ///
-    /// Has cost of making 1 allocation (32 bytes).
+    /// Has cost of making 2 allocations (32 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::TSNamespaceExportDeclaration(Dummy::dummy(allocator))
+        Self::ExportDefaultDeclaration(Dummy::dummy(allocator))
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -18,22 +18,6 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
@@ -43,6 +27,22 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Only the last call to `jest.setTimeout` will have an effect.
 
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+    ╭─[no_confusing_set_timeout.tsx:10:17]
+  9 │                 });
+ 10 │                 jest.setTimeout(800);
+    ·                 ───────────────
+ 11 │             
+    ╰────
+
   ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);

--- a/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_identical_title.snap
@@ -30,11 +30,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of test.
 
   ⚠ eslint-plugin-jest(no-identical-title): Test title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:3:20]
+   ╭─[no_identical_title.tsx:2:21]
+ 1 │ 
  2 │               xtest('this', () => {});
+   ·                     ──────
  3 │               test('this', () => {});
-   ·                    ──────
- 4 │             
    ╰────
   help: Change the title of test.
 
@@ -75,20 +75,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:24]
- 1 │ 
+   ╭─[no_identical_title.tsx:3:25]
  2 │               describe('foo', () => {});
-   ·                        ─────
  3 │               xdescribe('foo', () => {});
+   ·                         ─────
+ 4 │             
    ╰────
   help: Change the title of describe block.
 
   ⚠ eslint-plugin-jest(no-identical-title): Describe block title is used multiple times in the same describe block.
-   ╭─[no_identical_title.tsx:2:25]
- 1 │ 
+   ╭─[no_identical_title.tsx:3:24]
  2 │               fdescribe('foo', () => {});
-   ·                         ─────
  3 │               describe('foo', () => {});
+   ·                        ─────
+ 4 │             
    ╰────
   help: Change the title of describe block.
 

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_test_blocks.snap
@@ -17,15 +17,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Make sure there is an empty new line before the test block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
-   ╭─[padding_around_test_blocks.tsx:2:1]
- 1 │ it('foo', () => {});
- 2 │ fit('bar', () => {});
-   · ▲
- 3 │ test('baz', () => {});
-   ╰────
-  help: Make sure there is an empty new line before the fit block
-
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
    ╭─[padding_around_test_blocks.tsx:3:1]
  2 │ fit('bar', () => {});
@@ -35,6 +26,42 @@ source: crates/oxc_linter/src/tester.rs
   help: Make sure there is an empty new line before the test block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
+   ╭─[padding_around_test_blocks.tsx:2:1]
+ 1 │ it('foo', () => {});
+ 2 │ fit('bar', () => {});
+   · ▲
+ 3 │ test('baz', () => {});
+   ╰────
+  help: Make sure there is an empty new line before the fit block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+   ╭─[padding_around_test_blocks.tsx:4:1]
+ 3 │ const bar = 'baz';
+ 4 │ it('foo', () => {
+   · ▲
+ 5 │   // stuff
+   ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:18:6]
+ 17 │      });
+ 18 │      // With a comment
+    ·      ▲
+ 19 │      it('is another bar w/ it', () => {
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
+    ╭─[padding_around_test_blocks.tsx:22:6]
+ 21 │      test.skip('skipping', () => {}); // Another comment
+ 22 │      it.skip('skipping too', () => {});
+    ·      ▲
+ 23 │  });xtest('weird', () => {});
+    ╰────
+  help: Make sure there is an empty new line before the it block
+
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before fit block
    ╭─[padding_around_test_blocks.tsx:7:1]
  6 │ });
  7 │ fit('bar', () => {
@@ -42,15 +69,6 @@ source: crates/oxc_linter/src/tester.rs
  8 │   // stuff
    ╰────
   help: Make sure there is an empty new line before the fit block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
-    ╭─[padding_around_test_blocks.tsx:26:2]
- 25 │    .skip('skippy skip', () => {});
- 26 │  xit('bar foo', () => {});
-    ·  ▲
- 27 │             
-    ╰────
-  help: Make sure there is an empty new line before the xit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before test block
     ╭─[padding_around_test_blocks.tsx:10:1]
@@ -106,32 +124,14 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Make sure there is an empty new line before the xtest block
 
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-   ╭─[padding_around_test_blocks.tsx:4:1]
- 3 │ const bar = 'baz';
- 4 │ it('foo', () => {
-   · ▲
- 5 │   // stuff
-   ╰────
-  help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:18:6]
- 17 │      });
- 18 │      // With a comment
-    ·      ▲
- 19 │      it('is another bar w/ it', () => {
+  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before xit block
+    ╭─[padding_around_test_blocks.tsx:26:2]
+ 25 │    .skip('skippy skip', () => {});
+ 26 │  xit('bar foo', () => {});
+    ·  ▲
+ 27 │             
     ╰────
-  help: Make sure there is an empty new line before the it block
-
-  ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
-    ╭─[padding_around_test_blocks.tsx:22:6]
- 21 │      test.skip('skipping', () => {}); // Another comment
- 22 │      it.skip('skipping too', () => {});
-    ·      ▲
- 23 │  });xtest('weird', () => {});
-    ╰────
-  help: Make sure there is an empty new line before the it block
+  help: Make sure there is an empty new line before the xit block
 
   ⚠ eslint-plugin-jest(padding-around-test-blocks): Missing padding before it block
    ╭─[padding_around_test_blocks.tsx:5:5]

--- a/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
@@ -180,15 +180,6 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Works!"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
-   ╭─[prefer_lowercase_title.tsx:3:30]
- 2 │                 describe('MyClass', () => {
- 3 │                     describe('MyMethod', () => {
-   ·                              ──────────
- 4 │                         it('Does things', () => {
-   ╰────
-  help: `"MyMethod"`s should begin with lowercase
-
-  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:4:28]
  3 │                     describe('MyMethod', () => {
  4 │                         it('Does things', () => {
@@ -196,6 +187,15 @@ source: crates/oxc_linter/src/tester.rs
  5 │                             //
    ╰────
   help: `"Does things"`s should begin with lowercase
+
+  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:3:30]
+ 2 │                 describe('MyClass', () => {
+ 3 │                     describe('MyMethod', () => {
+   ·                              ──────────
+ 4 │                         it('Does things', () => {
+   ╰────
+  help: `"MyMethod"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:4:29]
@@ -216,6 +216,15 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Does things"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:4:28]
+ 3 │                     describe('MyMethod', () => {
+ 4 │                         it('Does things', () => {
+   ·                            ─────────────
+ 5 │                             //
+   ╰────
+  help: `"Does things"`s should begin with lowercase
+
+  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:3:30]
  2 │                 describe('MyClass', () => {
  3 │                     describe('MyMethod', () => {
@@ -232,12 +241,3 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     describe('MyMethod', () => {
    ╰────
   help: `"MyClass"`s should begin with lowercase
-
-  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
-   ╭─[prefer_lowercase_title.tsx:4:28]
- 3 │                     describe('MyMethod', () => {
- 4 │                         it('Does things', () => {
-   ·                            ─────────────
- 5 │                             //
-   ╰────
-  help: `"Does things"`s should begin with lowercase

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -3,7 +3,7 @@ use oxc_allocator::{Box, TakeIn, Vec};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{Atom, GetSpan, Ident, Span};
 use oxc_syntax::{
     number::{BigintBase, NumberBase},
     precedence::Precedence,
@@ -117,11 +117,11 @@ impl<'a> ParserImpl<'a> {
     }
 
     #[inline]
-    pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Atom<'a>) {
+    pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Ident<'a>) {
         let span = self.cur_token().span();
         let name = self.cur_string();
         self.advance(kind);
-        (span, Atom::from(name))
+        (span, Ident::from(name))
     }
 
     pub(crate) fn check_identifier(&mut self, kind: Kind, ctx: Context) {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -587,7 +587,7 @@ impl<'a> ParserImpl<'a> {
 
                         // `local` becomes a reference for `export { local }`.
                         specifier.local = ModuleExportName::IdentifierReference(
-                            self.ast.identifier_reference(ident.span, ident.name.as_str()),
+                            self.ast.identifier_reference(ident.span, ident.name),
                         );
                     }
                     // No prior code path should lead to parsing `ModuleExportName` as `IdentifierReference`.

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -389,9 +389,14 @@ impl<'a> Binder<'a> for TSEnumDeclaration<'a> {
 
 impl<'a> Binder<'a> for TSEnumMember<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
+        // Extract Ident directly from Identifier variant to preserve precomputed hash.
+        let name = match &self.id {
+            TSEnumMemberName::Identifier(ident) => ident.name,
+            _ => Ident::from(self.id.static_name()),
+        };
         builder.declare_symbol(
             self.span,
-            Ident::from(self.id.static_name()),
+            name,
             SymbolFlags::EnumMember,
             SymbolFlags::EnumMemberExcludes,
         );

--- a/crates/oxc_str/Cargo.toml
+++ b/crates/oxc_str/Cargo.toml
@@ -25,7 +25,6 @@ oxc_estree = { workspace = true }
 
 compact_str = { workspace = true }
 hashbrown = { workspace = true }
-rustc-hash = { workspace = true }
 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -1183,8 +1183,8 @@ fn get_read_identifier_reference<'a>(
     name: Atom<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let reference_id =
-        ctx.create_reference_in_current_scope(Ident::from(name), ReferenceFlags::Read);
+    let name = Ident::from(name);
+    let reference_id = ctx.create_reference_in_current_scope(name, ReferenceFlags::Read);
     let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
     Expression::Identifier(ident)
 }

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -280,7 +280,7 @@ impl<'a> TypeScript<'a> {
     ) -> Statement<'a> {
         let member = match key {
             PropertyKey::StaticIdentifier(ident) => {
-                create_this_property_access(SPAN, ident.name.into(), ctx)
+                create_this_property_access(SPAN, ident.name, ctx)
             }
             PropertyKey::PrivateIdentifier(_) => {
                 unreachable!("PrivateIdentifier is skipped in transform_class_fields");
@@ -386,7 +386,7 @@ impl<'a> TypeScript<'a> {
             .filter(|param| param.has_modifier())
             .filter_map(|param| param.pattern.get_binding_identifier())
             .map(|id| {
-                let target = create_this_property_assignment(id.span, id.name.into(), ctx);
+                let target = create_this_property_assignment(id.span, id.name, ctx);
                 let value = BoundIdentifier::from_binding_ident(id).create_read_expression(ctx);
                 Self::create_assignment(target, value, ctx)
             })

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -8,7 +8,7 @@ use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_ecmascript::{ToInt32, ToUint32};
 use oxc_semantic::{ScopeFlags, ScopeId};
-use oxc_span::{Atom, Ident, SPAN, Span};
+use oxc_span::{Atom, Ident, IdentHashMap, SPAN, Span};
 use oxc_syntax::{
     number::{NumberBase, ToJsString},
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -23,12 +23,12 @@ use crate::{context::TraverseCtx, state::TransformState};
 type PrevMembers<'a> = FxHashMap<Atom<'a>, Option<ConstantValue<'a>>>;
 
 pub struct TypeScriptEnum<'a> {
-    enums: FxHashMap<Ident<'a>, PrevMembers<'a>>,
+    enums: IdentHashMap<'a, PrevMembers<'a>>,
 }
 
 impl TypeScriptEnum<'_> {
     pub fn new() -> Self {
-        Self { enums: FxHashMap::default() }
+        Self { enums: IdentHashMap::default() }
     }
 }
 

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -3,7 +3,7 @@ use std::iter;
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
-use oxc_span::{GetSpan, SPAN};
+use oxc_span::{GetSpan, Ident, SPAN};
 use oxc_traverse::BoundIdentifier;
 
 use crate::context::TraverseCtx;
@@ -100,7 +100,7 @@ pub fn create_property_access<'a>(
 #[inline]
 pub fn create_this_property_access<'a>(
     span: Span,
-    property: Atom<'a>,
+    property: Ident<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> MemberExpression<'a> {
     let object = ctx.ast.expression_this(span);
@@ -112,7 +112,7 @@ pub fn create_this_property_access<'a>(
 #[inline]
 pub fn create_this_property_assignment<'a>(
     span: Span,
-    property: Atom<'a>,
+    property: Ident<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> AssignmentTarget<'a> {
     AssignmentTarget::from(create_this_property_access(span, property, ctx))

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -475,7 +475,12 @@ fn calculate_layout_for_primitive(primitive_def: &PrimitiveDef) -> Layout {
         "f64" => Layout::from_type::<f64>(),
         "&str" => str_layout,
         "Atom" => str_layout,
-        "Ident" => str_layout,
+        // `Ident` is `NonNull<u8>` + `u64` on 64-bit, `NonNull<u8>` + `u32` + `u32` on 32-bit.
+        // Niche for 0 on the pointer field.
+        "Ident" => Layout {
+            layout_64: PlatformLayout::from_size_align_niche(16, 8, Niche::new(0, 8, 1, 0)),
+            layout_32: PlatformLayout::from_size_align_niche(12, 4, Niche::new(0, 4, 1, 0)),
+        },
         "NonZeroU8" => Layout::from_type_with_niche_for_zero::<num::NonZeroU8>(),
         "NonZeroU16" => Layout::from_type_with_niche_for_zero::<num::NonZeroU16>(),
         "NonZeroU32" => Layout::from_type_with_niche_for_zero::<num::NonZeroU32>(),

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -91,12 +91,12 @@ rebuilt        : SymbolId(164): Span { start: 0, end: 0 }
 Symbol span mismatch for "Inner4":
 after transform: SymbolId(195): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(165): Span { start: 12166, end: 12172 }
-Unresolved reference IDs mismatch for "Object":
-after transform: [ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(165), ReferenceId(181), ReferenceId(183), ReferenceId(195), ReferenceId(199), ReferenceId(215), ReferenceId(217), ReferenceId(229), ReferenceId(233), ReferenceId(249), ReferenceId(251), ReferenceId(263), ReferenceId(267), ReferenceId(283), ReferenceId(285), ReferenceId(394), ReferenceId(398), ReferenceId(414), ReferenceId(418), ReferenceId(422), ReferenceId(426)]
-rebuilt        : [ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(80), ReferenceId(118), ReferenceId(122), ReferenceId(144), ReferenceId(148), ReferenceId(170), ReferenceId(174), ReferenceId(263), ReferenceId(270), ReferenceId(336), ReferenceId(340), ReferenceId(356), ReferenceId(360), ReferenceId(364), ReferenceId(368)]
 Unresolved reference IDs mismatch for "Function":
 after transform: [ReferenceId(83), ReferenceId(89), ReferenceId(109), ReferenceId(123), ReferenceId(137), ReferenceId(151), ReferenceId(169), ReferenceId(185), ReferenceId(203), ReferenceId(219), ReferenceId(237), ReferenceId(253), ReferenceId(271), ReferenceId(287), ReferenceId(402), ReferenceId(430), ReferenceId(436), ReferenceId(444), ReferenceId(448), ReferenceId(452), ReferenceId(458), ReferenceId(462), ReferenceId(466), ReferenceId(472), ReferenceId(476), ReferenceId(480)]
 rebuilt        : [ReferenceId(84), ReferenceId(90), ReferenceId(126), ReferenceId(152), ReferenceId(178), ReferenceId(277), ReferenceId(344), ReferenceId(372), ReferenceId(378), ReferenceId(385), ReferenceId(391), ReferenceId(398)]
+Unresolved reference IDs mismatch for "Object":
+after transform: [ReferenceId(67), ReferenceId(71), ReferenceId(75), ReferenceId(79), ReferenceId(105), ReferenceId(107), ReferenceId(119), ReferenceId(121), ReferenceId(133), ReferenceId(135), ReferenceId(147), ReferenceId(149), ReferenceId(161), ReferenceId(165), ReferenceId(181), ReferenceId(183), ReferenceId(195), ReferenceId(199), ReferenceId(215), ReferenceId(217), ReferenceId(229), ReferenceId(233), ReferenceId(249), ReferenceId(251), ReferenceId(263), ReferenceId(267), ReferenceId(283), ReferenceId(285), ReferenceId(394), ReferenceId(398), ReferenceId(414), ReferenceId(418), ReferenceId(422), ReferenceId(426)]
+rebuilt        : [ReferenceId(68), ReferenceId(72), ReferenceId(76), ReferenceId(80), ReferenceId(118), ReferenceId(122), ReferenceId(144), ReferenceId(148), ReferenceId(170), ReferenceId(174), ReferenceId(263), ReferenceId(270), ReferenceId(336), ReferenceId(340), ReferenceId(356), ReferenceId(360), ReferenceId(364), ReferenceId(368)]
 
 semantic Error: tasks/coverage/misc/pass/oxc-13284.ts
 Symbol reference IDs mismatch for "_super":

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -4400,15 +4400,15 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstan
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(12): [ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
+Unresolved reference IDs mismatch for "Set":
+after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
+rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 Unresolved reference IDs mismatch for "Symbol":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
 rebuilt        : [ReferenceId(30), ReferenceId(34)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(1), ReferenceId(20)]
 rebuilt        : [ReferenceId(13)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -7882,15 +7882,15 @@ semantic Error: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_It
 Unresolved references mismatch:
 after transform: ["FinalizationRegistry", "Generator", "Iterable", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
 rebuilt        : ["FinalizationRegistry", "Object", "Set", "Symbol", "WeakMap", "WeakRef", "undefined"]
+Unresolved reference IDs mismatch for "Symbol":
+after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
+rebuilt        : [ReferenceId(81), ReferenceId(84)]
 Unresolved reference IDs mismatch for "WeakRef":
 after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(11), ReferenceId(15), ReferenceId(33)]
 rebuilt        : [ReferenceId(26)]
 Unresolved reference IDs mismatch for "Set":
 after transform: [ReferenceId(1), ReferenceId(14)]
 rebuilt        : [ReferenceId(10)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(8), ReferenceId(55), ReferenceId(69), ReferenceId(72)]
-rebuilt        : [ReferenceId(81), ReferenceId(84)]
 Unresolved reference IDs mismatch for "WeakMap":
 after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(108), ReferenceId(109), ReferenceId(110)]
 rebuilt        : [ReferenceId(7), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
@@ -19755,21 +19755,21 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPrimitiveTypes.ts
-Unresolved reference IDs mismatch for "BigInt":
-after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
-rebuilt        : [ReferenceId(16), ReferenceId(31)]
-Unresolved reference IDs mismatch for "Number":
-after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
-rebuilt        : [ReferenceId(4), ReferenceId(22)]
-Unresolved reference IDs mismatch for "String":
-after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
-rebuilt        : [ReferenceId(1), ReferenceId(19)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
-rebuilt        : [ReferenceId(13), ReferenceId(28)]
 Unresolved reference IDs mismatch for "Boolean":
 after transform: [ReferenceId(7), ReferenceId(20), ReferenceId(30)]
 rebuilt        : [ReferenceId(7), ReferenceId(25)]
+Unresolved reference IDs mismatch for "BigInt":
+after transform: [ReferenceId(16), ReferenceId(22), ReferenceId(36)]
+rebuilt        : [ReferenceId(16), ReferenceId(31)]
+Unresolved reference IDs mismatch for "Symbol":
+after transform: [ReferenceId(13), ReferenceId(21), ReferenceId(33)]
+rebuilt        : [ReferenceId(13), ReferenceId(28)]
+Unresolved reference IDs mismatch for "String":
+after transform: [ReferenceId(1), ReferenceId(18), ReferenceId(24)]
+rebuilt        : [ReferenceId(1), ReferenceId(19)]
+Unresolved reference IDs mismatch for "Number":
+after transform: [ReferenceId(4), ReferenceId(19), ReferenceId(27)]
+rebuilt        : [ReferenceId(4), ReferenceId(22)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 Bindings mismatch:
@@ -20859,36 +20859,36 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Unresolved reference IDs mismatch for "Uint16Array":
-after transform: [ReferenceId(6), ReferenceId(7)]
-rebuilt        : [ReferenceId(3)]
 Unresolved reference IDs mismatch for "BigInt64Array":
 after transform: [ReferenceId(16), ReferenceId(17)]
 rebuilt        : [ReferenceId(8)]
-Unresolved reference IDs mismatch for "Int8Array":
-after transform: [ReferenceId(0), ReferenceId(1)]
-rebuilt        : [ReferenceId(0)]
-Unresolved reference IDs mismatch for "Float32Array":
-after transform: [ReferenceId(12), ReferenceId(13)]
-rebuilt        : [ReferenceId(6)]
+Unresolved reference IDs mismatch for "BigUint64Array":
+after transform: [ReferenceId(18), ReferenceId(19)]
+rebuilt        : [ReferenceId(9)]
 Unresolved reference IDs mismatch for "Uint8Array":
 after transform: [ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(1)]
 Unresolved reference IDs mismatch for "Int16Array":
 after transform: [ReferenceId(4), ReferenceId(5)]
 rebuilt        : [ReferenceId(2)]
-Unresolved reference IDs mismatch for "Float64Array":
-after transform: [ReferenceId(14), ReferenceId(15)]
-rebuilt        : [ReferenceId(7)]
-Unresolved reference IDs mismatch for "BigUint64Array":
-after transform: [ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(9)]
 Unresolved reference IDs mismatch for "Int32Array":
 after transform: [ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(4)]
 Unresolved reference IDs mismatch for "Uint32Array":
 after transform: [ReferenceId(10), ReferenceId(11)]
 rebuilt        : [ReferenceId(5)]
+Unresolved reference IDs mismatch for "Uint16Array":
+after transform: [ReferenceId(6), ReferenceId(7)]
+rebuilt        : [ReferenceId(3)]
+Unresolved reference IDs mismatch for "Float32Array":
+after transform: [ReferenceId(12), ReferenceId(13)]
+rebuilt        : [ReferenceId(6)]
+Unresolved reference IDs mismatch for "Float64Array":
+after transform: [ReferenceId(14), ReferenceId(15)]
+rebuilt        : [ReferenceId(7)]
+Unresolved reference IDs mismatch for "Int8Array":
+after transform: [ReferenceId(0), ReferenceId(1)]
+rebuilt        : [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Namespaces exporting non-const are not supported by Oxc. Change to const or see: https://oxc.rs/docs/guide/usage/transformer/typescript.html#partial-namespace-support


### PR DESCRIPTION
## Summary

- Replace `Ident<'a>` (transparent `&'a str` wrapper) with a `#[repr(C)]` struct storing `NonNull<u8>` + packed `len_and_hash: u64` on 64-bit (16 bytes, same as `&str`)
- Add ~1ns head-tail XOR hash function (`ident_hash`) that reads first 4 + last 4 bytes, discriminating identifiers like `useState`/`useEffect`
- Add `IdentBuildHasher`/`IdentHasher` custom hasher that handles both precomputed `Ident::hash()` and `str::hash()` lookup paths
- `PartialEq<Ident>` fast-rejects via single `u64` compare before byte comparison
- Parser creates `Ident` directly in `parse_identifier_kind` (hash computed once, not recomputed on Atom→Ident conversion)
- All `Ident`-keyed HashMaps use `IdentBuildHasher` (`IdentHashMap`, `ArenaIdentHashMap`, `IdentHashSet`)
- Generalize arena `HashMap::new_in` and `CloneIn` to work with any `S: Default + BuildHasher`

Ref: https://github.com/oxc-project/backlog/issues/193

🤖 Generated with [Claude Code](https://claude.com/claude-code)