### PR TITLE
perf(mangler): pre-generate const lookup table for base54

### DIFF
--- a/crates/oxc_mangler/src/base54.rs
+++ b/crates/oxc_mangler/src/base54.rs
@@ -108,7 +108,7 @@ fn base54_dynamic(str: &mut InlineString<7, u8>, n: usize) {
 
 #[cfg(test)]
 mod test {
-    use super::{base54, base54_dynamic, TWO_CHAR_LIMIT};
+    use super::{TWO_CHAR_LIMIT, base54, base54_dynamic};
     use oxc_data_structures::inline_string::InlineString;
 
     #[test]
@@ -129,11 +129,7 @@ mod test {
             let from_table = base54(n);
             let mut from_dynamic = InlineString::new();
             base54_dynamic(&mut from_dynamic, n as usize);
-            assert_eq!(
-                from_table.as_str(),
-                from_dynamic.as_str(),
-                "Mismatch at n={n}"
-            );
+            assert_eq!(from_table.as_str(), from_dynamic.as_str(), "Mismatch at n={n}");
         }
         // Boundary: last two-char and first three-char
         assert_eq!(base54(TWO_CHAR_LIMIT as u32 - 1).len_usize(), 2);


### PR DESCRIPTION
## Summary

- Pre-compute a `const` `[[u8; 2]; 3456]` lookup table for all two-character base54 values (indices 54..3510), avoiding runtime division by 54 for the most common cases
- Single-char names (indices 0..54) use a direct array index into `BASE54_CHARS` — no division needed
- Three+ char names (indices 3510+) fall back to the existing dynamic algorithm, extracted to a separate `base54_dynamic` function to keep the hot path compact
- The 6912-byte table fits in L1 cache and covers the vast majority of real-world mangled names

🤖 Generated with [Claude Code](https://claude.com/claude-code)