### PR TITLE
test(linter/plugins): `mock` function in conformance tests take `via` param

### DIFF
--- a/apps/oxlint/conformance/src/groups/react_hooks.ts
+++ b/apps/oxlint/conformance/src/groups/react_hooks.ts
@@ -1,4 +1,4 @@
-import type { TestGroup } from "../index.ts";
+import type { MockFn, TestGroup } from "../index.ts";
 import type { TestCase } from "../rule_tester.ts";
 
 const group: TestGroup = {
@@ -20,7 +20,7 @@ const group: TestGroup = {
     }
   },
 
-  prepare(require: NodeJS.Require, mock: (path: string, value: unknown) => void) {
+  prepare(require: NodeJS.Require, mock: MockFn) {
     // Add `default` export to `eslint-plugin-react-hooks` module
     const plugin = require("eslint-plugin-react-hooks") as any;
     plugin.default = plugin;

--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import { join as pathJoin } from "node:path";
 import { currentRule } from "../capture.ts";
 
-import type { TestGroup } from "../index.ts";
+import type { MockFn, TestGroup } from "../index.ts";
 import type { TestCase, TestCases, ValidTestCase, InvalidTestCase } from "../rule_tester.ts";
 import type { Rule } from "#oxlint/plugins";
 
@@ -35,7 +35,7 @@ const group: TestGroup = {
     return `${meta.eslintId} (${parts[0]})`;
   },
 
-  prepare(require: NodeJS.Require, _mock: (path: string, value: unknown) => void) {
+  prepare(require: NodeJS.Require, _mock: MockFn) {
     // Patch SonarJS's rule tester classes.
     // Internally they use ESLint's `RuleTester`, which is already patched to use conformance `RuleTester`,
     // but we need to apply further patches.

--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -1,7 +1,7 @@
 import { unindent } from "eslint-vitest-rule-tester";
 import { RuleTester } from "../rule_tester.ts";
 
-import type { TestGroup } from "../index.ts";
+import type { MockFn, TestGroup } from "../index.ts";
 import type {
   ValidTestCase,
   InvalidTestCase,
@@ -31,7 +31,7 @@ const group: TestGroup = {
     return parts[0];
   },
 
-  prepare(require: NodeJS.Require, mock: (path: string, value: unknown) => void) {
+  prepare(require: NodeJS.Require, mock: MockFn) {
     // Load the copy of `@typescript-eslint/parser` which is used by the test cases
     const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
 


### PR DESCRIPTION
Conformance tests need to mock some modules to replace ESLint / TS-ESLint's `RuleTester` with our own, or to mock TS-ESLint parser.

Make this easier to do when then the module to be mocked is imported by test files via a chain of other imports by taking a `via` parameter. Example of usage in a doc comment added in this PR.

This supports #19184.