### PR TITLE
perf(transformer): remove TS-only nodes earlier in `enter_statements`

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -597,9 +597,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a> {
         stmts: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if let Some(typescript) = self.x0_typescript.as_mut() {
-            typescript.exit_statements(stmts, ctx);
-        }
         self.common.exit_statements(stmts, ctx);
     }
 

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -214,14 +214,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScript<'a> {
         self.annotations.enter_statements(stmts, ctx);
     }
 
-    fn exit_statements(
-        &mut self,
-        stmts: &mut ArenaVec<'a, Statement<'a>>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        self.annotations.exit_statements(stmts, ctx);
-    }
-
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         self.r#enum.enter_statement(stmt, ctx);
         self.module.enter_statement(stmt, ctx);

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 92c052dc
 
 semantic_babel Summary:
 AST Parsed     : 2224/2224 (100.00%)
-Positive Passed: 2024/2224 (91.01%)
+Positive Passed: 2025/2224 (91.05%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -655,12 +655,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/type-asi/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["A", "B", "a", "b"]
-rebuilt        : ScopeId(0): []
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/import/type-equals-require/input.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["a"]
+after transform: ScopeId(0): ["B", "b"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/interface/extends/input.ts

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 95e3aaa9
 
 semantic_typescript Summary:
 AST Parsed     : 5482/5482 (100.00%)
-Positive Passed: 2950/5482 (53.81%)
+Positive Passed: 2951/5482 (53.83%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -30085,11 +30085,6 @@ Bindings mismatch:
 after transform: ScopeId(0): ["from"]
 rebuilt        : ScopeId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
-Bindings mismatch:
-after transform: ScopeId(0): ["from"]
-rebuilt        : ScopeId(0): []
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/mergedWithLocalValue.ts
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | ConstVariable | TypeImport)
@@ -30231,7 +30226,7 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["CJSy", "CJSy2", "CJSy3", "types"]
+after transform: ScopeId(0): ["CJSy", "CJSy3", "types"]
 rebuilt        : ScopeId(0): ["CJSy"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts


### PR DESCRIPTION
Move the removal of TS-only nodes earlier from `exit_statements` to `enter_statements` to avoid deep traversal into the TS-only child nodes, which are never used.