### PR TITLE
fix(formatter): avoid unnecessary parentheses for string literal in labeled statement

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/literal/labeled-string.js
+++ b/crates/oxc_formatter/tests/fixtures/js/literal/labeled-string.js
@@ -1,0 +1,11 @@
+label: 'string literal'
+
+label: "string literal"
+
+function f() {
+  label: 'string literal'
+}
+
+if (x) {
+  label: 'string literal'
+}

--- a/crates/oxc_formatter/tests/fixtures/js/literal/labeled-string.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/literal/labeled-string.js.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+label: 'string literal'
+
+label: "string literal"
+
+function f() {
+  label: 'string literal'
+}
+
+if (x) {
+  label: 'string literal'
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+label: "string literal";
+
+label: "string literal";
+
+function f() {
+  label: "string literal";
+}
+
+if (x) {
+  label: "string literal";
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+label: "string literal";
+
+label: "string literal";
+
+function f() {
+  label: "string literal";
+}
+
+if (x) {
+  label: "string literal";
+}
+
+===================== End =====================


### PR DESCRIPTION
## Summary

Fix incorrect parenthesization of string literals in labeled statements.

**Before**: `label: 'string literal'` → `label: ("string literal");`
**After**: `label: 'string literal'` → `label: "string literal";`

## Root Cause

The `NeedsParentheses` implementation for `StringLiteral` was too broad — it wrapped string literals in parentheses whenever they appeared in any `ExpressionStatement` (except arrow function bodies). However, parentheses are only needed to prevent the string from being interpreted as a directive, which can only happen when the `ExpressionStatement` is directly inside a `Program`, `FunctionBody`, or `BlockStatement`.

For labeled statements like `label: 'string literal'`, the grandparent is `LabeledStatement`, so no parentheses are needed.

This matches Prettier's logic in [`needs-parentheses.js` (L719-L734)](https://github.com/prettier/prettier/blob/52829385bcc4d785e58ae2602c0b098a643c5ed6/src/language-js/parentheses/needs-parentheses.js#L719-L734).

## Test Plan

- Added test fixture `labeled-string.js` covering labeled string literals at top level, inside functions, and inside block statements
- All 169 formatter unit tests pass
- Prettier conformance unchanged (JS 746/753, TS 590/601)
- Clippy clean

Fixes #19253