### PR TITLE
feat(formatter/sort_imports): Support `{ newlinesBetween: bool }` inside `groups`

### DIFF
--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -123,9 +123,10 @@ export type SortImportsOptions = {
   /**
    * Groups configuration for organizing imports.
    * Each array element represents a group, and multiple group names in the same array are treated as one.
-   * Accepts both `string` and `string[]` as group elements.
+   * Accepts `string`, `string[]`, or `{ newlinesBetween: boolean }` marker objects.
+   * Marker objects override the global `newlinesBetween` setting for the boundary between the adjacent groups.
    */
-  groups?: (string | string[])[];
+  groups?: (string | string[] | { newlinesBetween: boolean })[];
   /** Define custom groups for matching specific imports. */
   customGroups?: {
     groupName: string;

--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -34,6 +34,7 @@ fn main() -> Result<(), String> {
         internal_pattern: default_internal_patterns(),
         groups: default_groups(),
         custom_groups: vec![],
+        newline_boundary_overrides: vec![],
     };
 
     // Read source file

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -36,6 +36,10 @@ pub struct SortImportsOptions {
     /// Define your own groups for matching very specific imports.
     /// Default is `[]`.
     pub custom_groups: Vec<CustomGroupDefinition>,
+    /// Per-boundary newline overrides.
+    /// `newline_boundary_overrides[i]` = override for boundary between `groups[i]` and `groups[i+1]`.
+    /// `None` means "use global `newlines_between`".
+    pub newline_boundary_overrides: Vec<Option<bool>>,
 }
 
 impl Default for SortImportsOptions {
@@ -50,6 +54,7 @@ impl Default for SortImportsOptions {
             internal_pattern: default_internal_patterns(),
             groups: default_groups(),
             custom_groups: vec![],
+            newline_boundary_overrides: vec![],
         }
     }
 }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/mod.rs
@@ -1,3 +1,4 @@
 mod basic;
 mod custom_groups;
 mod groups;
+mod newlines_between_override;

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/newlines_between_override.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/newlines_between_override.rs
@@ -1,0 +1,258 @@
+use super::super::assert_format;
+
+#[test]
+fn global_true_with_override_false_suppresses_blank_line() {
+    // Global newlinesBetween: true, but override suppresses blank line between
+    // value-builtin/value-external and value-parent
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import { bar } from "./bar";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": true,
+                "groups": [
+                    ["value-builtin", "value-external"],
+                    { "newlinesBetween": false },
+                    "value-parent",
+                    "value-sibling"
+                ]
+            }
+        }"#,
+        r#"
+import { baz } from "baz";
+import path from "path";
+import { foo } from "../foo";
+
+import { bar } from "./bar";
+"#,
+    );
+}
+
+#[test]
+fn global_false_with_override_true_inserts_blank_line() {
+    // Global newlinesBetween: false, but override inserts blank line between
+    // value-builtin/value-external and value-parent
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import { bar } from "./bar";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": false,
+                "groups": [
+                    ["value-builtin", "value-external"],
+                    { "newlinesBetween": true },
+                    "value-parent",
+                    "value-sibling"
+                ]
+            }
+        }"#,
+        r#"
+import { baz } from "baz";
+import path from "path";
+
+import { foo } from "../foo";
+import { bar } from "./bar";
+"#,
+    );
+}
+
+#[test]
+fn multiple_overrides() {
+    // Global newlinesBetween: true with multiple overrides
+    assert_format(
+        r#"
+import path from "path";
+import type { T } from "t";
+import { foo } from "../foo";
+import { bar } from "./bar";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": true,
+                "groups": [
+                    "type-import",
+                    { "newlinesBetween": false },
+                    ["value-builtin", "value-external"],
+                    "value-parent",
+                    { "newlinesBetween": false },
+                    "value-sibling"
+                ]
+            }
+        }"#,
+        r#"
+import type { T } from "t";
+import { baz } from "baz";
+import path from "path";
+
+import { foo } from "../foo";
+import { bar } from "./bar";
+"#,
+    );
+}
+
+#[test]
+fn override_with_subgroups() {
+    // Override between a subgroup and a single group
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import { bar } from "./bar";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": false,
+                "groups": [
+                    ["value-builtin", "value-external"],
+                    { "newlinesBetween": true },
+                    ["value-parent", "value-sibling"]
+                ]
+            }
+        }"#,
+        r#"
+import { baz } from "baz";
+import path from "path";
+
+import { foo } from "../foo";
+import { bar } from "./bar";
+"#,
+    );
+}
+
+#[test]
+fn all_overrides_false_is_same_as_global_false() {
+    // All boundaries explicitly set to false
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import { bar } from "./bar";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": true,
+                "groups": [
+                    ["value-builtin", "value-external"],
+                    { "newlinesBetween": false },
+                    "value-parent",
+                    { "newlinesBetween": false },
+                    "value-sibling"
+                ]
+            }
+        }"#,
+        r#"
+import { baz } from "baz";
+import path from "path";
+import { foo } from "../foo";
+import { bar } from "./bar";
+"#,
+    );
+}
+
+#[test]
+fn override_does_not_affect_non_adjacent_groups() {
+    // Override between groups 0 and 1, but groups 1 and 2 use global (true)
+    assert_format(
+        r#"
+import path from "path";
+import type { T } from "t";
+import { foo } from "../foo";
+import { baz } from "baz";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": true,
+                "groups": [
+                    "type-import",
+                    { "newlinesBetween": false },
+                    ["value-builtin", "value-external"],
+                    "value-parent"
+                ]
+            }
+        }"#,
+        r#"
+import type { T } from "t";
+import { baz } from "baz";
+import path from "path";
+
+import { foo } from "../foo";
+"#,
+    );
+}
+
+#[test]
+fn skipped_intermediate_groups_with_override_false() {
+    // Groups: type-import, value-builtin, value-internal, value-parent
+    // No imports match value-internal, so group index jumps from 1 to 3.
+    // Both intermediate overrides are false, so no blank line.
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import type { T } from "t";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": true,
+                "groups": [
+                    "type-import",
+                    { "newlinesBetween": false },
+                    "value-builtin",
+                    { "newlinesBetween": false },
+                    "value-internal",
+                    { "newlinesBetween": false },
+                    "value-parent"
+                ]
+            }
+        }"#,
+        r#"
+import type { T } from "t";
+import path from "path";
+import { foo } from "../foo";
+"#,
+    );
+}
+
+#[test]
+fn skipped_intermediate_groups_with_mixed_overrides() {
+    // Groups: type-import, value-builtin, value-internal, value-parent
+    // No imports match value-internal, so group index jumps from 1 to 3.
+    // Overrides: false between type-import/value-builtin, true between value-builtin/value-internal.
+    // Since one boundary in the path is true, a blank line IS inserted.
+    assert_format(
+        r#"
+import path from "path";
+import { foo } from "../foo";
+import type { T } from "t";
+"#,
+        r#"{
+            "experimentalSortImports": {
+                "newlinesBetween": false,
+                "groups": [
+                    "type-import",
+                    "value-builtin",
+                    { "newlinesBetween": true },
+                    "value-internal",
+                    "value-parent"
+                ]
+            }
+        }"#,
+        r#"
+import type { T } from "t";
+import path from "path";
+
+import { foo } from "../foo";
+"#,
+    );
+}

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -529,6 +529,7 @@ impl Oxc {
                     .unwrap_or_else(default_internal_patterns),
                 groups: sort_imports_config.groups.clone().unwrap_or_else(default_groups),
                 custom_groups: vec![],
+                newline_boundary_overrides: vec![],
             });
         }
 

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -552,6 +552,19 @@
         "ignore"
       ]
     },
