### PR TITLE
test(linter/plugins): fix mocking `RuleTester` modules

### DIFF
--- a/apps/oxlint/conformance/src/index.ts
+++ b/apps/oxlint/conformance/src/index.ts
@@ -249,7 +249,13 @@ function runGroup(group: TestGroup, mocks: Mocks) {
       mocks.set(resolveFromTestsDir(specifier), RuleTester);
     } else {
       const mod = requireFromTestsDir(specifier);
-      mod[propName] = RuleTester;
+      // Use `Object.defineProperty` to handle if `mod[propName]` is a getter (transpiled ESM module)
+      Object.defineProperty(mod, propName, {
+        value: RuleTester,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
   }
 


### PR DESCRIPTION
Conformance tests need to mock some modules to replace ESLint / TSESLint's `RuleTester` with our own. Prevent errors during mocking when the module is transpiled from ESM and so the property to replace is a getter.

This supports #19184.