### PR TITLE
fix(linter/import): count unique module sources in max-dependencies

### DIFF
--- a/crates/oxc_linter/src/snapshots/import_max_dependencies.snap
+++ b/crates/oxc_linter/src/snapshots/import_max_dependencies.snap
@@ -66,11 +66,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Reduce the number of dependencies in this file
 
   ⚠ eslint-plugin-import(max-dependencies): File has too many dependencies (3). Maximum allowed is 2.
-   ╭─[index.ts:4:39]
- 3 │             // This should still count, because only one is a type import
+   ╭─[index.ts:5:31]
  4 │             import { type x, y } from './bar';
-   ·                                       ───────
  5 │             import { z } from './baz';
+   ·                               ───────
+ 6 │             
    ╰────
   help: Reduce the number of dependencies in this file
 


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/19120