### PR TITLE
feat(linter): mark `typescript/no-invalid-this` as wont implement

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -123,6 +123,7 @@
     "typescript/sort-type-constituents": "Deprecated, replaced by `perfectionist/sort-intersection-types` and `perfectionist/sort-union-types` rules.",
     "typescript/no-type-alias": "Deprecated, replaced by `typescript-eslint/consistent-type-definitions` rule.",
     "typescript/typedef": "Deprecated.",
+    "typescript/no-invalid-this": "This rule is checked by the TypeScript compiler when the `noImplicitThis` compiler option is enabled. In TypeScript versions prior to 6.0, this compiler option is not enabled by default, however it is a best practice to enable it.",
 
     "eslint/array-bracket-newline": "Deprecated stylistic rule, can be used via the stylistic eslint plugin as a JS Plugin if necessary.",
     "eslint/array-bracket-spacing": "Deprecated stylistic rule, can be used via the stylistic eslint plugin as a JS Plugin if necessary.",


### PR DESCRIPTION
I see little value in supporting this rule (although it would be trivial to do so), as this is checked via the noImplicitThis TS compiler option, which is enabled by default in v6.

If users of oxlint which to use this rule, they should use type aware linting with --typecheck, and tsgolint will report these errors

@connorshea let me know if you disagree.