### PR TITLE
fix(oxfmt): Update tailwind plugin which fixes crash on non-js file

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "prettier": "3.8.1",
-    "prettier-plugin-tailwindcss": "0.0.0-insiders.2ac6e70",
+    "prettier-plugin-tailwindcss": "0.0.0-insiders.3997fbd",
     "tinypool": "2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 3.8.1
         version: 3.8.1
       prettier-plugin-tailwindcss:
-        specifier: 0.0.0-insiders.2ac6e70
-        version: 0.0.0-insiders.2ac6e70(prettier@3.8.1)
+        specifier: 0.0.0-insiders.3997fbd
+        version: 0.0.0-insiders.3997fbd(prettier@3.8.1)
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -3985,8 +3985,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.2ac6e70:
-    resolution: {integrity: sha512-BHWDfSnPiaCkGau1GXirxp8ROUxiQQLlHM71FWTb8OeHS7CNi5wXUpWmDTtor/C+HhgByjGPwfszikQjrx9p8g==}
+  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd:
+    resolution: {integrity: sha512-H45ADK++Dyd7tMKCT7D6s+6uMxcVMZI841kyvSBXWaU8UOHJp273arY/5/5NqEBNxsquPGId7CatqUGbFbd0aQ==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
@@ -8131,7 +8131,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.2ac6e70(prettier@3.8.1):
+  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier@3.8.1):
     dependencies:
       prettier: 3.8.1
 


### PR DESCRIPTION
Fixes #19255, #19293, closes #19294