### PR TITLE
test(linter/plugin): remove unnecessary optional chain in conformance tests

### DIFF
--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -37,7 +37,7 @@ const group: TestGroup = {
     if (
       ruleName === "no-invalid-this" &&
       code.includes("function (x, this: context) {") &&
-      err?.message === "Parsing failed"
+      err.message === "Parsing failed"
     ) {
       return true;
     }


### PR DESCRIPTION
Tiny change to conformance tests. `err` is always defined here so `err?.message` is unnecessary.