### PR TITLE
test(linter/plugins): add `eslint-plugin-testing-library` to conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -6,6 +6,7 @@ REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
 STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
 SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
 E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
+TESTING_LIBRARY_SHA="b8ef3772487a32c886cb5c338da2a144560a437b" # 7.15.4
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -167,6 +168,19 @@ cd ..
 
 # Clone E18E ESLint plugin repo into `submodules/e18e`
 clone e18e https://github.com/e18e/eslint-plugin.git "$E18E_SHA"
+
+# Install dependencies
+pnpm install --ignore-workspace
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# Testing Library
+###############################################################################
+
+# Clone `eslint-plugin-testing-library` repo into `submodules/testing_library`
+clone testing_library https://github.com/testing-library/eslint-plugin-testing-library.git "$TESTING_LIBRARY_SHA"
 
 # Install dependencies
 pnpm install --ignore-workspace

--- a/apps/oxlint/conformance/snapshots/testing_library.md
+++ b/apps/oxlint/conformance/snapshots/testing_library.md
@@ -1,0 +1,59 @@
+# Conformance test results - testing_library
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |    29 | 100.0% |
+| Fully passing     |    29 | 100.0% |
+| Partially passing |     0 |   0.0% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests | 17017 | 100.0% |
+| Passing     | 17016 | 100.0% |
+| Failing     |     0 |   0.0% |
+| Skipped     |     1 |   0.0% |
+
+## Fully Passing Rules
+
+- `await-async-events` (784 tests)
+- `await-async-queries` (841 tests)
+- `await-async-utils` (445 tests)
+- `consistent-data-testid` (38 tests)
+- `no-await-sync-events` (970 tests)
+- `no-await-sync-queries` (247 tests)
+- `no-container` (29 tests)
+- `no-debugging-utils` (73 tests) (1 skipped)
+- `no-dom-import` (99 tests)
+- `no-global-regexp-flag-in-query` (26 tests)
+- `no-manual-cleanup` (93 tests)
+- `no-node-access` (757 tests)
+- `no-promise-in-fire-event` (60 tests)
+- `no-render-in-lifecycle` (70 tests)
+- `no-test-id-queries` (62 tests)
+- `no-unnecessary-act` (51 tests)
+- `no-wait-for-multiple-assertions` (34 tests)
+- `no-wait-for-side-effects` (340 tests)
+- `no-wait-for-snapshot` (136 tests)
+- `prefer-explicit-assert` (406 tests)
+- `prefer-find-by` (4065 tests)
+- `prefer-implicit-assert` (378 tests)
+- `prefer-presence-queries` (2914 tests)
+- `prefer-query-by-disappearance` (280 tests)
+- `prefer-query-matchers` (648 tests)
+- `prefer-screen-queries` (1557 tests)
+- `prefer-user-event-setup` (44 tests)
+- `prefer-user-event` (1484 tests)
+- `render-result-naming-convention` (86 tests)
+
+## Rules with Failures
+
+No rules with failures

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -5,5 +5,13 @@ import reactHooks from "./react_hooks.ts";
 import stylistic from "./stylistic.ts";
 import sonarjs from "./sonarjs.ts";
 import e18e from "./e18e.ts";
+import testingLibrary from "./testing_library.ts";
 
-export const TEST_GROUPS: TestGroup[] = [eslint, reactHooks, stylistic, sonarjs, e18e];
+export const TEST_GROUPS: TestGroup[] = [
+  eslint,
+  reactHooks,
+  stylistic,
+  sonarjs,
+  e18e,
+  testingLibrary,
+];

