### PR TITLE
feat(linter/tsgolint): add support for labeled ranges in tsgolint diagnostics

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__tsgolint_--type-aware@oxlint.snap
@@ -301,18 +301,20 @@ working directory: fixtures/tsgolint
  10 | }
     `----
 
-  x typescript-eslint(no-unnecessary-condition): This condition will always return the same value since the types have no overlap.
-   ,-[prefer-nullish-coalescing.ts:1:1]
- 1 | declare const nullableString: string | null;
-   : ^
- 2 | const nullishResult = nullableString !== null && nullableString !== undefined ? nullableString : 'default';
-   `----
-
   x typescript-eslint(prefer-nullish-coalescing): Prefer using nullish coalescing operator (`??`) instead of a ternary expression, as it is simpler to read.
    ,-[prefer-nullish-coalescing.ts:2:23]
  1 | declare const nullableString: string | null;
  2 | const nullishResult = nullableString !== null && nullableString !== undefined ? nullableString : 'default';
    :                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+  x typescript-eslint(no-unnecessary-condition): This condition will always return the same value since the types have no overlap.
+   ,-[prefer-nullish-coalescing.ts:2:49]
+ 1 | declare const nullableString: string | null;
+ 2 | const nullishResult = nullableString !== null && nullableString !== undefined ? nullableString : 'default';
+   :                                                 ^^^^^^^|^^^^^^^    ^^^^^|^^^^
+   :                                                        |                `-- Type: undefined
+   :                                                        `-- Type: string
    `----
 
   x typescript-eslint(prefer-optional-chain): Prefer using an optional chain expression instead, as it's more concise and easier to read.


### PR DESCRIPTION
- related to https://github.com/oxc-project/tsgolint/issues/650

This adds support for labeled ranges coming from `tsgolint`. In some cases, this might mean the primary span is also completely zeroed out, indicating that labeled ranges are the only source of labels.

Before:

<img width="917" height="104" alt="Screenshot 2026-02-10 at 9 27 20 PM" src="https://github.com/user-attachments/assets/72102616-5bda-4306-bfcb-7ebfaadaef29" />



After:

<img width="925" height="128" alt="Screenshot 2026-02-10 at 9 26 49 PM" src="https://github.com/user-attachments/assets/26de8958-a52b-4157-921a-060e5280dfcc" />