+    "NewlinesBetweenMarker": {
+      "description": "A marker object for overriding `newlinesBetween` at a specific group boundary.",
+      "type": "object",
+      "required": [
+        "newlinesBetween"
+      ],
+      "properties": {
+        "newlinesBetween": {
+          "type": "boolean"
+        }
+      },
+      "markdownDescription": "A marker object for overriding `newlinesBetween` at a specific group boundary."
+    },
     "ObjectWrapConfig": {
       "type": "string",
       "enum": [
@@ -615,13 +628,26 @@
     "SortGroupItemConfig": {
       "anyOf": [
         {
-          "type": "string"
+          "description": "A `{ \"newlinesBetween\": bool }` marker object that overrides the global `newlinesBetween`\nsetting for the boundary between the previous and next groups.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NewlinesBetweenMarker"
+            }
+          ],
+          "markdownDescription": "A `{ \"newlinesBetween\": bool }` marker object that overrides the global `newlinesBetween`\nsetting for the boundary between the previous and next groups."
         },
         {
+          "description": "A single group name string (e.g. `\"value-builtin\"`).",
+          "type": "string",
+          "markdownDescription": "A single group name string (e.g. `\"value-builtin\"`)."
+        },
+        {
+          "description": "Multiple group names treated as one group (e.g. `[\"value-builtin\", \"value-external\"]`).",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "markdownDescription": "Multiple group names treated as one group (e.g. `[\"value-builtin\", \"value-external\"]`)."
         }
       ]
     },

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -556,6 +556,19 @@ expression: json
         "ignore"
       ]
     },
