### PR TITLE
refactor(oxfmt): Insert `options.(parser|filepath)` on Rust side

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -31,7 +31,7 @@ export declare const enum Severity {
  *
  * Since it internally uses `await prettier.format()` in JS side, `formatSync()` cannot be provided.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, parserName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -55,4 +55,4 @@ export interface FormatResult {
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, parserName: string, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>, sortTailwindcssClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -29,23 +29,14 @@ export async function disposeExternalFormatter(): Promise<void> {
   pool = null;
 }
 
-export async function formatEmbeddedCode(
-  options: Options,
-  parserName: string,
-  code: string,
-): Promise<string> {
-  return pool!.run({ options, code, parserName } satisfies FormatEmbeddedCodeParam, {
+export async function formatEmbeddedCode(options: Options, code: string): Promise<string> {
+  return pool!.run({ options, code } satisfies FormatEmbeddedCodeParam, {
     name: "formatEmbeddedCode",
   });
 }
 
-export async function formatFile(
-  options: Options,
-  parserName: string,
-  fileName: string,
-  code: string,
-): Promise<string> {
-  return pool!.run({ options, code, fileName, parserName } satisfies FormatFileParam, {
+export async function formatFile(options: Options, code: string): Promise<string> {
+  return pool!.run({ options, code } satisfies FormatFileParam, {
     name: "formatFile",
   });
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -17,8 +17,8 @@ export async function format(fileName: string, sourceText: string, options?: For
     sourceText,
     options ?? {},
     resolvePlugins,
-    (options, parserName, code) => formatEmbeddedCode({ options, parserName, code }),
-    (options, parserName, fileName, code) => formatFile({ options, parserName, fileName, code }),
+    (options, code) => formatEmbeddedCode({ options, code }),
+    (options, code) => formatFile({ options, code }),
     (filepath, options, classes) => sortTailwindClasses({ filepath, classes, options }),
   );
 }

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -46,7 +46,6 @@ export async function resolvePlugins(): Promise<string[]> {
 
 export type FormatEmbeddedCodeParam = {
   code: string;
-  parserName: string;
   options: Options;
 };
 
@@ -59,13 +58,9 @@ export type FormatEmbeddedCodeParam = {
  */
 export async function formatEmbeddedCode({
   code,
-  parserName,
   options,
 }: FormatEmbeddedCodeParam): Promise<string> {
   const prettier = await loadPrettier();
-
-  // SAFETY: `options` is created in Rust side, so it's safe to mutate here
-  options.parser = parserName;
 
   // Enable Tailwind CSS plugin for embedded code (e.g., html`...` in JS) if needed
   await setupTailwindPlugin(options);
@@ -81,8 +76,6 @@ export async function formatEmbeddedCode({
 
 export type FormatFileParam = {
   code: string;
-  parserName: string;
-  fileName: string;
   options: Options;
 };
 
@@ -91,19 +84,8 @@ export type FormatFileParam = {
  *
  * @returns Formatted code
  */
-export async function formatFile({
-  code,
-  parserName,
-  fileName,
-  options,
-}: FormatFileParam): Promise<string> {
+export async function formatFile({ code, options }: FormatFileParam): Promise<string> {
   const prettier = await loadPrettier();
-
-  // SAFETY: `options` is created in Rust side, so it's safe to mutate here
-  // We specify `parser` to skip parser inference for performance
-  options.parser = parserName;
-  // But some plugins rely on `filepath`, so we set it too
-  options.filepath = fileName;
 
   // Enable Tailwind CSS plugin for non-JS files if needed
   await setupTailwindPlugin(options);

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -31,14 +31,15 @@ pub type JsInitExternalFormatterCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (options, parser_name, code) as separate arguments and returns formatted code.
+/// Takes (options, code) as arguments and returns formatted code.
+/// The `options` object includes `parser` field set by Rust side.
 pub type JsFormatEmbeddedCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(Value, String, String)>, // (options, parser_name, code)
+    FnArgs<(Value, String)>, // (options, code)
     // Return type (what JS function returns)
     Promise<String>,
     // Arguments (repeated)
-    FnArgs<(Value, String, String)>,
+    FnArgs<(Value, String)>,
     // Error status
     Status,
     // CalleeHandled
@@ -46,14 +47,15 @@ pub type JsFormatEmbeddedCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (options, parser_name, file_name, code) as separate arguments and returns formatted code.
+/// Takes (options, code) as arguments and returns formatted code.
+/// The `options` object includes `parser` and `filepath` fields set by Rust side.
 pub type JsFormatFileCb = ThreadsafeFunction<
     // Input arguments
-    FnArgs<(Value, String, String, String)>, // (options, parser_name, file_name, code)
+    FnArgs<(Value, String)>, // (options, code)
     // Return type (what JS function returns)
     Promise<String>,
     // Arguments (repeated)
-    FnArgs<(Value, String, String, String)>,
+    FnArgs<(Value, String)>,
     // Error status
     Status,
     // CalleeHandled
@@ -95,14 +97,16 @@ impl TsfnHandles {
 }
 
 /// Callback function type for formatting embedded code with config.
-/// Takes (options, parser_name, code) and returns formatted code or an error.
+/// Takes (options, code) and returns formatted code or an error.
+/// The `options` Value is owned and includes `parser` set by the caller.
 type FormatEmbeddedWithConfigCallback =
-    Arc<dyn Fn(&Value, &str, &str) -> Result<String, String> + Send + Sync>;
+    Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
 /// Callback function type for formatting files with config.
-/// Takes (options, parser_name, file_name, code) and returns formatted code or an error.
+/// Takes (options, code) and returns formatted code or an error.
+/// The `options` Value is owned and includes `parser` and `filepath` set by the caller.
 type FormatFileWithConfigCallback =
-    Arc<dyn Fn(&Value, &str, &str, &str) -> Result<String, String> + Send + Sync>;
+    Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
 /// Callback function type for init external formatter.
 /// Takes num_threads and returns plugin languages.
@@ -186,7 +190,8 @@ impl ExternalFormatter {
 
     /// Initialize external formatter using the JS callback.
     pub fn init(&self, num_threads: usize) -> Result<Vec<String>, String> {
-        (self.init)(num_threads)
+        debug_span!("oxfmt::external::init", num_threads = num_threads)
+            .in_scope(|| (self.init)(num_threads))
     }
 
     /// Convert this external formatter to the oxc_formatter::ExternalCallbacks type.
@@ -207,7 +212,32 @@ impl ExternalFormatter {
                     // We need to keep unsupported content as-is.
                     return Err(format!("Unsupported language: {language}"));
                 };
-                (format_embedded)(&options_for_embedded, parser_name, code)
+                debug_span!("oxfmt::external::format_embedded", parser = parser_name).in_scope(
+                    || {
+                        // `clone()` is unavoidable here,
+                        // because there may be multiple embedded sections in one JS/TS file.
+                        let mut options = options_for_embedded.clone();
+                        if let Value::Object(ref mut map) = options {
+                            map.insert(
+                                "parser".to_string(),
+                                Value::String(parser_name.to_string()),
+                            );
+                        }
+                        (format_embedded)(options, code)
+                            .map(|mut code| {
+                                // Remove trailing newline added by Prettier without allocation
+                                // For embedded code, we never want trailing newlines, regardless of options.
+                                let trimmed_len = code.trim_end().len();
+                                code.truncate(trimmed_len);
+                                code
+                            })
+                            .map_err(|err| {
+                                format!(
+                                    "Failed to format embedded code for parser '{parser_name}': {err}"
+                                )
+                            })
+                    },
+                )
             }))
         } else {
             None
@@ -218,7 +248,8 @@ impl ExternalFormatter {
             let file_path = filepath.to_string_lossy().to_string();
             let sort_tailwindcss_classes = Arc::clone(&self.sort_tailwindcss_classes);
             Some(Arc::new(move |classes: Vec<String>| {
-                (sort_tailwindcss_classes)(&file_path, &options, classes)
+                debug_span!("oxfmt::external::sort_tailwind", classes_count = classes.len())
+                    .in_scope(|| (sort_tailwindcss_classes)(&file_path, &options, classes))
             }))
         } else {
             None
@@ -230,14 +261,9 @@ impl ExternalFormatter {
     }
 
     /// Format non-js file using the JS callback.
-    pub fn format_file(
-        &self,
-        options: &Value,
-        parser_name: &str,
-        file_name: &str,
-        code: &str,
-    ) -> Result<String, String> {
-        (self.format_file)(options, parser_name, file_name, code)
+    /// The `options` Value should already have `parser` and `filepath` set by the caller.
+    pub fn format_file(&self, options: Value, code: &str) -> Result<String, String> {
+        (self.format_file)(options, code)
     }
 
     #[cfg(test)]
@@ -252,8 +278,8 @@ impl ExternalFormatter {
                 sort_tailwind: Arc::new(RwLock::new(None)),
             },
             init: Arc::new(|_| Err("Dummy init called".to_string())),
-            format_embedded: Arc::new(|_, _, _| Err("Dummy format_embedded called".to_string())),
-            format_file: Arc::new(|_, _, _, _| Err("Dummy format_file called".to_string())),
+            format_embedded: Arc::new(|_, _| Err("Dummy format_embedded called".to_string())),
+            format_file: Arc::new(|_, _| Err("Dummy format_file called".to_string())),
             sort_tailwindcss_classes: Arc::new(|_, _, _| vec![]),
         }
     }
@@ -295,107 +321,73 @@ fn wrap_init_external_formatter(
     cb_handle: Arc<RwLock<Option<JsInitExternalFormatterCb>>>,
 ) -> InitExternalFormatterCallback {
     Arc::new(move |num_threads: usize| {
-        debug_span!("oxfmt::external::init", num_threads = num_threads).in_scope(|| {
-            let guard = cb_handle.read().unwrap();
-            let Some(cb) = guard.as_ref() else {
-                return Err("JS callback unavailable (environment shutting down)".to_string());
-            };
-            #[expect(clippy::cast_possible_truncation)]
-            let result = block_on(async {
-                let status = cb.call_async(FnArgs::from((num_threads as u32,))).await;
-                match status {
-                    Ok(promise) => match promise.await {
-                        Ok(languages) => Ok(languages),
-                        Err(err) => {
-                            Err(format!("JS initExternalFormatter promise rejected: {err}"))
-                        }
-                    },
-                    Err(err) => {
-                        Err(format!("Failed to call JS initExternalFormatter callback: {err}"))
-                    }
-                }
-            });
-            drop(guard);
-            result
-        })
+        let guard = cb_handle.read().unwrap();
+        let Some(cb) = guard.as_ref() else {
+            return Err("JS callback unavailable (environment shutting down)".to_string());
+        };
+        #[expect(clippy::cast_possible_truncation)]
+        let result = block_on(async {
+            let status = cb.call_async(FnArgs::from((num_threads as u32,))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(languages) => Ok(languages),
+                    Err(err) => Err(format!("JS initExternalFormatter promise rejected: {err}")),
+                },
+                Err(err) => Err(format!("Failed to call JS initExternalFormatter callback: {err}")),
+            }
+        });
+        drop(guard);
+        result
     })
 }
 
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
+/// The `options` Value is received with `parser` already set by the caller.
 fn wrap_format_embedded(
     cb_handle: Arc<RwLock<Option<JsFormatEmbeddedCb>>>,
 ) -> FormatEmbeddedWithConfigCallback {
-    Arc::new(move |options: &Value, parser_name: &str, code: &str| {
-        debug_span!("oxfmt::external::format_embedded", parser = %parser_name).in_scope(|| {
-            let guard = cb_handle.read().unwrap();
-            let Some(cb) = guard.as_ref() else {
-                return Err("JS callback unavailable (environment shutting down)".to_string());
-            };
-            let result = block_on(async {
-                let status = cb
-                    .call_async(FnArgs::from((
-                        options.clone(),
-                        parser_name.to_string(),
-                        code.to_string(),
-                    )))
-                    .await;
-                match status {
-                    Ok(promise) => match promise.await {
-                        Ok(mut formatted_code) => {
-                            // Trim trailing newline added by Prettier without allocation
-                            let trimmed_len = formatted_code.trim_end().len();
-                            formatted_code.truncate(trimmed_len);
-                            Ok(formatted_code)
-                        }
-                        Err(err) => Err(format!(
-                            "JS formatter promise rejected for parser '{parser_name}': {err}"
-                        )),
-                    },
-                    Err(err) => Err(format!(
-                        "Failed to call JS formatting callback for parser '{parser_name}': {err}"
-                    )),
-                }
-            });
-            drop(guard);
-            result
-        })
+    Arc::new(move |options: Value, code: &str| {
+        let guard = cb_handle.read().unwrap();
+        let Some(cb) = guard.as_ref() else {
+            return Err("JS callback unavailable (environment shutting down)".to_string());
+        };
+        let result = block_on(async {
+            let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(formatted_code) => Ok(formatted_code),
+                    Err(err) => Err(format!("JS formatEmbeddedCode promise rejected: {err}")),
+                },
+                Err(err) => Err(format!("Failed to call JS formatEmbeddedCode callback: {err}")),
+            }
+        });
+        drop(guard);
+        result
     })
 }
 
 /// Wrap JS `formatFile` callback as a normal Rust function.
+/// The `options` Value is received with `parser` and `filepath` already set by the caller.
 fn wrap_format_file(
     cb_handle: Arc<RwLock<Option<JsFormatFileCb>>>,
 ) -> FormatFileWithConfigCallback {
-    Arc::new(move |options: &Value, parser_name: &str, file_name: &str, code: &str| {
-        debug_span!("oxfmt::external::format_file", parser = %parser_name, file = %file_name).in_scope(|| {
-            let guard = cb_handle.read().unwrap();
-            let Some(cb) = guard.as_ref() else {
-                return Err("JS callback unavailable (environment shutting down)".to_string());
-            };
-            let result = block_on(async {
-                let status = cb
-                    .call_async(FnArgs::from((
-                        options.clone(),
-                        parser_name.to_string(),
-                        file_name.to_string(),
-                        code.to_string(),
-                    )))
-                    .await;
-                match status {
-                    Ok(promise) => match promise.await {
-                        Ok(formatted_code) => Ok(formatted_code),
-                        Err(err) => Err(format!(
-                            "JS formatFile promise rejected for file: '{file_name}', parser: '{parser_name}': {err}"
-                        )),
-                    },
-                    Err(err) => Err(format!(
-                        "Failed to call JS formatFile callback for file: '{file_name}', parser: '{parser_name}': {err}"
-                    )),
-                }
-            });
-            drop(guard);
-            result
-        })
+    Arc::new(move |options: Value, code: &str| {
+        let guard = cb_handle.read().unwrap();
+        let Some(cb) = guard.as_ref() else {
+            return Err("JS callback unavailable (environment shutting down)".to_string());
+        };
+        let result = block_on(async {
+            let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(formatted_code) => Ok(formatted_code),
+                    Err(err) => Err(format!("JS formatFile promise rejected: {err}")),
+                },
+                Err(err) => Err(format!("Failed to call JS formatFile callback: {err}")),
+            }
+        });
+        drop(guard);
+        result
     })
 }
 
@@ -404,33 +396,24 @@ fn wrap_sort_tailwind_classes(
     cb_handle: Arc<RwLock<Option<JsSortTailwindClassesCb>>>,
 ) -> TailwindWithConfigCallback {
     Arc::new(move |filepath: &str, options: &Value, classes: Vec<String>| {
-        debug_span!("oxfmt::external::sort_tailwind", classes_count = classes.len()).in_scope(
-            || {
-                let guard = cb_handle.read().unwrap();
-                let Some(cb) = guard.as_ref() else {
-                    // Return original classes if callback unavailable
-                    return classes;
-                };
-                let result = block_on(async {
-                    let args =
-                        FnArgs::from((filepath.to_string(), options.clone(), classes.clone()));
-                    match cb.call_async(args).await {
-                        Ok(promise) => match promise.await {
-                            Ok(sorted) => sorted,
-                            Err(_) => {
-                                // Return original classes on error
-                                classes
-                            }
-                        },
-                        Err(_) => {
-                            // Return original classes on error
-                            classes
-                        }
-                    }
-                });
-                drop(guard);
-                result
-            },
-        )
+        let guard = cb_handle.read().unwrap();
+        let Some(cb) = guard.as_ref() else {
+            // Return original classes if callback unavailable
+            return classes;
+        };
+        let result = block_on(async {
+            let args = FnArgs::from((filepath.to_string(), options.clone(), classes.clone()));
+            match cb.call_async(args).await {
+                Ok(promise) => match promise.await {
+                    Ok(sorted) => sorted,
+                    // Return original classes on error
+                    Err(_) => classes,
+                },
+                // Return original classes on error
+                Err(_) => classes,
+            }
+        });
+        drop(guard);
+        result
     })
 }

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -37,13 +37,9 @@ pub async fn run_cli(
     args: Vec<String>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, parserName: string, code: string) => Promise<string>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
     #[napi(
         ts_arg_type = "(filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>"
@@ -144,13 +140,9 @@ pub async fn format(
     options: Option<Value>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, parserName: string, code: string) => Promise<string>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_embedded_cb: JsFormatEmbeddedCb,
-    #[napi(
-        ts_arg_type = "(options: Record<string, any>, parserName: string, fileName: string, code: string) => Promise<string>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
     #[napi(
         ts_arg_type = "(filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>"


### PR DESCRIPTION
- Reduce work load on JS 
- Also simplify `wrap_xxx()` in Rust