### PR TITLE
test(linter/plugins): correct typo in comment

### DIFF
--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -182,7 +182,7 @@ const OPTIONS_KEYS: KeysSet = new Set(OPTIONS_KEYS_ARRAY);
 
 /**
  * Create a module to replace `eslint-plugin-stylistic`'s rule runner module,
- * which presents the same API, but used conformance `RuleTester`.
+ * which presents the same API, but uses conformance `RuleTester`.
  *
  * @param tsEslintParser - TSESLint parser module
  * @returns Module to replace `eslint-plugin-stylistic`'s rule runner module with


### PR DESCRIPTION
Just fix a small typo.