### PR TITLE
fix(semantic): make multi_index_vec clone panic-safe

### DIFF
--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -191,6 +191,7 @@ impl<'a> SemanticTester<'a> {
     }
 
     #[cfg(not(feature = "cfg"))]
+    #[expect(clippy::unused_self, reason = "keep method signature consistent across cfg modes")]
     pub fn basic_blocks_count(&self) -> usize {
         0
     }
@@ -214,6 +215,7 @@ impl<'a> SemanticTester<'a> {
     }
 
     #[cfg(not(feature = "cfg"))]
+    #[expect(clippy::unused_self, reason = "keep method signature consistent across cfg modes")]
     pub fn basic_blocks_printed(&self) -> String {
         String::default()
     }
@@ -225,6 +227,7 @@ impl<'a> SemanticTester<'a> {
     }
 
     #[cfg(not(feature = "cfg"))]
+    #[expect(clippy::unused_self, reason = "keep method signature consistent across cfg modes")]
     pub fn cfg_dot_diagram(&self) -> String {
         String::default()
     }


### PR DESCRIPTION
## Summary
Follow-up to #19138 after merge.

This PR fixes panic-safety in `multi_index_vec!` clone and keeps strict lint clean for `oxc_semantic` tests.

### Changes
- Make macro-generated `Clone` panic-safe by cloning row-by-row through `push`.
  - Avoids setting `len` before all elements are initialized.
  - Prevents dropping uninitialized elements if a field `clone()` panics.
- Add `#[expect(clippy::unused_self)]` to cfg-disabled integration helper methods to keep `cargo clippy -p oxc_semantic --lib --tests -D warnings` green.

## Validation
- `cargo clippy -p oxc_semantic --lib --tests -- -D warnings`
- `just lint`

## AI disclosure
AI-assisted: I used Codex to draft and apply this patch, then ran lint checks and reviewed the result before opening this PR.
