### PR TITLE
release(crates): oxc v0.113.0

### DIFF
--- a/crates/oxc_allocator/CHANGELOG.md
+++ b/crates/oxc_allocator/CHANGELOG.md
@@ -14,6 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🚀 Features
+
+- e316857 allocator/bitset: Add `Ones` iterator to `BitSet` (#19027) (sapphi-red)
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+
 ## [0.112.0] - 2026-02-02
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_ast/CHANGELOG.md
+++ b/crates/oxc_ast/CHANGELOG.md
@@ -18,6 +18,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🚀 Features
+
+- 18320c6 span: Store file extension in `SourceType` (#18893) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_ast_visit/CHANGELOG.md
+++ b/crates/oxc_ast_visit/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 🚀 Features

--- a/crates/oxc_codegen/CHANGELOG.md
+++ b/crates/oxc_codegen/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 48b0542 span: [**BREAKING**] SourceType::ts should set module to unambigious (#18873) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 48b0542 span: [**BREAKING**] SourceType::ts should set module to unambigious (#18873) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 🚀 Features

--- a/crates/oxc_ecmascript/CHANGELOG.md
+++ b/crates/oxc_ecmascript/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 110c300 oxc_ecmascript: `+[false]` and `+[true]` should evaluate to `NaN` (#19174) (copilot-swe-agent)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- 110c300 oxc_ecmascript: `+[false]` and `+[true]` should evaluate to `NaN` (#19174) (copilot-swe-agent)
+
 ## [0.109.0] - 2026-01-19
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_isolated_declarations/CHANGELOG.md
+++ b/crates/oxc_isolated_declarations/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 - 312e756 isolated-declarations: Preserve readonly literal initializers (#19177) (camc314)
 - d0ca8d0 isolated-declarations: Skip parenthesis when inferring type (#19176) (camc314)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- a7514e4 isolated-declarations: Preserve const context in literal type inference (#19178) (camc314)
+- 312e756 isolated-declarations: Preserve readonly literal initializers (#19177) (camc314)
+- d0ca8d0 isolated-declarations: Skip parenthesis when inferring type (#19176) (camc314)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_mangler/CHANGELOG.md
+++ b/crates/oxc_mangler/CHANGELOG.md
@@ -15,6 +15,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 - e7595d1 mangler: Use BitSet for exported symbols set (#19023) (sapphi-red)
 - 69a8d85 mangler: Use BitSet for keep_names symbols set (#19028) (sapphi-red)
 
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 2bf7293 mangler: [**BREAKING**] Enable `top_level` by default for modules and commonjs (#18278) (sapphi-red)
+
+### ⚡ Performance
+
+- e7595d1 mangler: Use BitSet for exported symbols set (#19023) (sapphi-red)
+- 69a8d85 mangler: Use BitSet for keep_names symbols set (#19028) (sapphi-red)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_minifier/CHANGELOG.md
+++ b/crates/oxc_minifier/CHANGELOG.md
@@ -19,6 +19,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 110c300 oxc_ecmascript: `+[false]` and `+[true]` should evaluate to `NaN` (#19174) (copilot-swe-agent)
 
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 2bf7293 mangler: [**BREAKING**] Enable `top_level` by default for modules and commonjs (#18278) (sapphi-red)
+
+### 🚀 Features
+
+- 500d071 minifier: Local traverse ctx and generated minifier traverse (#19106) (Boshen)
+- 742ad3f minifier: Default `invalid_import_side_effects` to `false` (#18916) (sapphi-red)
+
+### 🐛 Bug Fixes
+
+- 110c300 oxc_ecmascript: `+[false]` and `+[true]` should evaluate to `NaN` (#19174) (copilot-swe-agent)
+
 ## [0.112.0] - 2026-02-02
 
 ### 🐛 Bug Fixes

--- a/crates/oxc_parser/CHANGELOG.md
+++ b/crates/oxc_parser/CHANGELOG.md
@@ -25,6 +25,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 - f78c525 parser: Try hybrid parsing for jsx children and closing element/fragments (#18789) (camchenry)
 
+## [0.113.0] - 2026-02-10
+
+### 🚀 Features
+
+- 142a1be parser: Detect binary files with TS1490 error (#19047) (Boshen)
+- 0eff6be parser: Error JSX-like type assertions and generics in `.mts`/`.cts` (#18910) (Boshen)
+
+### 🐛 Bug Fixes
+
+- 56c086b parser: Add modifier ordering validation (TS1029) (#19024) (Boshen)
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+- 1f6b193 parser: Validate TypeScript import type options (#18889) (Boshen)
+- 1663184 parser: Allow conditional types in function type parameters (#18886) (Boshen)
+- 5758046 parser: Error on property access after instantiation expression (#18887) (Boshen)
+- 5eb4a94 parser: Handle `<<` as two `<` tokens in type argument contexts (#18885) (Boshen)
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+- f78c525 parser: Try hybrid parsing for jsx children and closing element/fragments (#18789) (camchenry)
+
 ## [0.112.0] - 2026-02-02
 
 ### 🚀 Features

--- a/crates/oxc_regular_expression/CHANGELOG.md
+++ b/crates/oxc_regular_expression/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - e3609e3 regular_expression: Preserve UnicodeEscape CharacterKind in string literals (#18998) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- e3609e3 regular_expression: Preserve UnicodeEscape CharacterKind in string literals (#18998) (Boshen)
+
 ## [0.109.0] - 2026-01-19
 
 ### 🚀 Features

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -20,6 +20,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 - 2537924 semantic: Optimize scope resolution with fast paths and inlining (#19029) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- f32ea19 semantic: Report redeclaration error for import bindings conflicting with value declarations (#19068) (Boshen)
+- 3aeba7a semantic: Report redeclaration error for `function a() {} var a` in module mode (#19041) (Boshen)
+- 463d60d semantic: Skip TS2391 for standalone computed-name class methods (#19025) (Boshen)
+- 6067a49 linter/jsdoc: False positive in `check-tag-names` for `@` in email addresses and npm scopes (#19021) (Boshen)
+- b13bb70 semantic/jsdoc: Inline tags like `{@link}` break jsdoc parsing (#19019) (Boshen)
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+- 2537924 semantic: Optimize scope resolution with fast paths and inlining (#19029) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_span/CHANGELOG.md
+++ b/crates/oxc_span/CHANGELOG.md
@@ -14,6 +14,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 18320c6 span: Store file extension in `SourceType` (#18893) (Boshen)
 
+### 🐛 Bug Fixes
+
+- 0441237 source-type: Don't treat `d.ts` as a declaration file (#19185) (Cameron)
+
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 48b0542 span: [**BREAKING**] SourceType::ts should set module to unambigious (#18873) (Boshen)
+
+### 🚀 Features
+
+- 18320c6 span: Store file extension in `SourceType` (#18893) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_str/CHANGELOG.md
+++ b/crates/oxc_str/CHANGELOG.md
@@ -10,3 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 9eb16b3 syntax: Pack ASCII identifier tables into single bitflag table (#19088) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### ⚡ Performance
+
+- 9eb16b3 syntax: Pack ASCII identifier tables into single bitflag table (#19088) (Boshen)
+
 ## [0.109.0] - 2026-01-19
 
 ### 🚀 Features

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -15,6 +15,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- 35e32c6 coverage: Match Babel's options.json inheritance for test fixtures (#19002) (Boshen)
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+
+### ⚡ Performance
+
+- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
+
 ## [0.112.0] - 2026-02-02
 
 ### 📚 Documentation

--- a/crates/oxc_transformer_plugins/CHANGELOG.md
+++ b/crates/oxc_transformer_plugins/CHANGELOG.md
@@ -14,6 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - d4a0867 transformer_plugins: Switch ReplaceGlobalDefines from Traverse to VisitMut (#19146) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 48b0542 span: [**BREAKING**] SourceType::ts should set module to unambigious (#18873) (Boshen)
+
+### ⚡ Performance
+
+- d4a0867 transformer_plugins: Switch ReplaceGlobalDefines from Traverse to VisitMut (#19146) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/crates/oxc_traverse/CHANGELOG.md
+++ b/crates/oxc_traverse/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
 
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+
 ## [0.111.0] - 2026-01-26
 
 ### 💥 BREAKING CHANGES

--- a/napi/minify/CHANGELOG.md
+++ b/napi/minify/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ### 🐛 Bug Fixes
 
+- bcd0f64 napi: Disable mimalloc global allocator on android targets (#19214) (Cameron)
+- 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
+
+## [0.113.0] - 2026-02-10
+
+### 💥 BREAKING CHANGES
+
+- 2bf7293 mangler: [**BREAKING**] Enable `top_level` by default for modules and commonjs (#18278) (sapphi-red)
+
+### 🐛 Bug Fixes
+
 - 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
 
 ## [0.111.0] - 2026-01-26

--- a/napi/parser/CHANGELOG.md
+++ b/napi/parser/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ### 🐛 Bug Fixes
 
+- bcd0f64 napi: Disable mimalloc global allocator on android targets (#19214) (Cameron)
+- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
+- 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
+
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
 - 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
 - 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
 

--- a/napi/transform/CHANGELOG.md
+++ b/napi/transform/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ### 🐛 Bug Fixes
 
+- bcd0f64 napi: Disable mimalloc global allocator on android targets (#19214) (Cameron)
+- 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
+
+## [0.113.0] - 2026-02-10
+
+### 🐛 Bug Fixes
+
 - 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
 
 ## [0.112.0] - 2026-02-02


### PR DESCRIPTION
### 💥 BREAKING CHANGES

- 2bf7293 mangler: [**BREAKING**] Enable `top_level` by default for modules and commonjs (#18278) (sapphi-red)
- 48b0542 span: [**BREAKING**] SourceType::ts should set module to unambigious (#18873) (Boshen)

### 🚀 Features

- 500d071 minifier: Local traverse ctx and generated minifier traverse (#19106) (Boshen)
- 142a1be parser: Detect binary files with TS1490 error (#19047) (Boshen)
- e316857 allocator/bitset: Add `Ones` iterator to `BitSet` (#19027) (sapphi-red)
- 742ad3f minifier: Default `invalid_import_side_effects` to `false` (#18916) (sapphi-red)
- 0eff6be parser: Error JSX-like type assertions and generics in `.mts`/`.cts` (#18910) (Boshen)
- 18320c6 span: Store file extension in `SourceType` (#18893) (Boshen)

### 🐛 Bug Fixes

- bcd0f64 napi: Disable mimalloc global allocator on android targets (#19214) (Cameron)
- 0441237 source-type: Don't treat `d.ts` as a declaration file (#19185) (Cameron)
- a7514e4 isolated-declarations: Preserve const context in literal type inference (#19178) (camc314)
- 312e756 isolated-declarations: Preserve readonly literal initializers (#19177) (camc314)
- d0ca8d0 isolated-declarations: Skip parenthesis when inferring type (#19176) (camc314)
- 110c300 oxc_ecmascript: `+[false]` and `+[true]` should evaluate to `NaN` (#19174) (copilot-swe-agent)
- f32ea19 semantic: Report redeclaration error for import bindings conflicting with value declarations (#19068) (Boshen)
- 3aeba7a semantic: Report redeclaration error for `function a() {} var a` in module mode (#19041) (Boshen)
- 35e32c6 coverage: Match Babel's options.json inheritance for test fixtures (#19002) (Boshen)
- 463d60d semantic: Skip TS2391 for standalone computed-name class methods (#19025) (Boshen)
- 56c086b parser: Add modifier ordering validation (TS1029) (#19024) (Boshen)
- 6067a49 linter/jsdoc: False positive in `check-tag-names` for `@` in email addresses and npm scopes (#19021) (Boshen)
- b13bb70 semantic/jsdoc: Inline tags like `{@link}` break jsdoc parsing (#19019) (Boshen)
- e3609e3 regular_expression: Preserve UnicodeEscape CharacterKind in string literals (#18998) (Boshen)
- 57917ee parser: Parse decorators on rest parameters (#18938) (Boshen)
- 487601b napi: Disable mimalloc on Windows to fix worker_threads crash (#18923) (Boshen)
- 1f6b193 parser: Validate TypeScript import type options (#18889) (Boshen)
- 1663184 parser: Allow conditional types in function type parameters (#18886) (Boshen)
- 5758046 parser: Error on property access after instantiation expression (#18887) (Boshen)
- 5eb4a94 parser: Handle `<<` as two `<` tokens in type argument contexts (#18885) (Boshen)

### ⚡ Performance

- ed8c054 oxc_str: Add precomputed hash to Ident for fast HashMap lookups (#19143) (Boshen)
- d4a0867 transformer_plugins: Switch ReplaceGlobalDefines from Traverse to VisitMut (#19146) (Boshen)
- 9eb16b3 syntax: Pack ASCII identifier tables into single bitflag table (#19088) (Boshen)
- e7595d1 mangler: Use BitSet for exported symbols set (#19023) (sapphi-red)
- 2537924 semantic: Optimize scope resolution with fast paths and inlining (#19029) (Boshen)
- 69a8d85 mangler: Use BitSet for keep_names symbols set (#19028) (sapphi-red)
- f78c525 parser: Try hybrid parsing for jsx children and closing element/fragments (#18789) (camchenry)