### PR TITLE
refactor(linter/plugins): pass fix/suggestion offsets to Rust as `i64`s

### DIFF
--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -33,18 +33,18 @@ export interface Fix {
 /**
  * Fix, in form sent to Rust.
  *
- * Offsets have 1 added to them, so that -1 in `Fix`'s `range` is represented as 0 in `FixReport`.
- * This means that both `startPlusOne` and `endPlusOne` are valid `u32`s, even if original range elements were -1.
+ * `start` and `end` are relative to start of the source text.
+ * When the file has a BOM, they are relative to the start of the source text *without* the BOM.
  *
- * `Fix { range: [0, 10], text: "xxx" }` -> `FixReport { startPlusOne: 1, endPlusOne: 11, text: "xxx" }`.
- * `Fix { range: [-1, 0], text: "" }` -> `FixReport { startPlusOne: 0, endPlusOne: 1, text: "" }`.
- *
- * Range offsets can be -1 when the file has a BOM, and the fix starts before the BOM.
+ * To represent a position *before* a BOM, -1 is used to mean "before the BOM".
  * ESLint's `unicode-bom` rule produces a fix `{ range: [-1, 0], text: "" }` to remove a BOM.
+ *
+ * This type's equivalent on Rust side is `JsFix`, which has `start` and `end` properties as `i64`s,
+ * to allow negative values.
  */
 export interface FixReport {
-  startPlusOne: number;
-  endPlusOne: number;
+  start: number;
+  end: number;
   text: string;
 }
 
@@ -231,11 +231,8 @@ function validateAndConvertFix(fix: Fix): FixReport {
     const start = range[0],
       end = range[1];
     if (typeof start === "number" && typeof end === "number") {
-      // Add 1 to `start` and `end`, to allow original offsets to be -1 (meaning "before the BOM"),
-      // and `FixReport`'s `startPlusOne` and `endPlusOne` are still valid `u32`s on Rust side.
-      //
       // Converting `text` to string follows ESLint, which does that implicitly.
-      return { startPlusOne: start + 1, endPlusOne: end + 1, text: String(text) };
+      return { start, end, text: String(text) };
     }
   }
 

--- a/apps/oxlint/test/fixtures/fixes/fix.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/fix.snap.md
@@ -3,9 +3,13 @@
 
 # stdout
 ```
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 129
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_end_negative.js
+  | Invalid range: 0..0
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -15,9 +19,13 @@
   | File path: <fixture>/files/range_end_out_of_bounds.js
   | Invalid range: 7..7
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 138
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_end_too_large.js
+  | Invalid range: 0..0
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_after_end.js
@@ -27,13 +35,33 @@
   | File path: <fixture>/files/range_start_after_end.js
   | Negative range is invalid: Span { start: 3, end: 2 }
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 116
+  | Invalid range: 0..0
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_start_negative.js
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 125
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_start_too_large.js
+  | Invalid range: 0..0
+
+  x fixes-plugin(fixes): end negative
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): end negative multiple
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
 
   x fixes-plugin(fixes): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]
@@ -43,6 +71,18 @@
 
   x fixes-plugin(fixes): end out of bounds multiple
    ,-[files/range_end_out_of_bounds.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): end too large
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): end too large multiple
+   ,-[files/range_end_too_large.js:1:5]
  1 | let x;
    :     ^
    `----
@@ -59,7 +99,31 @@
    :     ^
    `----
 
-Found 0 warnings and 12 errors.
+  x fixes-plugin(fixes): start negative
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start negative multiple
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start too large
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start too large multiple
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+Found 0 warnings and 24 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/fixes/output.snap.md
+++ b/apps/oxlint/test/fixtures/fixes/output.snap.md
@@ -3,9 +3,13 @@
 
 # stdout
 ```
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 129
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_end_negative.js
+  | Invalid range: 0..0
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -15,9 +19,13 @@
   | File path: <fixture>/files/range_end_out_of_bounds.js
   | Invalid range: 7..7
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 138
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_end_too_large.js
+  | Invalid range: 0..0
 
   x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_after_end.js
@@ -27,13 +35,21 @@
   | File path: <fixture>/files/range_start_after_end.js
   | Negative range is invalid: Span { start: 3, end: 2 }
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 116
+  | Invalid range: 0..0
 
-  x Error running JS plugin.
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_start_negative.js
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 125
+  | Invalid range: 0..0
+
+  x Plugin `fixes-plugin/fixes` returned invalid fixes.
+  | File path: <fixture>/files/range_start_too_large.js
+  | Invalid range: 0..0
 
   x fixes-plugin(fixes): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]
@@ -253,6 +269,18 @@
     : ^^^^^^^^^
     `----
 
+  x fixes-plugin(fixes): end negative
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): end negative multiple
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x fixes-plugin(fixes): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]
  1 | let x;
@@ -265,6 +293,18 @@
    :     ^
    `----
 
+  x fixes-plugin(fixes): end too large
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): end too large multiple
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x fixes-plugin(fixes): start after end
    ,-[files/range_start_after_end.js:1:5]
  1 | let x;
