### PR TITLE
feat(linter/unicorn): add fixer for `unicorn/relative-url-style` rule

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
@@ -300,7 +300,7 @@ fn test() {
         (r#"new URL("./foo", base)"#, r#"new URL("foo", base)"#, None),
         (r"new URL('./foo', base)", r"new URL('foo', base)", None),
         (r#"new URL("././a", base)"#, r#"new URL("./a", base)"#, None),
-        (r#"new URL(`./${foo}`, base)"#, r#"new URL(`${foo}`, base)"#, None),
+        (r"new URL(`./${foo}`, base)", r"new URL(`${foo}`, base)", None),
         (
             r#"new URL("./", "https://example.com/a/b/")"#,
             r#"new URL("", "https://example.com/a/b/")"#,

--- a/crates/oxc_linter/src/snapshots/unicorn_relative_url_style.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_relative_url_style.snap
@@ -1,51 +1,58 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("./foo", base)
    ·         ───────
    ╰────
+  help: Remove leading `./`
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL('./foo', base)
    ·         ───────
    ╰────
+  help: Remove leading `./`
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("././a", base)
    ·         ───────
    ╰────
+  help: Remove leading `./`
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL(`./${foo}`, base)
    ·         ──────────
    ╰────
+  help: Remove leading `./`
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Remove the `./` prefix from the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("./", "https://example.com/a/b/")
    ·         ────
    ╰────
+  help: Remove leading `./`
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Add a `./` prefix to the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("foo", base)
    ·         ─────
    ╰────
+  help: Add `./` prefix
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Add a `./` prefix to the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL('foo', base)
    ·         ─────
    ╰────
+  help: Add `./` prefix
 
   ⚠ eslint-plugin-unicorn(relative-url-style): Add a `./` prefix to the relative URL.
    ╭─[relative_url_style.tsx:1:9]
  1 │ new URL("", "https://example.com/a/b/")
    ·         ──
    ╰────
+  help: Add `./` prefix


### PR DESCRIPTION
this PR adds fixer for `unicorn/relative-url-style` rule, issue #684

for template literal urls it uses suggestion, just like in original rule