### PR TITLE
feat(linter): Move `jsx-a11y/no-static-element-interactions` rule out of the nursery.

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -79,7 +79,7 @@ declare_oxc_lint!(
     /// ```
     NoStaticElementInteractions,
     jsx_a11y,
-    nursery,
+    correctness,
     config = NoStaticElementInteractionsConfig,
 );
 


### PR DESCRIPTION
The issues with this rule were fixed by #17817 a few weeks ago, and it should be safe to mark it as a correctness rule again. 

I've tested it briefly on mastadon and another decently-sized codebase, and it appears to perform identically now.