### PR TITLE
refactor(oxfmt): Fix all `options.filepath` usage

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -31,7 +31,7 @@ export declare const enum Severity {
  *
  * Since it internally uses `await prettier.format()` in JS side, `formatSync()` cannot be provided.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -55,4 +55,4 @@ export interface FormatResult {
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -5,7 +5,6 @@ import type {
   FormatFileParam,
   SortTailwindClassesArgs,
 } from "../libs/apis";
-import type { Options } from "prettier";
 
 // Worker pool for parallel Prettier formatting
 let pool: Tinypool | null = null;
@@ -29,24 +28,29 @@ export async function disposeExternalFormatter(): Promise<void> {
   pool = null;
 }
 
-export async function formatEmbeddedCode(options: Options, code: string): Promise<string> {
+export async function formatEmbeddedCode(
+  options: FormatEmbeddedCodeParam["options"],
+  code: string,
+): Promise<string> {
   return pool!.run({ options, code } satisfies FormatEmbeddedCodeParam, {
     name: "formatEmbeddedCode",
   });
 }
 
-export async function formatFile(options: Options, code: string): Promise<string> {
+export async function formatFile(
+  options: FormatFileParam["options"],
+  code: string,
+): Promise<string> {
   return pool!.run({ options, code } satisfies FormatFileParam, {
     name: "formatFile",
   });
 }
 
 export async function sortTailwindClasses(
-  filepath: string,
-  options: Options,
+  options: SortTailwindClassesArgs["options"],
   classes: string[],
 ): Promise<string[]> {
-  return pool!.run({ filepath, options, classes } satisfies SortTailwindClassesArgs, {
+  return pool!.run({ classes, options } satisfies SortTailwindClassesArgs, {
     name: "sortTailwindClasses",
   });
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -19,7 +19,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     resolvePlugins,
     (options, code) => formatEmbeddedCode({ options, code }),
     (options, code) => formatFile({ options, code }),
-    (filepath, options, classes) => sortTailwindClasses({ filepath, classes, options }),
+    (options, classes) => sortTailwindClasses({ options, classes }),
   );
 }
 

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -132,30 +132,29 @@ async function setupTailwindPlugin(options: Options): Promise<void> {
 // ---
 
 export interface SortTailwindClassesArgs {
-  filepath: string;
   classes: string[];
-  options?: {
+  options: {
+    filepath?: string;
     tailwindStylesheet?: string;
     tailwindConfig?: string;
     tailwindPreserveWhitespace?: boolean;
     tailwindPreserveDuplicates?: boolean;
-  } & Options;
+  };
 }
 
 /**
  * Process Tailwind CSS classes found in JS/TS files in batch.
- * @param args - Object containing filepath, classes, and options
+ * @param args - Object containing classes and options (filepath is in options.filepath)
  * @returns Array of sorted class strings (same order/length as input)
  */
 export async function sortTailwindClasses({
-  filepath,
   classes,
-  options = {},
+  options,
 }: SortTailwindClassesArgs): Promise<string[]> {
   const { createSorter } = await import("prettier-plugin-tailwindcss/sorter");
 
   const sorter = await createSorter({
-    filepath,
+    filepath: options.filepath,
     stylesheetPath: options.tailwindStylesheet,
     configPath: options.tailwindConfig,
     preserveWhitespace: options.tailwindPreserveWhitespace,

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -41,9 +41,7 @@ pub async fn run_cli(
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
-    #[napi(
-        ts_arg_type = "(filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[]>")]
     sort_tailwindcss_classes_cb: JsSortTailwindClassesCb,
 ) -> (String, Option<u8>) {
     // Convert `String` args to `OsString` for compatibility with `bpaf`
@@ -144,9 +142,7 @@ pub async fn format(
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
-    #[napi(
-        ts_arg_type = "(filepath: string, options: Record<string, any>, classes: string[]) => Promise<string[]>"
-    )]
+    #[napi(ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[]>")]
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
 ) -> FormatResult {
     let num_of_threads = 1;


### PR DESCRIPTION
Fixes #19194

- Changed from passing file name as `filepath` to using absolute path
- For Tailwind's sorter, retrieve it via `options.filepath`
- Ensure `filepath` is passed in all code paths
  - Also, path resolution should be handled at a higher flow