### PR TITLE
perf(transformer_plugins): switch ReplaceGlobalDefines from Traverse to VisitMut

### DIFF
--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -265,7 +265,8 @@ impl<'a> InjectGlobalVariables<'a> {
             Expression::StaticMemberExpression(member) => {
                 for DotDefineState { dot_define, value_atom } in &mut self.dot_defines {
                     if ReplaceGlobalDefines::is_dot_define(
-                        ctx,
+                        ctx.scoping(),
+                        ctx.current_scope_flags(),
                         dot_define,
                         DotDefineMemberExpression::StaticMemberExpression(member),
                     ) {

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -219,6 +219,31 @@ fn this_expr() {
 }
 
 #[test]
+fn this_expr_nested_functions() {
+    let config = config(&[("this", "1"), ("this.foo", "2")]);
+
+    // Arrow inside regular function: `this` captures function's `this`, should NOT be replaced.
+    test_same("export function foo() { return () => this.foo }", &config);
+
+    // Nested arrows without enclosing function: `this` captures module-level `this`, SHOULD be replaced.
+    test("export const f = () => () => this.foo", "export const f = () => () => 2;\n", &config);
+
+    // Arrow inside regular function inside arrow: innermost `this` is function's `this`.
+    test_same("export const outer = () => function() { return () => this.foo }", &config);
+}
+
+#[test]
+fn dot_define_with_destruct_nested() {
+    // Destructuring optimization should NOT apply when the define is nested inside a function call
+    let c = config(&[("process.env.NODE_ENV", "{'a': 1, b: 2, c: true}")]);
+    test(
+        "const {a} = foo(process.env.NODE_ENV)",
+        "const { a } = foo({\n\t'a': 1,\n\tb: 2,\n\tc: true\n});\n",
+        &c,
+    );
+}
+
+#[test]
 fn assignment_target() {
     let config =
         config(&[("d", "ident"), ("e.f", "ident"), ("g", "dot.chain"), ("h.i", "dot.chain")]);


### PR DESCRIPTION
## Summary

- Replace the heavy `Traverse` infrastructure with the lighter `VisitMut` visitor for `ReplaceGlobalDefines`, eliminating ~300 parent stack push/pop operations and ~136 scope tracking operations per AST walk
- Store `Scoping` directly on the struct, track function depth for `this` replacement scope flags, and collect destructuring keys in `visit_variable_declarator` instead of using the Ancestor stack
- Update `is_dot_define` signature to take `&Scoping, ScopeFlags` parameters, and update `InjectGlobalVariables` call site accordingly

Closes oxc-project/backlog#189 (for `ReplaceGlobalDefines`; `InjectGlobalVariables` migration can follow separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)