### PR TITLE
chore(lsp): introduce `LanguageId` struct

### DIFF
--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -1,10 +1,10 @@
 use tower_lsp_server::ls_types::Uri;
 
-use crate::ConcurrentHashMap;
+use crate::{ConcurrentHashMap, LanguageId};
 
 #[derive(Debug, Default)]
 pub struct LSPFileSystem {
-    files: ConcurrentHashMap<Uri, String>,
+    files: ConcurrentHashMap<Uri, (LanguageId, String)>,
 }
 
 impl LSPFileSystem {
@@ -13,10 +13,19 @@ impl LSPFileSystem {
     }
 
     pub fn set(&self, uri: Uri, content: String) {
-        self.files.pin().insert(uri, content);
+        let language_id = self.get_language_id(&uri).unwrap_or_default();
+        self.files.pin().insert(uri, (language_id, content));
     }
 
-    pub fn get(&self, uri: &Uri) -> Option<String> {
+    pub fn set_with_language(&self, uri: Uri, language_id: LanguageId, content: String) {
+        self.files.pin().insert(uri, (language_id, content));
+    }
+
+    pub fn get_language_id(&self, uri: &Uri) -> Option<LanguageId> {
+        self.files.pin().get(uri).map(|(lang, _)| lang.clone())
+    }
+
+    pub fn get(&self, uri: &Uri) -> Option<(LanguageId, String)> {
         self.files.pin().get(uri).cloned()
     }
 

--- a/crates/oxc_language_server/src/language_id.rs
+++ b/crates/oxc_language_server/src/language_id.rs
@@ -1,0 +1,17 @@
+/// Represents language IDs passed from the client in `textDocument/didOpen` notifications.
+///
+/// These are used to select the appropriate parser strategy for a given file.
+/// It is the tool's responsibility to use the correct parser strategy for a file
+/// based on its file extension, but newly created files may not have an extension,
+/// so we rely on the language ID to determine which parser strategy to use.
+///
+/// For a more complete list of known language identifiers, see:
+/// <https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers>
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LanguageId(String);
+
+impl LanguageId {
+    pub fn new(id: String) -> Self {
+        Self(id)
+    }
+}

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -4,6 +4,7 @@ use tower_lsp_server::{LspService, Server, ls_types::ServerInfo};
 mod backend;
 mod capabilities;
 mod file_system;
+mod language_id;
 mod options;
 #[cfg(test)]
 mod tests;
@@ -11,6 +12,7 @@ mod tool;
 mod worker;
 
 pub use crate::capabilities::{Capabilities, DiagnosticMode};
+pub use crate::language_id::LanguageId;
 pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
 
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -373,9 +373,8 @@ impl WorkspaceWorker {
                 };
 
                 for uri in file_system.keys() {
-                    let Ok(mut reports) =
-                        tool.run_diagnostic(&uri, file_system.get(&uri).as_deref())
-                    else {
+                    let content = file_system.get(&uri).map(|(_, content)| content);
+                    let Ok(mut reports) = tool.run_diagnostic(&uri, content.as_deref()) else {
                         // If diagnostics could not be run, skip this URI, but continue with others
                         // TODO: Should we aggregate errors instead? One by one, or all together?
                         continue;


### PR DESCRIPTION
related https://github.com/oxc-project/oxc-vscode/issues/25

> This PR introduces a `LanguageId` enum to represent LSP `languageId` values and threads that information through the in-memory `LSPFileSystem`, enabling tools to pick an appropriate parser strategy even when a file has no extension (e.g., newly created/untitled documents).