+    "NewlinesBetweenMarker": {
+      "description": "A marker object for overriding `newlinesBetween` at a specific group boundary.",
+      "type": "object",
+      "required": [
+        "newlinesBetween"
+      ],
+      "properties": {
+        "newlinesBetween": {
+          "type": "boolean"
+        }
+      },
+      "markdownDescription": "A marker object for overriding `newlinesBetween` at a specific group boundary."
+    },
     "ObjectWrapConfig": {
       "type": "string",
       "enum": [
@@ -619,13 +632,26 @@ expression: json
     "SortGroupItemConfig": {
       "anyOf": [
         {
-          "type": "string"
+          "description": "A `{ \"newlinesBetween\": bool }` marker object that overrides the global `newlinesBetween`\nsetting for the boundary between the previous and next groups.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NewlinesBetweenMarker"
+            }
+          ],
+          "markdownDescription": "A `{ \"newlinesBetween\": bool }` marker object that overrides the global `newlinesBetween`\nsetting for the boundary between the previous and next groups."
         },
         {
+          "description": "A single group name string (e.g. `\"value-builtin\"`).",
+          "type": "string",
+          "markdownDescription": "A single group name string (e.g. `\"value-builtin\"`)."
+        },
+        {
+          "description": "Multiple group names treated as one group (e.g. `[\"value-builtin\", \"value-external\"]`).",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "markdownDescription": "Multiple group names treated as one group (e.g. `[\"value-builtin\", \"value-external\"]`)."
         }
       ]
     },

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -211,14 +211,6 @@ type: `array | string`
 
 
 
-##### experimentalSortImports.groups[n][n]
-
-type: `string`
-
-
-
-
-
 ### experimentalSortImports.ignoreCase
 
 type: `boolean`
@@ -715,14 +707,6 @@ The list of modifiers is sorted from most to least important:
 ####### overrides[n].options.experimentalSortImports.groups[n]
 
 type: `array | string`
-
-
-
-
-
-######## overrides[n].options.experimentalSortImports.groups[n][n]
-
-type: `string`
 
 
 


### PR DESCRIPTION
Fixes #17830

Introduce new variant for `groups` like:

```json
  // "newlinesBetween": true, // Default
  "groups": [
      ["value-builtin", "value-external"],
      { "newlinesBetween": false }, // 👈🏻 
      "value-parent",
      "value-sibling"
  ]
```

This allows you to specify line breaks globally between groups while reverting them at any position.

Conversely, you can also add line breaks at any position while specifying `newlinesBetween: false`.