### PR TITLE
test(formatter,oxfmt): Use practical glob patterns in tests

### DIFF
--- a/apps/oxfmt/test/api/sort_imports.test.ts
+++ b/apps/oxfmt/test/api/sort_imports.test.ts
@@ -11,8 +11,8 @@ import { store } from "~/stores/store";
       experimentalSortImports: {
         newlinesBetween: false,
         customGroups: [
-          { elementNamePattern: ["~/stores/*"], groupName: "stores" },
-          { elementNamePattern: ["~/utils/*"], groupName: "utils" },
+          { elementNamePattern: ["~/stores/**"], groupName: "stores" },
+          { elementNamePattern: ["~/utils/**"], groupName: "utils" },
         ],
         groups: ["stores", "utils", "sibling"],
       },

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
@@ -81,47 +81,47 @@ import CartComponentB from "./cart/CartComponentB.vue";
     "experimentalSortImports": {
         "customGroups": [
             {
-                "elementNamePattern": ["~/validators/*"],
+                "elementNamePattern": ["~/validators/**"],
                 "groupName": "validators"
             },
             {
-                "elementNamePattern": ["~/composable/*"],
+                "elementNamePattern": ["~/composable/**"],
                 "groupName": "composable"
             },
             {
-                "elementNamePattern": ["~/components/*"],
+                "elementNamePattern": ["~/components/**"],
                 "groupName": "components"
             },
             {
-                "elementNamePattern": ["~/services/*"],
+                "elementNamePattern": ["~/services/**"],
                 "groupName": "services"
             },
             {
-                "elementNamePattern": ["~/widgets/*"],
+                "elementNamePattern": ["~/widgets/**"],
                 "groupName": "widgets"
             },
             {
-                "elementNamePattern": ["~/stores/*"],
+                "elementNamePattern": ["~/stores/**"],
                 "groupName": "stores"
             },
             {
-                "elementNamePattern": ["~/logics/*"],
+                "elementNamePattern": ["~/logics/**"],
                 "groupName": "logics"
             },
             {
-                "elementNamePattern": ["~/assets/*"],
+                "elementNamePattern": ["~/assets/**"],
                 "groupName": "assets"
             },
             {
-                "elementNamePattern": ["~/utils/*"],
+                "elementNamePattern": ["~/utils/**"],
                 "groupName": "utils"
             },
             {
-                "elementNamePattern": ["~/pages/*"],
+                "elementNamePattern": ["~/pages/**"],
                 "groupName": "pages"
             },
             {
-                "elementNamePattern": ["~/ui/*"],
+                "elementNamePattern": ["~/ui/**"],
                 "groupName": "ui"
             }
         ],
@@ -196,47 +196,47 @@ import ComponentC from "~/components/ComponentC.vue";
     "experimentalSortImports": {
         "customGroups": [
             {
-                "elementNamePattern": ["~/validators/*"],
+                "elementNamePattern": ["~/validators/**"],
                 "groupName": "validators"
             },
             {
-                "elementNamePattern": ["~/composable/*"],
+                "elementNamePattern": ["~/composable/**"],
                 "groupName": "composable"
             },
             {
-                "elementNamePattern": ["~/components/*"],
+                "elementNamePattern": ["~/components/**"],
                 "groupName": "components"
             },
             {
-                "elementNamePattern": ["~/services/*"],
+                "elementNamePattern": ["~/services/**"],
                 "groupName": "services"
             },
             {
-                "elementNamePattern": ["~/widgets/*"],
+                "elementNamePattern": ["~/widgets/**"],
                 "groupName": "widgets"
             },
             {
-                "elementNamePattern": ["~/stores/*"],
+                "elementNamePattern": ["~/stores/**"],
                 "groupName": "stores"
             },
             {
-                "elementNamePattern": ["~/logics/*"],
+                "elementNamePattern": ["~/logics/**"],
                 "groupName": "logics"
             },
             {
-                "elementNamePattern": ["~/assets/*"],
+                "elementNamePattern": ["~/assets/**"],
                 "groupName": "assets"
             },
             {
-                "elementNamePattern": ["~/utils/*"],
+                "elementNamePattern": ["~/utils/**"],
                 "groupName": "utils"
             },
             {
-                "elementNamePattern": ["~/pages/*"],
+                "elementNamePattern": ["~/pages/**"],
                 "groupName": "pages"
             },
             {
-                "elementNamePattern": ["~/ui/*"],
+                "elementNamePattern": ["~/ui/**"],
                 "groupName": "ui"
             }
         ],


### PR DESCRIPTION
No behavior changes.

Generally, when using `customElementPattern`, we assume it targets everything under the directory.