### PR TITLE
fix(oxfmt): Fix relative -> absolute path resolution with refactoring

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -30,6 +30,9 @@ export declare const enum Severity {
  * NAPI based format API entry point.
  *
  * Since it internally uses `await prettier.format()` in JS side, `formatSync()` cannot be provided.
+ *
+ * # Panics
+ * Panics if the current working directory cannot be determined.
  */
 export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
 


### PR DESCRIPTION
Follow up on #19000.

- Replace `fs::canonicalize()` with `utils::normalize_relative_path()`
  - to avoid Windows `\\?\` prefix
- Fix `config_dir` being `None` due to `Option::take()` in `build_and_validate()`
  - Which made the previous path resolution dead code 🙈
- Move tailwind path resolution earlier:
  - from JSON Value manipulation in `finalize_external_options()`
  - to typed `FormatConfig::resolve_tailwind_paths()`
- Pass `cwd` explicitly to `resolve_options_from_value()` instead of calling `current_dir()` internally
