### PR TITLE
fix(linter): accept digits after 'use' in hook names

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -568,6 +568,22 @@ fn test() {
               useHook();
             }
         ",
+        // Valid because 'use' followed by a digit is a valid hook name (/^use[A-Z0-9]/).
+        "
+            function use2FAMutation() {
+              return useState(null);
+            }
+        ",
+        "
+            function Component() {
+              use2FAMutation();
+            }
+        ",
+        "
+            function use3DEngine() {
+              useEffect(() => {}, []);
+            }
+        ",
         // Valid because hooks can use hooks.
         "
             function createHook() {

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -58,6 +58,14 @@ source: crates/oxc_linter/src/tester.rs
  3 │             Hook._useState();
    ╰────
 
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use42" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+   ╭─[rules_of_hooks.tsx:4:13]
+ 3 │             Hook._useState();
+ 4 │             Hook.use42();
+   ·             ────────────
+ 5 │             Hook.useHook();
+   ╰────
+
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
    ╭─[rules_of_hooks.tsx:5:13]
  4 │             Hook.use42();
@@ -702,6 +710,14 @@ source: crates/oxc_linter/src/tester.rs
  4 │             Hook.useState();
    ·             ───────────────
  5 │             Hook._useState();
+   ╰────
+
+  ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "use42" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.
+   ╭─[rules_of_hooks.tsx:6:13]
+ 5 │             Hook._useState();
+ 6 │             Hook.use42();
+   ·             ────────────
+ 7 │             Hook.useHook();
    ╰────
 
   ⚠ eslint-plugin-react-hooks(rules-of-hooks): React Hook "useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -484,18 +484,17 @@ pub fn parse_jsx_value(value: &JSXAttributeValue) -> Result<f64, ()> {
 ///
 /// Identifies `use(...)` as a valid hook.
 ///
-/// Hook names must start with use followed by a capital letter,
-/// like useState (built-in) or useOnlineStatus (custom).
+/// Hook names must start with use followed by a capital letter or digit,
+/// like useState (built-in), useOnlineStatus (custom), or use2FAMutation.
+/// Matches ESLint's `/^use[A-Z0-9]/`.
 pub fn is_react_hook_name(name: &str) -> bool {
-    name.starts_with("use") && name.chars().nth(3).is_none_or(char::is_uppercase)
+    name.starts_with("use")
+        && name.chars().nth(3).is_none_or(|c| c.is_uppercase() || c.is_ascii_digit())
 }
 
 /// Checks whether the `name` follows the official conventions of React Hooks.
 ///
 /// Identifies `use(...)` as a valid hook.
-///
-/// Hook names must start with use followed by a capital letter,
-/// like useState (built-in) or useOnlineStatus (custom).
 pub fn is_react_hook(expr: &Expression) -> bool {
     match expr {
         Expression::StaticMemberExpression(static_expr) => {
@@ -780,6 +779,8 @@ mod test {
         assert!(is_react_hook_name("useFooBar"));
         assert!(is_react_hook_name("useEffect"));
         assert!(is_react_hook_name("use"));
+        assert!(is_react_hook_name("use2FAMutation"));
+        assert!(is_react_hook_name("use3DEngine"));
         // Bad names:
         assert!(!is_react_hook_name("userError"));
         assert!(!is_react_hook_name("notAHook"));


### PR DESCRIPTION
Fix a `rules-of-hooks` divergence from ESLint's `eslint-plugin-react-hooks`: hook name validation rejects digits after `use` (e.g. `use2FAMutation`).

---

### Details

ESLint's [`isHookName`](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts#L31-L33) uses the regex `/^use[A-Z0-9]/`:

```ts
function isHookName(s: string): boolean {
  return s === 'use' || /^use[A-Z0-9]/.test(s);
}
```

Oxlint's [`is_react_hook_name`](https://github.com/oxc-project/oxc/blob/1b2f354/crates/oxc_linter/src/utils/react.rs#L489-L491) only checked `char::is_uppercase`, which doesn't include digits:

```rust
name.starts_with("use") && name.chars().nth(3).is_none_or(char::is_uppercase)
```

This means `use2FAMutation`, `use3DEngine` etc. were not recognized as valid custom hooks — causing false positives when called inside components and false negatives when called at the top level.

The fix adds `|| c.is_ascii_digit()` to match ESLint's behavior:

```rust
name.starts_with("use")
    && name.chars().nth(3).is_none_or(|c| c.is_uppercase() || c.is_ascii_digit())
```

The snapshot update confirms this is correct: `Hook.use42()` called at the top level now produces a diagnostic. The existing test comments already expected this (`topLevelError('Hook.use42')`).

Also see: https://github.com/oxc-project/oxc/pull/19220