### PR TITLE
refactor(allocator): merge vec2 internals into vec module

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -62,7 +62,6 @@ mod take_in;
 #[cfg(all(feature = "track_allocations", not(feature = "disable_track_allocations")))]
 mod tracking;
 mod vec;
-mod vec2;
 
 pub use accessor::AllocatorAccessor;
 pub use address::{Address, GetAddress, UnstableAddress};

--- a/crates/oxc_allocator/src/vec/inner.rs
+++ b/crates/oxc_allocator/src/vec/inner.rs
@@ -119,8 +119,7 @@ use oxc_data_structures::assert_unchecked;
 
 use crate::alloc::Alloc;
 
-mod raw_vec;
-use raw_vec::{AllocError, RawVec};
+use super::raw_vec::{AllocError, RawVec};
 
 unsafe fn arith_offset<T>(p: *const T, offset: isize) -> *const T {
     p.offset(offset)

--- a/crates/oxc_allocator/src/vec/mod.rs
+++ b/crates/oxc_allocator/src/vec/mod.rs
@@ -18,11 +18,17 @@ use std::{
 use serde::{Serialize, Serializer as SerdeSerializer};
 
 #[cfg(any(feature = "serialize", test))]
-use oxc_estree::{ConcatElement, ESTree, SequenceSerializer, Serializer as ESTreeSerializer};
+use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
 
-use crate::{Allocator, Box, bump::Bump, vec2::Vec as InnerVecGeneric};
+#[cfg(feature = "serialize")]
+use oxc_estree::{ConcatElement, SequenceSerializer};
 
-type InnerVec<'a, T> = InnerVecGeneric<'a, T, Bump>;
+use crate::{Allocator, Box, bump::Bump};
+
+mod inner;
+mod raw_vec;
+
+type InnerVec<'a, T> = inner::Vec<'a, T, Bump>;
 
 /// A `Vec` without [`Drop`], which stores its data in the arena allocator.
 ///

--- a/crates/oxc_allocator/src/vec/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec/raw_vec.rs
@@ -804,7 +804,7 @@ impl<T, A: Alloc> RawVec<'_, T, A> {
                     old_layout: Layout,
                     new_layout: Layout,
                 ) -> NonNull<u8> {
-                    alloc.grow(ptr, old_layout, new_layout)
+                    unsafe { alloc.grow(ptr, old_layout, new_layout) }
                 }
                 debug_assert!(new_layout.align() == layout.align());
                 grow(self.alloc, self.ptr.cast(), layout, new_layout)
@@ -827,7 +827,7 @@ impl<T, A: Alloc> RawVec<'_, T, A> {
         if elem_size != 0
             && let Some(layout) = self.current_layout()
         {
-            self.alloc.dealloc(self.ptr.cast(), layout);
+            unsafe { self.alloc.dealloc(self.ptr.cast(), layout) };
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the separate `vec2` module wiring from `oxc_allocator`
- move former `vec2` internals under `vec/` (`inner.rs` + `raw_vec.rs`)
- keep public `oxc_allocator::Vec` behavior and API shape unchanged

## Changes
- `crates/oxc_allocator/src/vec.rs` -> `crates/oxc_allocator/src/vec/mod.rs`
- `crates/oxc_allocator/src/vec2/mod.rs` -> `crates/oxc_allocator/src/vec/inner.rs`
- `crates/oxc_allocator/src/vec2/raw_vec.rs` -> `crates/oxc_allocator/src/vec/raw_vec.rs`
- remove `mod vec2;` from `crates/oxc_allocator/src/lib.rs`

## Validation
- `cargo check -p oxc_allocator`
- `cargo check -p oxc_allocator --all-features`
- `cargo test -p oxc_allocator`
- `just fmt`

## Related
- https://github.com/oxc-project/backlog/issues/199

## AI usage disclosure
- This PR was prepared with AI assistance (ChatGPT/Codex); I reviewed and validated the changes locally.