### PR TITLE
refactor(parser): remove `bump_remap` in favor of direct `advance` calls

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -96,7 +96,7 @@ impl<'a> ParserImpl<'a> {
     /// Move to the next token
     /// Checks if the current token is escaped if it is a keyword
     #[inline]
-    fn advance(&mut self, kind: Kind) {
+    pub(crate) fn advance(&mut self, kind: Kind) {
         // Manually inlined escaped keyword check - escaped identifiers are extremely rare
         if self.token.escaped() && kind.is_any_keyword() {
             self.report_escaped_keyword(self.token.span());
@@ -135,12 +135,6 @@ impl<'a> ParserImpl<'a> {
     #[inline]
     pub(crate) fn bump_any(&mut self) {
         self.advance(self.cur_kind());
-    }
-
-    /// Advance and change token type, useful for changing keyword to ident
-    #[inline]
-    pub(crate) fn bump_remap(&mut self, kind: Kind) {
-        self.advance(kind);
     }
 
     /// [Automatic Semicolon Insertion](https://tc39.es/ecma262/#sec-automatic-semicolon-insertion)

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -120,7 +120,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_identifier_kind(&mut self, kind: Kind) -> (Span, Atom<'a>) {
         let span = self.cur_token().span();
         let name = self.cur_string();
-        self.bump_remap(kind);
+        self.advance(kind);
         (span, Atom::from(name))
     }
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -351,7 +351,7 @@ impl<'a> ParserImpl<'a> {
             Kind::Assert if !self.cur_token().is_on_new_line() => WithClauseKeyword::Assert,
             _ => return None,
         };
-        self.bump_remap(keyword_kind);
+        self.advance(keyword_kind);
 
         let span = self.start_span();
         let opening_span = self.cur_token().span();
@@ -654,7 +654,7 @@ impl<'a> ParserImpl<'a> {
         decorators: Vec<'a, Decorator<'a>>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
         let default_keyword_span = self.cur_token().span();
-        self.bump_remap(Kind::Default);
+        self.advance(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
         let span = self.end_span(span);
         let export_default_decl = self.ast.alloc_export_default_declaration(span, declaration);


### PR DESCRIPTION
## Summary
- Remove `bump_remap` wrapper method, call `advance` directly at all 3 call sites
- Make `advance` `pub(crate)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)