### PR TITLE
test(linter/plugins): conformance tester support parsers as named exports

### DIFF
--- a/apps/oxlint/conformance/src/groups/e18e.ts
+++ b/apps/oxlint/conformance/src/groups/e18e.ts
@@ -17,18 +17,11 @@ const group: TestGroup = {
   },
 
   prepare(require: NodeJS.Require, mock: MockFn) {
-    // Load the copy of `@typescript-eslint/parser` which is used by the test cases
-    const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
+    // Load the copy of TS-ESLint parser which is used by the test cases
+    const tsEslintParser = require("typescript-eslint").parser as TSEslintParser;
 
     // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester`
     mock("@typescript-eslint/rule-tester", createTsRuleTester(tsEslintParser));
-
-    // Mock `@typescript-eslint/parser` exported by `typescript-eslint`.
-    // This is imported by `no-indexof-equality` test file.
-    mock("@typescript-eslint/parser", tsEslintParser, [
-      "typescript-eslint",
-      "@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw-plugin",
-    ]);
   },
 
   shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
@@ -63,7 +56,7 @@ const group: TestGroup = {
 
   ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
 
-  parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
+  parsers: [{ specifier: "typescript-eslint", propName: "parser", lang: "ts" }],
 };
 
 export default group;


### PR DESCRIPTION
Refactor of conformance tests.

Sometimes a custom parser is a named export of a module, not the default export. Support this case in the conformance runner, and simplify the E18E conformance tests setup by using it.