### PR TITLE
fix(linter): avoid applying object-level docs to nested object methods in require-param

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -349,6 +349,7 @@ fn test() {
             None,
             None,
         ),
+
 ("
 			          /**
 			           * @param root0
@@ -786,7 +787,21 @@ fn test() {
              * @type {import('node:module').ResolveHook}
              */
             async function resolveJSONC(specifier, ctx, nextResolve) {}
-        ", None, None)
+        ", None, None),
+        (
+            r#"
+			      /**
+			       * A shiki transformer.
+			       */
+			      const shikiTransformer: ShikiTransformer = {
+			        name: "example",
+			        tokens(tokens) {
+			        }
+			      };
+			      "#,
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -1410,6 +1425,21 @@ fn test() {
 			        /** Foo. */
 			        function foo(a, b, c) {}
 			      ",
+            None,
+            None,
+        ),
+        // https://github.com/oxc-project/oxc/issues/19139#issuecomment-3875380106
+        (
+            r#"
+			const shikiTransformer: ShikiTransformer = {
+				name: "example",
+				/**
+				 * A shiki transformer.
+				 */
+			        tokens(tokens) {
+			        }
+			      };
+			      "#,
             None,
             None,
         ),

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_param.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_param.snap
@@ -424,3 +424,12 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Add `@param` tag with name.
+
+  ⚠ eslint-plugin-jsdoc(require-param): Missing JSDoc `@param` declaration for function parameters.
+   ╭─[require_param.tsx:7:19]
+ 6 │                  */
+ 7 │                     tokens(tokens) {
+   ·                            ──────
+ 8 │                     }
+   ╰────
+  help: Add `@param` tag with name.

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -74,6 +74,9 @@ pub fn get_function_nearest_jsdoc_node<'a, 'b>(
             {
                 return None;
             }
+            // Do not apply object-level docs to functions nested in object literals.
+            // e.g. `const x = /** ... */ { method(arg) {} }`
+            AstKind::ObjectExpression(_) |
             AstKind::Program(_) => return None,
             AstKind::VariableDeclaration(_)
             | AstKind::MethodDefinition(_)


### PR DESCRIPTION
fixes #19139