### PR TITLE
refactor(oxfmt/lsp): pass `LanguageId` to `run_format`

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::ls_types::{Pattern, Position, Range, ServerCapabilities, T
 use tracing::{debug, error, warn};
 
 use oxc_data_structures::rope::{Rope, get_line_column};
-use oxc_language_server::{Capabilities, Tool, ToolBuilder, ToolRestartChanges};
+use oxc_language_server::{Capabilities, LanguageId, Tool, ToolBuilder, ToolRestartChanges};
 
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, SourceFormatter,
@@ -243,7 +243,12 @@ impl Tool for ServerFormatter {
         }
     }
 
-    fn run_format(&self, uri: &Uri, content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+    fn run_format(
+        &self,
+        uri: &Uri,
+        _language_id: &LanguageId,
+        content: Option<&str>,
+    ) -> Result<Vec<TextEdit>, String> {
         let Some(path) = uri.to_file_path() else { return Err("Invalid file URI".to_string()) };
 
         if self.is_ignored(&path) {

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -6,7 +6,7 @@ use tower_lsp_server::{
     },
 };
 
-use crate::capabilities::Capabilities;
+use crate::{LanguageId, capabilities::Capabilities};
 
 pub trait ToolBuilder: Send + Sync {
     /// Modify the server capabilities to include capabilities provided by this tool.
@@ -97,7 +97,12 @@ pub trait Tool: Send + Sync {
     ///
     /// # Errors
     /// Return [`Err`] when an error occurs, ignoring formatting should return [`Ok`] with an empty vector.
-    fn run_format(&self, _uri: &Uri, _content: Option<&str>) -> Result<Vec<TextEdit>, String> {
+    fn run_format(
+        &self,
+        _uri: &Uri,
+        _language_id: &LanguageId,
+        _content: Option<&str>,
+    ) -> Result<Vec<TextEdit>, String> {
         Ok(Vec::new())
     }
 

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -13,7 +13,7 @@ use tower_lsp_server::{
 use tracing::debug;
 
 use crate::{
-    ToolRestartChanges,
+    LanguageId, ToolRestartChanges,
     capabilities::DiagnosticMode,
     file_system::LSPFileSystem,
     tool::{DiagnosticResult, Tool, ToolBuilder},
@@ -191,10 +191,11 @@ impl WorkspaceWorker {
     pub async fn format_file(
         &self,
         uri: &Uri,
+        language_id: &LanguageId,
         content: Option<&str>,
     ) -> Result<Vec<TextEdit>, String> {
         for tool in self.tools.read().await.iter() {
-            let edits = tool.run_format(uri, content)?;
+            let edits = tool.run_format(uri, language_id, content)?;
             // If no edits are made, continue to the next tool
             if edits.is_empty() {
                 continue;


### PR DESCRIPTION
related https://github.com/oxc-project/oxc-vscode/issues/25

> This PR updates the language server formatting pipeline so that a document’s `LanguageId` (from `textDocument/didOpen`) is propagated down into tool formatting hooks, enabling formatters to make decisions even when file extensions are missing.