### PR TITLE
feat(ecmascript): port rolldown side-effect detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,6 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "phf",
- "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
 name = "oxc_ecmascript"
 version = "0.113.0"
 dependencies = [
+ "bitflags",
  "cow-utils",
  "num-bigint",
  "num-traits",
@@ -1915,6 +1916,8 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
+ "phf",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -32,4 +32,3 @@ bitflags = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
-rustc-hash = { workspace = true }

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -28,5 +28,8 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
 
 cow-utils = { workspace = true }
+bitflags = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+phf = { workspace = true, features = ["macros"] }
+rustc-hash = { workspace = true }

--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -1,4 +1,4 @@
-use oxc_ast::ast::Expression;
+use oxc_ast::ast::{CallExpression, Expression};
 
 use crate::GlobalContext;
 
@@ -7,6 +7,15 @@ pub enum PropertyReadSideEffects {
     /// Treat all property read accesses as side effect free.
     None,
     /// Treat all property read accesses as possible side effects.
+    #[default]
+    All,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyWriteSideEffects {
+    /// Treat all property write accesses as side effect free.
+    None,
+    /// Treat all property write accesses as possible side effects.
     #[default]
     All,
 }
@@ -33,6 +42,14 @@ pub trait MayHaveSideEffectsContext<'a>: GlobalContext<'a> {
     /// <https://rollupjs.org/configuration-options/#treeshake-propertyreadsideeffects>
     fn property_read_side_effects(&self) -> PropertyReadSideEffects;
 
+    /// Whether property write accesses have side effects.
+    ///
+    /// This is used by bundlers that support
+    /// <https://rollupjs.org/configuration-options/#treeshake-propertywritesideeffects>.
+    fn property_write_side_effects(&self) -> PropertyWriteSideEffects {
+        PropertyWriteSideEffects::All
+    }
+
     /// Whether accessing a global variable has side effects.
     ///
     /// Accessing a non-existing global variable will throw an error.
@@ -40,4 +57,12 @@ pub trait MayHaveSideEffectsContext<'a>: GlobalContext<'a> {
     ///
     /// <https://rollupjs.org/configuration-options/#treeshake-unknownglobalsideeffects>
     fn unknown_global_side_effects(&self) -> bool;
+
+    /// Whether this call expression should be treated as pure.
+    ///
+    /// This is used by consumers that discover extra call-site purity information
+    /// during cross-module analysis.
+    fn is_pure_call_expression(&self, _expr: &CallExpression<'a>) -> bool {
+        false
+    }
 }

--- a/crates/oxc_ecmascript/src/side_effects/detector.rs
+++ b/crates/oxc_ecmascript/src/side_effects/detector.rs
@@ -1,0 +1,946 @@
+use super::detector_utils::{
+    PrimitiveType, can_change_strict_to_loose, extract_member_expr_chain, is_primitive_literal,
+    is_side_effect_free_member_expr_of_len_three, is_side_effect_free_member_expr_of_len_two,
+    is_side_effect_free_unbound_identifier_ref, is_well_known_global_ident_ref,
+    known_primitive_type, maybe_side_effect_free_global_constructor,
+    maybe_side_effect_free_global_function_call,
+};
+use super::{
+    MayHaveSideEffectsContext, PropertyReadSideEffects, PropertyWriteSideEffects, SideEffectDetail,
+};
+use bitflags::bitflags;
+use oxc_ast::ast::{
+    self, Argument, ArrayExpressionElement, AssignmentTarget, BindingPattern, CallExpression,
+    ChainElement, Expression, IdentifierReference, PropertyKey, UnaryOperator,
+    VariableDeclarationKind,
+};
+use oxc_ast::{match_expression, match_member_expression};
+use oxc_span::Ident;
+
+bitflags! {
+  #[derive(Debug, Clone, Copy)]
+  /// Property could be read and write at the same time, so we need to distinguish them. e.g.
+  /// For a UpdateExpr `obj.prop++`, it is both read and write.
+  pub struct PropertyAccessFlag: u8 {
+    const Read = 1 << 0;
+    const Write = 1 << 1;
+  }
+}
+
+/// Detect if a statement "may" have side effect.
+pub struct SideEffectDetector<'ctx, 'a, Ctx: MayHaveSideEffectsContext<'a>> {
+    ctx: &'ctx Ctx,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'ctx, 'a, Ctx: MayHaveSideEffectsContext<'a>> SideEffectDetector<'ctx, 'a, Ctx> {
+    pub fn new(ctx: &'ctx Ctx) -> Self {
+        Self { ctx, _marker: std::marker::PhantomData }
+    }
+
+    #[inline]
+    fn is_unresolved_reference(&self, ident_ref: &IdentifierReference<'a>) -> bool {
+        self.ctx.is_global_reference(ident_ref)
+    }
+
+    fn detect_side_effect_of_property_key(
+        &self,
+        key: &PropertyKey<'a>,
+        is_computed: bool,
+    ) -> SideEffectDetail {
+        match key {
+            PropertyKey::StaticIdentifier(_) | PropertyKey::PrivateIdentifier(_) => false.into(),
+            key @ match_expression!(PropertyKey) => (is_computed && {
+                let key_expr = key.to_expression();
+                match key_expr {
+                    match_member_expression!(Expression) => {
+                        if let Some((ident_ref, chain)) =
+                            extract_member_expr_chain(key_expr.to_member_expression(), 2)
+                        {
+                            !(chain == ["Symbol", "iterator"]
+                                && self.is_unresolved_reference(ident_ref))
+                        } else {
+                            true
+                        }
+                    }
+                    _ => !is_primitive_literal(self.ctx, key_expr),
+                }
+            })
+            .into(),
+        }
+    }
+
+    /// ref: https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast_helpers.go#L2298-L2393
+    fn detect_side_effect_of_class(&self, cls: &ast::Class<'a>) -> SideEffectDetail {
+        use oxc_ast::ast::ClassElement;
+        if !cls.decorators.is_empty() {
+            return true.into();
+        }
+        cls.body
+            .body
+            .iter()
+            .any(|elm| match elm {
+                ClassElement::StaticBlock(static_block) => static_block
+                    .body
+                    .iter()
+                    .any(|stmt| self.detect_side_effect_of_stmt(stmt).has_side_effect()),
+                ClassElement::MethodDefinition(def) => {
+                    if !def.decorators.is_empty() {
+                        return true;
+                    }
+                    if self
+                        .detect_side_effect_of_property_key(&def.key, def.computed)
+                        .has_side_effect()
+                    {
+                        return true;
+                    }
+
+                    def.value.params.items.iter().any(|item| !item.decorators.is_empty())
+                }
+                ClassElement::PropertyDefinition(def) => {
+                    if !def.decorators.is_empty() {
+                        return true;
+                    }
+                    if self
+                        .detect_side_effect_of_property_key(&def.key, def.computed)
+                        .has_side_effect()
+                    {
+                        return true;
+                    }
+
+                    def.r#static
+                        && def.value.as_ref().is_some_and(|init| {
+                            self.detect_side_effect_of_expr(init).has_side_effect()
+                        })
+                }
+                ClassElement::AccessorProperty(def) => {
+                    if !def.decorators.is_empty() {
+                        return true;
+                    }
+                    (match &def.key {
+                        PropertyKey::StaticIdentifier(_) | PropertyKey::PrivateIdentifier(_) => {
+                            false
+                        }
+                        key @ match_expression!(PropertyKey) => {
+                            self.detect_side_effect_of_expr(key.to_expression()).has_side_effect()
+                        }
+                    } || def.value.as_ref().is_some_and(|init| {
+                        self.detect_side_effect_of_expr(init).has_side_effect()
+                    }))
+                }
+                ClassElement::TSIndexSignature(_) => true,
+            })
+            .into()
+    }
+
+    fn detect_side_effect_of_computed_member_expr(
+        &self,
+        expr: &ast::ComputedMemberExpression<'a>,
+        property_access_kind: PropertyAccessFlag,
+    ) -> SideEffectDetail {
+        let mut property_access_side_effects = false;
+        if property_access_kind.contains(PropertyAccessFlag::Read) {
+            property_access_side_effects |=
+                self.ctx.property_read_side_effects() != PropertyReadSideEffects::None;
+        }
+        if property_access_kind.contains(PropertyAccessFlag::Write) {
+            property_access_side_effects |=
+                self.ctx.property_write_side_effects() != PropertyWriteSideEffects::None;
+        }
+
+        let mut side_effects_detail = SideEffectDetail::empty();
+        let max_len = 3;
+        let mut chains = vec![];
+        if let ast::Expression::StringLiteral(ref str) = expr.expression {
+            chains.push(str.value.into());
+        } else {
+            side_effects_detail |= self.detect_side_effect_of_expr(&expr.expression);
+        }
+        let cur = &expr.object;
+        self.common_member_chain_processing(
+            property_access_side_effects,
+            &mut side_effects_detail,
+            max_len,
+            &mut chains,
+            cur,
+            property_access_kind,
+        );
+        side_effects_detail
+    }
+
+    fn detect_side_effect_of_static_member_expr(
+        &self,
+        expr: &ast::StaticMemberExpression<'a>,
+        property_access_kind: PropertyAccessFlag,
+    ) -> SideEffectDetail {
+        let mut property_access_side_effects = false;
+        if property_access_kind.contains(PropertyAccessFlag::Read) {
+            property_access_side_effects |=
+                self.ctx.property_read_side_effects() != PropertyReadSideEffects::None;
+        }
+        if property_access_kind.contains(PropertyAccessFlag::Write) {
+            property_access_side_effects |=
+                self.ctx.property_write_side_effects() != PropertyWriteSideEffects::None;
+        }
+
+        let mut side_effects_detail = SideEffectDetail::empty();
+        let max_len = 3;
+        let mut chains = vec![expr.property.name];
+        let cur = &expr.object;
+        self.common_member_chain_processing(
+            property_access_side_effects,
+            &mut side_effects_detail,
+            max_len,
+            &mut chains,
+            cur,
+            property_access_kind,
+        );
+        side_effects_detail
+    }
+
+    fn detect_side_effect_of_member_expr(
+        &self,
+        expr: &ast::MemberExpression<'a>,
+        property_access_kind: PropertyAccessFlag,
+    ) -> SideEffectDetail {
+        if self.is_expr_manual_pure_functions(expr.object()) {
+            return false.into();
+        }
+
+        match expr {
+            ast::MemberExpression::ComputedMemberExpression(computed_expr) => {
+                self.detect_side_effect_of_computed_member_expr(computed_expr, property_access_kind)
+            }
+            ast::MemberExpression::StaticMemberExpression(static_expr) => {
+                self.detect_side_effect_of_static_member_expr(static_expr, property_access_kind)
+            }
+            ast::MemberExpression::PrivateFieldExpression(_) => true.into(),
+        }
+    }
+
+    fn common_member_chain_processing(
+        &self,
+        property_access_side_effects: bool,
+        side_effects_detail: &mut SideEffectDetail,
+        max_len: usize,
+        chains: &mut Vec<Ident<'a>>,
+        mut cur: &Expression<'a>,
+        property_access_flag: PropertyAccessFlag,
+    ) {
+        loop {
+            match cur {
+                ast::Expression::StaticMemberExpression(expr) => {
+                    cur = &expr.object;
+                    chains.push(expr.property.name);
+                }
+                ast::Expression::ComputedMemberExpression(computed_expr) => {
+                    if let ast::Expression::StringLiteral(ref str) = computed_expr.expression {
+                        chains.push(str.value.into());
+                    } else {
+                        *side_effects_detail |=
+                            self.detect_side_effect_of_expr(&computed_expr.expression);
+                    }
+                    cur = &computed_expr.object;
+                }
+                ast::Expression::Identifier(ident_ref) => {
+                    chains.push(ident_ref.name);
+                    chains.reverse();
+                    side_effects_detail.set(
+                        SideEffectDetail::GlobalVarAccess,
+                        self.is_unresolved_reference(ident_ref),
+                    );
+                    break;
+                }
+                ast::Expression::MetaProperty(_) => {
+                    // Only `import.meta.url` is a spec-defined side-effect-free property read.
+                    // Other accesses like `import.meta.hot.accept()` may have side effects.
+                    if chains.len() == 1 && chains[0] == "url" {
+                        return;
+                    }
+                    break;
+                }
+                _ => {
+                    *side_effects_detail |= self.detect_side_effect_of_expr(cur);
+                    break;
+                }
+            }
+            if chains.len() >= max_len && property_access_side_effects {
+                *side_effects_detail = true.into();
+                return;
+            }
+        }
+
+        if property_access_flag.contains(PropertyAccessFlag::Write)
+            && side_effects_detail.contains(SideEffectDetail::GlobalVarAccess)
+        {
+            // If it is a write operation on a global variable, we consider it has side effect.
+            *side_effects_detail |= true.into();
+            return;
+        }
+        if !property_access_side_effects {
+            return;
+        }
+        *side_effects_detail |= (match chains.len() {
+            2 => !is_side_effect_free_member_expr_of_len_two(chains),
+            3 => !is_side_effect_free_member_expr_of_len_three(chains),
+            _ => true,
+        })
+        .into();
+    }
+
+    fn detect_side_effect_of_assignment_target(
+        &self,
+        expr: &AssignmentTarget<'a>,
+    ) -> SideEffectDetail {
+        match expr {
+            AssignmentTarget::ComputedMemberExpression(_)
+            | AssignmentTarget::StaticMemberExpression(_) => {
+                let member_expr = expr.to_member_expression();
+                match member_expr.object() {
+                    Expression::Identifier(ident) => {
+                        // - exports.a = ...;
+                        // - exports['a'] = ...;
+                        if self.is_unresolved_reference(ident)
+                            && ident.name == "exports"
+                            && member_expr.static_property_name().is_some()
+                        {
+                            SideEffectDetail::PureCjs
+                        } else if self.ctx.property_write_side_effects()
+                            != PropertyWriteSideEffects::None
+                        {
+                            true.into()
+                        } else {
+                            self.detect_side_effect_of_member_expr(
+                                member_expr,
+                                PropertyAccessFlag::Write,
+                            )
+                        }
+                    }
+                    _ => {
+                        if self.ctx.property_write_side_effects() != PropertyWriteSideEffects::None
+                        {
+                            true.into()
+                        } else {
+                            self.detect_side_effect_of_member_expr(
+                                member_expr,
+                                PropertyAccessFlag::Write,
+                            )
+                        }
+                    }
+                }
+            }
+
+            AssignmentTarget::AssignmentTargetIdentifier(_)
+            | AssignmentTarget::PrivateFieldExpression(_)
+            | AssignmentTarget::TSAsExpression(_)
+            | AssignmentTarget::TSSatisfiesExpression(_)
+            | AssignmentTarget::TSNonNullExpression(_)
+            | AssignmentTarget::TSTypeAssertion(_) => true.into(),
+
+            AssignmentTarget::ArrayAssignmentTarget(array_pattern) => {
+                (!array_pattern.elements.is_empty() || array_pattern.rest.is_some()).into()
+            }
+            AssignmentTarget::ObjectAssignmentTarget(object_pattern) => {
+                (!object_pattern.properties.is_empty() || object_pattern.rest.is_some()).into()
+            }
+        }
+    }
+
+    fn detect_side_effect_of_call_expr(&self, expr: &CallExpression<'a>) -> SideEffectDetail {
+        if self.is_expr_manual_pure_functions(&expr.callee) {
+            return false.into();
+        }
+
+        // TODO: with cjs tree shaking remove this may cause some runtime behavior incorrect.
+        // But marking `Object.defineProperty(exports, "__esModule", { value: true })` as has side effect may incraese bundle size a little.
+        // if is_object_define_property_es_module(self.scope, expr).unwrap_or_default() {
+        //   return StmtSideEffect::Unknown;
+        // }
+
+        let is_pure =
+            self.ctx.annotations() && (expr.pure || self.ctx.is_pure_call_expression(expr));
+        if is_pure {
+            // Even it is pure, we also wants to know if the callee has access global var
+            // But we need to ignore the `Unknown` flag, since it is already marked as `pure`.
+            let mut detail = SideEffectDetail::PureAnnotation;
+            detail |= self.detect_side_effect_of_expr(&expr.callee) - SideEffectDetail::Unknown;
+            for arg in &expr.arguments {
+                detail |= match arg {
+                    Argument::SpreadElement(_) => true.into(),
+                    _ => self.detect_side_effect_of_expr(arg.to_expression()),
+                };
+                if detail.has_side_effect() {
+                    break;
+                }
+            }
+            detail
+        } else {
+            let is_side_effect_free_global_function =
+                maybe_side_effect_free_global_function_call(self.ctx, expr);
+            if is_side_effect_free_global_function {
+                SideEffectDetail::GlobalVarAccess
+            } else {
+                true.into()
+            }
+        }
+    }
+
+    fn is_expr_manual_pure_functions(&self, expr: &Expression<'a>) -> bool {
+        self.ctx.manual_pure_functions(expr)
+    }
+
+    #[expect(clippy::too_many_lines)]
+    pub fn detect_side_effect_of_expr(&self, expr: &Expression<'a>) -> SideEffectDetail {
+        match expr {
+      Expression::BooleanLiteral(_)
+      | Expression::NullLiteral(_)
+      | Expression::NumericLiteral(_)
+      | Expression::BigIntLiteral(_)
+      | Expression::RegExpLiteral(_)
+      | Expression::FunctionExpression(_)
+      | Expression::ArrowFunctionExpression(_)
+      | Expression::MetaProperty(_)
+      | Expression::ThisExpression(_)
+      | Expression::StringLiteral(_) => false.into(),
+      Expression::ObjectExpression(obj_expr) => {
+        let mut detail = SideEffectDetail::empty();
+        for obj_prop in &obj_expr.properties {
+          detail |= match obj_prop {
+            ast::ObjectPropertyKind::ObjectProperty(prop) => {
+              self.detect_side_effect_of_property_key(&prop.key, prop.computed)
+                | self.detect_side_effect_of_expr(&prop.value)
+            }
+            // refer https://github.com/rollup/rollup/blob/f7633942/src/ast/nodes/SpreadElement.ts#L32
+            ast::ObjectPropertyKind::SpreadProperty(res) => {
+              if self.ctx.property_read_side_effects() != PropertyReadSideEffects::None {
+                return true.into();
+              }
+              self.detect_side_effect_of_expr(&res.argument)
+            }
+          };
+          if detail.has_side_effect() {
+            break;
+          }
+        }
+        detail
+      }
+      // https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_ast/js_ast_helpers.go#L2533-L2539
+      Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
+        ast::UnaryOperator::Typeof if matches!(unary_expr.argument, Expression::Identifier(_)) => {
+          false.into()
+        }
+        _ => self.detect_side_effect_of_expr(&unary_expr.argument),
+      },
+      oxc_ast::match_member_expression!(Expression) => self
+        .detect_side_effect_of_member_expr(expr.to_member_expression(), PropertyAccessFlag::Read),
+      Expression::ClassExpression(cls) => self.detect_side_effect_of_class(cls),
+      // Accessing global variables considered as side effect.
+      Expression::Identifier(ident) => self.detect_side_effect_of_identifier(ident),
+      // https://github.com/evanw/esbuild/blob/360d47230813e67d0312ad754cad2b6ee09b151b/internal/js_ast/js_ast_helpers.go#L2576-L2588
+      Expression::TemplateLiteral(literal) => {
+        let mut detail = SideEffectDetail::empty();
+        for expr in &literal.expressions {
+          // Primitive type detection is more strict and faster than side_effects detection of
+          // `Expr`, put it first to fail fast.
+          detail |= (known_primitive_type(self.ctx, expr) == PrimitiveType::Unknown).into();
+          detail |= self.detect_side_effect_of_expr(expr);
+          if detail.has_side_effect() {
+            break;
+          }
+        }
+        detail
+      }
+      Expression::LogicalExpression(logic_expr) => match logic_expr.operator {
+        ast::LogicalOperator::Or => {
+          let lhs = self.detect_side_effect_of_expr(&logic_expr.left);
+          let mut rhs = self.detect_side_effect_of_expr(&logic_expr.right);
+          rhs.set(
+            SideEffectDetail::Unknown,
+            !is_side_effect_free_unbound_identifier_ref(
+              self.ctx,
+              &logic_expr.right,
+              &logic_expr.left,
+              false,
+            )
+            .unwrap_or_default()
+              && rhs.contains(SideEffectDetail::Unknown),
+          );
+          lhs | rhs
+        }
+        ast::LogicalOperator::And => {
+          let lhs = self.detect_side_effect_of_expr(&logic_expr.left);
+          let mut rhs = self.detect_side_effect_of_expr(&logic_expr.right);
+          rhs.set(
+            SideEffectDetail::Unknown,
+            !is_side_effect_free_unbound_identifier_ref(
+              self.ctx,
+              &logic_expr.right,
+              &logic_expr.left,
+              true,
+            )
+            .unwrap_or_default()
+              && rhs.contains(SideEffectDetail::Unknown),
+          );
+          lhs | rhs
+        }
+        ast::LogicalOperator::Coalesce => {
+          self.detect_side_effect_of_expr(&logic_expr.left)
+            | self.detect_side_effect_of_expr(&logic_expr.right)
+        }
+      },
+      Expression::ParenthesizedExpression(paren_expr) => {
+        self.detect_side_effect_of_expr(&paren_expr.expression)
+      }
+      Expression::SequenceExpression(seq_expr) => {
+        let mut detail = SideEffectDetail::empty();
+
+        for expr in &seq_expr.expressions {
+          detail |= self.detect_side_effect_of_expr(expr);
+          if detail.has_side_effect() {
+            break;
+          }
+        }
+        detail
+      }
+      // https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_ast/js_ast_helpers.go#L2460-L2463
+      Expression::ConditionalExpression(cond_expr) => {
+        let detail = self.detect_side_effect_of_expr(&cond_expr.test);
+        let mut consequent_detail = self.detect_side_effect_of_expr(&cond_expr.consequent);
+        consequent_detail.set(
+          SideEffectDetail::Unknown,
+          !is_side_effect_free_unbound_identifier_ref(
+            self.ctx,
+            &cond_expr.consequent,
+            &cond_expr.test,
+            true,
+          )
+          .unwrap_or_default()
+            && consequent_detail.contains(SideEffectDetail::Unknown),
+        );
+        let mut alternate_detail = self.detect_side_effect_of_expr(&cond_expr.alternate);
+        alternate_detail.set(
+          SideEffectDetail::Unknown,
+          !is_side_effect_free_unbound_identifier_ref(
+            self.ctx,
+            &cond_expr.alternate,
+            &cond_expr.test,
+            false,
+          )
+          .unwrap_or_default()
+            && alternate_detail.contains(SideEffectDetail::Unknown),
+        );
+        detail | consequent_detail | alternate_detail
+      }
+      // Untranspiled TS/JSX syntax should be caught during scan stage.
+      // Conservatively treat as side-effectful since they should not appear here.
+      Expression::TSAsExpression(_)
+      | Expression::TSSatisfiesExpression(_)
+      | Expression::TSTypeAssertion(_)
+      | Expression::TSNonNullExpression(_)
+      | Expression::TSInstantiationExpression(_)
+      | Expression::JSXElement(_)
+      | Expression::JSXFragment(_)
+      // Inherently side-effectful expressions.
+      | Expression::Super(_)
+      | Expression::AwaitExpression(_)
+      | Expression::ImportExpression(_)
+      | Expression::YieldExpression(_)
+      | Expression::V8IntrinsicExpression(_) => true.into(),
+      // https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_ast/js_ast_helpers.go#L2541-L2574
+      Expression::BinaryExpression(binary_expr) => {
+        match binary_expr.operator {
+          ast::BinaryOperator::StrictEquality | ast::BinaryOperator::StrictInequality => {
+            self.detect_side_effect_of_expr(&binary_expr.left)
+              | self.detect_side_effect_of_expr(&binary_expr.right)
+          }
+          // Special-case "<" and ">" with string, number, or bigint arguments
+          ast::BinaryOperator::GreaterThan
+          | ast::BinaryOperator::LessThan
+          | ast::BinaryOperator::GreaterEqualThan
+          | ast::BinaryOperator::LessEqualThan => {
+            let lt = known_primitive_type(self.ctx, &binary_expr.left);
+            match lt {
+              PrimitiveType::Number | PrimitiveType::String | PrimitiveType::BigInt => {
+                SideEffectDetail::from(known_primitive_type(self.ctx, &binary_expr.right) != lt)
+                  | self.detect_side_effect_of_expr(&binary_expr.left)
+                  | self.detect_side_effect_of_expr(&binary_expr.right)
+              }
+              _ => true.into(),
+            }
+          }
+
+          // For "==" and "!=", pretend the operator was actually "===" or "!==". If
+          // we know that we can convert it to "==" or "!=", then we can consider the
+          // operator itself to have no side effects. This matters because our mangle
+          // logic will convert "typeof x === 'object'" into "typeof x == 'object'"
+          // and since "typeof x === 'object'" is considered to be side-effect free,
+          // we must also consider "typeof x == 'object'" to be side-effect free.
+          ast::BinaryOperator::Equality | ast::BinaryOperator::Inequality => {
+            SideEffectDetail::from(!can_change_strict_to_loose(
+              self.ctx,
+              &binary_expr.left,
+              &binary_expr.right,
+            )) | self.detect_side_effect_of_expr(&binary_expr.left)
+              | self.detect_side_effect_of_expr(&binary_expr.right)
+          }
+
+          _ => true.into(),
+        }
+      }
+      Expression::PrivateInExpression(private_in_expr) => {
+        self.detect_side_effect_of_expr(&private_in_expr.right)
+      }
+      Expression::AssignmentExpression(expr) => {
+        self.detect_side_effect_of_assignment_target(&expr.left)
+          | self.detect_side_effect_of_expr(&expr.right)
+      }
+
+      Expression::ChainExpression(expr) => match &expr.expression {
+        ChainElement::CallExpression(call_expr) => self.detect_side_effect_of_call_expr(call_expr),
+        ChainElement::TSNonNullExpression(expr) => {
+          self.detect_side_effect_of_expr(&expr.expression)
+        }
+        match_member_expression!(ChainElement) => self.detect_side_effect_of_member_expr(
+          expr.expression.to_member_expression(),
+          PropertyAccessFlag::Read,
+        ),
+      },
+      Expression::TaggedTemplateExpression(expr) => {
+        (!self.is_expr_manual_pure_functions(&expr.tag)).into()
+      }
+      Expression::UpdateExpression(expr) => {
+        // Handle update expressions like obj.prop++ or obj[prop]++
+        match &expr.argument {
+          ast::SimpleAssignmentTarget::StaticMemberExpression(static_member_expr) => {
+            if self.ctx.property_write_side_effects() != PropertyWriteSideEffects::None {
+              true.into()
+            } else {
+              // If property_write_side_effects is false, we consider property updates
+              // as side-effect-free
+
+              self.detect_side_effect_of_static_member_expr(
+                static_member_expr,
+                PropertyAccessFlag::all(),
+              )
+            }
+          }
+          ast::SimpleAssignmentTarget::ComputedMemberExpression(computed_expr) => self
+            .detect_side_effect_of_computed_member_expr(computed_expr, PropertyAccessFlag::all()),
+          _ => true.into(),
+        }
+      }
+      Expression::ArrayExpression(expr) => self.detect_side_effect_of_array_expr(expr),
+      Expression::NewExpression(expr) => {
+        let is_side_effect_free_global_constructor =
+          maybe_side_effect_free_global_constructor(self.ctx, expr);
+        let is_pure = expr.pure || is_side_effect_free_global_constructor;
+
+        let mut detail = SideEffectDetail::empty();
+        detail.set(SideEffectDetail::GlobalVarAccess, is_side_effect_free_global_constructor);
+        detail.set(SideEffectDetail::Unknown, !is_pure);
+        detail.set(SideEffectDetail::PureAnnotation, expr.pure);
+
+        for arg in &expr.arguments {
+          detail |= match arg {
+            Argument::SpreadElement(_) => true.into(),
+            _ => self.detect_side_effect_of_expr(arg.to_expression()),
+          };
+          if detail.has_side_effect() {
+            break;
+          }
+        }
+        detail
+      }
+      Expression::CallExpression(expr) => self.detect_side_effect_of_call_expr(expr),
+    }
+    }
+
+    fn detect_side_effect_of_array_expr(
+        &self,
+        expr: &ast::ArrayExpression<'a>,
+    ) -> SideEffectDetail {
+        let mut detail = SideEffectDetail::empty();
+        for elem in &expr.elements {
+            let cur = match elem {
+                ArrayExpressionElement::SpreadElement(ele) => {
+                    // https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_ast/js_ast_helpers.go#L2466-L2477
+                    // Spread of an inline array such as "[...[x]]" is side-effect free
+                    match &ele.argument {
+                        Expression::ArrayExpression(arr) => {
+                            self.detect_side_effect_of_array_expr(arr)
+                        }
+                        _ => return true.into(),
+                    }
+                }
+                ArrayExpressionElement::Elision(_) => false.into(),
+                match_expression!(ArrayExpressionElement) => {
+                    self.detect_side_effect_of_expr(elem.to_expression())
+                }
+            };
+            detail |= cur;
+        }
+        detail
+    }
+
+    fn detect_side_effect_of_var_decl(
+        &self,
+        var_decl: &ast::VariableDeclaration<'a>,
+    ) -> SideEffectDetail {
+        match var_decl.kind {
+            VariableDeclarationKind::AwaitUsing => true.into(),
+            VariableDeclarationKind::Using => {
+                self.detect_side_effect_of_using_declarators(&var_decl.declarations)
+            }
+            _ => {
+                let mut detail = SideEffectDetail::empty();
+                for declarator in &var_decl.declarations {
+                    // Whether to destructure import.meta
+                    if let BindingPattern::ObjectPattern(ref obj_pat) = declarator.id {
+                        if !obj_pat.properties.is_empty() {
+                            if let Some(Expression::MetaProperty(_)) = declarator.init {
+                                return true.into();
+                            }
+                        }
+                    }
+                    detail |= match &declarator.id {
+                        // Destructuring the initializer has no side effects if the
+                        // initializer is an array, since we assume the iterator is then
+                        // the built-in side-effect free array iterator.
+                        BindingPattern::ObjectPattern(_) => {
+                            // Object destructuring only has side effects when property_read_side_effects is Always
+                            if self.ctx.property_read_side_effects()
+                                != PropertyReadSideEffects::None
+                            {
+                                true.into()
+                            } else {
+                                declarator
+                                    .init
+                                    .as_ref()
+                                    .map(|init| self.detect_side_effect_of_expr(init))
+                                    .unwrap_or(false.into())
+                            }
+                        }
+                        BindingPattern::ArrayPattern(pat) => {
+                            for p in &pat.elements {
+                                if p.as_ref().is_some_and(|pat| {
+                                    !matches!(pat, BindingPattern::BindingIdentifier(_))
+                                }) {
+                                    return true.into();
+                                }
+                            }
+                            declarator
+                                .init
+                                .as_ref()
+                                .map(|init| self.detect_side_effect_of_expr(init))
+                                .unwrap_or(false.into())
+                        }
+                        BindingPattern::BindingIdentifier(_)
+                        | BindingPattern::AssignmentPattern(_) => declarator
+                            .init
+                            .as_ref()
+                            .map(|init| self.detect_side_effect_of_expr(init))
+                            .unwrap_or(false.into()),
+                    };
+                }
+                detail
+            }
+        }
+    }
+
+    fn detect_side_effect_of_decl(&self, decl: &ast::Declaration<'a>) -> SideEffectDetail {
+        use oxc_ast::ast::Declaration;
+        match decl {
+            Declaration::VariableDeclaration(var_decl) => {
+                self.detect_side_effect_of_var_decl(var_decl)
+            }
+            Declaration::FunctionDeclaration(_) => false.into(),
+            Declaration::ClassDeclaration(cls_decl) => self.detect_side_effect_of_class(cls_decl),
+            Declaration::TSTypeAliasDeclaration(_)
+            | Declaration::TSInterfaceDeclaration(_)
+            | Declaration::TSEnumDeclaration(_)
+            | Declaration::TSModuleDeclaration(_)
+            | Declaration::TSImportEqualsDeclaration(_)
+            | Declaration::TSGlobalDeclaration(_) => true.into(),
+        }
+    }
+
+    fn detect_side_effect_of_using_declarators(
+        &self,
+        declarators: &[ast::VariableDeclarator<'a>],
+    ) -> SideEffectDetail {
+        let mut detail = SideEffectDetail::empty();
+        for decl in declarators {
+            detail |= decl
+                .init
+                .as_ref()
+                .map(|init| match init {
+                    Expression::NullLiteral(_) => false.into(),
+                    // Side effect detection of identifier is different with other position when as initialization of using declaration.
+                    // Global variable `undefined` is considered as side effect free.
+                    Expression::Identifier(id) => {
+                        (!(id.name == "undefined" && self.is_unresolved_reference(id))).into()
+                    }
+                    Expression::UnaryExpression(expr)
+                        if matches!(expr.operator, UnaryOperator::Void) =>
+                    {
+                        self.detect_side_effect_of_expr(&expr.argument)
+                    }
+                    _ => true.into(),
+                })
+                .unwrap_or(SideEffectDetail::empty());
+            if detail.has_side_effect() {
+                break;
+            }
+        }
+        detail
+    }
+
+    fn detect_side_effect_of_identifier(
+        &self,
+        ident_ref: &IdentifierReference<'a>,
+    ) -> SideEffectDetail {
+        let mut detail = SideEffectDetail::empty();
+        detail.set(SideEffectDetail::GlobalVarAccess, self.is_unresolved_reference(ident_ref));
+        if detail.contains(SideEffectDetail::GlobalVarAccess) {
+            detail.set(
+                SideEffectDetail::Unknown,
+                detail.contains(SideEffectDetail::GlobalVarAccess)
+                    && self.ctx.unknown_global_side_effects()
+                    && !is_well_known_global_ident_ref(ident_ref.name.as_str()),
+            );
+        }
+        detail
+    }
+
+    pub fn detect_side_effect_of_stmt(&self, stmt: &ast::Statement<'a>) -> SideEffectDetail {
+        use oxc_ast::ast::Statement;
+        match stmt {
+            oxc_ast::match_declaration!(Statement) => {
+                self.detect_side_effect_of_decl(stmt.to_declaration())
+            }
+            Statement::ExpressionStatement(expr) => {
+                self.detect_side_effect_of_expr(&expr.expression)
+            }
+            oxc_ast::match_module_declaration!(Statement) => match stmt.to_module_declaration() {
+                ast::ModuleDeclaration::ExportAllDeclaration(_)
+                | ast::ModuleDeclaration::ImportDeclaration(_) => {
+                    // We consider `import ...` has no side effect. However, `import ...` might be rewritten to other statements by the bundler.
+                    // In that case, we will mark the statement as having side effect in link stage.
+                    false.into()
+                }
+                ast::ModuleDeclaration::ExportDefaultDeclaration(default_decl) => {
+                    use oxc_ast::ast::ExportDefaultDeclarationKind;
+                    match &default_decl.declaration {
+                        decl @ match_expression!(ExportDefaultDeclarationKind) => {
+                            self.detect_side_effect_of_expr(decl.to_expression())
+                        }
+                        ast::ExportDefaultDeclarationKind::FunctionDeclaration(_) => false.into(),
+                        ast::ExportDefaultDeclarationKind::ClassDeclaration(decl) => {
+                            self.detect_side_effect_of_class(decl)
+                        }
+                        ast::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => true.into(),
+                    }
+                }
+                ast::ModuleDeclaration::ExportNamedDeclaration(named_decl) => {
+                    if named_decl.source.is_some() {
+                        false.into()
+                    } else {
+                        named_decl
+                            .declaration
+                            .as_ref()
+                            .map(|decl| self.detect_side_effect_of_decl(decl))
+                            .unwrap_or(false.into())
+                    }
+                }
+                ast::ModuleDeclaration::TSExportAssignment(_)
+                | ast::ModuleDeclaration::TSNamespaceExportDeclaration(_) => true.into(),
+            },
+            Statement::BlockStatement(block) => self.detect_side_effect_of_block(block),
+            Statement::DoWhileStatement(do_while) => {
+                self.detect_side_effect_of_stmt(&do_while.body)
+                    | self.detect_side_effect_of_expr(&do_while.test)
+            }
+            Statement::WhileStatement(while_stmt) => {
+                self.detect_side_effect_of_expr(&while_stmt.test)
+                    | self.detect_side_effect_of_stmt(&while_stmt.body)
+            }
+            Statement::IfStatement(if_stmt) => {
+                self.detect_side_effect_of_expr(&if_stmt.test)
+                    | self.detect_side_effect_of_stmt(&if_stmt.consequent)
+                    | if_stmt
+                        .alternate
+                        .as_ref()
+                        .map(|stmt| self.detect_side_effect_of_stmt(stmt))
+                        .unwrap_or(false.into())
+            }
+            Statement::ReturnStatement(ret_stmt) => ret_stmt
+                .argument
+                .as_ref()
+                .map(|expr| self.detect_side_effect_of_expr(expr))
+                .unwrap_or(false.into()),
+            Statement::LabeledStatement(labeled_stmt) => {
+                self.detect_side_effect_of_stmt(&labeled_stmt.body)
+            }
+            Statement::TryStatement(try_stmt) => {
+                let mut detail = self.detect_side_effect_of_block(&try_stmt.block);
+                detail |= try_stmt
+                    .handler
+                    .as_ref()
+                    .map(|handler| self.detect_side_effect_of_block(&handler.body))
+                    .unwrap_or(SideEffectDetail::empty());
+                detail |= try_stmt
+                    .finalizer
+                    .as_ref()
+                    .map(|finalizer| self.detect_side_effect_of_block(finalizer))
+                    .unwrap_or(SideEffectDetail::empty());
+                detail
+            }
+            Statement::SwitchStatement(switch_stmt) => {
+                let mut detail = self.detect_side_effect_of_expr(&switch_stmt.discriminant);
+                if detail.has_side_effect() {
+                    return detail;
+                }
+                'outer: for case in &switch_stmt.cases {
+                    detail |= case
+                        .test
+                        .as_ref()
+                        .map(|expr| self.detect_side_effect_of_expr(expr))
+                        .unwrap_or(SideEffectDetail::empty());
+                    for stmt in &case.consequent {
+                        detail |= self.detect_side_effect_of_stmt(stmt);
+                        if detail.has_side_effect() {
+                            break 'outer;
+                        }
+                    }
+
+                    if detail.has_side_effect() {
+                        break;
+                    }
+                }
+                detail
+            }
+
+            Statement::EmptyStatement(_)
+            | Statement::ContinueStatement(_)
+            | Statement::BreakStatement(_) => false.into(),
+
+            Statement::DebuggerStatement(_)
+            | Statement::ForInStatement(_)
+            | Statement::ForOfStatement(_)
+            | Statement::ForStatement(_)
+            | Statement::ThrowStatement(_)
+            | Statement::WithStatement(_) => true.into(),
+        }
+    }
+
+    fn detect_side_effect_of_block(&self, block: &ast::BlockStatement<'a>) -> SideEffectDetail {
+        let mut detail = SideEffectDetail::empty();
+        for stmt in &block.body {
+            detail |= self.detect_side_effect_of_stmt(stmt);
+            if detail.has_side_effect() {
+                break;
+            }
+        }
+        detail
+    }
+}

--- a/crates/oxc_ecmascript/src/side_effects/detector_utils.rs
+++ b/crates/oxc_ecmascript/src/side_effects/detector_utils.rs
@@ -1,0 +1,1445 @@
+use oxc_allocator::Vec as ArenaVec;
+use oxc_ast::ast::{self, Expression, IdentifierReference, MemberExpression};
+use oxc_span::Ident;
+use oxc_syntax::operator::{
+    AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
+};
+
+use super::{MayHaveSideEffectsContext, is_valid_regexp};
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub enum PrimitiveType {
+    Null,
+    Undefined,
+    Boolean,
+    Number,
+    String,
+    BigInt,
+    Mixed,
+    Unknown,
+}
+
+fn merged_known_primitive_types<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    left: &Expression<'a>,
+    right: &Expression<'a>,
+) -> PrimitiveType {
+    let left_type = known_primitive_type(ctx, left);
+    if left_type == PrimitiveType::Unknown {
+        return PrimitiveType::Unknown;
+    }
+    let right_type = known_primitive_type(ctx, right);
+    if right_type == PrimitiveType::Unknown {
+        return PrimitiveType::Unknown;
+    }
+    if right_type == left_type {
+        return right_type;
+    }
+    PrimitiveType::Mixed
+}
+
+pub fn known_primitive_type<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    expr: &Expression<'a>,
+) -> PrimitiveType {
+    match expr {
+        Expression::NullLiteral(_) => PrimitiveType::Null,
+        Expression::Identifier(id) if id.name == "undefined" && ctx.is_global_reference(id) => {
+            PrimitiveType::Undefined
+        }
+        Expression::BooleanLiteral(_) => PrimitiveType::Boolean,
+        Expression::NumericLiteral(_) => PrimitiveType::Number,
+        Expression::StringLiteral(_) => PrimitiveType::String,
+        Expression::BigIntLiteral(_) => PrimitiveType::BigInt,
+        Expression::TemplateLiteral(e) => {
+            if e.expressions.is_empty() {
+                PrimitiveType::String
+            } else {
+                PrimitiveType::Unknown
+            }
+        }
+        Expression::UpdateExpression(e) => {
+            match e.operator {
+                UpdateOperator::Increment | UpdateOperator::Decrement => {
+                    PrimitiveType::Mixed // Can be number or bigint
+                }
+            }
+        }
+        Expression::UnaryExpression(e) => match e.operator {
+            UnaryOperator::Void => PrimitiveType::Undefined,
+            UnaryOperator::Typeof => PrimitiveType::String,
+            UnaryOperator::LogicalNot | UnaryOperator::Delete => PrimitiveType::Boolean,
+            UnaryOperator::UnaryPlus => PrimitiveType::Number, // Cannot be bigint because that throws an exception
+            UnaryOperator::UnaryNegation | UnaryOperator::BitwiseNot => {
+                let value = known_primitive_type(ctx, &e.argument);
+                if value == PrimitiveType::BigInt {
+                    return PrimitiveType::BigInt;
+                }
+                if value != PrimitiveType::Unknown && value != PrimitiveType::Mixed {
+                    return PrimitiveType::Number;
+                }
+                PrimitiveType::Mixed // Can be number or bigint
+            }
+        },
+        Expression::LogicalExpression(e) => match e.operator {
+            LogicalOperator::Or | LogicalOperator::And => {
+                merged_known_primitive_types(ctx, &e.left, &e.right)
+            }
+            LogicalOperator::Coalesce => {
+                let left = known_primitive_type(ctx, &e.left);
+                let right = known_primitive_type(ctx, &e.right);
+                if left == PrimitiveType::Null || left == PrimitiveType::Undefined {
+                    return right;
+                }
+                if left != PrimitiveType::Unknown {
+                    if left != PrimitiveType::Mixed {
+                        return left; // Definitely not null or undefined
+                    }
+                    if right != PrimitiveType::Unknown {
+                        return PrimitiveType::Mixed; // Definitely some kind of primitive
+                    }
+                }
+                PrimitiveType::Unknown
+            }
+        },
+        Expression::BinaryExpression(e) => match e.operator {
+            BinaryOperator::StrictEquality
+            | BinaryOperator::StrictInequality
+            | BinaryOperator::Equality
+            | BinaryOperator::Inequality
+            | BinaryOperator::LessThan
+            | BinaryOperator::GreaterThan
+            | BinaryOperator::GreaterEqualThan
+            | BinaryOperator::LessEqualThan
+            | BinaryOperator::Instanceof
+            | BinaryOperator::In => PrimitiveType::Boolean,
+            BinaryOperator::Addition => {
+                let left = known_primitive_type(ctx, &e.left);
+                let right = known_primitive_type(ctx, &e.right);
+                if left == PrimitiveType::String || right == PrimitiveType::String {
+                    PrimitiveType::String
+                } else if left == PrimitiveType::BigInt && right == PrimitiveType::BigInt {
+                    PrimitiveType::BigInt
+                } else if !matches!(
+                    left,
+                    PrimitiveType::Unknown | PrimitiveType::Mixed | PrimitiveType::BigInt
+                ) && !matches!(
+                    right,
+                    PrimitiveType::Unknown | PrimitiveType::Mixed | PrimitiveType::BigInt
+                ) {
+                    PrimitiveType::Number
+                } else {
+                    PrimitiveType::Mixed // Can be number or bigint or string (or an exception)
+                }
+            }
+            BinaryOperator::Subtraction
+            | BinaryOperator::Multiplication
+            | BinaryOperator::Division
+            | BinaryOperator::Remainder
+            | BinaryOperator::Exponential
+            | BinaryOperator::BitwiseAnd
+            | BinaryOperator::BitwiseOR
+            | BinaryOperator::ShiftRight
+            | BinaryOperator::ShiftLeft
+            | BinaryOperator::ShiftRightZeroFill
+            | BinaryOperator::BitwiseXOR => PrimitiveType::Mixed,
+        },
+
+        Expression::AssignmentExpression(e) => match e.operator {
+            AssignmentOperator::Assign => known_primitive_type(ctx, &e.right),
+            AssignmentOperator::Addition => {
+                let right = known_primitive_type(ctx, &e.right);
+                if right == PrimitiveType::String {
+                    PrimitiveType::String
+                } else {
+                    PrimitiveType::Mixed // Can be number or bigint or string (or an exception)
+                }
+            }
+            AssignmentOperator::Subtraction
+            | AssignmentOperator::Multiplication
+            | AssignmentOperator::Division
+            | AssignmentOperator::Remainder
+            | AssignmentOperator::ShiftLeft
+            | AssignmentOperator::ShiftRight
+            | AssignmentOperator::ShiftRightZeroFill
+            | AssignmentOperator::BitwiseOR
+            | AssignmentOperator::BitwiseXOR
+            | AssignmentOperator::BitwiseAnd
+            | AssignmentOperator::LogicalAnd
+            | AssignmentOperator::LogicalOr
+            | AssignmentOperator::LogicalNullish
+            | AssignmentOperator::Exponential => PrimitiveType::Mixed,
+        },
+        _ => PrimitiveType::Unknown,
+    }
+}
+
+pub fn can_change_strict_to_loose<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    a: &Expression<'a>,
+    b: &Expression<'a>,
+) -> bool {
+    let x = known_primitive_type(ctx, a);
+    let y = known_primitive_type(ctx, b);
+    x == y && !matches!(x, PrimitiveType::Unknown | PrimitiveType::Mixed)
+}
+
+pub fn is_primitive_literal<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    expr: &Expression<'a>,
+) -> bool {
+    match expr {
+        Expression::NullLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::BigIntLiteral(_) => true,
+        // Include `+1` / `-1`.
+        Expression::UnaryExpression(e) => match e.operator {
+            UnaryOperator::Void => is_primitive_literal(ctx, &e.argument),
+            UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus => {
+                matches!(e.argument, Expression::NumericLiteral(_))
+            }
+            _ => false,
+        },
+        Expression::Identifier(id) if id.name == "undefined" && ctx.is_global_reference(id) => true,
+        _ => false,
+    }
+}
+
+pub fn extract_member_expr_chain<'a, 'b>(
+    expr: &'b MemberExpression<'a>,
+    max_len: usize,
+) -> Option<(&'b IdentifierReference<'a>, Vec<Ident<'a>>)> {
+    if max_len == 0 {
+        return None;
+    }
+
+    let mut chain = vec![];
+    let mut cur = match expr {
+        MemberExpression::ComputedMemberExpression(computed_expr) => {
+            let Expression::StringLiteral(ref str) = computed_expr.expression else {
+                return None;
+            };
+            chain.push(str.value.into());
+            &computed_expr.object
+        }
+        MemberExpression::StaticMemberExpression(static_expr) => {
+            chain.push(static_expr.property.name);
+            &static_expr.object
+        }
+        MemberExpression::PrivateFieldExpression(_) => return None,
+    };
+
+    // extract_rest_member_expr_chain
+    loop {
+        match cur {
+            Expression::StaticMemberExpression(expr) => {
+                cur = &expr.object;
+                chain.push(expr.property.name);
+            }
+            Expression::ComputedMemberExpression(expr) => {
+                let Expression::StringLiteral(ref str) = expr.expression else {
+                    break;
+                };
+                chain.push(str.value.into());
+                cur = &expr.object;
+            }
+            Expression::Identifier(ident) => {
+                chain.push(ident.name);
+                chain.reverse();
+                return Some((ident, chain));
+            }
+            _ => break,
+        }
+        // If chain exceeds the max length, that means we are not interest in this member expression.
+        // return `None`
+        if chain.len() >= max_len {
+            return None;
+        }
+    }
+    None
+}
+
+/// https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_ast/js_ast_helpers.go#L2594-L2639
+pub fn is_side_effect_free_unbound_identifier_ref<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    value: &Expression<'a>,
+    guard_condition: &Expression<'a>,
+    mut is_yes_branch: bool,
+) -> Option<bool> {
+    let Expression::Identifier(ident) = value else {
+        return None;
+    };
+    if !ctx.is_global_reference(ident) {
+        return Some(false);
+    }
+    let Expression::BinaryExpression(bin_expr) = guard_condition else {
+        return None;
+    };
+    match bin_expr.operator {
+        BinaryOperator::StrictEquality
+        | BinaryOperator::StrictInequality
+        | BinaryOperator::Equality
+        | BinaryOperator::Inequality => {
+            let (mut ty_of, mut string) = (&bin_expr.left, &bin_expr.right);
+            if matches!(ty_of, Expression::StringLiteral(_)) {
+                std::mem::swap(&mut string, &mut ty_of);
+            }
+            let Expression::UnaryExpression(unary) = ty_of else {
+                return Some(false);
+            };
+            if !(unary.operator == UnaryOperator::Typeof
+                && matches!(unary.argument, Expression::Identifier(_)))
+            {
+                return Some(false);
+            }
+            let Expression::StringLiteral(string) = string else {
+                return Some(false);
+            };
+
+            if (string.value.eq("undefined") == is_yes_branch)
+                == matches!(
+                    bin_expr.operator,
+                    BinaryOperator::Inequality | BinaryOperator::StrictInequality
+                )
+            {
+                let Expression::Identifier(type_of_value) = &unary.argument else {
+                    return Some(false);
+                };
+                if type_of_value.name == ident.name {
+                    return Some(true);
+                }
+            }
+        }
+        BinaryOperator::LessThan
+        | BinaryOperator::LessEqualThan
+        | BinaryOperator::GreaterThan
+        | BinaryOperator::GreaterEqualThan => {
+            let (mut ty_of, mut string) = (&bin_expr.left, &bin_expr.right);
+            if matches!(ty_of, Expression::StringLiteral(_)) {
+                std::mem::swap(&mut string, &mut ty_of);
+                is_yes_branch = !is_yes_branch;
+            }
+
+            let Expression::UnaryExpression(unary) = ty_of else {
+                return Some(false);
+            };
+            if !(unary.operator == UnaryOperator::Typeof
+                && matches!(unary.argument, Expression::Identifier(_)))
+            {
+                return Some(false);
+            }
+
+            let Expression::StringLiteral(string) = string else {
+                return Some(false);
+            };
+
+            if string.value == "u"
+                && is_yes_branch
+                    == matches!(
+                        bin_expr.operator,
+                        BinaryOperator::LessThan | BinaryOperator::LessEqualThan
+                    )
+            {
+                let Expression::Identifier(type_of_value) = &unary.argument else {
+                    return Some(false);
+                };
+                if type_of_value.name == ident.name {
+                    return Some(true);
+                }
+            }
+        }
+        _ => {}
+    }
+    Some(false)
+}
+
+/// https://github.com/evanw/esbuild/blob/d34e79e2a998c21bb71d57b92b0017ca11756912/internal/js_parser/js_parser.go#L16119-L16237
+pub fn maybe_side_effect_free_global_constructor<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    expr: &ast::NewExpression<'a>,
+) -> bool {
+    let Expression::Identifier(ident) = &expr.callee else {
+        return false;
+    };
+
+    if ctx.is_global_reference(ident) {
+        match ident.name.as_str() {
+            // TypedArray constructors - considered side-effect free with no args, null, or undefined
+            "Int8Array" | "Uint8Array" | "Uint8ClampedArray" | "Int16Array" | "Uint16Array"
+            | "Int32Array" | "Uint32Array" | "Float32Array" | "Float64Array" | "BigInt64Array"
+            | "BigUint64Array" => match expr.arguments.len() {
+                0 => return true,
+                1 => {
+                    let arg = &expr.arguments[0];
+                    match arg {
+                        ast::Argument::NullLiteral(_) => return true,
+                        ast::Argument::Identifier(id)
+                            if id.name == "undefined" && ctx.is_global_reference(id) =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            },
+            "WeakSet" | "WeakMap" => match expr.arguments.len() {
+                0 => return true,
+                1 => {
+                    let arg = &expr.arguments[0];
+                    match arg {
+                        ast::Argument::NullLiteral(_) => return true,
+                        ast::Argument::Identifier(id)
+                            if id.name == "undefined" && ctx.is_global_reference(id) =>
+                        {
+                            return true;
+                        }
+                        ast::Argument::ArrayExpression(arr) if arr.elements.is_empty() => {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            },
+            "Date" => match expr.arguments.len() {
+                0 => return true,
+                1 => {
+                    let arg = &expr.arguments[0];
+                    let known_primitive_type =
+                        arg.as_expression().map(|item| known_primitive_type(ctx, item));
+                    if let Some(primitive_ty) = known_primitive_type {
+                        if matches!(
+                            primitive_ty,
+                            PrimitiveType::Number
+                                | PrimitiveType::String
+                                | PrimitiveType::Null
+                                | PrimitiveType::Undefined
+                                | PrimitiveType::Boolean
+                        ) {
+                            return true;
+                        }
+                    }
+                }
+                _ => {}
+            },
+            "Set" => match expr.arguments.len() {
+                0 => return true,
+                1 => {
+                    let arg = &expr.arguments[0];
+                    match arg {
+                        ast::Argument::NullLiteral(_) | ast::Argument::ArrayExpression(_) => {
+                            return true;
+                        }
+                        ast::Argument::Identifier(id)
+                            if id.name == "undefined" && ctx.is_global_reference(id) =>
+                        {
+                            return true;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            },
+            "Map" => match expr.arguments.len() {
+                0 => return true,
+                1 => {
+                    let arg = &expr.arguments[0];
+                    match arg {
+                        ast::Argument::NullLiteral(_) => return true,
+                        ast::Argument::Identifier(id)
+                            if id.name == "undefined" && ctx.is_global_reference(id) =>
+                        {
+                            return true;
+                        }
+                        ast::Argument::ArrayExpression(arr) => {
+                            let all_entries_are_arrays = arr.elements.iter().all(|item| {
+                                item.as_expression().is_some_and(|expr| {
+                                    matches!(expr, ast::Expression::ArrayExpression(_))
+                                })
+                            });
+                            if all_entries_are_arrays {
+                                return true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            },
+            _ => {
+                return check_global_free_constructor_args(
+                    ident.name.as_str(),
+                    &expr.arguments,
+                    InvocationKind::New,
+                    ctx,
+                );
+            }
+        }
+    }
+    false
+}
+
+/// Represents the kind of invocation expression
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationKind {
+    /// CallExpression: `foo()`
+    Call,
+    /// NewExpression: `new Foo()`
+    New,
+}
+
+/// Checks if a BigInt argument is safe (won't throw at runtime).
+/// BigInt() throws for:
+/// - Non-integer numbers (1.5, NaN, Infinity, -Infinity)
+/// - Non-numeric strings ("abc")
+///
+/// We can only confidently say BigInt() is safe for:
+/// - Integer numeric literals
+/// - Boolean literals (true -> 1n, false -> 0n)
+/// - BigInt literals
+fn is_safe_bigint_argument(arg: &Expression) -> bool {
+    match arg {
+        // Boolean literals are always safe for BigInt (true -> 1n, false -> 0n)
+        // BigInt literals are always safe
+        Expression::BooleanLiteral(_) | Expression::BigIntLiteral(_) => true,
+        // Numeric literals are safe only if they are integers (no decimal, not NaN, not Infinity)
+        Expression::NumericLiteral(num) => {
+            let value = num.value;
+            // Check if it's a finite integer
+            value.is_finite() && value.fract() == 0.0
+        }
+        // Unary expressions like -1 or +1
+        Expression::UnaryExpression(unary) => {
+            matches!(unary.operator, UnaryOperator::UnaryNegation | UnaryOperator::UnaryPlus)
+                && matches!(unary.argument, Expression::NumericLiteral(ref num) if num.value.is_finite() && num.value.fract() == 0.0)
+        }
+        // String literals could be numeric but we can't easily validate, so consider them unsafe
+        // For example, BigInt("123") is safe but BigInt("abc") or BigInt("1.5") throws
+        _ => false,
+    }
+}
+
+/// Checks if the arguments for a global free constructor/function are safe (side-effect free).
+/// This function validates that all arguments are primitive types appropriate for the given symbol.
+///
+/// # Arguments
+/// * `symbol_name` - The name of the global constructor/function (e.g., "Symbol", "BigInt", "String")
+/// * `arguments` - The arguments being passed to the constructor/function
+/// * `kind` - Whether this is a CallExpression or NewExpression
+/// * `ctx` - Side effect context for global reference checks
+///
+/// # Note
+/// The caller is responsible for ensuring that the symbol is global (unresolved) before calling this function.
+pub fn check_global_free_constructor_args<'a>(
+    symbol_name: &str,
+    arguments: &ArenaVec<'a, ast::Argument<'a>>,
+    kind: InvocationKind,
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+) -> bool {
+    // Note: `_kind` is reserved for future use to differentiate between Call and New expression logic
+    match symbol_name {
+        // BigInt() is special - it throws for non-integer numbers and non-numeric strings
+        // We need to be more conservative and only allow proven-safe arguments
+        "BigInt" => {
+            if matches!(kind, InvocationKind::New) {
+                // new BigInt() always throws TypeError
+                return false;
+            }
+            // BigInt() requires at least one argument - BigInt() with no args throws TypeError
+            if arguments.is_empty() {
+                return false;
+            }
+            // BigInt() as a function call is only safe with proven-safe arguments
+            arguments.iter().all(|arg| {
+                if matches!(arg, ast::Argument::SpreadElement(_)) {
+                    return false;
+                }
+                is_safe_bigint_argument(arg.to_expression())
+            })
+        }
+        // RegExp() and new RegExp() - validate using oxc's regex parser
+        // Invalid patterns or flags throw SyntaxError at runtime
+        "RegExp" => is_valid_regexp(arguments),
+        // Symbol() is side-effect-free only when arguments are primitive types
+        // Calling toString() on an object can have side effects
+        "Symbol" | "String" | "Number" | "Boolean" | "Object" => {
+            // Check if all arguments are safe (primitives or no arguments)
+            let is_side_effect_free = arguments.iter().all(|arg| {
+                if matches!(arg, ast::Argument::SpreadElement(_)) {
+                    return false;
+                }
+                let arg_expr = arg.to_expression();
+                let prim_type = known_primitive_type(ctx, arg_expr);
+                matches!(
+                    prim_type,
+                    PrimitiveType::Null
+                        | PrimitiveType::Undefined
+                        | PrimitiveType::Boolean
+                        | PrimitiveType::Number
+                        | PrimitiveType::String
+                        | PrimitiveType::BigInt
+                )
+            });
+
+            if matches!(kind, InvocationKind::New) {
+                matches!(symbol_name, "Object" | "Number" | "String" | "Boolean")
+                    && is_side_effect_free
+            } else {
+                is_side_effect_free
+            }
+        }
+        _ => false,
+    }
+}
+
+pub fn maybe_side_effect_free_global_function_call<'a>(
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+    expr: &ast::CallExpression<'a>,
+) -> bool {
+    let Expression::Identifier(ident) = &expr.callee else {
+        return false;
+    };
+
+    if ctx.is_global_reference(ident) {
+        check_global_free_constructor_args(
+            ident.name.as_str(),
+            &expr.arguments,
+            InvocationKind::Call,
+            ctx,
+        )
+    } else {
+        false
+    }
+}
+
+// Ported from Rolldown global reference tables for side-effect detection parity.
+static GLOBAL_IDENT: phf::Set<&str> = phf::phf_set![
+    // Rolldown specific, because oxc treated them as identifiers, esbuild did not
+    "Infinity",
+    "undefined",
+    "NaN",
+    // These global identifiers should exist in all JavaScript environments.
+    "Array",
+    "Boolean",
+    "Function",
+    "Math",
+    "Number",
+    "Object",
+    "RegExp",
+    "String",
+    // Other globals present in both the browser and node (except "eval" because
+    // it has special behavior)
+    "AbortController",
+    "AbortSignal",
+    "AggregateError",
+    "ArrayBuffer",
+    "BigInt",
+    "DataView",
+    "Date",
+    "Error",
+    "EvalError",
+    "Event",
+    "EventTarget",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Intl",
+    "JSON",
+    "Map",
+    "MessageChannel",
+    "MessageEvent",
+    "MessagePort",
+    "Promise",
+    "Proxy",
+    "RangeError",
+    "ReferenceError",
+    "Reflect",
+    "Set",
+    "Symbol",
+    "SyntaxError",
+    "TextDecoder",
+    "TextEncoder",
+    "TypeError",
+    "URIError",
+    "URL",
+    "URLSearchParams",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "WeakMap",
+    "WeakSet",
+    "WebAssembly",
+    "clearInterval",
+    "clearTimeout",
+    "console",
+    "decodeURI",
+    "decodeURIComponent",
+    "encodeURI",
+    "encodeURIComponent",
+    "escape",
+    "globalThis",
+    "isFinite",
+    "isNaN",
+    "parseFloat",
+    "parseInt",
+    "queueMicrotask",
+    "setInterval",
+    "setTimeout",
+    "unescape",
+    // CSSOM APIs
+    "CSSAnimation",
+    "CSSFontFaceRule",
+    "CSSImportRule",
+    "CSSKeyframeRule",
+    "CSSKeyframesRule",
+    "CSSMediaRule",
+    "CSSNamespaceRule",
+    "CSSPageRule",
+    "CSSRule",
+    "CSSRuleList",
+    "CSSStyleDeclaration",
+    "CSSStyleRule",
+    "CSSStyleSheet",
+    "CSSSupportsRule",
+    "CSSTransition",
+    // SVG DOM
+    "SVGAElement",
+    "SVGAngle",
+    "SVGAnimateElement",
+    "SVGAnimateMotionElement",
+    "SVGAnimateTransformElement",
+    "SVGAnimatedAngle",
+    "SVGAnimatedBoolean",
+    "SVGAnimatedEnumeration",
+    "SVGAnimatedInteger",
+    "SVGAnimatedLength",
+    "SVGAnimatedLengthList",
+    "SVGAnimatedNumber",
+    "SVGAnimatedNumberList",
+    "SVGAnimatedPreserveAspectRatio",
+    "SVGAnimatedRect",
+    "SVGAnimatedString",
+    "SVGAnimatedTransformList",
+    "SVGAnimationElement",
+    "SVGCircleElement",
+    "SVGClipPathElement",
+    "SVGComponentTransferFunctionElement",
+    "SVGDefsElement",
+    "SVGDescElement",
+    "SVGElement",
+    "SVGEllipseElement",
+    "SVGFEBlendElement",
+    "SVGFEColorMatrixElement",
+    "SVGFEComponentTransferElement",
+    "SVGFECompositeElement",
+    "SVGFEConvolveMatrixElement",
+    "SVGFEDiffuseLightingElement",
+    "SVGFEDisplacementMapElement",
+    "SVGFEDistantLightElement",
+    "SVGFEDropShadowElement",
+    "SVGFEFloodElement",
+    "SVGFEFuncAElement",
+    "SVGFEFuncBElement",
+    "SVGFEFuncGElement",
+    "SVGFEFuncRElement",
+    "SVGFEGaussianBlurElement",
+    "SVGFEImageElement",
+    "SVGFEMergeElement",
+    "SVGFEMergeNodeElement",
+    "SVGFEMorphologyElement",
+    "SVGFEOffsetElement",
+    "SVGFEPointLightElement",
+    "SVGFESpecularLightingElement",
+    "SVGFESpotLightElement",
+    "SVGFETileElement",
+    "SVGFETurbulenceElement",
+    "SVGFilterElement",
+    "SVGForeignObjectElement",
+    "SVGGElement",
+    "SVGGeometryElement",
+    "SVGGradientElement",
+    "SVGGraphicsElement",
+    "SVGImageElement",
+    "SVGLength",
+    "SVGLengthList",
+    "SVGLineElement",
+    "SVGLinearGradientElement",
+    "SVGMPathElement",
+    "SVGMarkerElement",
+    "SVGMaskElement",
+    "SVGMatrix",
+    "SVGMetadataElement",
+    "SVGNumber",
+    "SVGNumberList",
+    "SVGPathElement",
+    "SVGPatternElement",
+    "SVGPoint",
+    "SVGPointList",
+    "SVGPolygonElement",
+    "SVGPolylineElement",
+    "SVGPreserveAspectRatio",
+    "SVGRadialGradientElement",
+    "SVGRect",
+    "SVGRectElement",
+    "SVGSVGElement",
+    "SVGScriptElement",
+    "SVGSetElement",
+    "SVGStopElement",
+    "SVGStringList",
+    "SVGStyleElement",
+    "SVGSwitchElement",
+    "SVGSymbolElement",
+    "SVGTSpanElement",
+    "SVGTextContentElement",
+    "SVGTextElement",
+    "SVGTextPathElement",
+    "SVGTextPositioningElement",
+    "SVGTitleElement",
+    "SVGTransform",
+    "SVGTransformList",
+    "SVGUnitTypes",
+    "SVGUseElement",
+    "SVGViewElement",
+    // Other browser APIs
+    //
+    // This list contains all globals present in modern versions of Chrome, Safari,
+    // and Firefox except for the following properties, since they have a side effect
+    // of triggering layout (https://gist.github.com/paulirish/5d52fb081b3570c81e3a):
+    //
+    //   - scrollX
+    //   - scrollY
+    //   - innerWidth
+    //   - innerHeight
+    //   - pageXOffset
+    //   - pageYOffset
+    //
+    // The following globals have also been removed since they sometimes throw an
+    // exception when accessed, which is a side effect (for more information see
+    // https://stackoverflow.com/a/33047477):
+    //
+    //   - localStorage
+    //   - sessionStorage
+    //
+    "AnalyserNode",
+    "Animation",
+    "AnimationEffect",
+    "AnimationEvent",
+    "AnimationPlaybackEvent",
+    "AnimationTimeline",
+    "Attr",
+    "Audio",
+    "AudioBuffer",
+    "AudioBufferSourceNode",
+    "AudioDestinationNode",
+    "AudioListener",
+    "AudioNode",
+    "AudioParam",
+    "AudioProcessingEvent",
+    "AudioScheduledSourceNode",
+    "BarProp",
+    "BeforeUnloadEvent",
+    "BiquadFilterNode",
+    "Blob",
+    "BlobEvent",
+    "ByteLengthQueuingStrategy",
+    "CDATASection",
+    "CSS",
+    "CanvasGradient",
+    "CanvasPattern",
+    "CanvasRenderingContext2D",
+    "ChannelMergerNode",
+    "ChannelSplitterNode",
+    "CharacterData",
+    "ClipboardEvent",
+    "CloseEvent",
+    "Comment",
+    "CompositionEvent",
+    "ConvolverNode",
+    "CountQueuingStrategy",
+    "Crypto",
+    "CustomElementRegistry",
+    "CustomEvent",
+    "DOMException",
+    "DOMImplementation",
+    "DOMMatrix",
+    "DOMMatrixReadOnly",
+    "DOMParser",
+    "DOMPoint",
+    "DOMPointReadOnly",
+    "DOMQuad",
+    "DOMRect",
+    "DOMRectList",
+    "DOMRectReadOnly",
+    "DOMStringList",
+    "DOMStringMap",
+    "DOMTokenList",
+    "DataTransfer",
+    "DataTransferItem",
+    "DataTransferItemList",
+    "DelayNode",
+    "Document",
+    "DocumentFragment",
+    "DocumentTimeline",
+    "DocumentType",
+    "DragEvent",
+    "DynamicsCompressorNode",
+    "Element",
+    "ErrorEvent",
+    "EventSource",
+    "File",
+    "FileList",
+    "FileReader",
+    "FocusEvent",
+    "FontFace",
+    "FormData",
+    "GainNode",
+    "Gamepad",
+    "GamepadButton",
+    "GamepadEvent",
+    "Geolocation",
+    "GeolocationPositionError",
+    "HTMLAllCollection",
+    "HTMLAnchorElement",
+    "HTMLAreaElement",
+    "HTMLAudioElement",
+    "HTMLBRElement",
+    "HTMLBaseElement",
+    "HTMLBodyElement",
+    "HTMLButtonElement",
+    "HTMLCanvasElement",
+    "HTMLCollection",
+    "HTMLDListElement",
+    "HTMLDataElement",
+    "HTMLDataListElement",
+    "HTMLDetailsElement",
+    "HTMLDirectoryElement",
+    "HTMLDivElement",
+    "HTMLDocument",
+    "HTMLElement",
+    "HTMLEmbedElement",
+    "HTMLFieldSetElement",
+    "HTMLFontElement",
+    "HTMLFormControlsCollection",
+    "HTMLFormElement",
+    "HTMLFrameElement",
+    "HTMLFrameSetElement",
+    "HTMLHRElement",
+    "HTMLHeadElement",
+    "HTMLHeadingElement",
+    "HTMLHtmlElement",
+    "HTMLIFrameElement",
+    "HTMLImageElement",
+    "HTMLInputElement",
+    "HTMLLIElement",
+    "HTMLLabelElement",
+    "HTMLLegendElement",
+    "HTMLLinkElement",
+    "HTMLMapElement",
+    "HTMLMarqueeElement",
+    "HTMLMediaElement",
+    "HTMLMenuElement",
+    "HTMLMetaElement",
+    "HTMLMeterElement",
+    "HTMLModElement",
+    "HTMLOListElement",
+    "HTMLObjectElement",
+    "HTMLOptGroupElement",
+    "HTMLOptionElement",
+    "HTMLOptionsCollection",
+    "HTMLOutputElement",
+    "HTMLParagraphElement",
+    "HTMLParamElement",
+    "HTMLPictureElement",
+    "HTMLPreElement",
+    "HTMLProgressElement",
+    "HTMLQuoteElement",
+    "HTMLScriptElement",
+    "HTMLSelectElement",
+    "HTMLSlotElement",
+    "HTMLSourceElement",
+    "HTMLSpanElement",
+    "HTMLStyleElement",
+    "HTMLTableCaptionElement",
+    "HTMLTableCellElement",
+    "HTMLTableColElement",
+    "HTMLTableElement",
+    "HTMLTableRowElement",
+    "HTMLTableSectionElement",
+    "HTMLTemplateElement",
+    "HTMLTextAreaElement",
+    "HTMLTimeElement",
+    "HTMLTitleElement",
+    "HTMLTrackElement",
+    "HTMLUListElement",
+    "HTMLUnknownElement",
+    "HTMLVideoElement",
+    "HashChangeEvent",
+    "Headers",
+    "History",
+    "IDBCursor",
+    "IDBCursorWithValue",
+    "IDBDatabase",
+    "IDBFactory",
+    "IDBIndex",
+    "IDBKeyRange",
+    "IDBObjectStore",
+    "IDBOpenDBRequest",
+    "IDBRequest",
+    "IDBTransaction",
+    "IDBVersionChangeEvent",
+    "Image",
+    "ImageData",
+    "InputEvent",
+    "IntersectionObserver",
+    "IntersectionObserverEntry",
+    "KeyboardEvent",
+    "KeyframeEffect",
+    "Location",
+    "MediaCapabilities",
+    "MediaElementAudioSourceNode",
+    "MediaEncryptedEvent",
+    "MediaError",
+    "MediaList",
+    "MediaQueryList",
+    "MediaQueryListEvent",
+    "MediaRecorder",
+    "MediaSource",
+    "MediaStream",
+    "MediaStreamAudioDestinationNode",
+    "MediaStreamAudioSourceNode",
+    "MediaStreamTrack",
+    "MediaStreamTrackEvent",
+    "MimeType",
+    "MimeTypeArray",
+    "MouseEvent",
+    "MutationEvent",
+    "MutationObserver",
+    "MutationRecord",
+    "NamedNodeMap",
+    "Navigator",
+    "Node",
+    "NodeFilter",
+    "NodeIterator",
+    "NodeList",
+    "Notification",
+    "OfflineAudioCompletionEvent",
+    "Option",
+    "OscillatorNode",
+    "PageTransitionEvent",
+    "Path2D",
+    "Performance",
+    "PerformanceEntry",
+    "PerformanceMark",
+    "PerformanceMeasure",
+    "PerformanceNavigation",
+    "PerformanceObserver",
+    "PerformanceObserverEntryList",
+    "PerformanceResourceTiming",
+    "PerformanceTiming",
+    "PeriodicWave",
+    "Plugin",
+    "PluginArray",
+    "PointerEvent",
+    "PopStateEvent",
+    "ProcessingInstruction",
+    "ProgressEvent",
+    "PromiseRejectionEvent",
+    "RTCCertificate",
+    "RTCDTMFSender",
+    "RTCDTMFToneChangeEvent",
+    "RTCDataChannel",
+    "RTCDataChannelEvent",
+    "RTCIceCandidate",
+    "RTCPeerConnection",
+    "RTCPeerConnectionIceEvent",
+    "RTCRtpReceiver",
+    "RTCRtpSender",
+    "RTCRtpTransceiver",
+    "RTCSessionDescription",
+    "RTCStatsReport",
+    "RTCTrackEvent",
+    "RadioNodeList",
+    "Range",
+    "ReadableStream",
+    "Request",
+    "ResizeObserver",
+    "ResizeObserverEntry",
+    "Response",
+    "Screen",
+    "ScriptProcessorNode",
+    "SecurityPolicyViolationEvent",
+    "Selection",
+    "ShadowRoot",
+    "SourceBuffer",
+    "SourceBufferList",
+    "SpeechSynthesisEvent",
+    "SpeechSynthesisUtterance",
+    "StaticRange",
+    "Storage",
+    "StorageEvent",
+    "StyleSheet",
+    "StyleSheetList",
+    "Text",
+    "TextMetrics",
+    "TextTrack",
+    "TextTrackCue",
+    "TextTrackCueList",
+    "TextTrackList",
+    "TimeRanges",
+    "TrackEvent",
+    "TransitionEvent",
+    "TreeWalker",
+    "UIEvent",
+    "VTTCue",
+    "ValidityState",
+    "VisualViewport",
+    "WaveShaperNode",
+    "WebGLActiveInfo",
+    "WebGLBuffer",
+    "WebGLContextEvent",
+    "WebGLFramebuffer",
+    "WebGLProgram",
+    "WebGLQuery",
+    "WebGLRenderbuffer",
+    "WebGLRenderingContext",
+    "WebGLSampler",
+    "WebGLShader",
+    "WebGLShaderPrecisionFormat",
+    "WebGLSync",
+    "WebGLTexture",
+    "WebGLUniformLocation",
+    "WebKitCSSMatrix",
+    "WebSocket",
+    "WheelEvent",
+    "Window",
+    "Worker",
+    "XMLDocument",
+    "XMLHttpRequest",
+    "XMLHttpRequestEventTarget",
+    "XMLHttpRequestUpload",
+    "XMLSerializer",
+    "XPathEvaluator",
+    "XPathExpression",
+    "XPathResult",
+    "XSLTProcessor",
+    "alert",
+    "atob",
+    "blur",
+    "btoa",
+    "cancelAnimationFrame",
+    "captureEvents",
+    "close",
+    "closed",
+    "confirm",
+    "customElements",
+    "devicePixelRatio",
+    "document",
+    "event",
+    "fetch",
+    "find",
+    "focus",
+    "frameElement",
+    "frames",
+    "getComputedStyle",
+    "getSelection",
+    "history",
+    "indexedDB",
+    "isSecureContext",
+    "length",
+    "location",
+    "locationbar",
+    "matchMedia",
+    "menubar",
+    "moveBy",
+    "moveTo",
+    "name",
+    "navigator",
+    "onabort",
+    "onafterprint",
+    "onanimationend",
+    "onanimationiteration",
+    "onanimationstart",
+    "onbeforeprint",
+    "onbeforeunload",
+    "onblur",
+    "oncanplay",
+    "oncanplaythrough",
+    "onchange",
+    "onclick",
+    "oncontextmenu",
+    "oncuechange",
+    "ondblclick",
+    "ondrag",
+    "ondragend",
+    "ondragenter",
+    "ondragleave",
+    "ondragover",
+    "ondragstart",
+    "ondrop",
+    "ondurationchange",
+    "onemptied",
+    "onended",
+    "onerror",
+    "onfocus",
+    "ongotpointercapture",
+    "onhashchange",
+    "oninput",
+    "oninvalid",
+    "onkeydown",
+    "onkeypress",
+    "onkeyup",
+    "onlanguagechange",
+    "onload",
+    "onloadeddata",
+    "onloadedmetadata",
+    "onloadstart",
+    "onlostpointercapture",
+    "onmessage",
+    "onmousedown",
+    "onmouseenter",
+    "onmouseleave",
+    "onmousemove",
+    "onmouseout",
+    "onmouseover",
+    "onmouseup",
+    "onoffline",
+    "ononline",
+    "onpagehide",
+    "onpageshow",
+    "onpause",
+    "onplay",
+    "onplaying",
+    "onpointercancel",
+    "onpointerdown",
+    "onpointerenter",
+    "onpointerleave",
+    "onpointermove",
+    "onpointerout",
+    "onpointerover",
+    "onpointerup",
+    "onpopstate",
+    "onprogress",
+    "onratechange",
+    "onrejectionhandled",
+    "onreset",
+    "onresize",
+    "onscroll",
+    "onseeked",
+    "onseeking",
+    "onselect",
+    "onstalled",
+    "onstorage",
+    "onsubmit",
+    "onsuspend",
+    "ontimeupdate",
+    "ontoggle",
+    "ontransitioncancel",
+    "ontransitionend",
+    "ontransitionrun",
+    "ontransitionstart",
+    "onunhandledrejection",
+    "onunload",
+    "onvolumechange",
+    "onwaiting",
+    "onwebkitanimationend",
+    "onwebkitanimationiteration",
+    "onwebkitanimationstart",
+    "onwebkittransitionend",
+    "onwheel",
+    "open",
+    "opener",
+    "origin",
+    "outerHeight",
+    "outerWidth",
+    "parent",
+    "performance",
+    "personalbar",
+    "postMessage",
+    "print",
+    "prompt",
+    "releaseEvents",
+    "requestAnimationFrame",
+    "resizeBy",
+    "resizeTo",
+    "screen",
+    "screenLeft",
+    "screenTop",
+    "screenX",
+    "screenY",
+    "scroll",
+    "scrollBy",
+    "scrollTo",
+    "scrollbars",
+    "self",
+    "speechSynthesis",
+    "status",
+    "statusbar",
+    "stop",
+    "toolbar",
+    "top",
+    "webkitURL",
+    "window",
+];
+
+/// `Math`
+static MATH_SECOND_PROP: phf::Set<&str> = phf::phf_set![
+    // Math: Static properties
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math#Static_properties
+    "E", "LN10", "LN2", "LOG10E", "LOG2E", "PI", "SQRT1_2", "SQRT2",
+    // Math: Static methods
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math#Static_methods
+    "abs", "acos", "acosh", "asin", "asinh", "atan", "atan2", "atanh", "cbrt", "ceil", "clz32",
+    "cos", "cosh", "exp", "expm1", "floor", "fround", "hypot", "imul", "log", "log10", "log1p",
+    "log2", "max", "min", "pow", "random", "round", "sign", "sin", "sinh", "sqrt", "tan", "tanh",
+    "trunc",
+];
+
+/// Console method references are assumed to have no side effects
+/// https://developer.mozilla.org/en-US/docs/Web/API/console
+/// `console`
+static CONSOLE_SECOND_PROP: [&str; 19] = [
+    "assert",
+    "clear",
+    "count",
+    "countReset",
+    "debug",
+    "dir",
+    "dirxml",
+    "error",
+    "group",
+    "groupCollapsed",
+    "groupEnd",
+    "info",
+    "log",
+    "table",
+    "time",
+    "timeEnd",
+    "timeLog",
+    "trace",
+    "warn",
+];
+
+/// Reflect: Static methods
+/// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect#static_methods
+/// `Reflect`
+static REFLECT_SECOND_PROP: [&str; 13] = [
+    "apply",
+    "construct",
+    "defineProperty",
+    "deleteProperty",
+    "get",
+    "getOwnPropertyDescriptor",
+    "getPrototypeOf",
+    "has",
+    "isExtensible",
+    "ownKeys",
+    "preventExtensions",
+    "set",
+    "setPrototypeOf",
+];
+
+/// `Object`
+static OBJECT_SECOND_PROP: [&str; 21] = [
+    // Object: Static methods
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#Static_methods
+    "assign",
+    "create",
+    "defineProperties",
+    "defineProperty",
+    "entries",
+    "freeze",
+    "fromEntries",
+    "getOwnPropertyDescriptor",
+    "getOwnPropertyDescriptors",
+    "getOwnPropertyNames",
+    "getOwnPropertySymbols",
+    "getPrototypeOf",
+    "is",
+    "isExtensible",
+    "isFrozen",
+    "isSealed",
+    "keys",
+    "preventExtensions",
+    "seal",
+    "setPrototypeOf",
+    "values",
+];
+
+/// `Symbol`
+static SYMBOL_SECOND_PROP: [&str; 15] = [
+    // Symbol: Static properties
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#static_properties
+    "asyncDispose",
+    "asyncIterator",
+    "dispose",
+    "hasInstance",
+    "isConcatSpreadable",
+    "iterator",
+    "match",
+    "matchAll",
+    "replace",
+    "search",
+    "species",
+    "split",
+    "toPrimitive",
+    "toStringTag",
+    "unscopables",
+];
+
+/// `Object.prototype`
+static OBJECT_PROTOTYPE_THIRD_PROP: [&str; 12] = [
+    // Object: Instance methods
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object#Instance_methods
+    "__defineGetter__",
+    "__defineSetter__",
+    "__lookupGetter__",
+    "__lookupSetter__",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toLocaleString",
+    "toString",
+    "unwatch",
+    "valueOf",
+    "watch",
+];
+
+#[inline]
+pub fn is_well_known_global_ident_ref(ident: &str) -> bool {
+    GLOBAL_IDENT.contains(ident)
+}
+
+pub fn is_side_effect_free_member_expr_of_len_two(member_expr: &[Ident]) -> bool {
+    match member_expr {
+        [first, second] => {
+            let second = second.as_str();
+            match first.as_str() {
+                "console" => CONSOLE_SECOND_PROP.contains(&second),
+                "Reflect" => REFLECT_SECOND_PROP.contains(&second),
+                "Math" => MATH_SECOND_PROP.contains(second),
+                "Object" => OBJECT_SECOND_PROP.contains(&second),
+                "Symbol" => SYMBOL_SECOND_PROP.contains(&second),
+                "JSON" => second == "stringify" || second == "parse",
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+pub fn is_side_effect_free_member_expr_of_len_three(member_expr: &[Ident]) -> bool {
+    match member_expr {
+        [first, second, third] => {
+            first == "Object"
+                && second == "prototype"
+                && OBJECT_PROTOTYPE_THIRD_PROP.contains(&third.as_str())
+        }
+        _ => false,
+    }
+}

--- a/crates/oxc_ecmascript/src/side_effects/side_effect_detail.rs
+++ b/crates/oxc_ecmascript/src/side_effects/side_effect_detail.rs
@@ -1,0 +1,25 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+    /// Detailed side-effect information for tree-shaking decisions.
+    pub struct SideEffectDetail: u8 {
+        const GlobalVarAccess = 1;
+        const PureCjs = 1 << 1;
+        const Unknown = 1 << 2;
+        const PureAnnotation = 1 << 3;
+    }
+}
+
+impl SideEffectDetail {
+    #[inline]
+    pub fn has_side_effect(self) -> bool {
+        self.intersects(SideEffectDetail::PureCjs | SideEffectDetail::Unknown)
+    }
+}
+
+impl From<bool> for SideEffectDetail {
+    fn from(value: bool) -> Self {
+        if value { SideEffectDetail::Unknown } else { SideEffectDetail::empty() }
+    }
+}

--- a/crates/oxc_ecmascript/src/side_effects/statements.rs
+++ b/crates/oxc_ecmascript/src/side_effects/statements.rs
@@ -2,7 +2,10 @@ use oxc_ast::ast::*;
 
 use crate::constant_evaluation::{DetermineValueType, ValueType};
 
-use super::{MayHaveSideEffects, PropertyReadSideEffects, context::MayHaveSideEffectsContext};
+use super::{
+    MayHaveSideEffects, PropertyReadSideEffects, SideEffectDetail, SideEffectDetector,
+    context::MayHaveSideEffectsContext,
+};
 
 impl<'a> MayHaveSideEffects<'a> for Statement<'a> {
     fn may_have_side_effects(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> bool {
@@ -31,6 +34,10 @@ impl<'a> MayHaveSideEffects<'a> for Statement<'a> {
             #[expect(clippy::match_same_arms)]
             match_module_declaration!(Statement) => true,
         }
+    }
+
+    fn side_effect_detail(&self, ctx: &impl MayHaveSideEffectsContext<'a>) -> SideEffectDetail {
+        SideEffectDetector::new(ctx).detect_side_effect_of_stmt(self)
     }
 }
 


### PR DESCRIPTION
## Summary
- port Rolldown's side-effect detector implementation into `oxc_ecmascript::side_effects`
- add detector primitives and exports (`SideEffectDetector`, `SideEffectDetail`, detector utils)
- extend side-effect context with:
  - `property_write_side_effects`
  - `is_pure_call_expression`
- add `side_effect_detail` plumbing for expressions/statements
- include parity fixes needed to preserve Rolldown behavior:
  - `Symbol(() => 0)` handling in side-effect analysis
  - JSX `pragmaFrag` literal parsing + raw literal preservation for generated pragma literals

## Validation
- `cargo check -p oxc_ecmascript -p oxc_transformer -p oxc_codegen`
- downstream validation in Rolldown: full `cargo test -p rolldown` passed with unchanged snapshots

## AI Usage Disclosure
This PR was prepared with AI assistance and then reviewed/tested by the author.
