### PR TITLE
feat(oxfmt/lsp): support `untitled://` schema

### DIFF
--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -1,4 +1,7 @@
-use oxc_language_server::run_server;
+use std::path::{Path, PathBuf};
+
+use oxc_language_server::{LanguageId, run_server};
+use tower_lsp_server::ls_types::Uri;
 
 use crate::core::ExternalFormatter;
 
@@ -7,6 +10,41 @@ mod server_formatter;
 #[cfg(test)]
 mod tester;
 const FORMAT_CONFIG_FILES: &[&str; 2] = &[".oxfmtrc.json", ".oxfmtrc.jsonc"];
+
+fn get_file_extension_from_language_id(language_id: &LanguageId) -> Option<&'static str> {
+    match language_id.as_str() {
+        "javascript" => Some("js"),
+        "typescript" => Some("ts"),
+        "javascriptreact" => Some("jsx"),
+        "typescriptreact" => Some("tsx"),
+        "toml" => Some("toml"),
+        "css" => Some("css"),
+        "graphql" => Some("graphql"),
+        "handlebars" => Some("handlebars"),
+        "json" => Some("json"),
+        "jsonc" => Some("jsonc"),
+        "json5" => Some("json5"),
+        "markdown" => Some("md"),
+        "mdx" => Some("mdx"),
+        "mjml" => Some("mjml"),
+        "html" => Some("html"),
+        "scss" => Some("scss"),
+        "less" => Some("less"),
+        "vue" => Some("vue"),
+        "yaml" => Some("yaml"),
+        _ => None,
+    }
+}
+
+pub fn create_fake_file_path_from_language_id(
+    language_id: &LanguageId,
+    root: &Path,
+    uri: &Uri,
+) -> Option<PathBuf> {
+    let file_extension = get_file_extension_from_language_id(language_id)?;
+    let file_name = format!("{}.{}", uri.authority()?, file_extension);
+    Some(root.join(file_name))
+}
 
 /// Run the language server
 pub async fn run_lsp(external_formatter: ExternalFormatter) {

--- a/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
+++ b/apps/oxfmt/test/lsp/format/__snapshots__/format.test.ts.snap
@@ -234,3 +234,81 @@ debugger
 
 --------------------"
 `;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/formatted.ts 1`] = `
+"--- FILE -----------
+format/formatted.ts
+--- BEFORE ---------
+const x = 1;
+
+--- AFTER ----------
+const x = 1;
+
+--------------------"
+`;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/test.json 1`] = `
+"--- FILE -----------
+format/test.json
+--- BEFORE ---------
+{"name":"test","version":"1.0.0"}
+
+--- AFTER ----------
+{ "name": "test", "version": "1.0.0" }
+
+--------------------"
+`;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/test.toml 1`] = `
+"--- FILE -----------
+format/test.toml
+--- BEFORE ---------
+[package]
+name="test"
+version="1.0.0"
+
+--- AFTER ----------
+[package]
+name = "test"
+version = "1.0.0"
+
+--------------------"
+`;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/test.tsx 1`] = `
+"--- FILE -----------
+format/test.tsx
+--- BEFORE ---------
+const   App:   React.FC   =   ()   =>   <div>Hello</div>
+
+--- AFTER ----------
+const App: React.FC = () => <div>Hello</div>;
+
+--------------------"
+`;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/test.txt 1`] = `
+"--- FILE -----------
+format/test.txt
+--- BEFORE ---------
+hello   world
+
+--- AFTER ----------
+hello   world
+
+--------------------"
+`;
+
+exports[`LSP formatting > unsaved document > should format unsaved file format/test.vue 1`] = `
+"--- FILE -----------
+format/test.vue
+--- BEFORE ---------
+<script>const   x   =   1;</script>
+
+--- AFTER ----------
+<script>
+const x = 1;
+</script>
+
+--------------------"
+`;

--- a/apps/oxfmt/test/lsp/format/format.test.ts
+++ b/apps/oxfmt/test/lsp/format/format.test.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { formatFixture } from "../utils";
+import { formatFixture, formatFixtureContent } from "../utils";
 
 const FIXTURES_DIR = join(import.meta.dirname, "fixtures");
 
@@ -30,6 +30,26 @@ describe("LSP formatting", () => {
       ["editorconfig/test.ts", "typescript"],
     ])("should apply config from %s", async (path, languageId) => {
       expect(await formatFixture(FIXTURES_DIR, path, languageId)).toMatchSnapshot();
+    });
+  });
+
+  describe("unsaved document", () => {
+    it.each([
+      ["format/test.tsx", "typescriptreact"],
+      ["format/test.json", "json"],
+      ["format/test.vue", "vue"],
+      ["format/test.toml", "toml"],
+      ["format/formatted.ts", "typescript"],
+      ["format/test.txt", "plaintext"],
+    ])("should format unsaved file %s", async (path, languageId) => {
+      expect(
+        await formatFixtureContent(
+          FIXTURES_DIR,
+          path,
+          "untitled://Untitled-" + languageId,
+          languageId,
+        ),
+      ).toMatchSnapshot();
     });
   });
 

--- a/apps/oxfmt/test/lsp/utils.ts
+++ b/apps/oxfmt/test/lsp/utils.ts
@@ -27,7 +27,9 @@ import type {
 const CLI_PATH = join(import.meta.dirname, "..", "..", "dist", "cli.js");
 
 export function createLspConnection() {
-  const proc = spawn("node", [CLI_PATH, "--lsp"]);
+  const proc = spawn("node", [CLI_PATH, "--lsp"], {
+    // env: { ...process.env, OXC_LOG: "info" }, for debugging
+  });
 
   const connection = createMessageConnection(
     new StreamMessageReader(proc.stdout),
@@ -107,8 +109,26 @@ export async function formatFixture(
   initializationOptions?: OxfmtLSPConfig,
 ): Promise<string> {
   const filePath = join(fixturesDir, fixturePath);
-  const dirPath = dirname(filePath);
   const fileUri = pathToFileURL(filePath).href;
+
+  return await formatFixtureContent(
+    fixturesDir,
+    fixturePath,
+    fileUri,
+    languageId,
+    initializationOptions,
+  );
+}
+
+export async function formatFixtureContent(
+  fixturesDir: string,
+  fixturePath: string,
+  fileUri: string,
+  languageId: string,
+  initializationOptions?: OxfmtLSPConfig,
+): Promise<string> {
+  const filePath = join(fixturesDir, fixturePath);
+  const dirPath = dirname(filePath);
   const content = await fs.readFile(filePath, "utf-8");
 
   await using client = createLspConnection();

--- a/crates/oxc_language_server/src/language_id.rs
+++ b/crates/oxc_language_server/src/language_id.rs
@@ -14,4 +14,8 @@ impl LanguageId {
     pub fn new(id: String) -> Self {
         Self(id)
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }


### PR DESCRIPTION
related https://github.com/oxc-project/oxc-vscode/issues/25

> This PR adds support for formatting unsaved documents using the untitled:// URI scheme in the oxfmt LSP server. This enables VS Code and other LSP clients to format in-memory documents that haven't been saved to disk yet.

Angular is not supported for the moment, could not find a VS Code extension which defines a language ID for it  :/ 