### PR TITLE
test(linter/plugins): bump ESLint version used in conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-ESLINT_SHA="8f360ad6a7a743d33a83eed8973ee4a50731e55b" # 10.0.0-rc.0
+ESLINT_SHA="4e6c4ac042e321da8fc29ce53ed03c86dcaa44a7" # 10.0.0
 REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
 STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
 SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
 
-# Shallow clone a repo at a specific commit.
+# Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
 clone() {
   local dir="$1"
@@ -35,16 +35,8 @@ clone eslint https://github.com/eslint/eslint.git "$ESLINT_SHA"
 # Install dependencies
 pnpm install --ignore-workspace
 
-# Copy TS-ESLint parser shim into `node_modules/@typescript-eslint/parser`
-rm node_modules/@typescript-eslint/parser
-cp -r tools/typescript-eslint-parser node_modules/@typescript-eslint/parser
-cd node_modules/@typescript-eslint/parser
-
-# Install dependencies of TS-ESLint parser shim
-pnpm install --ignore-workspace
-
 # Return to `submodules` directory
-cd ../../../..
+cd ..
 
 ###############################################################################
 # React

--- a/apps/oxlint/conformance/snapshots/eslint.md
+++ b/apps/oxlint/conformance/snapshots/eslint.md
@@ -17,17 +17,17 @@
 
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
-| Total tests | 33159 | 100.0% |
-| Passing     | 32880 |  99.2% |
+| Total tests | 33285 | 100.0% |
+| Passing     | 33005 |  99.2% |
 | Failing     |     0 |   0.0% |
-| Skipped     |   279 |   0.8% |
+| Skipped     |   280 |   0.8% |
 
 ## Fully Passing Rules
 
 - `accessor-pairs` (302 tests)
 - `array-bracket-newline` (209 tests)
 - `array-bracket-spacing` (143 tests) (4 skipped)
-- `array-callback-return` (216 tests)
+- `array-callback-return` (230 tests)
 - `array-element-newline` (155 tests)
 - `arrow-body-style` (87 tests)
 - `arrow-parens` (109 tests) (21 skipped)
@@ -137,7 +137,7 @@
 - `no-empty-static-block` (10 tests)
 - `no-empty` (35 tests)
 - `no-eq-null` (5 tests)
-- `no-eval` (101 tests)
+- `no-eval` (102 tests)
 - `no-ex-assign` (8 tests)
 - `no-extend-native` (40 tests)
 - `no-extra-bind` (43 tests)
@@ -151,12 +151,12 @@
 - `no-global-assign` (18 tests) (3 skipped)
 - `no-implicit-coercion` (134 tests)
 - `no-implicit-globals` (245 tests) (83 skipped)
-- `no-implied-eval` (138 tests)
+- `no-implied-eval` (175 tests)
 - `no-import-assign` (116 tests)
 - `no-inline-comments` (49 tests)
 - `no-inner-declarations` (68 tests)
 - `no-invalid-regexp` (108 tests)
-- `no-invalid-this` (562 tests) (1 skipped)
+- `no-invalid-this` (572 tests) (1 skipped)
 - `no-irregular-whitespace` (280 tests)
 - `no-iterator` (9 tests)
 - `no-label-var` (5 tests)
@@ -205,7 +205,7 @@
 - `no-restricted-imports` (263 tests) (1 skipped)
 - `no-restricted-modules` (44 tests)
 - `no-restricted-properties` (89 tests)
-- `no-restricted-syntax` (32 tests)
+- `no-restricted-syntax` (34 tests)
 - `no-return-assign` (30 tests)
 - `no-return-await` (71 tests)
 - `no-script-url` (10 tests)
@@ -214,7 +214,7 @@
 - `no-sequences` (42 tests)
 - `no-setter-return` (164 tests) (1 skipped)
 - `no-shadow-restricted-names` (44 tests)
-- `no-shadow` (308 tests)
+- `no-shadow` (368 tests)
 - `no-spaced-func` (28 tests)
 - `no-sparse-arrays` (6 tests)
 - `no-sync` (10 tests)
@@ -303,7 +303,7 @@
 - `space-infix-ops` (74 tests) (7 skipped)
 - `space-unary-ops` (112 tests)
 - `spaced-comment` (99 tests)
-- `strict` (126 tests)
+- `strict` (128 tests) (1 skipped)
 - `switch-colon-spacing` (46 tests)
 - `symbol-description` (8 tests)
 - `template-curly-spacing` (57 tests)

--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -19,9 +19,9 @@ const group: TestGroup = {
     // `RuleTester` does not support enabling other rules beyond the rule under test.
     if (code.match(/^\s*\/\*\s*(globals?|exported|eslint)\s/)) return true;
 
-    // Skip test cases which include `// eslint-disable` comments.
+    // Skip test cases which include `// eslint-disable` or `/* eslint-disable` comments.
     // These are not handled by `RuleTester`.
-    if (code.match(/\/\/\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
+    if (code.match(/\/[/*]\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
 
     // Test relies on scope analysis to follow ES5 semantics where function declarations in blocks are bound in parent scope.
     // TS-ESLint scope manager does not support ES5. Oxc also doesn't support parsing/semantic as ES5.

--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -90,7 +90,7 @@ const group: TestGroup = {
   },
 
   shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
-    // Skip test cases which include `// eslint-disable` comments.
+    // Skip test cases which include `// eslint-disable` or `/* eslint-disable` comments.
     // These are not handled by `RuleTester`.
     if (code.match(/\/[/*]\s*eslint-disable((-next)?-line)?(\s|$)/)) return true;
 


### PR DESCRIPTION
ESLint v10 [is out](https://eslint.org/blog/2026/02/eslint-v10.0.0-released/). Bump the version of ESLint used in conformance tests to 10.0.0. All tests still pass.