@@ -273,6 +313,30 @@
 
   x fixes-plugin(fixes): start after end multiple
    ,-[files/range_start_after_end.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start negative
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start negative multiple
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start too large
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x fixes-plugin(fixes): start too large multiple
+   ,-[files/range_start_too_large.js:1:5]
  1 | let x;
    :     ^
    `----
@@ -305,7 +369,7 @@
    :     ^
    `----
 
-Found 0 warnings and 46 errors.
+Found 0 warnings and 58 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix-suggestions.snap.md
@@ -3,9 +3,13 @@
 
 # stdout
 ```
-  x Error running JS plugin.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
+  | Invalid range: 0..0
+
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
+  | File path: <fixture>/files/range_end_negative.js
+  | Invalid range: 0..0
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_out_of_bounds.js
@@ -15,9 +19,13 @@
   | File path: <fixture>/files/range_end_out_of_bounds.js
   | Invalid range: 7..7
 
-  x Error running JS plugin.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
+  | Invalid range: 0..0
+
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
+  | File path: <fixture>/files/range_end_too_large.js
+  | Invalid range: 0..0
 
   x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_after_end.js
@@ -27,13 +35,33 @@
   | File path: <fixture>/files/range_start_after_end.js
   | Negative range is invalid: Span { start: 3, end: 2 }
 
-  x Error running JS plugin.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
+  | Invalid range: 0..0
 
-  x Error running JS plugin.
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
+  | File path: <fixture>/files/range_start_negative.js
+  | Invalid range: 0..0
+
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
   | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
+  | Invalid range: 0..0
+
+  x Plugin `suggestions-plugin/suggestions` returned invalid suggestions.
+  | File path: <fixture>/files/range_start_too_large.js
+  | Invalid range: 0..0
+
+  x suggestions-plugin(suggestions): end negative
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end negative multiple
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
 
   x suggestions-plugin(suggestions): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]
@@ -43,6 +71,18 @@
 
   x suggestions-plugin(suggestions): end out of bounds multiple
    ,-[files/range_end_out_of_bounds.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end too large
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end too large multiple
+   ,-[files/range_end_too_large.js:1:5]
  1 | let x;
    :     ^
    `----
@@ -59,7 +99,31 @@
    :     ^
    `----
 
-Found 0 warnings and 12 errors.
+  x suggestions-plugin(suggestions): start negative
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start negative multiple
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large multiple
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+Found 0 warnings and 24 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/suggestions/fix.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/fix.snap.md
@@ -3,22 +3,6 @@
 
 # stdout
 ```
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
-
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]
  1 | ﻿a = c;
@@ -245,6 +229,18 @@
     : ^^^^^^^^^
     `----
 
+  x suggestions-plugin(suggestions): end negative
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end negative multiple
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x suggestions-plugin(suggestions): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]
  1 | let x;
@@ -257,6 +253,18 @@
    :     ^
    `----
 
+  x suggestions-plugin(suggestions): end too large
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end too large multiple
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x suggestions-plugin(suggestions): start after end
    ,-[files/range_start_after_end.js:1:5]
  1 | let x;
@@ -265,6 +273,30 @@
 
   x suggestions-plugin(suggestions): start after end multiple
    ,-[files/range_start_after_end.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start negative
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start negative multiple
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large multiple
+   ,-[files/range_start_too_large.js:1:5]
  1 | let x;
    :     ^
    `----
@@ -297,7 +329,7 @@
    :     ^
    `----
 
-Found 0 warnings and 43 errors.
+Found 0 warnings and 47 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/suggestions/output.snap.md
+++ b/apps/oxlint/test/fixtures/suggestions/output.snap.md
@@ -3,22 +3,6 @@
 
 # stdout
 ```
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_end_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 193
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_end_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 202
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_start_negative.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `-9`, expected u32 at line 1 column 180
-
-  x Error running JS plugin.
-  | File path: <fixture>/files/range_start_too_large.js
-  | Failed to deserialize JSON returned by `lintFile`: invalid value: integer `4294967297`, expected u32 at line 1 column 189
-
   x suggestions-plugin(suggestions): Replace "a" with "daddy"
    ,-[files/bom.js:1:4]
  1 | ﻿a = c;
@@ -245,6 +229,18 @@
     : ^^^^^^^^^
     `----
 
+  x suggestions-plugin(suggestions): end negative
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end negative multiple
+   ,-[files/range_end_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x suggestions-plugin(suggestions): end out of bounds
    ,-[files/range_end_out_of_bounds.js:1:5]
  1 | let x;
@@ -257,6 +253,18 @@
    :     ^
    `----
 
+  x suggestions-plugin(suggestions): end too large
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): end too large multiple
+   ,-[files/range_end_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
   x suggestions-plugin(suggestions): start after end
    ,-[files/range_start_after_end.js:1:5]
  1 | let x;
@@ -265,6 +273,30 @@
 
   x suggestions-plugin(suggestions): start after end multiple
    ,-[files/range_start_after_end.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start negative
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start negative multiple
+   ,-[files/range_start_negative.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large
+   ,-[files/range_start_too_large.js:1:5]
+ 1 | let x;
+   :     ^
+   `----
+
+  x suggestions-plugin(suggestions): start too large multiple
+   ,-[files/range_start_too_large.js:1:5]
  1 | let x;
    :     ^
    `----
@@ -297,7 +329,7 @@
    :     ^
    `----
 
-Found 0 warnings and 43 errors.
+Found 0 warnings and 47 errors.
 Finished in Xms on 12 files with 1 rules using X threads.
 ```
 


### PR DESCRIPTION
Follow-on after #19092.

That PR added 1 to offsets of fixes before sending them to Rust side, to support offset `-1` (legal when fix is to remove a BOM).

Upon reflection, I think that solution is too complicated and confusing. Instead, represent `start` and `end` offsets of fixes as `i64`s in `JsFix`. This supports `-1` as an offset, and also the full range of valid `u32` values. Check on Rust side that the values are in range before converting to `u32`s.

This also makes for better error messages for invalid offsets - no more inexplicable "Failed to deserialize JSON returned by `lintFile`" errors.