### PR TITLE
feat(oxfmt/lsp): Do not refer `.gitignore`

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -365,15 +365,15 @@ fn compute_minimal_text_edit<'a>(
     (start, end, replacement)
 }
 
-// Almost the same as `oxfmt::walk::load_ignore_paths`, but does not handle custom ignore files.
+// Almost the same as `cli::walk::load_ignore_paths`, but does not handle custom ignore files.
+//
+// NOTE: `.gitignore` is intentionally NOT included here.
+// In LSP, every file is explicitly opened by the user (like directly specifying a file in CLI),
+// so `.gitignore` should not prevent formatting.
+// Only formatter-specific ignore files apply.
 fn load_ignore_paths(cwd: &Path) -> Vec<PathBuf> {
-    [".gitignore", ".prettierignore"]
-        .iter()
-        .filter_map(|file_name| {
-            let path = cwd.join(file_name);
-            if path.exists() { Some(path) } else { None }
-        })
-        .collect::<Vec<_>>()
+    let path = cwd.join(".prettierignore");
+    if path.exists() { vec![path] } else { vec![] }
 }
 
 // ---

--- a/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
+++ b/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
@@ -217,29 +217,6 @@ null
 --------------------"
 `;
 
-exports[`LSP formatting > ignore patterns > should respect .gitignore 1`] = `
-"--- FILE -----------
-ignore-gitignore/ignored.ts
---- BEFORE ---------
-const   x   =   1
-
---- AFTER ----------
-null
---------------------"
-`;
-
-exports[`LSP formatting > ignore patterns > should respect .gitignore 2`] = `
-"--- FILE -----------
-ignore-gitignore/not-ignored.ts
---- BEFORE ---------
-const   x   =   1
-
---- AFTER ----------
-const x = 1;
-
---------------------"
-`;
-
 exports[`LSP formatting > initializationOptions > should use custom config path from fmt.configPath 1`] = `
 "--- FILE -----------
 custom_config_path/semicolons-as-needed.ts

--- a/apps/oxfmt/test/lsp/format/format.test.ts
+++ b/apps/oxfmt/test/lsp/format/format.test.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { formatFixture } from "../utils";
 
@@ -40,37 +39,6 @@ describe("LSP formatting", () => {
       ["ignore-config/file.generated.ts", "typescript"],
     ])("should handle %s", async (path, languageId) => {
       expect(await formatFixture(FIXTURES_DIR, path, languageId)).toMatchSnapshot();
-    });
-
-    // .gitignore is created dynamically to avoid git ignoring the test fixture
-    it("should respect .gitignore", async () => {
-      const testDir = join(FIXTURES_DIR, "ignore-gitignore");
-      const gitignorePath = join(testDir, ".gitignore");
-      const ignoredPath = join(testDir, "ignored.ts");
-      const notIgnoredPath = join(testDir, "not-ignored.ts");
-
-      try {
-        await fs.mkdir(testDir, { recursive: true });
-        await fs.writeFile(gitignorePath, "ignored.ts\n");
-        await fs.writeFile(ignoredPath, "const   x   =   1\n");
-        await fs.writeFile(notIgnoredPath, "const   x   =   1\n");
-
-        const ignoredResult = await formatFixture(
-          FIXTURES_DIR,
-          "ignore-gitignore/ignored.ts",
-          "typescript",
-        );
-        const notIgnoredResult = await formatFixture(
-          FIXTURES_DIR,
-          "ignore-gitignore/not-ignored.ts",
-          "typescript",
-        );
-
-        expect(ignoredResult).toMatchSnapshot();
-        expect(notIgnoredResult).toMatchSnapshot();
-      } finally {
-        await fs.rm(testDir, { recursive: true, force: true });
-      }
     });
   });
 


### PR DESCRIPTION
Fixes #19082

The CLI can format paths specified directly, even if they are `.gitignore`d.
LSP should also be able to format files if they are open in the editor.