### PR TITLE
fix(isolated-declarations): preserve readonly literal initializers

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
@@ -1,0 +1,17 @@
+export class ReadonlyLiteralInitializers {
+  readonly directTrue = true;
+  readonly parenTrue = (true);
+  readonly constAssertTrue = true as const;
+  readonly nestedConstAssert = ((true as const));
+
+  readonly directString = "x";
+  readonly parenString = ("x");
+  readonly templateNoExpr = `x`;
+  readonly constAssertString = ("x" as const);
+
+  readonly unaryNumber = -1;
+  readonly unaryParenNumber = (-1);
+  readonly constAssertNumber = (1 as const);
+
+  writableTrue = true;
+}

--- a/crates/oxc_isolated_declarations/tests/fixtures/readonly-satisfies.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/readonly-satisfies.ts
@@ -1,0 +1,3 @@
+export class ReadonlySatisfies {
+  readonly falseSatisfies = (false satisfies boolean);
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/readonly-class-property-initializer.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/readonly-class-property-initializer.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class ReadonlyLiteralInitializers {
+	readonly directTrue = true;
+	readonly parenTrue = true;
+	readonly constAssertTrue = true;
+	readonly nestedConstAssert = true;
+	readonly directString = "x";
+	readonly parenString = "x";
+	readonly templateNoExpr = "x";
+	readonly constAssertString = "x";
+	readonly unaryNumber = -1;
+	readonly unaryParenNumber = -1;
+	readonly constAssertNumber = 1;
+	writableTrue: boolean;
+}

--- a/crates/oxc_isolated_declarations/tests/snapshots/readonly-satisfies.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/readonly-satisfies.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/readonly-satisfies.ts
+---
+```
+==================== .D.TS ====================
+
+export declare class ReadonlySatisfies {
+	readonly falseSatisfies;
+}
+
+
+==================== Errors ====================
+
+  x TS9012: Property must have an explicit type annotation with
+  | --isolatedDeclarations.
+   ,-[2:12]
+ 1 | export class ReadonlySatisfies {
+ 2 |   readonly falseSatisfies = (false satisfies boolean);
+   :            ^^^^^^^^^^^^^^
+ 3 | }
+   `----
+
+
+```


### PR DESCRIPTION
This is the cause of the current monitor oxc failure



TS's Behaviour:

![Screenshot 2026-02-09 at 12.18.51.png](https://app.graphite.com/user-attachments/assets/858f029d-5427-4593-95c1-ae5efd3239e1.png)



Us Before:

![Screenshot 2026-02-09 at 12.18.17.png](https://app.graphite.com/user-attachments/assets/a4df3235-e4cd-4526-b632-df7371181922.png)



Us After:

```
export declare class ReadonlyLiteralInitializers {

	readonly directTrue = true;
	readonly constAssertTrue = true;
	writableTrue: boolean;
}
```