--- a/apps/oxlint/conformance/src/groups/testing_library.ts
+++ b/apps/oxlint/conformance/src/groups/testing_library.ts
@@ -1,0 +1,140 @@
+import { RuleTester } from "../rule_tester.ts";
+
+import type { MockFn, TestGroup } from "../index.ts";
+import type { LanguageOptions, TestCase, TestCases } from "../rule_tester.ts";
+import type { Rule } from "#oxlint/plugins";
+
+type TSEslintParser = typeof import("@typescript-eslint/parser");
+
+const group: TestGroup = {
+  name: "testing_library",
+
+  submoduleName: "testing_library",
+  testFilesDirPath: "tests/rules",
+
+  transformTestFilename(filename: string) {
+    if (!filename.endsWith(".test.ts")) return null;
+    return filename.slice(0, -".test.ts".length);
+  },
+
+  prepare(require: NodeJS.Require, mock: MockFn) {
+    // Load the copy of TS-ESLint parser which is used by the test cases
+    const tsEslintParser = require("typescript-eslint").parser as TSEslintParser;
+
+    // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester` with patches
+    mock("@typescript-eslint/rule-tester", createRuleTesterModule(tsEslintParser));
+  },
+
+  shouldSkipTest(ruleName: string, test: TestCase, code: string, err: Error): boolean {
+    // Test case defines an option as `undefined`. We can't support that as `undefined` is not JSON-serializable.
+    if (
+      ruleName === "no-debugging-utils" &&
+      code.trim().replace(/\n\s+/g, "\n") ===
+        "import { screen } from '@testing-library/dom'\nscreen.logTestingPlaygroundURL()" &&
+      err.message.startsWith("Should have no errors but had 1:")
+    ) {
+      const { options } = test;
+      if (options != null && options.length === 1) {
+        const firstOption = options[0];
+        if (
+          typeof firstOption === "object" &&
+          firstOption !== null &&
+          !Array.isArray(firstOption) &&
+          Object.hasOwn(firstOption, "utilsToCheckFor") &&
+          firstOption.utilsToCheckFor === undefined
+        ) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  },
+
+  ruleTesters: [],
+
+  parsers: [{ specifier: "typescript-eslint", propName: "parser", lang: "ts" }],
+};
+
+export default group;
+
+/**
+ * Create a module to replace `@typescript-eslint/rule-tester`,
+ * which presents the same API, but uses conformance `RuleTester` with TS-ESLint parser.
+ *
+ * @param tsEslintParser - TSESLint parser module
+ * @returns Module to replace `@typescript-eslint/rule-tester` module with
+ */
+function createRuleTesterModule(tsEslintParser: TSEslintParser): { RuleTester: typeof RuleTester } {
+  class PatchedRuleTester extends RuleTester {
+    #languageOptions: LanguageOptions;
+
+    constructor(config?: { languageOptions?: LanguageOptions } | null) {
+      // Set parser as TS-ESLint parser
+      const languageOptions = {
+        parser: tsEslintParser,
+        ...config?.languageOptions,
+      };
+
+      super({ ...config, languageOptions });
+
+      // Store config `languageOptions` for use in `patchTestCase`
+      this.#languageOptions = languageOptions;
+    }
+
+    // Patch test cases
+    run(ruleName: string, rule: Rule, tests: TestCases): void {
+      const languageOptions = this.#languageOptions;
+
+      tests = {
+        valid: tests.valid.map((test) => {
+          if (typeof test === "string") test = { code: test };
+
+          // Some valid test cases have `errors: []` property, which is illegal. Remove it.
+          const { errors, ...rest } = test as typeof test & { errors?: unknown[] };
+          if (Array.isArray(errors)) test = rest;
+
+          // Alter file extension for JSX files
+          return patchTestCase(test, languageOptions);
+        }),
+        invalid: tests.invalid.map((test) => {
+          // TS-ESlint `RuleTester` accepts `output` as an array of strings,
+          // where first string is the output after 1 round of fixes
+          const output = test.output as string | string[] | null | undefined;
+          if (Array.isArray(output) && output.length > 0) test = { ...test, output: output[0] };
+
+          // Alter file extension for JSX files
+          return patchTestCase(test, languageOptions);
+        }),
+      };
+      super.run(ruleName, rule, tests);
+    }
+  }
+
+  return { RuleTester: PatchedRuleTester };
+}
+
+/**
+ * Patch test case to make `filename`'s extension `.tsx` if `languageOptions.parserOptions.ecmaFeatures.jsx` is `true`.
+ * Otherwise, `filename: "whatever.test.js"` takes precedence over `jsx: true`, and fails to parse.
+ * @param test - Test case
+ * @param languageOptions - Language options from config
+ * @returns Patched test case
+ */
+function patchTestCase<T extends TestCase>(test: T, languageOptions: LanguageOptions): T {
+  // If no `filename` specified, no patching is required - `RuleTester` will determine language as TSX
+  const { filename } = test;
+  if (filename == null) return test;
+
+  // Get `jsx` option from config or test case
+  let isJsx = languageOptions.parserOptions?.ecmaFeatures?.jsx ?? false;
+  const testIsJsx = test.languageOptions?.parserOptions?.ecmaFeatures?.jsx;
+  if (testIsJsx != null) isJsx = testIsJsx;
+
+  // Change file extension
+  if (isJsx && filename.endsWith(".js")) {
+    return { ...test, filename: `${filename.slice(0, -2)}tsx` };
+  }
+
+  return test;
+}


### PR DESCRIPTION
Add `eslint-plugin-testing-library` to conformance tests. 100% pass.