### PR TITLE
fix(isolated-declarations): preserve const context in literal type inference

### DIFF
--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -44,7 +44,14 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::TSAsExpression(expr) => {
                 if expr.type_annotation.is_const_type_reference() {
-                    self.transform_expression_to_ts_type(&expr.expression)
+                    self.transform_const_expression_to_ts_type(&expr.expression)
+                } else {
+                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                }
+            }
+            Expression::TSTypeAssertion(expr) => {
+                if expr.type_annotation.is_const_type_reference() {
+                    self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
                     Some(expr.type_annotation.clone_in(self.ast.allocator))
                 }
@@ -61,9 +68,6 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::TSSatisfiesExpression(expr) => {
                 self.infer_type_from_expression(&expr.expression)
-            }
-            Expression::TSTypeAssertion(expr) => {
-                Some(expr.type_annotation.clone_in(self.ast.allocator))
             }
             Expression::UnaryExpression(expr) => {
                 if Self::can_infer_unary_expression(expr) {

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -196,7 +196,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                         PropertyKind::Init => {
                             let type_annotation = if is_const {
-                                self.transform_expression_to_ts_type(&object.value)
+                                self.transform_const_expression_to_ts_type(&object.value)
                             } else {
                                 self.infer_type_from_expression(&object.value)
                             };
@@ -255,7 +255,10 @@ impl<'a> IsolatedDeclarations<'a> {
                     Some(TSTupleElement::from(self.ast.ts_type_undefined_keyword(elision.span)))
                 }
                 _ => self
-                    .transform_expression_to_ts_type(element.to_expression())
+                    .transform_expression_to_ts_type_with_const_context(
+                        element.to_expression(),
+                        is_const,
+                    )
                     .map(TSTupleElement::from)
                     .or_else(|| {
                         self.error(inferred_type_of_expression(element.span()));
@@ -276,6 +279,21 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn transform_expression_to_ts_type(
         &self,
         expr: &Expression<'a>,
+    ) -> Option<TSType<'a>> {
+        self.transform_expression_to_ts_type_with_const_context(expr, false)
+    }
+
+    pub(crate) fn transform_const_expression_to_ts_type(
+        &self,
+        expr: &Expression<'a>,
+    ) -> Option<TSType<'a>> {
+        self.transform_expression_to_ts_type_with_const_context(expr, true)
+    }
+
+    fn transform_expression_to_ts_type_with_const_context(
+        &self,
+        expr: &Expression<'a>,
+        is_const: bool,
     ) -> Option<TSType<'a>> {
         match expr {
             Expression::BooleanLiteral(lit) => Some(self.ast.ts_type_literal_type(
@@ -315,10 +333,10 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             Expression::ArrayExpression(expr) => {
-                Some(self.transform_array_expression_to_ts_type(expr, true))
+                Some(self.transform_array_expression_to_ts_type(expr, is_const))
             }
             Expression::ObjectExpression(expr) => {
-                Some(self.transform_object_expression_to_ts_type(expr, true))
+                Some(self.transform_object_expression_to_ts_type(expr, is_const))
             }
             Expression::FunctionExpression(func) => self.transform_function_to_ts_type(func),
             Expression::ArrowFunctionExpression(func) => {
@@ -326,13 +344,20 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::TSAsExpression(expr) => {
                 if expr.type_annotation.is_const_type_reference() {
-                    self.transform_expression_to_ts_type(&expr.expression)
+                    self.transform_const_expression_to_ts_type(&expr.expression)
+                } else {
+                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                }
+            }
+            Expression::TSTypeAssertion(expr) => {
+                if expr.type_annotation.is_const_type_reference() {
+                    self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
                     Some(expr.type_annotation.clone_in(self.ast.allocator))
                 }
             }
             Expression::ParenthesizedExpression(expr) => {
-                self.transform_expression_to_ts_type(&expr.expression)
+                self.transform_expression_to_ts_type_with_const_context(&expr.expression, is_const)
             }
             _ => None,
         }

--- a/crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
@@ -13,5 +13,14 @@ export class ReadonlyLiteralInitializers {
   readonly unaryParenNumber = (-1);
   readonly constAssertNumber = (1 as const);
 
+  readonly directObject = { a: 1 };
+  readonly parenObject = ({ a: 1 });
+  readonly constAssertObject = ({ a: 1 } as const);
+  readonly nestedConstAssertObject = ((({ a: 1 } as const)));
+
+  readonly directNestedObject = { nested: { a: 1 } };
+  readonly constAssertNestedObject = ({ nested: { a: 1 } } as const);
+
+  writableObject = { a: 1 };
   writableTrue = true;
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/readonly-class-property-initializer.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/readonly-class-property-initializer.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_isolated_declarations/tests/mod.rs
+assertion_line: 54
 input_file: crates/oxc_isolated_declarations/tests/fixtures/readonly-class-property-initializer.ts
 ---
 ```
@@ -17,5 +18,30 @@ export declare class ReadonlyLiteralInitializers {
 	readonly unaryNumber = -1;
 	readonly unaryParenNumber = -1;
 	readonly constAssertNumber = 1;
+	readonly directObject: {
+		a: number;
+	};
+	readonly parenObject: {
+		a: number;
+	};
+	readonly constAssertObject: {
+		readonly a: 1;
+	};
+	readonly nestedConstAssertObject: {
+		readonly a: 1;
+	};
+	readonly directNestedObject: {
+		nested: {
+			a: number;
+		};
+	};
+	readonly constAssertNestedObject: {
+		readonly nested: {
+			readonly a: 1;
+		};
+	};
+	writableObject: {
+		a: number;
+	};
 	writableTrue: boolean;
 }


### PR DESCRIPTION
TypeScript:

![Screenshot 2026-02-09 at 12.23.39.png](https://app.graphite.com/user-attachments/assets/0f4738f8-9ab8-42be-a737-d5eaf9674997.png)



Us before: (we incorrectly add `readonly` on `a` when `readonly `should only be on the top level object

![Screenshot 2026-02-09 at 12.23.55.png](https://app.graphite.com/user-attachments/assets/7d56a8dc-30a1-40b6-8c7d-b9a595fd8889.png)





Us after:



![Screenshot 2026-02-09 at 12.25.03.png](https://app.graphite.com/user-attachments/assets/a5a95deb-0e5a-4c62-9170-16c451a88507.png)

