### PR TITLE
fix(linter/describe-function-title): skip autofix for type-only imports

### DIFF
--- a/crates/oxc_linter/src/snapshots/vitest_prefer_describe_function_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_describe_function_title.snap
@@ -28,3 +28,12 @@ source: crates/oxc_linter/src/tester.rs
  5 │                     }
    ╰────
   help: Pass the function as a description title argument or modify the description title to not match any imported function name.
+
+  ⚠ eslint-plugin-vitest(prefer-describe-function-title): Title description can not have the same content as a imported function name.
+   ╭─[prefer_describe_function_title.tsx:3:21]
+ 2 │                     import type { Button } from "./button"
+ 3 │                     describe("Button", () => {})
+   ·                              ────────
+ 4 │                   
+   ╰────
+  help: Pass the function as a description title argument or modify the description title to not match any imported function name.


### PR DESCRIPTION
fixed #19325