### PR TITLE
fix(linter/plugins): support legacy `context.report(node, ...)` calls

### DIFF
--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "legacy-report-plugin/legacy-report": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/files/index.js
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/output.snap.md
@@ -1,0 +1,25 @@
+# Exit code
+1
+
+# stdout
+```
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+  x legacy-report-plugin(legacy-report): Unexpected Debugger Statement
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+
+Found 1 warning and 1 error.
+Finished in Xms on 1 file with 94 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/report_legacy_positional_args/plugin.ts
+++ b/apps/oxlint/test/fixtures/report_legacy_positional_args/plugin.ts
@@ -1,0 +1,21 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "legacy-report-plugin",
+  },
+  rules: {
+    "legacy-report": {
+      create(context) {
+        return {
+          DebuggerStatement(node) {
+            // @ts-expect-error ESLint legacy report signature still used by external plugins.
+            context.report(node as never, "Unexpected Debugger Statement" as never);
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
fixes #19192
