### PR TITLE
build(oxlint): fix publish workflows to publish `@oxlint/plugins` package

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -272,6 +272,7 @@ jobs:
       id-token: write # for `pnpm publish --provenance`
     env:
       package_path: npm/oxlint
+      plugins_package_path: npm/oxlint-plugins
       npm_dir: npm/oxlint-release
       PUBLISH_FLAGS: "--provenance --access public --no-git-checks"
     steps:
@@ -299,7 +300,7 @@ jobs:
 
       - name: Copy dist files to @oxlint/plugins npm package
         run: |
-          cp apps/oxlint/dist-pkg-plugins/* npm/oxlint-plugins/
+          cp apps/oxlint/dist-pkg-plugins/* ${plugins_package_path}/
 
       - run: npm install -g npm@latest # For trusted publishing support
 
@@ -311,7 +312,10 @@ jobs:
           # Trusted publishing is configured, publish token is not required.
           # Publish sub-packages and adds `optionalDependencies` to main package.
           pnpm napi pre-publish --no-gh-release -t npm --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
+          # Publish `oxlint` package
           pnpm publish ${package_path}/ ${PUBLISH_FLAGS}
+          # Publish `@oxlint/plugins` package
+          pnpm publish ${plugins_package_path}/ ${PUBLISH_FLAGS}
 
   build-oxfmt:
     needs: check

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -305,7 +305,9 @@ jobs:
       - run: npm install -g npm@latest # For trusted publishing support
 
       - name: Check Publish
-        run: node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"
+        run: |
+          node .github/scripts/check-npm-packages.js "${npm_dir}/*" "${package_path}"
+          node .github/scripts/check-npm-packages.js "${plugins_package_path}"
 
       - name: Trusted Publish
         run: |

--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -21,6 +21,7 @@ versioned_files = [
   "apps/oxlint/package.json",
   "crates/oxc_linter/Cargo.toml",
   "npm/oxlint/package.json",
+  "npm/oxlint-plugins/package.json",
 ]
 
 [[releases]]


### PR DESCRIPTION
#18824 added a `@oxlint/plugins` NPM package, and #18903 altered the release workflow. It seems neither worked correctly - the package hasn't been getting published during the release process.

It's still on version 1.43.0 on NPM: https://www.npmjs.com/package/@oxlint/plugins

This PR alters the pre-release and release workflows to (hopefully) bump version of this package and release it alongside `oxlint` package.

There have been no changes to content of `@oxlint/plugins` package since the last published version, and it has no dependencies, so it doesn't really matter that we've skipped these releases. But this PR should get it publishing correctly from next release onwards.