### PR TITLE
fix(formatter): arrow function body incorrectly broken when return type has comment

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -164,6 +164,8 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                     };
                 }
 
+                write!(f, formatted_signature);
+
                 let body_has_soft_line_break =
                     arrow_expression.is_none_or(|expression| match expression {
                         Expression::ArrowFunctionExpression(_)
@@ -178,7 +180,7 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
                     });
 
                 if body_has_soft_line_break {
-                    write!(f, [formatted_signature, space(), format_body]);
+                    write!(f, [space(), format_body]);
                 } else {
                     let should_add_parens = arrow.expression && should_add_parens(body);
 
@@ -194,24 +196,21 @@ impl<'a, 'b> FormatJsArrowFunctionExpression<'a, 'b> {
 
                     write!(
                         f,
-                        [
-                            formatted_signature,
-                            group(&format_args!(
-                                soft_line_indent_or_space(&format_with(|f| {
-                                    if should_add_parens {
-                                        write!(f, if_group_fits_on_line(&"("));
-                                    }
+                        group(&format_args!(
+                            soft_line_indent_or_space(&format_with(|f| {
+                                if should_add_parens {
+                                    write!(f, if_group_fits_on_line(&"("));
+                                }
 
-                                    write!(f, format_body);
+                                write!(f, format_body);
 
-                                    if should_add_parens {
-                                        write!(f, if_group_fits_on_line(&")"));
-                                    }
-                                })),
-                                is_last_call_arg.then_some(&FormatTrailingCommas::All),
-                                should_add_soft_line.then_some(soft_line_break())
-                            ))
-                        ]
+                                if should_add_parens {
+                                    write!(f, if_group_fits_on_line(&")"));
+                                }
+                            })),
+                            is_last_call_arg.then_some(&FormatTrailingCommas::All),
+                            should_add_soft_line.then_some(soft_line_break())
+                        ))
                     );
                 }
             }

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-19335.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-19335.ts
@@ -1,0 +1,6 @@
+(): {
+  any
+  // this comment causes function body in a new line
+} => ({
+  any
+});

--- a/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-19335.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/arrow-function/issue-19335.ts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+(): {
+  any
+  // this comment causes function body in a new line
+} => ({
+  any
+});
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+(): {
+  any;
+  // this comment causes function body in a new line
+} => ({
+  any,
+});
+
+-------------------
+{ printWidth: 100 }
+-------------------
+(): {
+  any;
+  // this comment causes function body in a new line
+} => ({
+  any,
+});
+
+===================== End =====================


### PR DESCRIPTION
Fixes #19335

Format the arrow signature before checking `has_leading_own_line_comment` on the body, so that comments inside the return type annotation are already consumed and not mistakenly detected as body-leading comments.
