### PR TITLE
refactor(allocator): disallow zero-sized types in Vec

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -41,9 +41,9 @@
 mod accessor;
 mod address;
 mod alloc;
-mod arena;
 mod allocator;
 mod allocator_api2;
+mod arena;
 #[cfg(feature = "bitset")]
 mod bitset;
 mod boxed;
@@ -66,8 +66,8 @@ mod vec;
 
 pub use accessor::AllocatorAccessor;
 pub use address::{Address, GetAddress, UnstableAddress};
-pub use arena::Arena;
 pub use allocator::Allocator;
+pub use arena::Arena;
 #[cfg(feature = "bitset")]
 pub use bitset::BitSet;
 pub use boxed::Box;


### PR DESCRIPTION
## Summary
- remove public allocator-`Vec` support for zero-sized element types
- enforce this via compile-time assertions in all `Vec` constructors
- update `Vec` docs to reflect that zero-sized types are unsupported

## Validation
- `cargo lint -p oxc_allocator -- -D warnings`
- `cargo test -p oxc_allocator`

## AI usage disclosure
- This PR was prepared with AI assistance (ChatGPT/Codex); I reviewed and validated the changes locally.
