### PR TITLE
docs(linter): Mark `eslint/dot-notation` and `eslint/consistent-return` as unsupported, we will implement them via tsgolint.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -17,6 +17,8 @@
     "n/no-hide-core-modules": "This rule is deprecated in eslint-plugin-n for being inherently incorrect, no need for us to implement it.",
     "unicorn/no-array-push-push": "Replaced by `unicorn/prefer-single-call`.",
     "import/imports-first": "Replaced by `import/first`, which we support.",
+    "eslint/dot-notation": "Use `typescript/dot-notation` instead, which we support as a type-aware rule.",
+    "eslint/consistent-return": "Use `typescript/consistent-return` instead, which we support as a type-aware rule.",
     "react/jsx-sort-default-props": "Replaced by `react/sort-default-props`.",
     "vitest/no-done-callback": "[Deprecated in eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest/issues/158).",
     "eslint/no-return-await": "Deprecated, not recommended anymore by ESLint.",


### PR DESCRIPTION
Simple enough, see https://github.com/oxc-project/tsgolint/pull/658