### PR TITLE
refactor(transformer): use IdentHashMap for class private props

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -1,7 +1,6 @@
 //! ES2022: Class Properties
 //! Transform of class itself.
 
-use indexmap::map::Entry;
 use oxc_allocator::{Address, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{Ident, SPAN};
@@ -20,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    ClassBindings, ClassDetails, ClassProperties, FxIndexMap, PrivateProp,
+    ClassBindings, ClassDetails, ClassProperties, IdentIndexMap, PrivateProp,
     constructor::InstanceInitsInsertLocation,
     utils::{create_variable_declaration, exprs_into_stmts},
 };
@@ -79,8 +78,8 @@ impl<'a> ClassProperties<'a> {
         let mut has_static_prop = false;
         let mut has_instance_private_method = false;
         let mut has_static_private_method_or_static_block = false;
-        // TODO: Store `FxIndexMap`s in a pool and re-use them
-        let mut private_props = FxIndexMap::default();
+        // TODO: Store `IdentIndexMap`s in a pool and re-use them
+        let mut private_props: IdentIndexMap<'a, PrivateProp<'a>> = IdentIndexMap::default();
         for element in &mut body.body {
             match element {
                 ClassElement::PropertyDefinition(prop) => {
@@ -97,7 +96,7 @@ impl<'a> ClassProperties<'a> {
                         // Note: Current scope is outside class.
                         let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
                         private_props.insert(
-                            ident.name.into(),
+                            ident.name,
                             PrivateProp::new(binding, prop.r#static, None, false),
                         );
                     }
@@ -134,20 +133,20 @@ impl<'a> ClassProperties<'a> {
                             SymbolFlags::Function,
                         );
 
-                        match private_props.entry(ident.name.into()) {
-                            Entry::Occupied(mut entry) => {
-                                // If there's already a binding for this private property,
-                                // it's a setter or getter, so store the binding in `binding2`.
-                                entry.get_mut().set_binding2(binding);
-                            }
-                            Entry::Vacant(entry) => {
-                                entry.insert(PrivateProp::new(
+                        if let Some(prop) = private_props.get_mut(&ident.name) {
+                            // If there's already a binding for this private property,
+                            // it's a setter or getter, so store the binding in `binding2`.
+                            prop.set_binding2(binding);
+                        } else {
+                            private_props.insert(
+                                ident.name,
+                                PrivateProp::new(
                                     binding,
                                     method.r#static,
                                     Some(method.kind),
                                     false,
-                                ));
-                            }
+                                ),
+                            );
                         }
                     }
                 }
@@ -157,7 +156,7 @@ impl<'a> ClassProperties<'a> {
                     if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
                         let dummy_binding = BoundIdentifier::new(Ident::empty(), SymbolId::new(0));
                         private_props.insert(
-                            ident.name.into(),
+                            ident.name,
                             PrivateProp::new(dummy_binding, prop.r#static, None, true),
                         );
                     }
@@ -851,7 +850,7 @@ impl<'a> ClassProperties<'a> {
     }
 
     /// `_classPrivateFieldLooseKey("prop")`
-    fn create_private_prop_key_loose(name: Atom<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
+    fn create_private_prop_key_loose(name: Ident<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldLooseKey,
             SPAN,

--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -1,9 +1,8 @@
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::NonEmptyStack;
-use oxc_span::Atom;
 use oxc_traverse::BoundIdentifier;
 
-use super::{ClassBindings, ClassProperties, FxIndexMap};
+use super::{ClassBindings, ClassProperties, IdentIndexMap};
 
 /// Details of a class.
 ///
@@ -17,7 +16,7 @@ pub(super) struct ClassDetails<'a> {
     /// Mapping private prop name to binding for temp var.
     /// This is then used as lookup when transforming e.g. `this.#x`.
     /// `None` if class has no private properties.
-    pub private_props: Option<FxIndexMap<Atom<'a>, PrivateProp<'a>>>,
+    pub private_props: Option<IdentIndexMap<'a, PrivateProp<'a>>>,
     /// Bindings for class name and temp var for class
     pub bindings: ClassBindings<'a>,
 }
@@ -130,7 +129,7 @@ impl<'a> ClassesStack<'a> {
         // TODO: Check there are tests for bindings in enclosing classes.
         for class in self.stack[1..].iter_mut().rev() {
             if let Some(private_props) = &mut class.private_props
-                && let Some(prop) = private_props.get(&Atom::from(ident.name))
+                && let Some(prop) = private_props.get(&ident.name)
             {
                 return ret_fn(prop, &mut class.bindings, class.is_declaration);
             }

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -198,9 +198,10 @@
 //! * Class properties TC39 proposal: <https://github.com/tc39/proposal-class-fields>
 
 use indexmap::IndexMap;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
+use oxc_allocator::IdentBuildHasher;
 use oxc_ast::ast::*;
 use oxc_span::Ident;
 use oxc_syntax::symbol::SymbolId;
@@ -223,7 +224,7 @@ mod utils;
 use class_bindings::ClassBindings;
 use class_details::{ClassDetails, ClassesStack, PrivateProp, ResolvedPrivateProp};
 
-type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
+type IdentIndexMap<'a, V> = IndexMap<Ident<'a>, V, IdentBuildHasher>;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase")]

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -80,7 +80,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let private_props = self.current_class().private_props.as_ref().unwrap();
-        let prop = &private_props[&Atom::from(ident.name)];
+        let prop = &private_props[&ident.name];
         let arguments = ctx.ast.vec_from_array([
             Argument::from(ctx.ast.expression_this(SPAN)),
             Argument::from(prop.binding.create_read_expression(ctx)),
@@ -213,7 +213,7 @@ impl<'a> ClassProperties<'a> {
         // Insert after class
         let class_details = self.current_class();
         let private_props = class_details.private_props.as_ref().unwrap();
-        let prop_binding = &private_props[&Atom::from(ident.name)].binding;
+        let prop_binding = &private_props[&ident.name].binding;
 
         if class_details.is_declaration {
             // `var _prop = {_: value};`
@@ -377,7 +377,7 @@ impl<'a> ClassProperties<'a> {
         );
 
         let private_props = self.current_class().private_props.as_ref().unwrap();
-        let prop_binding = &private_props[&Atom::from(ident.name)].binding;
+        let prop_binding = &private_props[&ident.name].binding;
         let arguments = ctx.ast.vec_from_array([
             Argument::from(assignee),
             Argument::from(prop_binding.create_read_expression(ctx)),


### PR DESCRIPTION
## Summary
- switch `ClassDetails::private_props` from `FxIndexMap<Atom<'a>, PrivateProp<'a>>` to `IndexMap<Ident<'a>, PrivateProp<'a>, IdentBuildHasher>`
- add `IdentIndexMap<'a, V>` alias in class-properties module for readability
- update class-properties construction and lookups to use `Ident` keys directly (`ident.name`) rather than `Atom::from(ident.name)` conversions
- remove now-unused `FxIndexMap` alias plumbing in class-properties module
- keep loose-key generation on `Ident` (`create_private_prop_key_loose(name: Ident<'a>, ...)`)

## Why
- preserves insertion order behavior of previous `IndexMap`-based flow
- keeps private-property bookkeeping in the `Ident` domain where keys already carry precomputed ident hash
- removes unnecessary key conversions in lookup/insert paths

## Testing
- `cargo test -p oxc_transformer --lib`

## AI Disclosure
- This PR was prepared with AI assistance and reviewed before submission.