### PR TITLE
docs(linter/typescript): skip docs for deprecated type aware rule options

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_boolean_literal_compare.rs
@@ -18,6 +18,7 @@ pub struct NoUnnecessaryBooleanLiteralCompareConfig {
     pub allow_comparing_nullable_booleans_to_true: bool,
     /// Whether to allow this rule to run without `strictNullChecks` enabled.
     /// This is not recommended as the rule may produce incorrect results.
+    #[schemars(skip)]
     pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_nullish_coalescing.rs
@@ -48,6 +48,7 @@ pub struct PreferNullishCoalescingConfig {
     /// (or `strict`) set to `true`.
     ///
     /// It is _not_ recommended to enable this config option.
+    #[schemars(skip)]
     pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
     /// Whether to ignore arguments to the `Boolean` constructor.
     pub ignore_boolean_coercion: bool,

--- a/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/strict_boolean_expressions.rs
@@ -28,6 +28,7 @@ pub struct StrictBooleanExpressionsConfig {
     pub allow_number: bool,
     /// Whether to allow this rule to run without `strictNullChecks` enabled.
     /// This is not recommended as the rule may produce incorrect results.
+    #[schemars(skip)]
     pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
 }
 


### PR DESCRIPTION
related to #425