### PR TITLE
ci(tools): enable `unicode-bom` Oxlint rule

### DIFF
--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -26,6 +26,7 @@
         "VariableDeclarator": { "array": false, "object": true }
       }
     ],
+    "unicode-bom": ["error", "never"],
     "typescript/consistent-indexed-object-style": ["error", "record"],
     "typescript/ban-ts-comment": ["error", { "ts-expect-error": "allow-with-description" }],
     "eslint-js/prefer-const": ["error", { "destructuring": "all" }]


### PR DESCRIPTION
Enable `unicode-bom` rule in our Oxlint config. We don't want our source code to contain BOMs.

It also makes sure that the JS plugins fixtures files which *do* contain BOMs - and need to because that's what they're testing - aren't getting linted.