### PR TITLE
fix(transformer): ignore invalid JSX pragma identifiers

### DIFF
--- a/crates/oxc_transformer/src/jsx/diagnostics.rs
+++ b/crates/oxc_transformer/src/jsx/diagnostics.rs
@@ -13,8 +13,10 @@ pub fn pragma_and_pragma_frag_cannot_be_set() -> OxcDiagnostic {
 #[cold]
 #[cfg_attr(not(test), expect(dead_code))]
 pub fn invalid_pragma() -> OxcDiagnostic {
-    OxcDiagnostic::warn("pragma and pragmaFrag must be of the form `foo` or `foo.bar`.")
-        .with_help("Fix `pragma` and `pragmaFrag` options.")
+    OxcDiagnostic::warn(
+        "pragma and pragmaFrag must be valid member expressions such as `h`, `React.createElement`, `this.h`, or `import.meta.h`.",
+    )
+    .with_help("Fix `pragma` and `pragmaFrag` options.")
 }
 
 #[cold]


### PR DESCRIPTION
## Summary
- keep pragma validation centralized in classic JSX pragma parsing (`Pragma::parse_impl`)
- ignore invalid non-empty pragma values (for example `` ` ``) by falling back to default classic pragmas
- simplify the change by removing duplicated comment-level pragma validation and extra diagnostics/tests
- keep one focused regression test for invalid pragma fallback

Fixes #16653.

## Testing
- `cargo test -p oxc_transformer invalid_pragma_falls_back_to_default`
- `cargo test -p oxc_transformer test_find_jsx_pragma`
- `just lint`

## AI Usage Disclosure
- This change was drafted with AI assistance (Codex / GPT-5).