### PR TITLE
fix(isolated-declarations): skip parenthesis when inferring type

### DIFF
--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -331,6 +331,9 @@ impl<'a> IsolatedDeclarations<'a> {
                     Some(expr.type_annotation.clone_in(self.ast.allocator))
                 }
             }
+            Expression::ParenthesizedExpression(expr) => {
+                self.transform_expression_to_ts_type(&expr.expression)
+            }
             _ => None,
         }
     }

--- a/crates/oxc_isolated_declarations/tests/fixtures/readonly-object-as-const.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/readonly-object-as-const.ts
@@ -1,0 +1,4 @@
+export class ReadonlyObjectAsConst {
+  writableTrue = true;
+  readonly objectAsConst = ({ a: 1 } as const);
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/readonly-object-as-const.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/readonly-object-as-const.snap
@@ -1,0 +1,13 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/readonly-object-as-const.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class ReadonlyObjectAsConst {
+	writableTrue: boolean;
+	readonly objectAsConst: {
+		readonly a: 1;
+	};
+}


### PR DESCRIPTION
before:

![Screenshot 2026-02-09 at 12.16.13.png](https://app.graphite.com/user-attachments/assets/2853a2bc-daba-4f78-885c-ef534055652a.png)



TS

After:

Isolated declaration emit succeeds.



