### PR TITLE
refactor(parser): remove `bump_remap` in favor of direct `advance` calls

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -120,7 +120,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Atom<'a>) {
         let span = self.cur_token().span();
         let name = self.cur_string();
-        self.bump_remap(kind);
+        self.advance(kind);
         (span, Atom::from(name))
     }
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -351,7 +351,7 @@ impl<'a> ParserImpl<'a> {
             Kind::Assert if !self.cur_token().is_on_new_line() => WithClauseKeyword::Assert,
             _ => return None,
         };
-        self.bump_remap(keyword_kind);
+        self.advance(keyword_kind);
 
         let span = self.start_span();
         let opening_span = self.cur_token().span();
@@ -654,7 +654,7 @@ impl<'a> ParserImpl<'a> {
         decorators: Vec<'a, Decorator<'a>>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
         let default_keyword_span = self.cur_token().span();
-        self.bump_remap(Kind::Default);
+        self.advance(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
         let span = self.end_span(span);
         let export_default_decl = self.ast.alloc_export_default_declaration(span, declaration);


### PR DESCRIPTION
## Summary
- Remove `bump_remap` method from `cursor.rs`, which was a trivial wrapper around `advance`
- Make `advance` `pub(crate)` and call it directly from the 3 call sites
- No behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)