### PR TITLE
chore(ci): update cargo-shear in CI/local and fix shear warnings

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           restore-cache: true
           cache-key: warm
-          tools: just,cargo-shear@1.9.0
+          tools: just,cargo-shear@1.9.1
           components: rustfmt
 
       - name: cargo-shear

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           cache-key: warm
           save-cache: false
-          tools: just,cargo-insta,typos-cli,cargo-shear,ast-grep
+          tools: just,cargo-insta,typos-cli,cargo-shear@1.9.1,ast-grep
           components: clippy rust-docs rustfmt rust-analyzer
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: oxc-project/setup-rust@c8224157c0bf235aabc633e8cd50d344f087a7de # v1.0.12
         with:
           cache-key: conformance
-          tools: just,cargo-shear@1.3.0
+          tools: just,cargo-shear@1.9.1
           components: rustfmt
 
       - name: Get latest SHAs for all submodules

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -35,3 +35,6 @@ serde = { workspace = true, optional = true }
 default = []
 serialize = ["compact_str/serde", "dep:serde", "oxc_estree/serialize", "oxc_str/serialize"]
 schemars = ["dep:schemars", "oxc_str/schemars"]
+
+[package.metadata.cargo-shear]
+ignored = ["schemars"]

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ alias f := fix
 # Initialize the project by installing all necessary tools
 init:
   # Rust related init
-  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear -y
+  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.9.1 -y
   # Node.js related init
   pnpm install
 


### PR DESCRIPTION
## Summary
- pin `cargo-shear` to `1.9.1` in local setup (`just init`)
- pin `cargo-shear` to `1.9.1` in CI workflows (`autofix`, `update_submodules`, `copilot-setup-steps`)
- add `cargo-shear` ignore metadata for `schemars` in `crates/oxc_span` to avoid a known optional-dependency false-positive

## Validation
- `cargo shear`
- `cargo shear --fix`

## AI Usage Disclosure
This PR was prepared with assistance from an AI coding tool (Codex).
I have reviewed the generated changes and take full responsibility for this PR.