### PR TITLE
perf(parser): add #[inline(never)] to cold parser paths

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -648,6 +648,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Section 13.3 ImportCall or ImportMeta
+    #[inline(never)]
     fn parse_import_meta_or_call(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let meta = self.parse_keyword_identifier(Kind::Import);
@@ -685,6 +686,7 @@ impl<'a> ParserImpl<'a> {
 
     /// V8 Runtime calls.
     /// See: [runtime.h](https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/runtime/runtime.h#L43)
+    #[inline(never)]
     pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         self.expect(Kind::Percent);
@@ -768,6 +770,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Section 13.3 Super Call
+    #[inline(never)]
     fn parse_super(&mut self) -> Expression<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `super`
@@ -1575,6 +1578,7 @@ impl<'a> ParserImpl<'a> {
         self.parse_update_expression(lhs_span)
     }
 
+    #[inline(never)]
     fn parse_decorated_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let decorators = self.parse_decorators();

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -794,6 +794,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Parse import statement or import expression.
+    #[inline(never)]
     fn parse_import_statement(&mut self) -> Statement<'a> {
         let checkpoint = self.checkpoint();
         let span = self.start_span();
@@ -823,6 +824,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Parse statements that start with `@`.
+    #[inline(never)]
     fn parse_decorated_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let span = self.start_span();
         let decorators = self.parse_decorators();


### PR DESCRIPTION
## Summary

- Add `#[inline(never)]` to 6 rare/cold parser functions to prevent them from being inlined into the hot dispatch functions (`parse_statement_list_item`, `parse_primary_expression`), reducing code bloat and improving L1 instruction cache utilization

Cold paths annotated:
- `parse_import_statement` — uses checkpoint/rewind, top-level only
- `parse_decorated_statement` — requires `@` decorator, rare syntax
- `parse_import_meta_or_call` — only `import()` / `import.meta`
- `parse_v8_intrinsic_expression` — V8 `%` intrinsics, almost never used
- `parse_super` — only valid inside class methods
- `parse_decorated_expression` — requires `@` decorator, rare syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)