### PR TITLE
docs(linter): fix typo in oxc/erasing-op

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/erasing_op.rs
+++ b/crates/oxc_linter/src/rules/oxc/erasing_op.rs
@@ -22,7 +22,7 @@ pub struct ErasingOp;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Checks for erasing operations, e.g., `x * 0``.
+    /// Checks for erasing operations, e.g., `x * 0`.
     ///
     /// Based on https://rust-lang.github.io/rust-clippy/master/#/erasing_op
     ///


### PR DESCRIPTION
fix typo of oxc/erasing-op