### PR TITLE
fix(formatter): treat `PrivateFieldExpression` as simple call argument

### DIFF
--- a/crates/oxc_formatter/src/utils/member_chain/simple_argument.rs
+++ b/crates/oxc_formatter/src/utils/member_chain/simple_argument.rs
@@ -96,6 +96,14 @@ impl<'a, 'b> SimpleArgument<'a, 'b> {
                     Self::from(&computed_expression.expression).is_simple_impl(depth)
                         && Self::from(&computed_expression.object).is_simple_impl(depth)
                 }
+                // In Prettier's default `typescript` parser (typescript-estree) AST,
+                // `this.#v` is a `MemberExpression` with a `PrivateIdentifier` property.
+                // In oxc's AST, it's a separate type.
+                // The private field name is always simple, so only check the object.
+                // https://github.com/prettier/prettier/blob/093745f0ec429d3db47c1edd823357e0ef24e226/src/language-js/utilities/index.js#L643-L648
+                Expression::PrivateFieldExpression(private_field) => {
+                    Self::from(&private_field.object).is_simple_impl(depth)
+                }
                 Expression::NewExpression(expr) => {
                     Self::is_simple_call_like(&expr.callee, &expr.arguments, depth)
                 }

--- a/crates/oxc_formatter/tests/fixtures/ts/private-field-call-args.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/private-field-call-args.ts
@@ -1,0 +1,15 @@
+// Private field access should not force multi-line call arguments
+class Foo {
+  #t: NodeJS.Timeout | undefined = undefined;
+  #v: number;
+
+  constructor(v: number) {
+    this.#v = v;
+  }
+
+  start() {
+    this.#t = setInterval(() => {
+      console.log();
+    }, this.#v);
+  }
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/private-field-call-args.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/private-field-call-args.ts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Private field access should not force multi-line call arguments
+class Foo {
+  #t: NodeJS.Timeout | undefined = undefined;
+  #v: number;
+
+  constructor(v: number) {
+    this.#v = v;
+  }
+
+  start() {
+    this.#t = setInterval(() => {
+      console.log();
+    }, this.#v);
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Private field access should not force multi-line call arguments
+class Foo {
+  #t: NodeJS.Timeout | undefined = undefined;
+  #v: number;
+
+  constructor(v: number) {
+    this.#v = v;
+  }
+
+  start() {
+    this.#t = setInterval(() => {
+      console.log();
+    }, this.#v);
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Private field access should not force multi-line call arguments
+class Foo {
+  #t: NodeJS.Timeout | undefined = undefined;
+  #v: number;
+
+  constructor(v: number) {
+    this.#v = v;
+  }
+
+  start() {
+    this.#t = setInterval(() => {
+      console.log();
+    }, this.#v);
+  }
+}
+
+===================== End =====================


### PR DESCRIPTION
## Summary

- Treat `PrivateFieldExpression` (`this.#v`) as a simple call argument, matching Prettier's behavior where it's a `MemberExpression` with a `PrivateIdentifier`
- Without this fix, `this.#v` as a call argument causes the formatter to break arguments into multiple lines unnecessarily

**Before:**
```ts
this.#t = setInterval(
  () => {
    console.log();
  },
  this.#v,
);
```

**After (matches Prettier):**
```ts
this.#t = setInterval(() => {
  console.log();
}, this.#v);
```

Closes #19330

## Test plan

- [x] Added test fixture `private-field-call-args.ts` reproducing the issue
- [x] All 171 formatter tests pass
- [x] Prettier conformance unchanged: JS 746/753 (99.07%), TS 591/601 (98.34%)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)