### PR TITLE
refactor(oxc_str): share JS global Ident constants from oxc_str::ident

### DIFF
--- a/crates/oxc_allocator/src/ident_hasher.rs
+++ b/crates/oxc_allocator/src/ident_hasher.rs
@@ -98,12 +98,10 @@ const fn hashbrown_state(len: u32, hash: u32) -> u64 {
 }
 
 /// Unpack `len` (low 32 bits) and `hash` (high 32 bits) from packed `u64`.
+#[expect(clippy::cast_possible_truncation)]
 #[inline]
 const fn unpack_len_hash(packed: u64) -> (u32, u32) {
-    let bytes = packed.to_le_bytes();
-    let len = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-    let hash = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-    (len, hash)
+    (packed as u32, (packed >> 32) as u32)
 }
 
 /// A [`BuildHasher`] for `Ident`-keyed hash maps.

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
 };
 use oxc_ecmascript::{ToBoolean, WithoutGlobalReferenceInformation};
 use oxc_semantic::{AstNode, AstNodes, IsGlobalReference, NodeId, ReferenceId, Semantic, SymbolId};
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::REQUIRE};
 use oxc_syntax::{
     identifier::is_irregular_whitespace,
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -405,7 +405,7 @@ pub fn is_global_require_call(call_expr: &CallExpression, ctx: &Semantic) -> boo
     if call_expr.arguments.len() != 1 {
         return false;
     }
-    call_expr.callee.is_global_reference_name(Ident::new_const("require"), ctx.scoping())
+    call_expr.callee.is_global_reference_name(REQUIRE, ctx.scoping())
 }
 
 pub fn is_function_node(node: &AstNode) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::ARRAY};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -79,7 +79,7 @@ impl Rule for NoArrayConstructor {
         let last_arg_is_spread = arguments.last().is_some_and(Argument::is_spread);
         let arg_len = arguments.len();
 
-        if ident.is_global_reference_name(Ident::new_const("Array"), ctx.scoping())
+        if ident.is_global_reference_name(ARRAY, ctx.scoping())
             && (arg_len != 1 || last_arg_is_spread)
             && type_parameters.is_none()
             && !optional

--- a/crates/oxc_linter/src/rules/eslint/no_new_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_func.rs
@@ -2,7 +2,7 @@ use oxc_ast::{AstKind, ast::IdentifierReference};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::FUNCTION};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -118,7 +118,7 @@ impl Rule for NoNewFunc {
 }
 
 fn check(ident: &IdentifierReference, arguments_span: Option<Span>, ctx: &LintContext) {
-    if ident.is_global_reference_name(Ident::new_const("Function"), ctx.scoping()) {
+    if ident.is_global_reference_name(FUNCTION, ctx.scoping()) {
         ctx.diagnostic(no_new_func(ident.span, arguments_span));
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::OBJECT};
 
 use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
 
@@ -75,8 +75,7 @@ impl Rule for PreferObjectHasOwn {
 
         let object_property_name = object.static_property_name();
         let is_object = has_left_hand_object(object);
-        let is_global_scope =
-            ctx.scoping().find_binding(node.scope_id(), Ident::new_const("Object")).is_none();
+        let is_global_scope = ctx.scoping().find_binding(node.scope_id(), OBJECT).is_none();
 
         if is_method_call(call_expr, None, Some(&["call"]), Some(2), Some(2))
             && object_property_name == Some("hasOwnProperty")

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -2,7 +2,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::ARGUMENTS};
 
 fn prefer_rest_params_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use the rest parameters instead of `arguments`.").with_label(span)
@@ -73,8 +73,7 @@ impl Rule for PreferRestParams {
             {
                 return;
             }
-            let binding =
-                ctx.scoping().find_binding(node.scope_id(), Ident::new_const("arguments"));
+            let binding = ctx.scoping().find_binding(node.scope_id(), ARGUMENTS);
             if binding.is_none() {
                 ctx.diagnostic(prefer_rest_params_diagnostic(node.span()));
             }

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -7,7 +7,10 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{IsGlobalReference, ScopeFlags};
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{
+    GetSpan, Span,
+    ident::{AGGREGATE_ERROR, ERROR, TYPE_ERROR},
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -198,13 +201,13 @@ fn is_builtin_error_constructor(expr: &Expression, ctx: &LintContext) -> bool {
         return false;
     };
 
-    ident.is_global_reference_name(Ident::new_const("Error"), ctx.scoping())
-        || ident.is_global_reference_name(Ident::new_const("TypeError"), ctx.scoping())
+    ident.is_global_reference_name(ERROR, ctx.scoping())
+        || ident.is_global_reference_name(TYPE_ERROR, ctx.scoping())
         || is_aggregate_error(ident, ctx)
 }
 
 fn is_aggregate_error(ident: &IdentifierReference, ctx: &LintContext) -> bool {
-    ident.is_global_reference_name(Ident::new_const("AggregateError"), ctx.scoping())
+    ident.is_global_reference_name(AGGREGATE_ERROR, ctx.scoping())
 }
 
 fn has_cause_property(

--- a/crates/oxc_linter/src/rules/import/no_commonjs.rs
+++ b/crates/oxc_linter/src/rules/import/no_commonjs.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Span, ident::REQUIRE};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -233,11 +233,7 @@ impl Rule for NoCommonjs {
                     return;
                 }
 
-                if ctx
-                    .scoping()
-                    .find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require"))
-                    .is_some()
-                {
+                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), REQUIRE).is_some() {
                     return;
                 }
 

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -5,7 +5,10 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{GetSpan, Ident, Span};
+use oxc_span::{
+    GetSpan, Span,
+    ident::{EXPORTS, MODULE},
+};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -19,7 +22,7 @@ fn is_exports(node: &AssignmentTarget, ctx: &LintContext) -> bool {
     let AssignmentTarget::AssignmentTargetIdentifier(id) = node else {
         return false;
     };
-    id.is_global_reference_name(Ident::new_const("exports"), ctx.scoping())
+    id.is_global_reference_name(EXPORTS, ctx.scoping())
 }
 
 fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool {
@@ -32,7 +35,7 @@ fn is_module_exports(expr: Option<&MemberExpression>, ctx: &LintContext) -> bool
     };
 
     mem_expr.static_property_name() == Some("exports")
-        && obj_id.is_global_reference_name(Ident::new_const("module"), ctx.scoping())
+        && obj_id.is_global_reference_name(MODULE, ctx.scoping())
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/node/no_process_env.rs
+++ b/crates/oxc_linter/src/rules/node/no_process_env.rs
@@ -2,7 +2,7 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, GetSpan, Ident, Span};
+use oxc_span::{CompactStr, GetSpan, Span, ident::PROCESS};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ fn is_process_global_object(object_expr: &oxc_ast::ast::Expression, ctx: &LintCo
     let Some(obj_id) = object_expr.get_identifier_reference() else {
         return false;
     };
-    obj_id.is_global_reference_name(Ident::new_const("process"), ctx.scoping())
+    obj_id.is_global_reference_name(PROCESS, ctx.scoping())
 }
 
 impl Rule for NoProcessEnv {

--- a/crates/oxc_linter/src/rules/oxc/approx_constant.rs
+++ b/crates/oxc_linter/src/rules/oxc/approx_constant.rs
@@ -5,7 +5,7 @@ use std::f64::consts as f64;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Ident, Span};
+use oxc_span::{Span, ident::MATH};
 
 use crate::{AstNode, context::LintContext, fixer::RuleFixer, rule::Rule};
 
@@ -60,11 +60,7 @@ impl Rule for ApproxConstant {
                 ctx.diagnostic_with_suggestion(
                     approx_constant_diagnostic(number_literal.span, name),
                     |fixer| {
-                        if ctx
-                            .scoping()
-                            .find_binding(node.scope_id(), Ident::new_const("Math"))
-                            .is_some()
-                        {
+                        if ctx.scoping().find_binding(node.scope_id(), MATH).is_some() {
                             fixer.noop()
                         } else {
                             Self::fix_with_math_constant(fixer, number_literal.span, name)

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -9,6 +9,8 @@ use crate::{
     rule::Rule,
 };
 
+const REACT: Ident<'static> = Ident::new_const("React");
+
 fn react_in_jsx_scope_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`React` must be in scope when using JSX.")
         .with_help("When using JSX, `<a />` expands to `React.createElement(\"a\")`. Therefore the `React` variable must be in scope.")
@@ -64,7 +66,7 @@ impl Rule for ReactInJsxScope {
             _ => return,
         };
         let scope = ctx.scoping();
-        let react_name = Ident::new_const("React");
+        let react_name = REACT;
         if scope.get_binding(scope.root_scope_id(), react_name).is_some() {
             return;
         }

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{CompactStr, Ident, Span};
+use oxc_span::{CompactStr, Span, ident::REQUIRE};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -133,7 +133,7 @@ impl Rule for NoRequireImports {
             AstKind::CallExpression(call_expr) => {
                 if node.scope_id() != ctx.scoping().root_scope_id()
                     && let Some(id) = call_expr.callee.get_identifier_reference()
-                    && !id.is_global_reference_name(Ident::new_const("require"), ctx.scoping())
+                    && !id.is_global_reference_name(REQUIRE, ctx.scoping())
                 {
                     return;
                 }
@@ -170,11 +170,7 @@ impl Rule for NoRequireImports {
                     }
                 }
 
-                if ctx
-                    .scoping()
-                    .find_binding(ctx.scoping().root_scope_id(), Ident::new_const("require"))
-                    .is_some()
-                {
+                if ctx.scoping().find_binding(ctx.scoping().root_scope_id(), REQUIRE).is_some() {
                     return;
                 }
 

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -5,7 +5,10 @@ use oxc_ast::{
 };
 use oxc_regular_expression::{ConstructorParser, Options, ast::Pattern};
 use oxc_semantic::IsGlobalReference;
-use oxc_span::{Ident, Span};
+use oxc_span::{
+    Span,
+    ident::{GLOBAL_THIS, REG_EXP},
+};
 
 use crate::{AstNode, context::LintContext};
 
@@ -94,13 +97,13 @@ where
 
 // Accepts both RegExp and globalThis.RegExp
 fn is_regexp_callee<'a>(callee: &'a Expression<'a>, ctx: &'a LintContext<'_>) -> bool {
-    if callee.is_global_reference_name(Ident::new_const("RegExp"), ctx.semantic().scoping()) {
+    if callee.is_global_reference_name(REG_EXP, ctx.semantic().scoping()) {
         return true;
     }
     // Check for globalThis.RegExp (StaticMemberExpression)
     if let Expression::StaticMemberExpression(member) = callee
         && let Expression::Identifier(obj) = &member.object
-        && obj.is_global_reference_name(Ident::new_const("globalThis"), ctx.semantic().scoping())
+        && obj.is_global_reference_name(GLOBAL_THIS, ctx.semantic().scoping())
         && member.property.name == "RegExp"
     {
         return true;

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -724,13 +724,15 @@ impl Scoping {
     ///
     /// Bindings are resolved by walking up the scope tree until a binding is
     /// found. If no binding is found, [`None`] is returned.
-    pub fn find_binding(&self, scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
-        for scope_id in self.scope_ancestors(scope_id) {
-            if let Some(symbol_id) = self.get_binding(scope_id, name) {
-                return Some(symbol_id);
+    pub fn find_binding(&self, mut scope_id: ScopeId, name: Ident<'_>) -> Option<SymbolId> {
+        let cell = self.cell.borrow_dependent();
+        loop {
+            if let Some(symbol_id) = cell.bindings[scope_id].get(&name) {
+                return Some(*symbol_id);
             }
+            let parent_scope_id = self.scope_parent_ids[scope_id]?;
+            scope_id = parent_scope_id;
         }
-        None
     }
 
     /// Get all bound identifiers in a scope.

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -9,6 +9,7 @@ mod source_type;
 mod span;
 
 pub use cmp::ContentEq;
+pub use oxc_str::ident;
 pub use oxc_str::{
     ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet,
     MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -449,6 +449,35 @@ pub type ArenaIdentHashMap<'alloc, V> =
 /// Hash set of [`Ident`], using precomputed ident hash.
 pub type IdentHashSet<'a> = hashbrown::HashSet<Ident<'a>, IdentBuildHasher>;
 
+#[expect(missing_docs)]
+pub const AGGREGATE_ERROR: Ident<'static> = Ident::new_const("AggregateError");
+#[expect(missing_docs)]
+pub const ARGUMENTS: Ident<'static> = Ident::new_const("arguments");
+#[expect(missing_docs)]
+pub const ARRAY: Ident<'static> = Ident::new_const("Array");
+#[expect(missing_docs)]
+pub const ERROR: Ident<'static> = Ident::new_const("Error");
+#[expect(missing_docs)]
+pub const EXPORTS: Ident<'static> = Ident::new_const("exports");
+#[expect(missing_docs)]
+pub const FUNCTION: Ident<'static> = Ident::new_const("Function");
+#[expect(missing_docs)]
+pub const GLOBAL_THIS: Ident<'static> = Ident::new_const("globalThis");
+#[expect(missing_docs)]
+pub const MATH: Ident<'static> = Ident::new_const("Math");
+#[expect(missing_docs)]
+pub const MODULE: Ident<'static> = Ident::new_const("module");
+#[expect(missing_docs)]
+pub const OBJECT: Ident<'static> = Ident::new_const("Object");
+#[expect(missing_docs)]
+pub const PROCESS: Ident<'static> = Ident::new_const("process");
+#[expect(missing_docs)]
+pub const REG_EXP: Ident<'static> = Ident::new_const("RegExp");
+#[expect(missing_docs)]
+pub const REQUIRE: Ident<'static> = Ident::new_const("require");
+#[expect(missing_docs)]
+pub const TYPE_ERROR: Ident<'static> = Ident::new_const("TypeError");
+
 /// Creates an [`Ident`] using interpolation of runtime expressions.
 ///
 /// Identical to [`std`'s `format!` macro](std::format), except:

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -6,7 +6,7 @@
 
 mod atom;
 mod compact_str;
-mod ident;
+pub mod ident;
 
 pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};


### PR DESCRIPTION
## Summary
- expose `oxc_str::ident` publicly and re-export it via `oxc_span::ident`
- move reusable JS-global `Ident::new_const` values into shared constants (without `IDENT_` prefix)
- replace repeated inline `Ident::new_const("...")` usage in linter rules/utilities with shared constants
- keep non-reused/special constants local (e.g. Vite SSR keys, React)
- remove doc comments on const idents in `ident.rs` as requested

## Why
- avoids repeated const construction sites and centralizes canonical JS-global idents
- reduces duplication and simplifies follow-up reuse across crates

## Validation
- `cargo fmt --all`
- `cargo test -p oxc_str --lib --tests`
- `cargo test -p oxc_span --lib --tests`
- `cargo test -p oxc_linter --lib --tests`
- `cargo test -p oxc_transformer_plugins --lib --tests`

## AI usage disclosure
This PR was prepared with assistance from an AI coding agent (Codex). I reviewed the generated changes and test runs, and I take responsibility for the final content.
