### PR TITLE
perf(allocator): inline BitSet accessors

### DIFF
--- a/crates/oxc_allocator/src/bitset.rs
+++ b/crates/oxc_allocator/src/bitset.rs
@@ -40,16 +40,19 @@ impl<'alloc> BitSet<'alloc> {
     }
 
     /// Returns `true` if the bit at the given position is set.
+    #[inline]
     pub fn has_bit(&self, bit: usize) -> bool {
         (self.entries[bit / USIZE_BITS] & (1 << (bit % USIZE_BITS))) != 0
     }
 
     /// Set the bit at the given position.
+    #[inline]
     pub fn set_bit(&mut self, bit: usize) {
         self.entries[bit / USIZE_BITS] |= 1 << (bit % USIZE_BITS);
     }
 
     /// Remove the bit at the given position.
+    #[inline]
     pub fn unset_bit(&mut self, bit: usize) {
         self.entries[bit / USIZE_BITS] &= !(1 << (bit % USIZE_BITS));
     }
@@ -66,6 +69,7 @@ impl<'alloc> BitSet<'alloc> {
     }
 
     /// Clear all bits in the bitset, setting them to 0.
+    #[inline]
     pub fn clear(&mut self) {
         self.entries.fill(0);
     }


### PR DESCRIPTION
## Summary
- mark `BitSet::has_bit`, `BitSet::set_bit`, `BitSet::unset_bit`, and `BitSet::clear` as `#[inline]`
- this targets hot mangler loops where these tiny helpers are called frequently

## Validation
- `cargo test -p oxc_mangler --lib`

## AI Disclosure
This PR was prepared with assistance from an AI coding tool (Codex). The change and test results were reviewed before submission.