### PR TITLE
test(linter/plugins): add `@e18e/eslint-plugin` to conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -5,6 +5,7 @@ ESLINT_SHA="4e6c4ac042e321da8fc29ce53ed03c86dcaa44a7" # 10.0.0
 REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
 STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
 SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
+E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -156,6 +157,19 @@ if [[ "$OSTYPE" == darwin* ]]; then
 else
   sed -i "$PATTERN3" "$CHECKER_PATH"
 fi
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# E18E
+###############################################################################
+
+# Clone E18E ESLint plugin repo into `submodules/e18e`
+clone e18e https://github.com/e18e/eslint-plugin.git "$E18E_SHA"
+
+# Install dependencies
+pnpm install --ignore-workspace
 
 # Return to `submodules` directory
 cd ..

--- a/apps/oxlint/conformance/snapshots/e18e.md
+++ b/apps/oxlint/conformance/snapshots/e18e.md
@@ -1,0 +1,48 @@
+# Conformance test results - e18e
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |    18 | 100.0% |
+| Fully passing     |    18 | 100.0% |
+| Partially passing |     0 |   0.0% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |   512 | 100.0% |
+| Passing     |   474 |  92.6% |
+| Failing     |     0 |   0.0% |
+| Skipped     |    38 |   7.4% |
+
+## Fully Passing Rules
+
+- `ban-dependencies` (12 tests) (4 skipped)
+- `no-indexof-equality` (27 tests) (27 skipped)
+- `prefer-array-at` (34 tests) (3 skipped)
+- `prefer-array-fill` (27 tests)
+- `prefer-array-from-map` (21 tests)
+- `prefer-array-some` (39 tests)
+- `prefer-array-to-reversed` (17 tests)
+- `prefer-array-to-sorted` (17 tests)
+- `prefer-array-to-spliced` (13 tests)
+- `prefer-date-now` (42 tests)
+- `prefer-exponentiation-operator` (18 tests)
+- `prefer-includes` (42 tests)
+- `prefer-nullish-coalescing` (21 tests)
+- `prefer-object-has-own` (22 tests)
+- `prefer-regex-test` (41 tests) (4 skipped)
+- `prefer-spread-syntax` (37 tests)
+- `prefer-timer-args` (74 tests)
+- `prefer-url-canparse` (8 tests)
+
+## Rules with Failures
+
+No rules with failures

--- a/apps/oxlint/conformance/src/groups/e18e.ts
+++ b/apps/oxlint/conformance/src/groups/e18e.ts
@@ -1,0 +1,96 @@
+import { RuleTester } from "../rule_tester.ts";
+
+import type { MockFn, TestGroup } from "../index.ts";
+import type { LanguageOptions, TestCase } from "../rule_tester.ts";
+
+type TSEslintParser = typeof import("@typescript-eslint/parser");
+
+const group: TestGroup = {
+  name: "e18e",
+
+  submoduleName: "e18e",
+  testFilesDirPath: "src/rules",
+
+  transformTestFilename(filename: string) {
+    if (!filename.endsWith(".test.ts")) return null;
+    return filename.slice(0, -".test.ts".length);
+  },
+
+  prepare(require: NodeJS.Require, mock: MockFn) {
+    // Load the copy of `@typescript-eslint/parser` which is used by the test cases
+    const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
+
+    // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester`
+    mock("@typescript-eslint/rule-tester", createTsRuleTester(tsEslintParser));
+
+    // Mock `@typescript-eslint/parser` exported by `typescript-eslint`.
+    // This is imported by `no-indexof-equality` test file.
+    mock("@typescript-eslint/parser", tsEslintParser, [
+      "typescript-eslint",
+      "@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw-plugin",
+    ]);
+  },
+
+  shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
+    // Cannot lint JSON files
+    if (
+      err.message === "Parsing failed" &&
+      ((ruleName === "ban-dependencies" && test.filename === "package.json") ||
+        (ruleName === "ban-dependencies (JSON)" && (test as any).language === "json/json"))
+    ) {
+      return true;
+    }
+
+    // Type-aware rules are not supported
+    if (
+      ((ruleName === "prefer-array-at (typed)" &&
+        err.message.startsWith("Should have no errors but had 1:")) ||
+        (ruleName === "prefer-regex-test (typed)" &&
+          err.message.startsWith("Should have 1 error but had 0:")) ||
+        (ruleName === "no-indexof-equality" &&
+          err.message.startsWith(
+            "You have used a rule which requires type information. " +
+              "Please ensure you have typescript-eslint setup alongside this plugin " +
+              "and configured to enable type-aware linting.",
+          ))) &&
+      (test.languageOptions?.parserOptions as any)?.projectService != null
+    ) {
+      return true;
+    }
+
+    return false;
+  },
+
+  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+
+  parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
+};
+
+export default group;
+
+/**
+ * Create a module to replace `@typescript-eslint/rule-tester`,
+ * which presents the same API, but uses conformance `RuleTester` with TS-ESLint parser.
+ *
+ * @param tsEslintParser - TSESLint parser module
+ * @returns Module to replace `@typescript-eslint/rule-tester` module with
+ */
+function createTsRuleTester(tsEslintParser: TSEslintParser): { RuleTester: typeof RuleTester } {
+  class TsRuleTester extends RuleTester {
+    constructor(config?: { languageOptions?: LanguageOptions } | null) {
+      if (config == null) {
+        config = {};
+      } else {
+        config = { ...config };
+      }
+
+      const languageOptions = { ...config.languageOptions };
+      config.languageOptions = languageOptions;
+      if (config.languageOptions.parser == null) config.languageOptions.parser = tsEslintParser;
+
+      super(config);
+    }
+  }
+
+  return { RuleTester: TsRuleTester };
+}

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -4,5 +4,6 @@ import eslint from "./eslint.ts";
 import reactHooks from "./react_hooks.ts";
 import stylistic from "./stylistic.ts";
 import sonarjs from "./sonarjs.ts";
+import e18e from "./e18e.ts";
 
-export const TEST_GROUPS: TestGroup[] = [eslint, reactHooks, stylistic, sonarjs];
+export const TEST_GROUPS: TestGroup[] = [eslint, reactHooks, stylistic, sonarjs, e18e];


### PR DESCRIPTION
Add `@e18e/eslint-plugin` to conformance tests. 100% pass (except for type-aware rules which we can't support).