### PR TITLE
refactor(transformer_plugins): remove Scoping dependency from ReplaceGlobalDefines and InjectGlobalVariables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,6 @@ dependencies = [
  "oxc_codegen",
  "oxc_minifier",
  "oxc_parser",
- "oxc_semantic",
  "oxc_span",
  "oxc_tasks_common",
  "oxc_transformer_plugins",

--- a/crates/oxc_transformer_plugins/examples/define.rs
+++ b/crates/oxc_transformer_plugins/examples/define.rs
@@ -19,7 +19,6 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
 use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};
 use oxc_parser::{ParseOptions, Parser};
-use oxc_semantic::SemanticBuilder;
 use oxc_sourcemap::SourcemapVisualizer;
 use oxc_span::SourceType;
 use oxc_transformer_plugins::{ReplaceGlobalDefines, ReplaceGlobalDefinesConfig};
@@ -40,9 +39,8 @@ fn main() -> std::io::Result<()> {
     let allocator = Allocator::default();
 
     let mut program = parse(&allocator, &source_text, source_type);
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let config = ReplaceGlobalDefinesConfig::new(&defines).unwrap();
-    let _ = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
+    let _ = ReplaceGlobalDefines::new(&allocator, config).build(&mut program);
     let printed = codegen(&program, sourcemap);
 
     println!("{printed}");

--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -5,7 +5,6 @@
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::Parser;
-use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 use oxc_transformer_plugins::{InjectGlobalVariables, InjectGlobalVariablesConfig, InjectImport};
@@ -18,8 +17,7 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty());
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
-    let ret = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);
+    let ret = InjectGlobalVariables::new(&allocator, config).build(&mut program);
     assert_eq!(ret.changed, source_text != expected);
     let result = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -146,7 +146,7 @@ impl Oxc {
 
         self.run_formatter(run_options, &source_text, source_type, &formatter_options);
 
-        let mut scoping = semantic.into_scoping();
+        let scoping = semantic.into_scoping();
 
         // Extract scope and symbol information if needed
         if !source_type.is_typescript_definition() {
@@ -174,14 +174,12 @@ impl Oxc {
         // Phase 5.5: Apply ReplaceGlobalDefines (before transformations)
         if let Some(define_opts) = define_options {
             let define_config = Self::build_define_config(&define_opts)?;
-            let ret =
-                ReplaceGlobalDefines::new(&allocator, define_config).build(scoping, &mut program);
-            scoping = ret.scoping;
+            let _ = ReplaceGlobalDefines::new(&allocator, define_config).build(&mut program);
         }
 
         // Phase 6: Apply transformations
         if run_options.transform {
-            scoping = self.apply_transformations(
+            self.apply_transformations(
                 &allocator,
                 &path,
                 &mut program,
@@ -193,8 +191,7 @@ impl Oxc {
         // Phase 6.5: Apply InjectGlobalVariables (after transformations)
         if let Some(inject_opts) = inject_options {
             let inject_config = Self::build_inject_config(&inject_opts)?;
-            let _ =
-                InjectGlobalVariables::new(&allocator, inject_config).build(scoping, &mut program);
+            let _ = InjectGlobalVariables::new(&allocator, inject_config).build(&mut program);
         }
 
         // Phase 7: Apply minification

--- a/tasks/minsize/Cargo.toml
+++ b/tasks/minsize/Cargo.toml
@@ -21,7 +21,6 @@ oxc_allocator = { workspace = true }
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_minifier = { workspace = true }
 oxc_parser = { workspace = true }
-oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_transformer_plugins = { workspace = true }

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -17,7 +17,6 @@ use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions};
 use oxc_parser::Parser;
-use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_tasks_common::{TestFile, TestFiles, project_root};
 use oxc_transformer_plugins::{ReplaceGlobalDefines, ReplaceGlobalDefinesConfig};
@@ -160,12 +159,11 @@ fn minify(source_text: &str, source_type: SourceType, options: Options) -> (Stri
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty());
     let mut program = ret.program;
-    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(
         &allocator,
         ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'development'")]).unwrap(),
     )
-    .build(scoping, &mut program);
+    .build(&mut program);
     let ret = Minifier::new(MinifierOptions {
         mangle: (!options.compress_only).then(MangleOptions::default),
         compress: Some(CompressOptions::default()),


### PR DESCRIPTION
Part 2 of https://github.com/oxc-project/backlog/issues/189 (depends on #19195)

Remove the requirement for pre-built `Scoping` from both `ReplaceGlobalDefines` and `InjectGlobalVariables`, allowing Rolldown to skip calling `SemanticBuilder` for these plugins.

## Motivation

In `compiler.rs` (lines 172-176), `SemanticBuilder::new().build()` was called specifically to rebuild scoping for these two plugins. These plugins only need to know whether an identifier is a global reference and whether it's an ambient declaration — they don't need the full scope/symbol infrastructure. Removing this dependency is a performance win for Rolldown.

## Changes

### New: `ScopeBindingTracker`

A lightweight scope binding tracker that replaces the full `Scoping` data structure. It tracks binding names in a stack of scopes during the `VisitMut` walk, handling:
- `var` hoisting to function scopes
- `declare` (ambient) declarations
- All binding forms: params, imports, `let`/`const`, function/class declarations

### `ReplaceGlobalDefines`
- Replace `scoping: Option<Scoping>` with `scope_tracker: ScopeBindingTracker`
- Add `VisitMut` hooks: `enter_scope`/`leave_scope`, `visit_variable_declaration`, `visit_function`, `visit_class`, `visit_formal_parameter`, `visit_import_declaration`
- Change `build()` signature: no longer takes or returns `Scoping`
- Replace `UpdateReplacedExpression` (which maintained reference IDs) with simpler `ClearSpans` (only clears spans for sourcemap)
- Use `scope_tracker.is_global()` and `scope_tracker.is_ambient()` instead of `IsGlobalReference` and `SymbolFlags::is_ambient()`

### `InjectGlobalVariables`
- Same scope tracking hooks as `ReplaceGlobalDefines`
- Add `unresolved_references: FxHashSet<CompactStr>` to collect global identifier references during the walk (replaces `root_unresolved_references()`)
- Change `build()` signature: no longer takes or returns `Scoping`

### `compiler.rs`
- Remove `SemanticBuilder::new().build()` call at lines 172-176
- DCE builds its own scoping on demand when needed

### Callers
- Update tests, examples, `tasks/minsize`, `napi/playground`
- Remove `oxc_semantic` dependency from `tasks/minsize`

## Test plan

- [x] `cargo test -p oxc_transformer_plugins` — all 102 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] `just conformance` — no regressions
- [x] `just minsize` — snapshots unchanged