### PR TITLE
docs(linter): Improve docs for `eslint/require-await` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -17,8 +17,8 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct RequireAwait;
 
 fn require_await_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Async function has no 'await' expression.")
-        .with_help("Consider removing the 'async' keyword.")
+    OxcDiagnostic::warn("Async function has no `await` expression.")
+        .with_help("Consider removing the `async` keyword.")
         .with_label(span)
 }
 
@@ -26,6 +26,12 @@ declare_oxc_lint!(
     /// ### What it does
     ///
     /// Disallow async functions which have no `await` expression.
+    ///
+    /// ::: warning NOTE
+    /// This rule is inferior to the accuracy of the type-aware
+    /// `typescript/require-await` rule. If using type-aware
+    /// rules, always prefer that rule over this one.
+    /// :::
     ///
     /// ### Why is this bad?
     ///
@@ -46,14 +52,15 @@ declare_oxc_lint!(
     ///     return data.map(processDataItem);
     /// }
     /// ```
-    /// Asynchronous functions that don’t use await might not need to be
+    ///
+    /// Asynchronous functions that don’t use `await` might not need to be
     /// asynchronous functions and could be the unintentional result of
     /// refactoring.
     ///
     /// Note: this rule ignores async generator functions. This is because
     /// generators yield rather than return a value and async generators might
     /// yield all the values of another async generator without ever actually
-    /// needing to use await.
+    /// needing to use `await`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/snapshots/eslint_require_await.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_await.snap
@@ -2,72 +2,72 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:16]
  1 │ async function foo() { doSomething() }
    ·                ───
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:2]
  1 │ (async function() { doSomething() })
    ·  ──────────────────────────────────
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:1]
  1 │ async () => { doSomething() }
    · ─────────────────────────────
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:1]
  1 │ async () => doSomething()
    · ─────────────────────────
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:10]
  1 │ ({ async foo() { doSomething() } })
    ·          ───
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:17]
  1 │ class A { async foo() { doSomething() } }
    ·                 ───
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:16]
  1 │ (class { async foo() { doSomething() } })
    ·                ───
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:18]
  1 │ (class { async ''() { doSomething() } })
    ·                  ────────────────────
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:16]
  1 │ async function foo() { async () => { await doSomething() } }
    ·                ───
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.
 
-  ⚠ eslint(require-await): Async function has no 'await' expression.
+  ⚠ eslint(require-await): Async function has no `await` expression.
    ╭─[require_await.mts:1:31]
  1 │ async function foo() { await (async () => { doSomething() }) }
    ·                               ─────────────────────────────
    ╰────
-  help: Consider removing the 'async' keyword.
+  help: Consider removing the `async` keyword.


### PR DESCRIPTION
Note that the type-aware version should be preferred.