### PR TITLE
chore(linter): Skip the deprecated field for no-unnecessary-condition rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_condition.rs
@@ -41,6 +41,7 @@ pub struct NoUnnecessaryConditionConfig {
     /// Whether to check type predicate functions.
     pub check_type_predicates: bool,
     /// DEPRECATED: Allow this rule to run without `strictNullChecks` enabled.
+    #[schemars(skip)]
     pub allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing: bool,
 }
 


### PR DESCRIPTION
`allow_rule_to_run_without_strict_null_checks_i_know_what_i_am_doing` should be skipped like other, similar fields in rules like this.

Not sure if there was a specific reason we opted to include this one where we have been skipping other, similar options?