### PR TITLE
refactor(formatter): use `AssignmentLike` for `AccessorProperty`

### DIFF
--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -166,34 +166,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StaticBlock<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, AccessorProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        write!(f, [self.decorators()]);
-
-        if let Some(accessibility) = self.accessibility() {
-            write!(f, [accessibility.as_str(), space()]);
-        }
-        if self.r#static {
-            write!(f, ["static", space()]);
-        }
-        if self.r#type.is_abstract() {
-            write!(f, ["abstract", space()]);
-        }
-        if self.r#override {
-            write!(f, ["override", space()]);
-        }
-        write!(f, ["accessor", space()]);
-        if self.computed {
-            write!(f, "[");
-        }
-        write!(f, self.key());
-        if self.computed {
-            write!(f, "]");
-        }
-        if let Some(type_annotation) = &self.type_annotation() {
-            write!(f, type_annotation);
-        }
-        if let Some(value) = &self.value() {
-            write!(f, [space(), "=", space(), value]);
-        }
+        AssignmentLike::AccessorProperty(self).fmt(f);
     }
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/class/accessor-property.js
+++ b/crates/oxc_formatter/tests/fixtures/js/class/accessor-property.js
@@ -1,0 +1,26 @@
+// Basic accessor property
+class Basic {
+  accessor foo = "bar";
+}
+
+// Accessor with long value that should trigger line breaking
+class LongValue {
+  accessor veryLongPropertyName = someReallyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+}
+
+// Static accessor
+class StaticAccessor {
+  static accessor foo = "bar";
+  static accessor veryLongPropertyName = someReallyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+}
+
+// Accessor without value
+class NoValue {
+  accessor foo;
+}
+
+// Computed accessor
+class Computed {
+  accessor [Symbol.iterator] = function* () {};
+  accessor ["computed"] = "value";
+}

