### PR TITLE
refactor(transformer_plugins): migrate InjectGlobalVariables from Traverse to VisitMut

### DIFF
--- a/crates/oxc_transformer_plugins/src/lib.rs
+++ b/crates/oxc_transformer_plugins/src/lib.rs
@@ -5,5 +5,3 @@ mod replace_global_defines;
 pub use inject_global_variables::*;
 pub use module_runner_transform::*;
 pub use replace_global_defines::*;
-
-type TraverseCtx<'a> = oxc_traverse::TraverseCtx<'a, ()>;

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -58,7 +58,7 @@ use oxc_span::{Ident, SPAN};
 use oxc_syntax::identifier::is_identifier_name;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse, traverse_mut};
 
-use crate::TraverseCtx;
+type TraverseCtx<'a> = oxc_traverse::TraverseCtx<'a, ()>;
 
 #[derive(Debug, Default)]
 pub struct ModuleRunnerTransform<'a> {


### PR DESCRIPTION
Part 1 of https://github.com/oxc-project/backlog/issues/189

Prerequisite for #19196. Replace `impl Traverse` with `impl VisitMut` for `InjectGlobalVariables`, following the same pattern as `ReplaceGlobalDefines` (PR #19146).

## Changes

- Replace `Traverse` trait impl with `VisitMut`
- Add `scoping` and `non_arrow_function_depth` fields to struct
- Add `scoping()` and `current_scope_flags()` helper methods
- Convert `enter_expression` to `visit_expression` + walk pattern
- Add `visit_function` to track `non_arrow_function_depth`
- Update `build()` to use `self.visit_program()` instead of `traverse_mut()`
- Move `TraverseCtx` type alias into `module_runner_transform` (only remaining user)
- Remove `TraverseCtx` from `lib.rs` (no longer needed at crate level)

## Test plan

- [x] `cargo test -p oxc_transformer_plugins` — all 102 tests pass unchanged