### PR TITLE
fix(linter/plugins): provide `parser.version`

### DIFF
--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -32,6 +32,7 @@ import { settings, initSettings } from "./settings.ts";
 import visitorKeys from "../generated/keys.ts";
 import { debugAssertIsNonNull } from "../utils/asserts.ts";
 import { envs, globals, initGlobals } from "./globals.ts";
+import { version as packageVersion } from "../../package.json" with { type: "json" };
 
 import type { Globals, Envs } from "./globals.ts";
 import type { RuleDetails } from "./load.ts";
@@ -91,13 +92,12 @@ const PARSER = Object.freeze({
   /**
    * Parser name.
    */
-  name: "oxc",
+  name: "oxlint",
 
   /**
    * Parser version.
    */
-  // TODO: This can be statically defined, but need it be to be updated when we make a new release.
-  version: "0.0.0",
+  version: packageVersion,
 
   /**
    * Parse code into an AST.

--- a/apps/oxlint/test/fixtures/languageOptions/output.snap.md
+++ b/apps/oxlint/test/fixtures/languageOptions/output.snap.md
@@ -16,7 +16,7 @@
 
   x language-options-plugin(lang): parser:
   | object keys: name,version,parse,VisitorKeys,Syntax,latestEcmaVersion,supportedEcmaVersions
-  | name: oxc
+  | name: oxlint
   | typeof version: string
   | typeof parse: function
   | latestEcmaVersion: 17


### PR DESCRIPTION
Add correct version for `context.languageOptions.parser.version`.

Blocker previously was that version should match `oxc-parser` package, which is not entirely trivial, as we release NAPI packages and Oxlint separately.

Work around this by giving `"oxlint"` as name of the parser, so we can use Oxlint version.

TSDown extracts the `version` field from `package.json` without including the whole contents of `package.json` in the bundled code.