--- a/crates/oxc_formatter/tests/fixtures/js/class/accessor-property.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/class/accessor-property.js.snap
@@ -1,0 +1,109 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Basic accessor property
+class Basic {
+  accessor foo = "bar";
+}
+
+// Accessor with long value that should trigger line breaking
+class LongValue {
+  accessor veryLongPropertyName = someReallyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+}
+
+// Static accessor
+class StaticAccessor {
+  static accessor foo = "bar";
+  static accessor veryLongPropertyName = someReallyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+}
+
+// Accessor without value
+class NoValue {
+  accessor foo;
+}
+
+// Computed accessor
+class Computed {
+  accessor [Symbol.iterator] = function* () {};
+  accessor ["computed"] = "value";
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Basic accessor property
+class Basic {
+  accessor foo = "bar";
+}
+
+// Accessor with long value that should trigger line breaking
+class LongValue {
+  accessor veryLongPropertyName = someReallyLongFunctionName(
+    argumentOne,
+    argumentTwo,
+    argumentThree,
+  );
+}
+
+// Static accessor
+class StaticAccessor {
+  static accessor foo = "bar";
+  static accessor veryLongPropertyName = someReallyLongFunctionName(
+    argumentOne,
+    argumentTwo,
+    argumentThree,
+  );
+}
+
+// Accessor without value
+class NoValue {
+  accessor foo;
+}
+
+// Computed accessor
+class Computed {
+  accessor [Symbol.iterator] = function* () {};
+  accessor ["computed"] = "value";
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Basic accessor property
+class Basic {
+  accessor foo = "bar";
+}
+
+// Accessor with long value that should trigger line breaking
+class LongValue {
+  accessor veryLongPropertyName = someReallyLongFunctionName(
+    argumentOne,
+    argumentTwo,
+    argumentThree,
+  );
+}
+
+// Static accessor
+class StaticAccessor {
+  static accessor foo = "bar";
+  static accessor veryLongPropertyName = someReallyLongFunctionName(
+    argumentOne,
+    argumentTwo,
+    argumentThree,
+  );
+}
+
+// Accessor without value
+class NoValue {
+  accessor foo;
+}
+
+// Computed accessor
+class Computed {
+  accessor [Symbol.iterator] = function* () {};
+  accessor ["computed"] = "value";
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/class/accessor-property.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/class/accessor-property.ts
@@ -1,0 +1,29 @@
+// Accessor with type annotation
+class Typed {
+  accessor foo: string = "bar";
+  accessor veryLongPropertyName: SomeReallyLongTypeName = someReallyLongFunctionName(argumentOne, argumentTwo);
+}
+
+// Accessor with modifiers
+class Modifiers {
+  public accessor foo: string = "bar";
+  private accessor bar: number = 42;
+  protected accessor baz: boolean = true;
+  static accessor qux: string = "static";
+  override accessor overridden: string = "overridden";
+}
+
+// Abstract accessor
+abstract class AbstractAccessor {
+  abstract accessor foo: string;
+}
+
+// Accessor with definite assignment
+class Definite {
+  accessor foo!: string;
+}
+
+// Accessor with long type annotation and value
+class LongAnnotation {
+  accessor veryLongPropertyName: Map<string, SomeReallyLongTypeName> = new Map<string, SomeReallyLongTypeName>();
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/class/accessor-property.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/class/accessor-property.ts.snap
@@ -1,0 +1,112 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Accessor with type annotation
+class Typed {
+  accessor foo: string = "bar";
+  accessor veryLongPropertyName: SomeReallyLongTypeName = someReallyLongFunctionName(argumentOne, argumentTwo);
+}
+
+// Accessor with modifiers
+class Modifiers {
+  public accessor foo: string = "bar";
+  private accessor bar: number = 42;
+  protected accessor baz: boolean = true;
+  static accessor qux: string = "static";
+  override accessor overridden: string = "overridden";
+}
+
+// Abstract accessor
+abstract class AbstractAccessor {
+  abstract accessor foo: string;
+}
+
+// Accessor with definite assignment
+class Definite {
+  accessor foo!: string;
+}
+
+// Accessor with long type annotation and value
+class LongAnnotation {
+  accessor veryLongPropertyName: Map<string, SomeReallyLongTypeName> = new Map<string, SomeReallyLongTypeName>();
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Accessor with type annotation
+class Typed {
+  accessor foo: string = "bar";
+  accessor veryLongPropertyName: SomeReallyLongTypeName =
+    someReallyLongFunctionName(argumentOne, argumentTwo);
+}
+
+// Accessor with modifiers
+class Modifiers {
+  public accessor foo: string = "bar";
+  private accessor bar: number = 42;
+  protected accessor baz: boolean = true;
+  static accessor qux: string = "static";
+  override accessor overridden: string = "overridden";
+}
+
+// Abstract accessor
+abstract class AbstractAccessor {
+  abstract accessor foo: string;
+}
+
+// Accessor with definite assignment
+class Definite {
+  accessor foo!: string;
+}
+
+// Accessor with long type annotation and value
+class LongAnnotation {
+  accessor veryLongPropertyName: Map<string, SomeReallyLongTypeName> = new Map<
+    string,
+    SomeReallyLongTypeName
+  >();
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Accessor with type annotation
+class Typed {
+  accessor foo: string = "bar";
+  accessor veryLongPropertyName: SomeReallyLongTypeName = someReallyLongFunctionName(
+    argumentOne,
+    argumentTwo,
+  );
+}
+
+// Accessor with modifiers
+class Modifiers {
+  public accessor foo: string = "bar";
+  private accessor bar: number = 42;
+  protected accessor baz: boolean = true;
+  static accessor qux: string = "static";
+  override accessor overridden: string = "overridden";
+}
+
+// Abstract accessor
+abstract class AbstractAccessor {
+  abstract accessor foo: string;
+}
+
+// Accessor with definite assignment
+class Definite {
+  accessor foo!: string;
+}
+
+// Accessor with long type annotation and value
+class LongAnnotation {
+  accessor veryLongPropertyName: Map<string, SomeReallyLongTypeName> = new Map<
+    string,
+    SomeReallyLongTypeName
+  >();
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-16176.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-16176.ts.snap
@@ -23,7 +23,7 @@ export default class TestUnionTypeAnnotation1 {
   private prop!: /* comment */
     LongLongLongLongLongLongType[] | LongLongLongLongLongLongType[];
 
-  private accessor prop2: /* comment */
+  private accessor prop2!: /* comment */
     LongLongLongLongLongLongType[] | LongLongLongLongLongLongType[];
 }
 
@@ -38,7 +38,7 @@ export interface TestUnionTypeAnnotation2 {
 export default class TestUnionTypeAnnotation1 {
   private prop!: /* comment */ LongLongLongLongLongLongType[] | LongLongLongLongLongLongType[];
 
-  private accessor prop2: /* comment */
+  private accessor prop2!: /* comment */
     LongLongLongLongLongLongType[] | LongLongLongLongLongLongType[];
 }
 


### PR DESCRIPTION
Align `AccessorProperty` formatting with Prettier
## Summary
- Align `AccessorProperty` printing logic with `PropertyDefinition` by delegating to `AssignmentLike`
- This gives accessor properties proper assignment-like line-breaking behavior for `= value` instead of naive inline formatting
- Added snapshot tests for both JS and TS fixtures, verified output matches Prettier 3.8.1

## Test plan
- [x] `cargo check` passes
- [x] Clippy passes (pre-commit hook)
- [x] Prettier conformance unchanged (js: 746/753, ts: 590/601)
- [x] Snapshot tests match Prettier output for all cases (JS/TS at width 80 and 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)