### PR TITLE
refactor(linter/plugins): correct comment

### DIFF
--- a/apps/oxlint/src/js_plugins/external_linter.rs
+++ b/apps/oxlint/src/js_plugins/external_linter.rs
@@ -207,7 +207,8 @@ fn wrap_lint_file(cb: JsLintFileCb) -> ExternalLinterLintFileCb {
                             Ok(LintFileReturnValue::Success(diagnostics)) => Ok(diagnostics),
                             // Error occurred on JS side
                             Ok(LintFileReturnValue::Failure(err)) => Err(err),
-                            // Invalid JSON - should be impossible, because we control serialization on JS side
+                            // JSON deserialization failure.
+                            // Possible if rule produces fixes/suggestions with out of range offsets.
                             Err(err) => Err(format!(
                                 "Failed to deserialize JSON returned by `lintFile`: {err}"
                             )),


### PR DESCRIPTION
Just correct a comment. JSON deserialization failures are possible. The tests include some such circumstances.