### PR TITLE
fix(linter): detect fallthrough from `default` when it is not the last case

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_fallthrough.snap
@@ -177,6 +177,24 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
+   ╭─[no_fallthrough.tsx:1:29]
+ 1 │ switch(foo) { default: a(); case 1: b(); }
+   ·                             ────────────
+   ╰────
+
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `default`.
+   ╭─[no_fallthrough.tsx:1:28]
+ 1 │ switch(foo) { case 0: a(); default: b(); case 1: c(); }
+   ·                            ─────────────
+   ╰────
+
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
+   ╭─[no_fallthrough.tsx:1:42]
+ 1 │ switch(foo) { case 0: a(); default: b(); case 1: c(); }
+   ·                                          ────────────
+   ╰────
+
+  ⚠ eslint(no-fallthrough): Expected a `break` statement before `case`.
    ╭─[no_fallthrough.tsx:1:46]
  1 │ switch(true) { case x === 1 || x === 2: a(); case x === 3: b(); }
    ·                                              ──────────────────


### PR DESCRIPTION
## Summary

- Fix `no-fallthrough` rule not detecting fallthrough FROM `default` when it is not the last case in a switch statement
- The BFS visitor unconditionally stopped at the default case's condition block, preventing exploration of default's body to find fallthrough edges to subsequent cases
- Now the visitor continues past default (while still stopping at the switch exit block when no default exists)

Closes #11340

🤖 Generated with [Claude Code](https://claude.com/claude-code)