### PR TITLE
refactor(oxlint/lsp): hold `external_linter` in local var

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -76,10 +76,11 @@ impl ServerLinterBuilder {
             }
         };
         let root_path = root_uri.to_file_path().unwrap();
-        let mut external_plugin_store = ExternalPluginStore::new(self.external_linter.is_some());
+        let mut external_linter = self.external_linter.as_ref();
+        let mut external_plugin_store = ExternalPluginStore::new(external_linter.is_some());
 
         // Setup JS workspace. This must be done before loading any configs
-        if let Some(external_linter) = &self.external_linter {
+        if let Some(external_linter) = external_linter {
             let res = (external_linter.create_workspace)(root_uri.as_str().to_string());
 
             if let Err(err) = res {
@@ -103,7 +104,7 @@ impl ServerLinterBuilder {
 
         let config_path = options.config_path.as_ref().filter(|p| !p.is_empty()).map(PathBuf::from);
         let loader = ConfigLoader::new(
-            self.external_linter.as_ref(),
+            external_linter,
             &mut external_plugin_store,
             &[],
             Some(root_uri.as_str()),
@@ -125,7 +126,7 @@ impl ServerLinterBuilder {
         let config_builder = ConfigStoreBuilder::from_oxlintrc(
             false,
             oxlintrc,
-            self.external_linter.as_ref(),
+            external_linter,
             &mut external_plugin_store,
             Some(root_uri.as_str()),
         )
@@ -154,14 +155,15 @@ impl ServerLinterBuilder {
             },
             ..Default::default()
         };
-        let external_linter =
-            if external_plugin_store.is_empty() { None } else { self.external_linter.as_ref() };
+        if external_plugin_store.is_empty() {
+            external_linter = None;
+        }
 
         let config_store = ConfigStore::new(base_config, nested_configs, external_plugin_store);
         let config_store_clone = config_store.clone();
 
         // Send JS plugins config to JS side
-        if let Some(external_linter) = &external_linter {
+        if let Some(external_linter) = external_linter {
             let res = config_store.external_plugin_store().setup_rule_configs(
                 root_path.to_string_lossy().into_owned(),
                 Some(root_uri.as_str()),


### PR DESCRIPTION
Pure refactor. In `ServerLinterBuilder::build`, hold `external_linter` in a local var instead of repeatedly accessing `self.external_linter`. This is preparation for #19289.