### PR TITLE
fix(linter/import-no-cycle): avoid traversal-order false negatives with type-only edges

### DIFF
--- a/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/aaaInternal.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/aaaInternal.ts
@@ -1,0 +1,3 @@
+import { simpleInterestLoanManager } from './simpleInterestLoanManager';
+
+export const aaaInternal = { call: () => simpleInterestLoanManager.call() };

--- a/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/balanceSweepDetailsManager.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/balanceSweepDetailsManager.ts
@@ -1,0 +1,8 @@
+import { installmentLoanManager } from './installmentLoanManager';
+import { aaaInternal } from './aaaInternal';
+
+export const balanceSweepDetailsManager = {
+  call(): string {
+    return installmentLoanManager.call() + aaaInternal.call();
+  },
+};

--- a/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/dataReport/avenAccountDataReportManager.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/dataReport/avenAccountDataReportManager.ts
@@ -1,0 +1,3 @@
+import { balanceSweepDetailsManager } from '../balanceSweepDetailsManager';
+
+export const getAvenAccountData = (): string => String(Boolean(balanceSweepDetailsManager));

--- a/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/installmentLoanManager.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/installmentLoanManager.ts
@@ -1,0 +1,5 @@
+import { getAvenAccountData } from './dataReport/avenAccountDataReportManager';
+
+export type InstallType = { x: number };
+
+export const installmentLoanManager = { call: () => getAvenAccountData() };

--- a/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/simpleInterestLoanManager.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/issue_19245/simpleInterestLoanManager.ts
@@ -1,0 +1,5 @@
+import type { InstallType } from './installmentLoanManager';
+
+export const simpleInterestLoanManager = {
+  call: (): string => String(Boolean(null as InstallType | null)),
+};

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -212,15 +212,14 @@ impl ModuleGraphVisitor {
 
             let loaded_module_record = weak_module_record.upgrade().unwrap();
 
-            let path = &loaded_module_record.resolved_absolute_path;
-
-            if !self.traversed.insert(path.clone()) {
-                continue;
-            }
-
             let pair = (&key, &loaded_module_record);
 
             if !filter(pair, module_record) {
+                continue;
+            }
+
+            let path = &loaded_module_record.resolved_absolute_path;
+            if !self.traversed.insert(path.clone()) {
                 continue;
             }
 

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -433,3 +433,26 @@ fn test() {
         .with_import_plugin(true)
         .test_and_snapshot();
 }
+
+#[test]
+fn test_issue_19245_type_only_branch_does_not_hide_cycle() {
+    use crate::tester::Tester;
+
+    let pass: Vec<&str> = vec![];
+    let fail = vec![
+        r"import { installmentLoanManager } from './installmentLoanManager';
+import { aaaInternal } from './aaaInternal';
+
+export const balanceSweepDetailsManager = {
+  call(): string {
+    return installmentLoanManager.call() + aaaInternal.call();
+  },
+};",
+    ];
+
+    Tester::new(NoCycle::NAME, NoCycle::PLUGIN, pass, fail)
+        .change_rule_path("cycles/typescript/issue_19245/balanceSweepDetailsManager.ts")
+        .with_import_plugin(true)
+        .with_snapshot_suffix("issue_19245")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/import_no_cycle@issue_19245.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_cycle@issue_19245.snap
@@ -1,0 +1,18 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
+   ╭─[cycles/typescript/issue_19245/balanceSweepDetailsManager.ts:1:40]
+ 1 │ import { installmentLoanManager } from './installmentLoanManager';
+   ·                                        ──────────────────────────
+ 2 │ import { aaaInternal } from './aaaInternal';
+   ╰────
+  help: Refactor to remove the cycle. Consider extracting shared code into a separate module that both files can import.
+  note: These paths form a cycle:
+           ╭──▶ ./installmentLoanManager (fixtures/import/cycles/typescript/issue_19245/installmentLoanManager.ts)
+           │         ⬇ imports
+           │    ./dataReport/avenAccountDataReportManager (fixtures/import/cycles/typescript/issue_19245/dataReport/avenAccountDataReportManager.ts)
+           │         ⬇ imports
+           │    ../balanceSweepDetailsManager (fixtures/import/cycles/typescript/issue_19245/balanceSweepDetailsManager.ts)
+           ╰─────────╯ imports the current file


### PR DESCRIPTION
Root cause:
`ModuleGraphVisitor` marked a module as `traversed` before applying the rule
filter. For `no-cycle` with `ignoreTypes: true`, a type-only edge could claim
a node first, then a later value edge to the same node was skipped. Because
sibling import iteration order is filename-dependent, this produced
deterministic-but-order-sensitive misses.

Before:
```text
parent
  -> type-only edge to X      (filtered out by rule)
       [X added to traversed too early]
  -> value edge to X
       [skipped: already traversed]
  => real cycle can be missed
```

After:
```text
parent
  -> type-only edge to X
       [filtered out first, not marked traversed]
  -> value edge to X
       [accepted, then marked traversed]
  => cycle path remains discoverable
```

Changes included:
- Move `traversed` insertion to run after `filter` in `ModuleGraphVisitor`.
- Add a dedicated regression test for issue #19245.
- Add TS fixture set reproducing the filename/type-only branch scenario.
- Add snapshot asserting the cycle diagnostic is emitted.

fixes #19245

AI disclosure: this commit was prepared with AI assistance and reviewed.