### PR TITLE
feat(linter): Move `typescript/prefer-optional-chain` rule out of the nursery.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_optional_chain.rs
@@ -58,10 +58,6 @@ declare_oxc_lint!(
     /// Enforce using concise optional chain expressions instead of chained logical AND
     /// operators, negated logical OR operators, or empty objects.
     ///
-    /// Note that this rule is in the nursery category while we ensure it is working
-    /// correctly in as many edge-case scenarios as possible. The logic for this is
-    /// complex and the autofix may cause logic changes in some edge-cases.
-    ///
     /// ### Why is this bad?
     ///
     /// TypeScript 3.7 introduced optional chaining (`?.`) which provides a more concise
@@ -93,7 +89,7 @@ declare_oxc_lint!(
     /// ```
     PreferOptionalChain(tsgolint),
     typescript,
-    nursery, // move to style after we've confirmed this works correctly on as many edge-cases as possible.
+    style,
     dangerous_fix_suggestion,
     config = PreferOptionalChainConfig,
 );

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -45,7 +45,7 @@
     }
   },
   "peerDependencies": {
-    "oxlint-tsgolint": ">=0.11.2"
+    "oxlint-tsgolint": ">=0.12.1"
   },
   "peerDependenciesMeta": {
     "oxlint-tsgolint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
   npm/oxlint:
     dependencies:
       oxlint-tsgolint:
-        specifier: '>=0.11.2'
+        specifier: '>=0.12.1'
         version: 0.12.1
 
   npm/oxlint-plugins: {}


### PR DESCRIPTION
The issues with this rule should mostly be resolved now with the various PRs in tsgolint over the last few weeks.

Bump the peer dep version to 0.12.1 or higher to ensure that the fixes are included for all users.