### PR TITLE
ci(miri): pin nightly to 2026-02-11

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -34,6 +34,10 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    env:
+      # FIXME: cargo-miri is broken on nightly-2026-02-12.
+      # https://github.com/rust-lang/miri/issues/4855
+      MIRI_TOOLCHAIN: nightly-2026-02-11
     steps:
       - name: Checkout
         uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
@@ -45,13 +49,12 @@ jobs:
 
       - name: Install Miri
         run: |
-          rustup toolchain install nightly --component miri
-          rustup override set nightly
-          cargo miri setup
+          rustup toolchain install "${MIRI_TOOLCHAIN}" --component miri
+          cargo +"${MIRI_TOOLCHAIN}" miri setup
 
       # `--lib --bins --tests` omits doctests, which Miri can't run
       # https://github.com/oxc-project/oxc/pull/11092
       - name: Test with Miri
         run: |
-          cargo miri test --lib --bins --tests --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
-          cargo miri test --lib --bins --tests -p oxc_parser -p oxc_transformer
+          cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
+          cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests -p oxc_parser -p oxc_transformer


### PR DESCRIPTION
## Summary
- pin Miri CI to `nightly-2026-02-11` in `.github/workflows/miri.yml`
- run `cargo +"${MIRI_TOOLCHAIN}" miri ...` explicitly for setup/tests
- add a `FIXME` comment linking the upstream Miri regression

## Why
The Miri workflow started failing on 2026-02-12 with:
`build-script-build contains outdated or invalid JSON`

Failing Oxc run:
- https://github.com/oxc-project/oxc/actions/runs/21939457683/job/63361185996

Upstream issue:
- https://github.com/rust-lang/miri/issues/4855

## Validation
- reproduced the same failure on `nightly-2026-02-12` with a minimal `build.rs` crate
- confirmed the same repro passes on `nightly-2026-02-11`

## AI Usage Disclosure
AI assistance (Codex) was used to inspect CI logs and draft this patch. The contributor is responsible for the final changes and PR.
