### PR TITLE
fix(linter/typescript/ban-types): mark rule as deprecated

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -42,6 +42,16 @@ declare_oxc_lint!(
     ///
     /// This rule bans specific types and can suggest alternatives. Note that it does not ban the corresponding runtime objects from being used.
     ///
+    /// ::: warning
+    /// This rule is deprecated and will be removed in a future release.
+    ///
+    /// Prefer these replacement rules:
+    /// - `typescript/no-empty-object-type`
+    /// - `typescript/no-unsafe-function-type`
+    /// - `typescript/no-wrapper-object-types`
+    /// - `typescript/no-restricted-types` (for custom type bans)
+    /// :::
+    ///
     /// ### Why is this bad?
     ///
     /// Some built-in types have aliases, while some types are considered dangerous or harmful. It's often a good idea to ban certain types to help with consistency and safety.
@@ -64,7 +74,7 @@ declare_oxc_lint!(
     BanTypes,
     typescript,
     pedantic,
-    pending
+    none
 );
 
 impl Rule for BanTypes {


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/19164