### PR TITLE
chore(oxlint): bump min tsgolint version to 0.12.2

### DIFF
--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -45,7 +45,7 @@
     }
   },
   "peerDependencies": {
-    "oxlint-tsgolint": ">=0.11.2"
+    "oxlint-tsgolint": ">=0.12.2"
   },
   "peerDependenciesMeta": {
     "oxlint-tsgolint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,7 +278,7 @@ importers:
   npm/oxlint:
     dependencies:
       oxlint-tsgolint:
-        specifier: '>=0.11.2'
+        specifier: '>=0.12.2'
         version: 0.12.2
 
   npm/oxlint-plugins: {}


### PR DESCRIPTION
Increase the tsgolint version requirement to ensure new rules are usable and fixes are always available.