### PR TITLE
docs(rust): add missing rustdocs and remove missing_docs lint attrs

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -36,8 +36,6 @@
 //! * `disable_track_allocations` - Disables `track_allocations` feature.
 //!   Purpose is to prevent `--all-features` enabling allocation tracking.
 
-#![warn(missing_docs)]
-
 mod accessor;
 mod address;
 mod alloc;

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 use bitflags::bitflags;
 
 use oxc_allocator::{Allocator, CloneIn};

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 use std::borrow::Cow;
 
 use oxc_allocator::{Allocator, AllocatorAccessor, Box, FromIn, IntoIn, Vec};

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1,4 +1,3 @@
-#![warn(missing_docs)]
 use std::{
     borrow::Cow,
     fmt::{self, Display},

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -2,7 +2,6 @@
 //!
 //! [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec)
 //! [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
-#![warn(missing_docs)]
 
 use std::fmt;
 

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,9 +1,6 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_kind.rs`.
 
-#![expect(missing_docs)]
-// FIXME (in ast_tools/src/generators/ast_kind.rs)
-
 use std::ptr;
 
 use oxc_allocator::{Address, GetAddress, UnstableAddress};

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -41,8 +41,6 @@
 //! [`Visit`]: <http://docs.rs/oxc_ast_visit>
 //! [`VisitMut`]: <http://docs.rs/oxc_ast_visit>
 
-#![warn(missing_docs)]
-
 #[cfg(feature = "serialize")]
 mod serialize;
 

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -3,8 +3,6 @@
 //! Code adapted from
 //! * [esbuild](https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_printer/js_printer.go)
 
-#![warn(missing_docs)]
-
 use std::{borrow::Cow, cmp, slice};
 
 use cow_utils::CowUtils;

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -1,7 +1,5 @@
 //! Data structures used across other oxc crates.
 
-#![warn(missing_docs)]
-
 #[cfg(feature = "assert_unchecked")]
 mod assert_unchecked;
 

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -18,6 +18,7 @@ enum ConstantValue {
 }
 
 impl<'a> IsolatedDeclarations<'a> {
+    /// Transform a TypeScript enum declaration into its declaration output form.
     pub fn transform_ts_enum_declaration(&self, decl: &TSEnumDeclaration<'a>) -> Declaration<'a> {
         let mut members = self.ast.vec();
         let mut prev_initializer_value = Some(ConstantValue::Number(-1.0));

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -32,6 +32,7 @@ mod signatures;
 mod types;
 
 #[derive(Debug, Default, Clone, Copy)]
+/// Options for isolated declarations generation.
 pub struct IsolatedDeclarationsOptions {
     /// Do not emit declarations for code that has an `@internal` annotation in its JSDoc comment.
     /// This is an internal compiler option; use at your own risk, because the compiler does not
@@ -45,11 +46,15 @@ pub struct IsolatedDeclarationsOptions {
 }
 
 #[non_exhaustive]
+/// Result of an isolated declarations transform.
 pub struct IsolatedDeclarationsReturn<'a> {
+    /// Generated declaration program (`.d.ts` AST).
     pub program: Program<'a>,
+    /// Diagnostics collected while generating declarations.
     pub errors: Vec<OxcDiagnostic>,
 }
 
+/// Transformer that emits declaration-only AST from TypeScript source AST.
 pub struct IsolatedDeclarations<'a> {
     ast: AstBuilder<'a>,
 
@@ -65,6 +70,7 @@ pub struct IsolatedDeclarations<'a> {
 }
 
 impl<'a> IsolatedDeclarations<'a> {
+    /// Create a new isolated declarations transformer.
     pub fn new(allocator: &'a Allocator, options: IsolatedDeclarationsOptions) -> Self {
         let strip_internal = options.strip_internal;
         Self {

--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -1,5 +1,4 @@
 //! Macros for declaring lints and secret scanners.
-#![warn(missing_docs)]
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -64,8 +64,6 @@
 //!
 //! See [full linter example](https://github.com/Boshen/oxc/blob/ab2ef4f89ba3ca50c68abb2ca43e36b7793f3673/crates/oxc_linter/examples/linter.rs#L38-L39)
 
-#![warn(missing_docs)]
-
 mod context;
 mod cursor;
 mod error_handler;

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -117,7 +117,9 @@ pub struct SemanticBuilder<'a> {
 
 /// Data returned by [`SemanticBuilder::build`].
 pub struct SemanticBuilderReturn<'a> {
+    /// Built semantic model.
     pub semantic: Semantic<'a>,
+    /// Diagnostics collected during semantic analysis.
     pub errors: Vec<OxcDiagnostic>,
 }
 
@@ -128,6 +130,7 @@ impl Default for SemanticBuilder<'_> {
 }
 
 impl<'a> SemanticBuilder<'a> {
+    /// Create a new semantic builder with default settings.
     pub fn new() -> Self {
         let scoping = Scoping::default();
         let current_scope_id = scoping.root_scope_id();
@@ -187,6 +190,7 @@ impl<'a> SemanticBuilder<'a> {
 
     #[cfg(not(feature = "cfg"))]
     #[must_use]
+    /// No-op when `cfg` feature is disabled.
     pub fn with_cfg(self, _cfg: bool) -> Self {
         self
     }

--- a/crates/oxc_semantic/src/is_global_reference.rs
+++ b/crates/oxc_semantic/src/is_global_reference.rs
@@ -26,7 +26,9 @@ use crate::{ReferenceId, Scoping};
 ///
 /// See: <https://github.com/oxc-project/oxc/issues/8365>
 pub trait IsGlobalReference {
+    /// Returns `true` when this reference has no local symbol binding.
     fn is_global_reference(&self, scoping: &Scoping) -> bool;
+    /// Returns `true` when this reference matches `name` and is global.
     fn is_global_reference_name(&self, name: Ident<'_>, scoping: &Scoping) -> bool;
 }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -124,22 +124,27 @@ impl<'a> Semantic<'a> {
         &self.nodes
     }
 
+    /// Scoping data collected for this program.
     pub fn scoping(&self) -> &Scoping {
         &self.scoping
     }
 
+    /// Mutable access to scoping data.
     pub fn scoping_mut(&mut self) -> &mut Scoping {
         &mut self.scoping
     }
 
+    /// Mutable access to scoping data together with read-only AST nodes.
     pub fn scoping_mut_and_nodes(&mut self) -> (&mut Scoping, &AstNodes<'a>) {
         (&mut self.scoping, &self.nodes)
     }
 
+    /// Class metadata collected during semantic analysis.
     pub fn classes(&self) -> &ClassTable<'_> {
         &self.classes
     }
 
+    /// Set recorded spans for irregular unicode whitespace in source text.
     pub fn set_irregular_whitespaces(&mut self, irregular_whitespaces: Box<[Span]>) {
         self.irregular_whitespaces = irregular_whitespaces;
     }
@@ -149,6 +154,7 @@ impl<'a> Semantic<'a> {
         self.comments
     }
 
+    /// Iterate comments within a byte range.
     pub fn comments_range<R>(&self, range: R) -> CommentsRange<'_>
     where
         R: RangeBounds<u32>,
@@ -156,10 +162,12 @@ impl<'a> Semantic<'a> {
         comments_range(self.comments, range)
     }
 
+    /// Returns `true` if any comment lies between `span.start` and `span.end`.
     pub fn has_comments_between(&self, span: Span) -> bool {
         has_comments_between(self.comments, span)
     }
 
+    /// Returns `true` if `pos` is inside a parsed comment.
     pub fn is_inside_comment(&self, pos: u32) -> bool {
         is_inside_comment(self.comments, pos)
     }
@@ -169,6 +177,7 @@ impl<'a> Semantic<'a> {
         get_comment_at(self.comments, pos)
     }
 
+    /// Spans of irregular whitespace discovered by the parser.
     pub fn irregular_whitespaces(&self) -> &[Span] {
         &self.irregular_whitespaces
     }
@@ -181,6 +190,7 @@ impl<'a> Semantic<'a> {
         &self.jsdoc
     }
 
+    /// Labels that were declared but never used.
     pub fn unused_labels(&self) -> &Vec<NodeId> {
         &self.unused_labels
     }
@@ -194,6 +204,9 @@ impl<'a> Semantic<'a> {
         self.cfg.as_ref()
     }
 
+    /// Control flow graph.
+    ///
+    /// Always returns `None` when the `cfg` feature is disabled.
     #[cfg(not(feature = "cfg"))]
     #[expect(clippy::unused_self)]
     pub fn cfg(&self) -> Option<&()> {
@@ -211,6 +224,7 @@ impl<'a> Semantic<'a> {
         )
     }
 
+    /// Returns `true` if `node_id` points to an unresolved identifier reference.
     pub fn is_unresolved_reference(&self, node_id: NodeId) -> bool {
         let reference_node = self.nodes.get_node(node_id);
         let AstKind::IdentifierReference(id) = reference_node.kind() else {
@@ -232,14 +246,17 @@ impl<'a> Semantic<'a> {
         self.scoping.get_resolved_references(symbol_id)
     }
 
+    /// Get the AST node that declares `symbol_id`.
     pub fn symbol_declaration(&self, symbol_id: SymbolId) -> &AstNode<'a> {
         self.nodes.get_node(self.scoping.symbol_declaration(symbol_id))
     }
 
+    /// Returns `true` if `ident` resolves to a global (unbound) reference.
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
         self.scoping.root_unresolved_references().contains_key(&ident.name)
     }
 
+    /// Get the textual name for a semantic reference.
     pub fn reference_name(&self, reference: &Reference) -> &str {
         let node = self.nodes.get_node(reference.node_id());
         match node.kind() {
@@ -248,6 +265,7 @@ impl<'a> Semantic<'a> {
         }
     }
 
+    /// Get the source span for a semantic reference.
     pub fn reference_span(&self, reference: &Reference) -> Span {
         let node = self.nodes.get_node(reference.node_id());
         node.kind().span()

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -124,11 +124,13 @@ impl<'a> AstNodes<'a> {
     }
 
     #[inline]
+    /// Get a node by [`NodeId`].
     pub fn get_node(&self, node_id: NodeId) -> &AstNode<'a> {
         &self.nodes[node_id]
     }
 
     #[inline]
+    /// Get a mutable node by [`NodeId`].
     pub fn get_node_mut(&mut self, node_id: NodeId) -> &mut AstNode<'a> {
         &mut self.nodes[node_id]
     }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -296,10 +296,12 @@ impl Scoping {
         self.symbol_table.is_empty()
     }
 
+    /// Iterate all symbol names in insertion order.
     pub fn symbol_names(&self) -> impl Iterator<Item = &str> + '_ {
         self.cell.borrow_dependent().symbol_names.iter().map(Ident::as_str)
     }
 
+    /// Iterate resolved reference ID lists for each symbol.
     pub fn resolved_references(&self) -> impl Iterator<Item = &ArenaVec<'_, ReferenceId>> + '_ {
         self.cell.borrow_dependent().resolved_references.iter()
     }
@@ -359,6 +361,7 @@ impl Scoping {
     }
 
     #[inline]
+    /// Get all redeclarations associated with a symbol.
     pub fn symbol_redeclarations(&self, symbol_id: SymbolId) -> &[Redeclaration] {
         self.cell.borrow_dependent().symbol_redeclarations.get(&symbol_id).map_or_else(
             || {
@@ -370,16 +373,19 @@ impl Scoping {
     }
 
     #[inline]
+    /// Union additional flags into an existing symbol.
     pub fn union_symbol_flag(&mut self, symbol_id: SymbolId, includes: SymbolFlags) {
         *self.symbol_table.symbol_flags_mut(symbol_id) |= includes;
     }
 
     #[inline]
+    /// Set the scope that owns `symbol_id`.
     pub fn set_symbol_scope_id(&mut self, symbol_id: SymbolId, scope_id: ScopeId) {
         *self.symbol_table.symbol_scope_ids_mut(symbol_id) = scope_id;
     }
 
     #[inline]
+    /// Get the scope that owns `symbol_id`.
     pub fn symbol_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
         *self.symbol_table.symbol_scope_ids(symbol_id)
     }
@@ -399,6 +405,7 @@ impl Scoping {
         *self.symbol_table.symbol_declarations(symbol_id)
     }
 
+    /// Create a new symbol and append symbol metadata to the symbol table.
     pub fn create_symbol(
         &mut self,
         span: Span,
@@ -414,6 +421,7 @@ impl Scoping {
         self.symbol_table.push(span, flags, scope_id, node_id)
     }
 
+    /// Record a redeclaration for an existing symbol.
     pub fn add_symbol_redeclaration(
         &mut self,
         symbol_id: SymbolId,
@@ -451,6 +459,7 @@ impl Scoping {
     }
 
     #[inline]
+    /// Create and store a reference entry.
     pub fn create_reference(&mut self, reference: Reference) -> ReferenceId {
         self.references.push(reference)
     }
@@ -464,6 +473,7 @@ impl Scoping {
     }
 
     #[inline]
+    /// Get mutable access to a reference.
     pub fn get_reference_mut(&mut self, reference_id: ReferenceId) -> &mut Reference {
         &mut self.references[reference_id]
     }
@@ -544,6 +554,7 @@ impl Scoping {
         });
     }
 
+    /// Reserve additional capacity for symbols, references, and scopes.
     pub fn reserve(
         &mut self,
         additional_symbols: usize,
@@ -563,6 +574,7 @@ impl Scoping {
         });
     }
 
+    /// Symbols marked with `@__NO_SIDE_EFFECTS__`.
     pub fn no_side_effects(&self) -> &FxHashSet<SymbolId> {
         &self.no_side_effects
     }
@@ -596,6 +608,7 @@ impl Scoping {
         std::iter::successors(Some(scope_id), |&scope_id| *self.scope_table.parent_ids(scope_id))
     }
 
+    /// Iterate all scope IDs from the root scope through all descendants.
     pub fn scope_descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + '_ {
         self.scope_table.iter_ids()
     }
@@ -618,10 +631,12 @@ impl Scoping {
     }
 
     #[inline]
+    /// Unresolved references recorded in the root scope.
     pub fn root_unresolved_references(&self) -> &UnresolvedReferences<'_> {
         &self.cell.borrow_dependent().root_unresolved_references
     }
 
+    /// Iterate unresolved reference IDs grouped by unresolved identifier name.
     pub fn root_unresolved_references_ids(
         &self,
     ) -> impl Iterator<Item = impl Iterator<Item = ReferenceId> + '_> + '_ {
@@ -663,11 +678,13 @@ impl Scoping {
     }
 
     #[inline]
+    /// Get scope flags for `scope_id`.
     pub fn scope_flags(&self, scope_id: ScopeId) -> ScopeFlags {
         *self.scope_table.flags(scope_id)
     }
 
     #[inline]
+    /// Get mutable scope flags for `scope_id`.
     pub fn scope_flags_mut(&mut self, scope_id: ScopeId) -> &mut ScopeFlags {
         self.scope_table.flags_mut(scope_id)
     }
@@ -679,10 +696,12 @@ impl Scoping {
     }
 
     #[inline]
+    /// Get the parent scope ID, if any.
     pub fn scope_parent_id(&self, scope_id: ScopeId) -> Option<ScopeId> {
         *self.scope_table.parent_ids(scope_id)
     }
 
+    /// Set the parent scope ID.
     pub fn set_scope_parent_id(&mut self, scope_id: ScopeId, parent_id: Option<ScopeId>) {
         *self.scope_table.parent_ids_mut(scope_id) = parent_id;
     }
@@ -700,6 +719,7 @@ impl Scoping {
         self.get_binding(self.root_scope_id(), name)
     }
 
+    /// Add an unresolved reference to the root scope map.
     pub fn add_root_unresolved_reference(&mut self, name: Ident<'_>, reference_id: ReferenceId) {
         self.cell.with_dependent_mut(|allocator, cell| {
             let name = name.clone_in(allocator);
@@ -872,6 +892,7 @@ impl Scoping {
         });
     }
 
+    /// Remove bindings that exist only in TypeScript type space.
     pub fn delete_typescript_bindings(&mut self) {
         self.cell.with_dependent_mut(|_allocator, cell| {
             for bindings in &mut cell.bindings {

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -65,9 +65,13 @@ macro_rules! assert_ge {
 /// [`Semantic::stats`]: super::Semantic::stats
 #[derive(Clone, Copy, Default, Debug)]
 pub struct Stats {
+    /// Number of AST nodes.
     pub nodes: u32,
+    /// Number of lexical scopes.
     pub scopes: u32,
+    /// Number of semantic symbols.
     pub symbols: u32,
+    /// Number of identifier references.
     pub references: u32,
 }
 

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! <https://doc.rust-lang.org/beta/nightly-rustc/rustc_span>
 
-#![warn(missing_docs)]
-
 mod cmp;
 mod source_type;
 mod span;

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -449,33 +449,19 @@ pub type ArenaIdentHashMap<'alloc, V> =
 /// Hash set of [`Ident`], using precomputed ident hash.
 pub type IdentHashSet<'a> = hashbrown::HashSet<Ident<'a>, IdentBuildHasher>;
 
-#[expect(missing_docs)]
 pub const AGGREGATE_ERROR: Ident<'static> = Ident::new_const("AggregateError");
-#[expect(missing_docs)]
 pub const ARGUMENTS: Ident<'static> = Ident::new_const("arguments");
-#[expect(missing_docs)]
 pub const ARRAY: Ident<'static> = Ident::new_const("Array");
-#[expect(missing_docs)]
 pub const ERROR: Ident<'static> = Ident::new_const("Error");
-#[expect(missing_docs)]
 pub const EXPORTS: Ident<'static> = Ident::new_const("exports");
-#[expect(missing_docs)]
 pub const FUNCTION: Ident<'static> = Ident::new_const("Function");
-#[expect(missing_docs)]
 pub const GLOBAL_THIS: Ident<'static> = Ident::new_const("globalThis");
-#[expect(missing_docs)]
 pub const MATH: Ident<'static> = Ident::new_const("Math");
-#[expect(missing_docs)]
 pub const MODULE: Ident<'static> = Ident::new_const("module");
-#[expect(missing_docs)]
 pub const OBJECT: Ident<'static> = Ident::new_const("Object");
-#[expect(missing_docs)]
 pub const PROCESS: Ident<'static> = Ident::new_const("process");
-#[expect(missing_docs)]
 pub const REG_EXP: Ident<'static> = Ident::new_const("RegExp");
-#[expect(missing_docs)]
 pub const REQUIRE: Ident<'static> = Ident::new_const("require");
-#[expect(missing_docs)]
 pub const TYPE_ERROR: Ident<'static> = Ident::new_const("TypeError");
 
 /// Creates an [`Ident`] using interpolation of runtime expressions.

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! This crate provides [`Atom`], [`Ident`], and [`CompactStr`] types for efficient string handling.
 
-#![warn(missing_docs)]
-
 mod atom;
 mod compact_str;
 pub mod ident;

--- a/crates/oxc_syntax/src/class.rs
+++ b/crates/oxc_syntax/src/class.rs
@@ -1,5 +1,4 @@
 //! Class and class element syntax items
-#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use oxc_index::define_index_type;
 

--- a/crates/oxc_syntax/src/es_target.rs
+++ b/crates/oxc_syntax/src/es_target.rs
@@ -5,7 +5,6 @@ use cow_utils::CowUtils;
 
 /// ECMAScript Target
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[expect(missing_docs)]
 pub enum ESTarget {
     ES2015,
     ES2016,

--- a/crates/oxc_syntax/src/identifier.rs
+++ b/crates/oxc_syntax/src/identifier.rs
@@ -1,5 +1,3 @@
-#![expect(missing_docs)] // fixme
-
 use unicode_id_start::{is_id_continue_unicode, is_id_start_unicode};
 
 use crate::line_terminator::{CR, LF, LS, PS};

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -429,7 +429,6 @@ pub struct DynamicImport {
     pub module_request: Span,
 }
 
-#[expect(missing_docs)]
 pub trait VisitMutModuleRecord {
     fn visit_module_record(&mut self, module_record: &mut ModuleRecord) {
         module_record.requested_modules.values_mut().for_each(|e| {

--- a/crates/oxc_syntax/src/number.rs
+++ b/crates/oxc_syntax/src/number.rs
@@ -1,5 +1,3 @@
-#![expect(missing_docs)] // fixme
-
 use oxc_allocator::{CloneIn, Dummy};
 use oxc_ast_macros::ast;
 use oxc_span::ContentEq;

--- a/crates/oxc_syntax/src/precedence.rs
+++ b/crates/oxc_syntax/src/precedence.rs
@@ -1,4 +1,3 @@
-#![expect(missing_docs)] // fixme
 pub trait GetPrecedence {
     fn precedence(&self) -> Precedence;
 }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,4 +1,3 @@
-#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use oxc_index::define_nonmax_u32_index_type;
 #[cfg(feature = "serialize")]

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -1,4 +1,3 @@
-#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_index::define_nonmax_u32_index_type;

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,4 +1,3 @@
-#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_index::define_nonmax_u32_index_type;

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -124,6 +124,7 @@ pub struct HelperLoaderOptions {
     /// The module name to import helper functions from.
     /// Default: `@oxc-project/runtime`
     pub module_name: Cow<'static, str>,
+    /// Strategy used to resolve helper calls.
     pub mode: HelperLoaderMode,
 }
 
@@ -140,38 +141,68 @@ fn default_as_module_name() -> Cow<'static, str> {
 /// Available helpers.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Helper {
+    /// Runtime helper `awaitAsyncGenerator`.
     AwaitAsyncGenerator,
+    /// Runtime helper `asyncGeneratorDelegate`.
     AsyncGeneratorDelegate,
+    /// Runtime helper `asyncIterator`.
     AsyncIterator,
+    /// Runtime helper `asyncToGenerator`.
     AsyncToGenerator,
+    /// Runtime helper `objectSpread2`.
     ObjectSpread2,
+    /// Runtime helper `wrapAsyncGenerator`.
     WrapAsyncGenerator,
+    /// Runtime helper `extends`.
     Extends,
+    /// Runtime helper `objectDestructuringEmpty`.
     ObjectDestructuringEmpty,
+    /// Runtime helper `objectWithoutProperties`.
     ObjectWithoutProperties,
+    /// Runtime helper `toPropertyKey`.
     ToPropertyKey,
+    /// Runtime helper `defineProperty`.
     DefineProperty,
+    /// Runtime helper `classPrivateFieldInitSpec`.
     ClassPrivateFieldInitSpec,
+    /// Runtime helper `classPrivateMethodInitSpec`.
     ClassPrivateMethodInitSpec,
+    /// Runtime helper `classPrivateFieldGet2`.
     ClassPrivateFieldGet2,
+    /// Runtime helper `classPrivateFieldSet2`.
     ClassPrivateFieldSet2,
+    /// Runtime helper `assertClassBrand`.
     AssertClassBrand,
+    /// Runtime helper `toSetter`.
     ToSetter,
+    /// Runtime helper `classPrivateFieldLooseKey`.
     ClassPrivateFieldLooseKey,
+    /// Runtime helper `classPrivateFieldLooseBase`.
     ClassPrivateFieldLooseBase,
+    /// Runtime helper `superPropGet`.
     SuperPropGet,
+    /// Runtime helper `superPropSet`.
     SuperPropSet,
+    /// Runtime helper `readOnlyError`.
     ReadOnlyError,
+    /// Runtime helper `writeOnlyError`.
     WriteOnlyError,
+    /// Runtime helper `checkInRHS`.
     CheckInRHS,
+    /// Runtime helper `decorate`.
     Decorate,
+    /// Runtime helper `decorateParam`.
     DecorateParam,
+    /// Runtime helper `decorateMetadata`.
     DecorateMetadata,
+    /// Runtime helper `usingCtx`.
     UsingCtx,
+    /// Runtime helper `taggedTemplateLiteral`.
     TaggedTemplateLiteral,
 }
 
 impl Helper {
+    /// Canonical helper export name used by runtime/external helper loaders.
     pub const fn name(self) -> &'static str {
         match self {
             Self::AwaitAsyncGenerator => "awaitAsyncGenerator",
@@ -206,6 +237,7 @@ impl Helper {
         }
     }
 
+    /// Whether calling this helper is side-effect free.
     pub const fn pure(self) -> bool {
         matches!(self, Self::ClassPrivateFieldLooseKey)
     }

--- a/crates/oxc_transformer/src/compiler_assumptions.rs
+++ b/crates/oxc_transformer/src/compiler_assumptions.rs
@@ -8,73 +8,92 @@ use serde::Deserialize;
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CompilerAssumptions {
+    /// Assume array-like values are iterable.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub array_like_is_iterable: bool,
 
+    /// Assume re-exported bindings are constant.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub constant_reexports: bool,
 
+    /// Assume `super` property writes do not require runtime checks.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub constant_super: bool,
 
+    /// Treat `import.meta` properties as enumerable.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub enumerable_module_meta: bool,
 
+    /// Ignore `Function#length` when lowering function wrappers.
     #[serde(default)]
     pub ignore_function_length: bool,
 
+    /// Ignore the preferred hint passed to `Symbol.toPrimitive`.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub ignore_to_primitive_hint: bool,
 
+    /// Assume iterable operations only receive arrays.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub iterable_is_array: bool,
 
+    /// Emit mutable template objects.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub mutable_template_object: bool,
 
+    /// Assume class constructors are never called without `new`.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub no_class_calls: bool,
 
+    /// Assume `document.all` is not special-cased.
     #[serde(default)]
     pub no_document_all: bool,
 
+    /// Skip namespace import completeness checks.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub no_incomplete_ns_import_detection: bool,
 
+    /// Assume no new `this` capture is needed for arrows.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub no_new_arrows: bool,
 
+    /// Assume private fields are always initialized before access.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub no_uninitialized_private_field_access: bool,
 
+    /// Assume object rest does not need to copy symbol properties.
     #[serde(default)]
     pub object_rest_no_symbols: bool,
 
+    /// Represent private fields as symbols.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub private_fields_as_symbols: bool,
 
+    /// Represent private fields as string-keyed properties.
     #[serde(default)]
     pub private_fields_as_properties: bool,
 
+    /// Assume property reads can be treated as pure.
     #[serde(default)]
     pub pure_getters: bool,
 
+    /// Assume class methods can be assigned directly.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub set_class_methods: bool,
 
+    /// Assume computed properties can be assigned directly.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub set_computed_properties: bool,
@@ -121,14 +140,17 @@ pub struct CompilerAssumptions {
     #[serde(default)]
     pub set_public_class_fields: bool,
 
+    /// Assume object spread can use direct assignment semantics.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub set_spread_properties: bool,
 
+    /// Skip `for..of` iterator closing logic.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub skip_for_of_iterator_closing: bool,
 
+    /// Assume `super` can be invoked as a normal callable constructor.
     #[serde(default)]
     #[deprecated = "Not Implemented"]
     pub super_is_callable_constructor: bool,

--- a/crates/oxc_transformer/src/decorator/options.rs
+++ b/crates/oxc_transformer/src/decorator/options.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// Decorator transform options.
 pub struct DecoratorOptions {
     /// Enables experimental support for decorators, which is a version of decorators that predates the TC39 standardization process.
     ///

--- a/crates/oxc_transformer/src/es2015/arrow_functions.rs
+++ b/crates/oxc_transformer/src/es2015/arrow_functions.rs
@@ -132,6 +132,7 @@ use oxc_traverse::Traverse;
 use crate::state::TransformState;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
+/// Options for the ES2015 arrow-function transform.
 pub struct ArrowFunctionsOptions {
     /// This option enables the following:
     /// * Wrap the generated function in .bind(this) and keeps uses of this inside the function as-is, instead of using a renamed this.

--- a/crates/oxc_transformer/src/es2015/options.rs
+++ b/crates/oxc_transformer/src/es2015/options.rs
@@ -4,7 +4,9 @@ use super::ArrowFunctionsOptions;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2015 transform options.
 pub struct ES2015Options {
+    /// Arrow-function transform options.
     #[serde(skip)]
     pub arrow_function: Option<ArrowFunctionsOptions>,
 }

--- a/crates/oxc_transformer/src/es2016/options.rs
+++ b/crates/oxc_transformer/src/es2016/options.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2016 transform options.
 pub struct ES2016Options {
+    /// Enable exponentiation operator transform.
     #[serde(skip)]
     pub exponentiation_operator: bool,
 }

--- a/crates/oxc_transformer/src/es2017/options.rs
+++ b/crates/oxc_transformer/src/es2017/options.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2017 transform options.
 pub struct ES2017Options {
+    /// Enable async-to-generator transform.
     #[serde(skip)]
     pub async_to_generator: bool,
 }

--- a/crates/oxc_transformer/src/es2018/options.rs
+++ b/crates/oxc_transformer/src/es2018/options.rs
@@ -4,10 +4,13 @@ use super::ObjectRestSpreadOptions;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2018 transform options.
 pub struct ES2018Options {
+    /// Object rest/spread transform options.
     #[serde(skip)]
     pub object_rest_spread: Option<ObjectRestSpreadOptions>,
 
+    /// Enable async generator function transform.
     #[serde(skip)]
     pub async_generator_functions: bool,
 }

--- a/crates/oxc_transformer/src/es2019/options.rs
+++ b/crates/oxc_transformer/src/es2019/options.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2019 transform options.
 pub struct ES2019Options {
+    /// Enable optional catch binding transform.
     #[serde(skip)]
     pub optional_catch_binding: bool,
 }

--- a/crates/oxc_transformer/src/es2020/options.rs
+++ b/crates/oxc_transformer/src/es2020/options.rs
@@ -2,19 +2,25 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2020 transform options.
 pub struct ES2020Options {
+    /// Enable `export * as ns from` transform.
     #[serde(skip)]
     pub export_namespace_from: bool,
 
+    /// Enable nullish coalescing transform.
     #[serde(skip)]
     pub nullish_coalescing_operator: bool,
 
+    /// Enable bigint syntax transform.
     #[serde(skip)]
     pub big_int: bool,
 
+    /// Enable optional chaining transform.
     #[serde(skip)]
     pub optional_chaining: bool,
 
+    /// Enable arbitrary module namespace name transform.
     #[serde(skip)]
     pub arbitrary_module_namespace_names: bool,
 }

--- a/crates/oxc_transformer/src/es2021/options.rs
+++ b/crates/oxc_transformer/src/es2021/options.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2021 transform options.
 pub struct ES2021Options {
+    /// Enable logical assignment operator transform.
     #[serde(skip)]
     pub logical_assignment_operators: bool,
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -228,7 +228,9 @@ type IdentIndexMap<'a, V> = IndexMap<Ident<'a>, V, IdentBuildHasher>;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
+/// Options for the class properties transform.
 pub struct ClassPropertiesOptions {
+    /// Use loose assignment semantics for class fields.
     pub loose: bool,
 }
 

--- a/crates/oxc_transformer/src/es2022/options.rs
+++ b/crates/oxc_transformer/src/es2022/options.rs
@@ -4,13 +4,17 @@ use super::ClassPropertiesOptions;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2022 transform options.
 pub struct ES2022Options {
+    /// Enable class static block transform.
     #[serde(skip)]
     pub class_static_block: bool,
 
+    /// Class properties transform options.
     #[serde(skip)]
     pub class_properties: Option<ClassPropertiesOptions>,
 
+    /// Enable top-level await transform.
     #[serde(skip)]
     pub top_level_await: bool,
 }

--- a/crates/oxc_transformer/src/es2026/options.rs
+++ b/crates/oxc_transformer/src/es2026/options.rs
@@ -2,7 +2,9 @@ use serde::Deserialize;
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// ES2026 transform options.
 pub struct ES2026Options {
+    /// Enable explicit resource management transform (`using` declarations).
     #[serde(skip)]
     pub explicit_resource_management: bool,
 }

--- a/crates/oxc_transformer/src/jsx/options.rs
+++ b/crates/oxc_transformer/src/jsx/options.rs
@@ -12,6 +12,7 @@ fn default_as_true() -> bool {
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum JsxRuntime {
+    /// Use the classic `React.createElement` runtime.
     Classic,
     /// The default runtime is switched to automatic in Babel 8.
     #[default]
@@ -19,10 +20,12 @@ pub enum JsxRuntime {
 }
 
 impl JsxRuntime {
+    /// Returns `true` when the classic runtime is selected.
     pub fn is_classic(self) -> bool {
         self == Self::Classic
     }
 
+    /// Returns `true` when the automatic runtime is selected.
     pub fn is_automatic(self) -> bool {
         self == Self::Automatic
     }
@@ -30,16 +33,21 @@ impl JsxRuntime {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// JSX transform configuration.
 pub struct JsxOptions {
+    /// Enable React JSX transform plugin.
     #[serde(skip)]
     pub jsx_plugin: bool,
 
+    /// Enable React display-name plugin.
     #[serde(skip)]
     pub display_name_plugin: bool,
 
+    /// Enable React `__self` development transform.
     #[serde(skip)]
     pub jsx_self_plugin: bool,
 
+    /// Enable React `__source` development transform.
     #[serde(skip)]
     pub jsx_source_plugin: bool,
 
@@ -114,6 +122,7 @@ impl Default for JsxOptions {
 }
 
 impl JsxOptions {
+    /// Normalize option combinations used by the JSX pipeline.
     pub fn conform(&mut self) {
         if self.development {
             self.jsx_plugin = true;
@@ -122,6 +131,7 @@ impl JsxOptions {
         }
     }
 
+    /// Create options with JSX transforms enabled.
     pub fn enable() -> Self {
         Self {
             jsx_plugin: true,
@@ -141,6 +151,7 @@ impl JsxOptions {
         }
     }
 
+    /// Create options with JSX transforms disabled.
     pub fn disable() -> Self {
         Self {
             jsx_plugin: false,
@@ -163,6 +174,7 @@ impl JsxOptions {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// React Fast Refresh transform configuration.
 pub struct ReactRefreshOptions {
     /// Specify the identifier of the refresh registration variable.
     ///

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -83,15 +83,21 @@ pub use crate::{
     typescript::{RewriteExtensionsMode, TypeScriptOptions},
 };
 
+/// Result of running [`Transformer::build_with_scoping`].
 #[non_exhaustive]
 pub struct TransformerReturn {
+    /// Diagnostics produced during transformation.
     pub errors: std::vec::Vec<OxcDiagnostic>,
+    /// Updated semantic scoping after all transforms have run.
     pub scoping: Scoping,
     /// Helpers used by this transform.
     #[deprecated = "Internal usage only"]
     pub helpers_used: FxHashMap<Helper, String>,
 }
 
+/// JavaScript/TypeScript transformer pipeline.
+///
+/// Create with [`Transformer::new`] and run with [`Transformer::build_with_scoping`].
 pub struct Transformer<'a> {
     state: TransformState<'a>,
     allocator: &'a Allocator,
@@ -106,6 +112,7 @@ pub struct Transformer<'a> {
 }
 
 impl<'a> Transformer<'a> {
+    /// Create a transformer with source path and transform options.
     pub fn new(allocator: &'a Allocator, source_path: &Path, options: &TransformOptions) -> Self {
         let state = TransformState::new(source_path, options);
         Self {
@@ -120,6 +127,7 @@ impl<'a> Transformer<'a> {
         }
     }
 
+    /// Run all configured transforms on `program` and return diagnostics and updated scoping.
     pub fn build_with_scoping(
         mut self,
         scoping: Scoping,

--- a/crates/oxc_transformer/src/options/babel/env/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/env/mod.rs
@@ -8,63 +8,85 @@ fn default_as_true() -> bool {
 
 #[derive(Default, Debug, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// Babel `preset-env` style configuration.
 pub struct BabelEnvOptions {
+    /// Target engines used to determine which transforms should be enabled.
     #[serde(default)]
     pub targets: EngineTargets,
 
+    /// Enable Babel's bugfix transforms.
     #[deprecated = "Not Implemented"]
     #[serde(default = "default_as_true")]
     pub bugfixes: bool,
 
+    /// Enable spec-compliant transforms over looser output.
     #[deprecated = "Not Implemented"]
     pub spec: bool,
 
+    /// Enable loose mode for eligible transforms.
     #[deprecated = "Not Implemented"]
     pub loose: bool,
 
+    /// Module transform mode.
     pub modules: Module,
 
+    /// Print debugging information while selecting transforms.
     #[deprecated = "Not Implemented"]
     pub debug: bool,
 
+    /// Force-enable specific transforms.
     #[deprecated = "Not Implemented"]
     pub include: Option<serde_json::Value>,
 
+    /// Force-disable specific transforms.
     #[deprecated = "Not Implemented"]
     pub exclude: Option<serde_json::Value>,
 
+    /// Polyfill injection mode.
     #[deprecated = "Not Implemented"]
     pub use_built_ins: Option<serde_json::Value>,
 
+    /// `core-js` version/options for polyfill injection.
     #[deprecated = "Not Implemented"]
     pub corejs: Option<serde_json::Value>,
 
+    /// Force all eligible transforms regardless of targets.
     #[deprecated = "Not Implemented"]
     pub force_all_transforms: bool,
 
+    /// Explicit path to config file.
     #[deprecated = "Not Implemented"]
     pub config_path: Option<String>,
 
+    /// Skip loading `.browserslistrc`.
     #[deprecated = "Not Implemented"]
     pub ignore_browserslist_config: bool,
 
+    /// Enable proposal transforms that are shipped in browsers.
     #[deprecated = "Not Implemented"]
     pub shipped_proposals: bool,
 }
 
 #[derive(Default, Debug, Clone, Deserialize)]
+/// Raw Babel `modules` option values.
 pub enum BabelModule {
+    /// Let Babel infer module behavior.
     #[default]
     #[serde(rename = "auto")]
     Auto,
+    /// Transform modules to AMD.
     #[serde(rename = "amd")]
     Amd,
+    /// Transform modules to UMD.
     #[serde(rename = "umd")]
     Umd,
+    /// Transform modules to SystemJS.
     #[serde(rename = "systemjs")]
     Systemjs,
+    /// Transform modules to CommonJS.
     #[serde(rename = "commonjs", alias = "cjs")]
     Commonjs,
+    /// Babel accepts booleans for module options in some configurations.
     #[serde(untagged)]
     Boolean(bool),
 }

--- a/crates/oxc_transformer/src/options/babel/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/mod.rs
@@ -18,26 +18,33 @@ pub use presets::BabelPresets;
 #[serde(rename_all = "camelCase")]
 pub struct BabelOptions {
     // Primary options
+    /// Working directory used to resolve relative paths in configuration.
     pub cwd: Option<PathBuf>,
 
     // Config Loading options
 
     // Plugin and Preset options
+    /// Explicit plugin entries.
     #[serde(default)]
     pub plugins: BabelPlugins,
 
+    /// Explicit preset entries.
     #[serde(default)]
     pub presets: BabelPresets,
 
     // Misc options
+    /// Parser source type mode (`"module"`, `"script"`, `"unambiguous"`, ...).
     pub source_type: Option<String>,
 
+    /// Compiler assumptions passed through Babel configuration.
     #[serde(default)]
     pub assumptions: CompilerAssumptions,
 
     // Test options
+    /// Expected error message used by Babel fixture tests.
     pub throws: Option<String>,
 
+    /// Babel 8 compatibility toggle used by fixture tests.
     #[serde(rename = "BABEL_8_BREAKING")]
     pub babel_8_breaking: Option<bool>,
 
@@ -45,21 +52,27 @@ pub struct BabelOptions {
     pub os: Option<Vec<TestOs>>,
 
     // Parser options for babel-parser
+    /// Allow `return` statements outside function bodies.
     #[serde(default)]
     pub allow_return_outside_function: bool,
 
+    /// Allow `await` outside async functions.
     #[serde(default)]
     pub allow_await_outside_function: bool,
 
+    /// Allow exported names without local declarations.
     #[serde(default)]
     pub allow_undeclared_exports: bool,
 
+    /// Allow `new.target` outside function bodies.
     #[serde(default)]
     pub allow_new_target_outside_function: bool,
 
+    /// Allow `super` outside class methods.
     #[serde(default)]
     pub allow_super_outside_method: bool,
 
+    /// Whether helpers are provided by external runtime instead of inlined behavior.
     #[serde(default = "default_as_true")]
     pub external_helpers: bool,
 }
@@ -184,6 +197,7 @@ impl BabelOptions {
         options
     }
 
+    /// Returns `true` when JSX parsing/transform should be enabled.
     pub fn is_jsx(&self) -> bool {
         self.plugins.syntax_jsx
             || self.presets.jsx.is_some()
@@ -191,26 +205,32 @@ impl BabelOptions {
             || self.plugins.react_jsx_dev.is_some()
     }
 
+    /// Returns `true` when TypeScript parsing is enabled.
     pub fn is_typescript(&self) -> bool {
         self.plugins.syntax_typescript.is_some()
     }
 
+    /// Returns `true` when parsing a TypeScript declaration file.
     pub fn is_typescript_definition(&self) -> bool {
         self.plugins.syntax_typescript.is_some_and(|o| o.dts)
     }
 
+    /// Returns `true` when ambiguous JSX-like syntax should be rejected.
     pub fn has_disallow_ambiguous_jsx_like(&self) -> bool {
         self.plugins.syntax_typescript.is_some_and(|o| o.disallow_ambiguous_jsx_like)
     }
 
+    /// Returns `true` when source type is explicitly module.
     pub fn is_module(&self) -> bool {
         self.source_type.as_ref().is_some_and(|s| s.as_str() == "module")
     }
 
+    /// Returns `true` when source type is Babel's `unambiguous` mode.
     pub fn is_unambiguous(&self) -> bool {
         self.source_type.as_ref().is_some_and(|s| s.as_str() == "unambiguous")
     }
 
+    /// Returns `true` when source type is explicitly CommonJS.
     pub fn is_commonjs(&self) -> bool {
         self.source_type.as_ref().is_some_and(|s| s.as_str() == "commonjs")
     }

--- a/crates/oxc_transformer/src/options/env.rs
+++ b/crates/oxc_transformer/src/options/env.rs
@@ -18,28 +18,39 @@ use oxc_compat::{ESFeature, EngineTargets};
 
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(try_from = "BabelEnvOptions")]
+/// Feature toggles selected from target runtime support.
 pub struct EnvOptions {
     /// Specify what module code is generated.
     pub module: Module,
 
+    /// RegExp transform options.
     pub regexp: RegExpOptions,
 
+    /// ES2015 transform options.
     pub es2015: ES2015Options,
 
+    /// ES2016 transform options.
     pub es2016: ES2016Options,
 
+    /// ES2017 transform options.
     pub es2017: ES2017Options,
 
+    /// ES2018 transform options.
     pub es2018: ES2018Options,
 
+    /// ES2019 transform options.
     pub es2019: ES2019Options,
 
+    /// ES2020 transform options.
     pub es2020: ES2020Options,
 
+    /// ES2021 transform options.
     pub es2021: ES2021Options,
 
+    /// ES2022 transform options.
     pub es2022: ES2022Options,
 
+    /// ES2026 transform options.
     pub es2026: ES2026Options,
 }
 

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -66,6 +66,7 @@ pub struct TransformOptions {
     /// Plugins
     pub plugins: PluginsOptions,
 
+    /// Helper loading configuration for generated runtime helpers.
     pub helper_loader: HelperLoaderOptions,
 }
 

--- a/crates/oxc_transformer/src/options/module.rs
+++ b/crates/oxc_transformer/src/options/module.rs
@@ -15,8 +15,11 @@ use crate::options::babel::BabelModule;
 #[non_exhaustive]
 pub enum Module {
     #[default]
+    /// Preserve input module format.
     Preserve,
+    /// Emit ECMAScript module output.
     Esm,
+    /// Emit CommonJS module output.
     CommonJS,
 }
 

--- a/crates/oxc_transformer/src/plugins/options.rs
+++ b/crates/oxc_transformer/src/plugins/options.rs
@@ -1,7 +1,10 @@
 use super::StyledComponentsOptions;
 
 #[derive(Default, Debug, Clone)]
+/// Plugin-specific transform options.
 pub struct PluginsOptions {
+    /// Options for `styled-components` transform.
     pub styled_components: Option<StyledComponentsOptions>,
+    /// Enable tagged template transform plugin.
     pub tagged_template_transform: bool,
 }

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -74,6 +74,7 @@ use crate::{context::TraverseCtx, state::TransformState};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// Configuration for the styled-components transform.
 pub struct StyledComponentsOptions {
     /// Enhances the attached CSS class name on each component with richer output to help
     /// identify your components in the DOM without React DevTools. It also allows you to

--- a/crates/oxc_transformer/src/proposals/options.rs
+++ b/crates/oxc_transformer/src/proposals/options.rs
@@ -1,5 +1,6 @@
 #[expect(clippy::empty_structs_with_brackets)]
 #[derive(Debug, Clone, Copy, Default)]
+/// Options for proposal transforms.
 pub struct ProposalOptions {
     // Currently no proposals are configured here.
 }

--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -19,6 +19,7 @@ fn default_as_true() -> bool {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+/// TypeScript transform options.
 pub struct TypeScriptOptions {
     /// Replace the function used when compiling JSX expressions.
     /// This is so that we know that the import is not a type import, and should not be removed.
@@ -36,7 +37,7 @@ pub struct TypeScriptOptions {
     /// This should only be used if you are using TypeScript >= 3.8.
     pub only_remove_type_imports: bool,
 
-    // Enables compilation of TypeScript namespaces.
+    /// Enables compilation of TypeScript namespaces.
     #[serde(default = "default_as_true")]
     pub allow_namespaces: bool,
 
@@ -114,6 +115,7 @@ impl Default for TypeScriptOptions {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
+/// Strategy for rewriting TypeScript import/export extensions.
 pub enum RewriteExtensionsMode {
     /// Rewrite `.ts`/`.mts`/`.cts` extensions in import/export declarations to `.js`/`.mjs`/`.cjs`.
     #[default]
@@ -123,6 +125,7 @@ pub enum RewriteExtensionsMode {
 }
 
 impl RewriteExtensionsMode {
+    /// Returns `true` when extensions should be removed instead of rewritten.
     pub fn is_remove(self) -> bool {
         matches!(self, Self::Remove)
     }

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -146,8 +146,6 @@ impl Generator for AstKindGenerator {
         let ast_type_max = number_lit(next_index - 1);
 
         let output = quote! {
-            #![expect(missing_docs)] ///@ FIXME (in ast_tools/src/generators/ast_kind.rs)
-
             ///@@line_break
             use std::ptr;
 


### PR DESCRIPTION
## Summary
- add rustdoc comments for remaining public APIs in:
  - `oxc_transformer`
  - `oxc_isolated_declarations`
  - `oxc_semantic`
- remove all `#![warn(missing_docs)]` crate attributes
- remove all `#![expect(missing_docs)]` and `#[expect(missing_docs)]` attributes
- update AST kind generator template and regenerate so generated code no longer reintroduces missing-doc lint expectations

## Validation
- `just fmt`
- `just ast`
- `cargo rustc -p oxc_ast --lib -- -Dmissing-docs`
- `cargo rustc -p oxc_codegen --lib -- -Dmissing-docs`
- `cargo rustc -p oxc_transformer --lib -- -Dmissing-docs`
- `cargo rustc -p oxc_isolated_declarations --lib -- -Dmissing-docs`
- `cargo rustc -p oxc_semantic --lib -- -Dmissing-docs`
- `cargo rustc -p oxc_span --lib -- -Dmissing-docs`
- `cargo check -p oxc_transformer -p oxc_isolated_declarations -p oxc_semantic`
- `cargo check -p oxc_ast -p oxc_syntax -p oxc_str -p oxc_parser -p oxc_codegen -p oxc_span -p oxc_allocator -p oxc_data_structures -p oxc_macros`

## AI usage disclosure
This PR was prepared with AI assistance (Codex / GPT-5). I reviewed and validated the generated changes and take responsibility for the final content.
