### PR TITLE
docs(linter): Disable formatting for `eslint/no-unsafe-negation` examples.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
+    /// <!-- prettier-ignore-start -->
     /// ```javascript
     /// if (!key in object) {}
     ///
@@ -64,6 +65,7 @@ declare_oxc_lint!(
     ///
     /// if (!(obj instanceof Ctor)) {}
     /// ```
+    /// <!-- prettier-ignore-end -->
     NoUnsafeNegation,
     eslint,
     correctness,


### PR DESCRIPTION
This was causing the examples to be reformatted such that they didn't really make sense anymore.

Fixes #19338.