### PR TITLE
Proof of Concept: Script for comparing JS-generated upstream test cases

### DIFF
--- a/tasks/rulegen/compare-all-ts-rules.mjs
+++ b/tasks/rulegen/compare-all-ts-rules.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * compare-all-ts-rules.mjs
+ *
+ * Runs compare-tests.mjs on all TypeScript rules and collects results.
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+
+// Get all TypeScript rule files
+const tsRulesDir = path.join(PROJECT_ROOT, "crates/oxc_linter/src/rules/typescript");
+const ruleFiles = fs.readdirSync(tsRulesDir).filter((f) => f.endsWith(".rs"));
+
+// Convert filename to kebab-case rule name
+function filenameToRuleName(filename) {
+  return filename.replace(/\.rs$/, "").replace(/_/g, "-");
+}
+
+const results = [];
+
+console.error(`Found ${ruleFiles.length} TypeScript rules. Running comparisons...\n`);
+
+for (const [index, file] of ruleFiles.entries()) {
+  const ruleName = filenameToRuleName(file);
+  console.error(`[${index + 1}/${ruleFiles.length}] Checking ${ruleName}...`);
+
+  try {
+    const output = execSync(
+      `node ${path.join(__dirname, "compare-tests.mjs")} ${ruleName} typescript --json`,
+      {
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const result = JSON.parse(output);
+    const totalMissing = result.missingValid.length + result.missingInvalid.length;
+    const totalOxlint = result.oxlint.valid + result.oxlint.invalid;
+
+    // Only include rules that have some implementation (non-zero oxlint tests)
+    if (totalOxlint > 0) {
+      results.push({
+        rule: ruleName,
+        missingTotal: totalMissing,
+        missingValid: result.missingValid.length,
+        missingInvalid: result.missingInvalid.length,
+        upstreamTotal: result.upstream.valid + result.upstream.invalid,
+        oxlintTotal: totalOxlint,
+        coverage:
+          result.upstream.valid + result.upstream.invalid > 0
+            ? ((totalOxlint / (result.upstream.valid + result.upstream.invalid)) * 100).toFixed(1)
+            : "N/A",
+      });
+    }
+  } catch (err) {
+    // Skip rules that fail (likely type-aware or have issues)
+    console.error(`  ⚠️  Skipped (${err.message.split("\n")[0]})`);
+  }
+}
+
+// Sort by most missing tests
+results.sort((a, b) => b.missingTotal - a.missingTotal);
+
+// Output results
+console.log("\n=== TypeScript Rules Missing Test Cases ===\n");
+console.log("Rule Name                                     Missing  Oxlint  Upstream  Coverage");
+console.log("─".repeat(85));
+
+for (const r of results) {
+  const rulePadded = r.rule.padEnd(45);
+  const missingPadded = String(r.missingTotal).padStart(7);
+  const oxlintPadded = String(r.oxlintTotal).padStart(7);
+  const upstreamPadded = String(r.upstreamTotal).padStart(9);
+  const coverage = String(r.coverage).padStart(7) + "%";
+  console.log(`${rulePadded}${missingPadded}${oxlintPadded}${upstreamPadded}  ${coverage}`);
+}
+
+console.log("\n");
+console.log(`Total rules analyzed: ${results.length}`);
+console.log(`Total missing test cases: ${results.reduce((sum, r) => sum + r.missingTotal, 0)}`);

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -146,29 +146,14 @@ function toSnakeCase(str) {
 
 /**
  * Normalize a code string for fuzzy comparison.
- * Trims whitespace, normalizes line endings, dedents common indentation.
+ * Collapses all whitespace (including newlines) to single spaces for comparison.
  */
 function normalize(code) {
   if (typeof code !== "string") return "";
-  let lines = code.replace(/\r\n/g, "\n").split("\n");
 
-  // Trim leading/trailing empty lines
-  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
-  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop();
-
-  // Dedent: find minimum indentation of non-empty lines
-  const nonEmpty = lines.filter((l) => l.trim().length > 0);
-  if (nonEmpty.length > 0) {
-    const minIndent = Math.min(...nonEmpty.map((l) => l.match(/^(\s*)/)[1].length));
-    if (minIndent > 0) {
-      lines = lines.map((l) => l.slice(minIndent));
-    }
-  }
-
-  return lines
-    .map((l) => l.trimEnd())
-    .join("\n")
-    .trim();
+  // Replace all sequences of whitespace (spaces, tabs, newlines) with a single space
+  // Then trim leading/trailing whitespace
+  return code.replace(/\s+/g, " ").trim();
 }
 
 // ── Step 1: Download and evaluate the upstream test file ────────────────

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -29,8 +29,7 @@ const PROJECT_ROOT = path.resolve(__dirname, "../..");
 
 const PLUGINS = {
   eslint: {
-    testUrl:
-      "https://raw.githubusercontent.com/eslint/eslint/main/tests/lib/rules",
+    testUrl: "https://raw.githubusercontent.com/eslint/eslint/main/tests/lib/rules",
     ext: ".js",
     rustDir: "eslint",
   },
@@ -47,8 +46,7 @@ const PLUGINS = {
     rustDir: "jest",
   },
   unicorn: {
-    testUrl:
-      "https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test",
+    testUrl: "https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test",
     ext: ".js",
     rustDir: "unicorn",
   },
@@ -77,8 +75,7 @@ const PLUGINS = {
     rustDir: "jsx_a11y",
   },
   nextjs: {
-    testUrl:
-      "https://raw.githubusercontent.com/vercel/next.js/canary/test/unit/eslint-plugin-next",
+    testUrl: "https://raw.githubusercontent.com/vercel/next.js/canary/test/unit/eslint-plugin-next",
     ext: ".test.ts",
     rustDir: "nextjs",
   },
@@ -102,14 +99,12 @@ const PLUGINS = {
     rustDir: "promise",
   },
   vitest: {
-    testUrl:
-      "https://raw.githubusercontent.com/vitest-dev/eslint-plugin-vitest/main/tests",
+    testUrl: "https://raw.githubusercontent.com/vitest-dev/eslint-plugin-vitest/main/tests",
     ext: ".test.ts",
     rustDir: "vitest",
   },
   vue: {
-    testUrl:
-      "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules",
+    testUrl: "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules",
     ext: ".js",
     rustDir: "vue",
   },
@@ -122,9 +117,7 @@ const jsonOutput = args.includes("--json");
 const positional = args.filter((a) => !a.startsWith("--"));
 
 if (positional.length < 2) {
-  console.error(
-    "Usage: node tasks/rulegen/compare-tests.mjs <rule-name> <plugin> [--json]",
-  );
+  console.error("Usage: node tasks/rulegen/compare-tests.mjs <rule-name> <plugin> [--json]");
   console.error("  Plugins: " + Object.keys(PLUGINS).join(", "));
   process.exit(1);
 }
@@ -166,9 +159,7 @@ function normalize(code) {
   // Dedent: find minimum indentation of non-empty lines
   const nonEmpty = lines.filter((l) => l.trim().length > 0);
   if (nonEmpty.length > 0) {
-    const minIndent = Math.min(
-      ...nonEmpty.map((l) => l.match(/^(\s*)/)[1].length),
-    );
+    const minIndent = Math.min(...nonEmpty.map((l) => l.match(/^(\s*)/)[1].length));
     if (minIndent > 0) {
       lines = lines.map((l) => l.slice(minIndent));
     }
@@ -205,8 +196,7 @@ async function downloadTestFile(ruleName, plugin) {
  *      type stripping (--experimental-strip-types), then naive regex stripping
  */
 function evaluateTestFile(source, originalUrl) {
-  const isTs =
-    originalUrl.endsWith(".ts") || originalUrl.endsWith(".tsx");
+  const isTs = originalUrl.endsWith(".ts") || originalUrl.endsWith(".tsx");
 
   // Strategy 1: Try esbuild for TypeScript (produces clean CJS)
   if (isTs) {
@@ -262,15 +252,20 @@ function tryEsbuild(source) {
   const tmpTs = path.join(os.tmpdir(), `oxc-compare-test-${Date.now()}.ts`);
   try {
     fs.writeFileSync(tmpTs, source);
-    const result = execSync(
-      `esbuild --bundle=false --loader=ts --format=cjs "${tmpTs}"`,
-      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024, stdio: ["pipe", "pipe", "pipe"] },
-    );
+    const result = execSync(`esbuild --bundle=false --loader=ts --format=cjs "${tmpTs}"`, {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
     return result;
   } catch {
     return null;
   } finally {
-    try { fs.unlinkSync(tmpTs); } catch { /* ignore */ }
+    try {
+      fs.unlinkSync(tmpTs);
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -298,14 +293,11 @@ function runWithMock(source, ext, extraNodeArgs = []) {
   try {
     const mockPath = path.join(__dirname, "mock-rule-tester.cjs");
     const nodeArgs = [...extraNodeArgs, `--require`, mockPath].join(" ");
-    const result = execSync(
-      `node ${nodeArgs} ${JSON.stringify(tmpRunner)}`,
-      {
-        encoding: "utf8",
-        maxBuffer: 10 * 1024 * 1024,
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-    );
+    const result = execSync(`node ${nodeArgs} ${JSON.stringify(tmpRunner)}`, {
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
     return JSON.parse(result);
   } catch (err) {
     if (process.env.DEBUG) {
@@ -313,8 +305,16 @@ function runWithMock(source, ext, extraNodeArgs = []) {
     }
     return null;
   } finally {
-    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
-    try { fs.unlinkSync(tmpRunner); } catch { /* ignore */ }
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {
+      /* ignore */
+    }
+    try {
+      fs.unlinkSync(tmpRunner);
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -344,10 +344,7 @@ function convertEsmToCjs(source) {
   );
 
   // import 'module' → require('module')
-  result = result.replace(
-    /import\s+['"]([^'"]+)['"]\s*;?/g,
-    (_, mod) => `require('${mod}');`,
-  );
+  result = result.replace(/import\s+['"]([^'"]+)['"]\s*;?/g, (_, mod) => `require('${mod}');`);
 
   // export default → module.exports =
   result = result.replace(/export\s+default\s+/g, "module.exports = ");
@@ -441,9 +438,7 @@ function extractRustTestCases(filePath) {
  */
 function extractVecBlock(content, name) {
   // Match `let pass = vec![` or `let fail = vec![`
-  const pattern = new RegExp(
-    `let\\s+${name}\\s*(?::\\s*Vec<[^>]*>)?\\s*=\\s*vec!\\[`,
-  );
+  const pattern = new RegExp(`let\\s+${name}\\s*(?::\\s*Vec<[^>]*>)?\\s*=\\s*vec!\\[`);
   const match = pattern.exec(content);
   if (!match) return [];
 
@@ -562,7 +557,10 @@ function extractStringLiterals(block) {
     if (block[i] === "r" && block[i + 1] === "#") {
       i++; // skip 'r'
       let hashes = 0;
-      while (block[i] === "#") { hashes++; i++; }
+      while (block[i] === "#") {
+        hashes++;
+        i++;
+      }
       if (block[i] === '"') {
         i++; // skip opening "
         const closer = '"' + "#".repeat(hashes);
@@ -590,10 +588,7 @@ function extractStringLiterals(block) {
   }
 
   function isStringStart(s, pos) {
-    return (
-      s[pos] === '"' ||
-      (s[pos] === "r" && (s[pos + 1] === '"' || s[pos + 1] === "#"))
-    );
+    return s[pos] === '"' || (s[pos] === "r" && (s[pos + 1] === '"' || s[pos + 1] === "#"));
   }
 
   function tryExtractString() {
@@ -604,7 +599,10 @@ function extractStringLiterals(block) {
     if (block[i] === "r" && block[i + 1] === "#") {
       i++; // skip 'r'
       let hashes = 0;
-      while (block[i] === "#") { hashes++; i++; }
+      while (block[i] === "#") {
+        hashes++;
+        i++;
+      }
       if (block[i] !== '"') return null;
       i++; // skip opening "
       const closer = '"' + "#".repeat(hashes);
@@ -633,12 +631,23 @@ function extractStringLiterals(block) {
         if (block[i] === "\\") {
           i++;
           switch (block[i]) {
-            case "n": str += "\n"; break;
-            case "t": str += "\t"; break;
-            case "r": str += "\r"; break;
-            case "\\": str += "\\"; break;
-            case '"': str += '"'; break;
-            default: str += block[i];
+            case "n":
+              str += "\n";
+              break;
+            case "t":
+              str += "\t";
+              break;
+            case "r":
+              str += "\r";
+              break;
+            case "\\":
+              str += "\\";
+              break;
+            case '"':
+              str += '"';
+              break;
+            default:
+              str += block[i];
           }
         } else {
           str += block[i];
@@ -684,14 +693,8 @@ function truncate(str, maxLen = 120) {
 }
 
 function printReport(upstreamResult, rustResult) {
-  const validComparison = compareSets(
-    upstreamResult.valid,
-    rustResult.valid,
-  );
-  const invalidComparison = compareSets(
-    upstreamResult.invalid,
-    rustResult.invalid,
-  );
+  const validComparison = compareSets(upstreamResult.valid, rustResult.valid);
+  const invalidComparison = compareSets(upstreamResult.invalid, rustResult.invalid);
 
   if (jsonOutput) {
     console.log(
@@ -728,37 +731,26 @@ function printReport(upstreamResult, rustResult) {
     `Oxlint (Rust file):           ${rustResult.valid.length} valid, ${rustResult.invalid.length} invalid`,
   );
 
-  if (
-    validComparison.missing.length === 0 &&
-    invalidComparison.missing.length === 0
-  ) {
-    console.log(
-      "\nAll upstream test cases are present in the oxlint rule file.",
-    );
+  if (validComparison.missing.length === 0 && invalidComparison.missing.length === 0) {
+    console.log("\nAll upstream test cases are present in the oxlint rule file.");
   }
 
   if (validComparison.missing.length > 0) {
-    console.log(
-      `\nMissing valid cases (${validComparison.missing.length}):`,
-    );
+    console.log(`\nMissing valid cases (${validComparison.missing.length}):`);
     for (const [i, t] of validComparison.missing.entries()) {
       console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
     }
   }
 
   if (invalidComparison.missing.length > 0) {
-    console.log(
-      `\nMissing invalid cases (${invalidComparison.missing.length}):`,
-    );
+    console.log(`\nMissing invalid cases (${invalidComparison.missing.length}):`);
     for (const [i, t] of invalidComparison.missing.entries()) {
       console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
     }
   }
 
   if (validComparison.extra.length > 0) {
-    console.log(
-      `\nExtra valid cases in oxlint not in upstream (${validComparison.extra.length}):`,
-    );
+    console.log(`\nExtra valid cases in oxlint not in upstream (${validComparison.extra.length}):`);
     for (const [i, t] of validComparison.extra.entries()) {
       console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
     }
@@ -788,10 +780,7 @@ async function main() {
     process.exit(1);
   }
 
-  if (
-    upstreamResult.valid.length === 0 &&
-    upstreamResult.invalid.length === 0
-  ) {
+  if (upstreamResult.valid.length === 0 && upstreamResult.invalid.length === 0) {
     console.error(
       "Warning: No test cases captured from upstream file. " +
         "The test file may use an unsupported pattern.",

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -709,8 +709,8 @@ function extractOptionsFromTuple(block, tupleStart) {
 
   if (afterComma.startsWith("None")) return null;
 
-  // Extract the JSON content from Some(serde_json::json!(...))
-  const jsonMatch = afterComma.match(/Some\s*\(\s*serde_json::json!\s*\(/);
+  // Extract the JSON content from Some(serde_json::json!(...)) or Some(json!(...))
+  const jsonMatch = afterComma.match(/Some\s*\(\s*(?:serde_json::)?json!\s*\(/);
   if (!jsonMatch) return null;
 
   // Find the content inside json!(...)

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -283,11 +283,11 @@ function runWithMock(source, ext, extraNodeArgs = []) {
   fs.writeFileSync(
     tmpRunner,
     `require(${JSON.stringify(tmpFile)});\n` +
-    `if (global.__capturedTests) {\n` +
-    `  process.stdout.write(JSON.stringify(global.__capturedTests));\n` +
-    `} else {\n` +
-    `  process.stdout.write(JSON.stringify({valid: [], invalid: []}));\n` +
-    `}\n`,
+      `if (global.__capturedTests) {\n` +
+      `  process.stdout.write(JSON.stringify(global.__capturedTests));\n` +
+      `} else {\n` +
+      `  process.stdout.write(JSON.stringify({valid: [], invalid: []}));\n` +
+      `}\n`,
   );
 
   try {
@@ -974,7 +974,7 @@ async function main() {
   if (upstreamResult.valid.length === 0 && upstreamResult.invalid.length === 0) {
     console.error(
       "Warning: No test cases captured from upstream file. " +
-      "The test file may use an unsupported pattern.",
+        "The test file may use an unsupported pattern.",
     );
   }
 

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -734,7 +734,11 @@ function extractOptionsFromTuple(block, tupleStart) {
   }
 
   // The JSON-like content (Rust serde_json::json! macro syntax)
-  const jsonContent = afterComma.slice(jsonStart, k - 1).trim();
+  let jsonContent = afterComma.slice(jsonStart, k - 1).trim();
+
+  // Remove trailing commas (valid in Rust json! macro but not in JSON)
+  // Match commas before closing brackets/braces/parens
+  jsonContent = jsonContent.replace(/,(\s*[}\]\)])/g, "$1");
 
   // Try to parse it as JSON (serde_json::json! uses JSON-like syntax)
   try {

--- a/tasks/rulegen/compare-tests.mjs
+++ b/tasks/rulegen/compare-tests.mjs
@@ -1,0 +1,820 @@
+#!/usr/bin/env node
+
+/**
+ * compare-tests.mjs
+ *
+ * Compares upstream ESLint test cases (evaluated via Node.js) against the
+ * statically-extracted test cases in oxlint's Rust rule files.
+ *
+ * Usage:
+ *   node tasks/rulegen/compare-tests.mjs <rule-name> <plugin>
+ *
+ * Examples:
+ *   node tasks/rulegen/compare-tests.mjs no-empty-function eslint
+ *   node tasks/rulegen/compare-tests.mjs no-unnecessary-condition typescript
+ *   node tasks/rulegen/compare-tests.mjs no-empty-function eslint --json
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+
+// ── Plugin configuration ────────────────────────────────────────────────
+// Maps plugin names to { testUrl, extension, rustDir }
+
+const PLUGINS = {
+  eslint: {
+    testUrl:
+      "https://raw.githubusercontent.com/eslint/eslint/main/tests/lib/rules",
+    ext: ".js",
+    rustDir: "eslint",
+  },
+  typescript: {
+    testUrl:
+      "https://raw.githubusercontent.com/typescript-eslint/typescript-eslint/main/packages/eslint-plugin/tests/rules",
+    ext: ".test.ts",
+    rustDir: "typescript",
+  },
+  jest: {
+    testUrl:
+      "https://raw.githubusercontent.com/jest-community/eslint-plugin-jest/main/src/rules/__tests__",
+    ext: ".test.ts",
+    rustDir: "jest",
+  },
+  unicorn: {
+    testUrl:
+      "https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test",
+    ext: ".js",
+    rustDir: "unicorn",
+  },
+  import: {
+    testUrl:
+      "https://raw.githubusercontent.com/import-js/eslint-plugin-import/main/tests/src/rules",
+    ext: ".js",
+    rustDir: "import",
+  },
+  react: {
+    testUrl:
+      "https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-react/master/tests/lib/rules",
+    ext: ".js",
+    rustDir: "react",
+  },
+  "react-perf": {
+    testUrl:
+      "https://raw.githubusercontent.com/cvazac/eslint-plugin-react-perf/master/tests/lib/rules",
+    ext: ".js",
+    rustDir: "react_perf",
+  },
+  "jsx-a11y": {
+    testUrl:
+      "https://raw.githubusercontent.com/jsx-eslint/eslint-plugin-jsx-a11y/main/__tests__/src/rules",
+    ext: "-test.js",
+    rustDir: "jsx_a11y",
+  },
+  nextjs: {
+    testUrl:
+      "https://raw.githubusercontent.com/vercel/next.js/canary/test/unit/eslint-plugin-next",
+    ext: ".test.ts",
+    rustDir: "nextjs",
+  },
+  jsdoc: {
+    testUrl:
+      "https://raw.githubusercontent.com/gajus/eslint-plugin-jsdoc/main/test/rules/assertions",
+    ext: ".js",
+    useCamelCase: true,
+    rustDir: "jsdoc",
+  },
+  node: {
+    testUrl:
+      "https://raw.githubusercontent.com/eslint-community/eslint-plugin-n/master/tests/lib/rules",
+    ext: ".js",
+    rustDir: "node",
+  },
+  promise: {
+    testUrl:
+      "https://raw.githubusercontent.com/eslint-community/eslint-plugin-promise/main/__tests__",
+    ext: ".js",
+    rustDir: "promise",
+  },
+  vitest: {
+    testUrl:
+      "https://raw.githubusercontent.com/vitest-dev/eslint-plugin-vitest/main/tests",
+    ext: ".test.ts",
+    rustDir: "vitest",
+  },
+  vue: {
+    testUrl:
+      "https://raw.githubusercontent.com/vuejs/eslint-plugin-vue/master/tests/lib/rules",
+    ext: ".js",
+    rustDir: "vue",
+  },
+};
+
+// ── CLI parsing ─────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const jsonOutput = args.includes("--json");
+const positional = args.filter((a) => !a.startsWith("--"));
+
+if (positional.length < 2) {
+  console.error(
+    "Usage: node tasks/rulegen/compare-tests.mjs <rule-name> <plugin> [--json]",
+  );
+  console.error("  Plugins: " + Object.keys(PLUGINS).join(", "));
+  process.exit(1);
+}
+
+const [ruleName, pluginName] = positional;
+const plugin = PLUGINS[pluginName];
+if (!plugin) {
+  console.error(`Unknown plugin: ${pluginName}`);
+  console.error("  Supported: " + Object.keys(PLUGINS).join(", "));
+  process.exit(1);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function toKebabCase(str) {
+  return str.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+function toCamelCase(str) {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+function toSnakeCase(str) {
+  return str.replace(/-/g, "_");
+}
+
+/**
+ * Normalize a code string for fuzzy comparison.
+ * Trims whitespace, normalizes line endings, dedents common indentation.
+ */
+function normalize(code) {
+  if (typeof code !== "string") return "";
+  let lines = code.replace(/\r\n/g, "\n").split("\n");
+
+  // Trim leading/trailing empty lines
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop();
+
+  // Dedent: find minimum indentation of non-empty lines
+  const nonEmpty = lines.filter((l) => l.trim().length > 0);
+  if (nonEmpty.length > 0) {
+    const minIndent = Math.min(
+      ...nonEmpty.map((l) => l.match(/^(\s*)/)[1].length),
+    );
+    if (minIndent > 0) {
+      lines = lines.map((l) => l.slice(minIndent));
+    }
+  }
+
+  return lines
+    .map((l) => l.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+// ── Step 1: Download and evaluate the upstream test file ────────────────
+
+async function downloadTestFile(ruleName, plugin) {
+  const kebab = toKebabCase(ruleName);
+  const name = plugin.useCamelCase ? toCamelCase(kebab) : kebab;
+  const url = `${plugin.testUrl}/${name}${plugin.ext}`;
+
+  console.error(`Downloading ${url} ...`);
+
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(`Failed to download test file: ${resp.status} ${url}`);
+  }
+  return { body: await resp.text(), url };
+}
+
+/**
+ * Evaluate the upstream test file with mocked RuleTester to capture test cases.
+ *
+ * Strategy:
+ *   1. For .js files: convert ESM→CJS, run with --require mock
+ *   2. For .ts files: convert ESM→CJS, try esbuild first, then Node's built-in
+ *      type stripping (--experimental-strip-types), then naive regex stripping
+ */
+function evaluateTestFile(source, originalUrl) {
+  const isTs =
+    originalUrl.endsWith(".ts") || originalUrl.endsWith(".tsx");
+
+  // Strategy 1: Try esbuild for TypeScript (produces clean CJS)
+  if (isTs) {
+    const esbuildResult = tryEsbuild(source);
+    if (esbuildResult !== null) {
+      const cjsSource = convertEsmToCjs(esbuildResult);
+      const result = runWithMock(cjsSource, ".cjs");
+      if (result) return result;
+    }
+  }
+
+  // Strategy 2: Try Node's built-in type stripping for TypeScript
+  // Save as .cts so Node uses CJS mode + type stripping
+  if (isTs) {
+    const cjsSource = convertEsmToCjs(source);
+    const result = runWithMock(cjsSource, ".cts", [
+      "--experimental-strip-types",
+      "--experimental-transform-types",
+    ]);
+    if (result) return result;
+  }
+
+  // Strategy 3: Naive TS strip + ESM→CJS conversion
+  if (isTs) {
+    const stripped = naiveStripTypeScript(source);
+    const cjsSource = convertEsmToCjs(stripped);
+    const result = runWithMock(cjsSource, ".cjs");
+    if (result) return result;
+  }
+
+  // Strategy 4: Plain JS (ESM→CJS only)
+  if (!isTs) {
+    const cjsSource = convertEsmToCjs(source);
+    const result = runWithMock(cjsSource, ".cjs");
+    if (result) return result;
+  }
+
+  console.error("Warning: All evaluation strategies failed.");
+  return null;
+}
+
+/**
+ * Try to transpile TypeScript using esbuild.
+ * Returns the JS source or null if esbuild is not available.
+ */
+function tryEsbuild(source) {
+  try {
+    execSync("which esbuild", { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+  } catch {
+    return null;
+  }
+
+  const tmpTs = path.join(os.tmpdir(), `oxc-compare-test-${Date.now()}.ts`);
+  try {
+    fs.writeFileSync(tmpTs, source);
+    const result = execSync(
+      `esbuild --bundle=false --loader=ts --format=cjs "${tmpTs}"`,
+      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    return result;
+  } catch {
+    return null;
+  } finally {
+    try { fs.unlinkSync(tmpTs); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Write source to a temp file and run it with the mock RuleTester preloaded.
+ * Returns the captured test cases or null on failure.
+ */
+function runWithMock(source, ext, extraNodeArgs = []) {
+  const timestamp = Date.now();
+  const tmpFile = path.join(os.tmpdir(), `oxc-compare-test-${timestamp}${ext}`);
+  const runnerExt = ext === ".cts" ? ".cts" : ".cjs";
+  const tmpRunner = path.join(os.tmpdir(), `oxc-compare-runner-${timestamp}${runnerExt}`);
+
+  fs.writeFileSync(tmpFile, source);
+  fs.writeFileSync(
+    tmpRunner,
+    `require(${JSON.stringify(tmpFile)});\n` +
+      `if (global.__capturedTests) {\n` +
+      `  process.stdout.write(JSON.stringify(global.__capturedTests));\n` +
+      `} else {\n` +
+      `  process.stdout.write(JSON.stringify({valid: [], invalid: []}));\n` +
+      `}\n`,
+  );
+
+  try {
+    const mockPath = path.join(__dirname, "mock-rule-tester.cjs");
+    const nodeArgs = [...extraNodeArgs, `--require`, mockPath].join(" ");
+    const result = execSync(
+      `node ${nodeArgs} ${JSON.stringify(tmpRunner)}`,
+      {
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    return JSON.parse(result);
+  } catch (err) {
+    if (process.env.DEBUG) {
+      console.error(`Strategy failed (${ext}):`, err.stderr?.slice(0, 500) || err.message);
+    }
+    return null;
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+    try { fs.unlinkSync(tmpRunner); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Naive ESM → CJS conversion for test files.
+ * Handles common patterns found in eslint/typescript-eslint test files.
+ */
+function convertEsmToCjs(source) {
+  let result = source;
+
+  // import { X, Y } from 'module' → const { X, Y } = require('module')
+  result = result.replace(
+    /import\s+\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]\s*;?/g,
+    (_, imports, mod) => `const {${imports}} = require('${mod}');`,
+  );
+
+  // import X from 'module' → const X = require('module')
+  result = result.replace(
+    /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?/g,
+    (_, name, mod) => `const ${name} = require('${mod}');`,
+  );
+
+  // import * as X from 'module' → const X = require('module')
+  result = result.replace(
+    /import\s+\*\s+as\s+(\w+)\s+from\s+['"]([^'"]+)['"]\s*;?/g,
+    (_, name, mod) => `const ${name} = require('${mod}');`,
+  );
+
+  // import 'module' → require('module')
+  result = result.replace(
+    /import\s+['"]([^'"]+)['"]\s*;?/g,
+    (_, mod) => `require('${mod}');`,
+  );
+
+  // export default → module.exports =
+  result = result.replace(/export\s+default\s+/g, "module.exports = ");
+
+  // export { X } — remove
+  result = result.replace(/export\s+\{[^}]*\}\s*;?/g, "");
+
+  // export const/let/var → const/let/var
+  result = result.replace(/export\s+(const|let|var)\s+/g, "$1 ");
+
+  return result;
+}
+
+/**
+ * Very naive regex-based TypeScript stripping. Only handles simple patterns.
+ */
+function naiveStripTypeScript(source) {
+  let result = source;
+
+  // Remove type imports: import type { ... } from '...'
+  result = result.replace(/import\s+type\s+\{[^}]*\}\s+from\s+['"][^'"]+['"]\s*;?/g, "");
+
+  // Remove type-only imports within braces: import { type X, Y } → import { Y }
+  result = result.replace(/\btype\s+(\w+)\s*,?\s*/g, "");
+
+  // Remove parameter/variable type annotations: `: Type`
+  // Match `: <identifier>` patterns but not inside strings
+  result = result.replace(
+    /:\s*(?:string|number|boolean|any|void|null|undefined|never|object|unknown|bigint|symbol)\b(?:\[\])*/g,
+    "",
+  );
+
+  // Remove more complex type annotations: `: Identifier` or `: Identifier[]`
+  // Only after parameter names (word char or `)` or `]`)
+  result = result.replace(/(?<=[\w)\]])\s*:\s*[A-Z]\w*(?:<[^>]*>)?(?:\[\])*/g, "");
+
+  // Remove `as Type` casts (but not `import * as X`)
+  result = result.replace(/(?<=[\w)\]>])\s+as\s+[A-Z]\w*(?:<[^>]*>)?(?:\[\])*/g, "");
+
+  // Remove generic type parameters on function calls/declarations
+  result = result.replace(/<[A-Z]\w*(?:\s*,\s*[A-Z]\w*)*>/g, "");
+
+  // Remove `satisfies Type`
+  result = result.replace(/\s+satisfies\s+\w+/g, "");
+
+  // Remove `<const>` assertions
+  result = result.replace(/<const>/g, "");
+
+  // Remove interface/type declarations (entire blocks)
+  result = result.replace(/(?:export\s+)?interface\s+\w+(?:<[^>]*>)?\s*\{[^}]*\}/g, "");
+  result = result.replace(/(?:export\s+)?type\s+\w+(?:<[^>]*>)?\s*=[^;]+;/g, "");
+
+  return result;
+}
+
+// ── Step 2: Extract test code strings from the Rust rule file ───────────
+
+function findRustRuleFile(ruleName, plugin) {
+  const snake = toSnakeCase(toKebabCase(ruleName));
+  const rustFile = path.join(
+    PROJECT_ROOT,
+    "crates/oxc_linter/src/rules",
+    plugin.rustDir,
+    `${snake}.rs`,
+  );
+
+  if (!fs.existsSync(rustFile)) {
+    return null;
+  }
+  return rustFile;
+}
+
+/**
+ * Extract code strings from `let pass = vec![...]` and `let fail = vec![...]`
+ * blocks in a Rust test file.
+ */
+function extractRustTestCases(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+
+  const passStrings = extractVecBlock(content, "pass");
+  const failStrings = extractVecBlock(content, "fail");
+
+  return {
+    valid: passStrings.map((code) => ({ code })),
+    invalid: failStrings.map((code) => ({ code })),
+  };
+}
+
+/**
+ * Find the `let <name> = vec![...]` block and extract all string literals from it.
+ */
+function extractVecBlock(content, name) {
+  // Match `let pass = vec![` or `let fail = vec![`
+  const pattern = new RegExp(
+    `let\\s+${name}\\s*(?::\\s*Vec<[^>]*>)?\\s*=\\s*vec!\\[`,
+  );
+  const match = pattern.exec(content);
+  if (!match) return [];
+
+  // Find the matching closing `];` by counting brackets
+  let depth = 1;
+  let i = match.index + match[0].length;
+  const start = i;
+
+  while (i < content.length && depth > 0) {
+    const ch = content[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") depth--;
+    else if (ch === '"') {
+      // Skip string literal
+      i++;
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === "\\") i++; // skip escaped char
+        i++;
+      }
+    } else if (ch === "r" && content[i + 1] === "#") {
+      // Raw string: count #'s
+      const hashStart = i + 1;
+      let hashes = 0;
+      while (content[hashStart + hashes] === "#") hashes++;
+      if (content[hashStart + hashes] === '"') {
+        // Skip to closing "###
+        const closer = '"' + "#".repeat(hashes);
+        const closeIdx = content.indexOf(closer, hashStart + hashes + 1);
+        if (closeIdx !== -1) {
+          i = closeIdx + closer.length - 1;
+        }
+      }
+    } else if (ch === "r" && content[i + 1] === '"') {
+      // r"..." raw string with no hashes
+      i += 2;
+      const closeIdx = content.indexOf('"', i);
+      if (closeIdx !== -1) {
+        i = closeIdx;
+      }
+    } else if (ch === "/" && content[i + 1] === "/") {
+      // Skip line comment
+      while (i < content.length && content[i] !== "\n") i++;
+    }
+    i++;
+  }
+
+  const block = content.slice(start, i - 1); // exclude the closing ]
+  return extractStringLiterals(block);
+}
+
+/**
+ * Extract code strings from a vec![...] block.
+ *
+ * Test cases come in two forms:
+ *   1. Tuple: ("code", None) or ("code", Some(serde_json::json!([...])))
+ *   2. Bare string: "code"
+ *
+ * We only want the FIRST string in each tuple (the code). Config strings
+ * like "allow", "constructors" etc. should be skipped.
+ */
+function extractStringLiterals(block) {
+  const strings = [];
+  let i = 0;
+
+  while (i < block.length) {
+    skipWhitespace();
+    if (i >= block.length) break;
+
+    if (block[i] === "(") {
+      // Tuple: extract only the first string, then skip to closing )
+      i++; // skip (
+      skipWhitespace();
+      const codeStr = tryExtractString();
+      if (codeStr !== null) {
+        strings.push(codeStr);
+      }
+      // Skip to the matching closing )
+      skipToClosingParen();
+    } else if (isStringStart(block, i)) {
+      // Bare string at top level
+      const codeStr = tryExtractString();
+      if (codeStr !== null) {
+        strings.push(codeStr);
+      }
+    } else {
+      i++;
+    }
+  }
+
+  return strings;
+
+  function skipToClosingParen() {
+    let depth = 1;
+    while (i < block.length && depth > 0) {
+      const ch = block[i];
+      if (ch === "(") depth++;
+      else if (ch === ")") depth--;
+      else if (ch === '"') {
+        // Skip string literal
+        i++;
+        while (i < block.length && block[i] !== '"') {
+          if (block[i] === "\\") i++;
+          i++;
+        }
+      } else if (ch === "r" && (block[i + 1] === "#" || block[i + 1] === '"')) {
+        skipRawString();
+        continue; // skipRawString already advances i
+      } else if (ch === "/" && block[i + 1] === "/") {
+        while (i < block.length && block[i] !== "\n") i++;
+      }
+      i++;
+    }
+  }
+
+  function skipRawString() {
+    if (block[i] === "r" && block[i + 1] === "#") {
+      i++; // skip 'r'
+      let hashes = 0;
+      while (block[i] === "#") { hashes++; i++; }
+      if (block[i] === '"') {
+        i++; // skip opening "
+        const closer = '"' + "#".repeat(hashes);
+        const closeIdx = block.indexOf(closer, i);
+        if (closeIdx !== -1) {
+          i = closeIdx + closer.length;
+        }
+      }
+    } else if (block[i] === "r" && block[i + 1] === '"') {
+      i += 2;
+      const closeIdx = block.indexOf('"', i);
+      if (closeIdx !== -1) {
+        i = closeIdx + 1;
+      }
+    }
+  }
+
+  function skipWhitespace() {
+    while (i < block.length && /[\s,]/.test(block[i])) i++;
+    // Also skip line comments
+    if (i < block.length && block[i] === "/" && block[i + 1] === "/") {
+      while (i < block.length && block[i] !== "\n") i++;
+      skipWhitespace();
+    }
+  }
+
+  function isStringStart(s, pos) {
+    return (
+      s[pos] === '"' ||
+      (s[pos] === "r" && (s[pos + 1] === '"' || s[pos + 1] === "#"))
+    );
+  }
+
+  function tryExtractString() {
+    skipWhitespace();
+    if (i >= block.length) return null;
+
+    // Raw string with hashes: r#"..."# or r##"..."##
+    if (block[i] === "r" && block[i + 1] === "#") {
+      i++; // skip 'r'
+      let hashes = 0;
+      while (block[i] === "#") { hashes++; i++; }
+      if (block[i] !== '"') return null;
+      i++; // skip opening "
+      const closer = '"' + "#".repeat(hashes);
+      const closeIdx = block.indexOf(closer, i);
+      if (closeIdx === -1) return null;
+      const str = block.slice(i, closeIdx);
+      i = closeIdx + closer.length;
+      return str;
+    }
+
+    // Raw string without hashes: r"..."
+    if (block[i] === "r" && block[i + 1] === '"') {
+      i += 2; // skip r"
+      const closeIdx = block.indexOf('"', i);
+      if (closeIdx === -1) return null;
+      const str = block.slice(i, closeIdx);
+      i = closeIdx + 1;
+      return str;
+    }
+
+    // Regular string: "..."
+    if (block[i] === '"') {
+      i++; // skip opening "
+      let str = "";
+      while (i < block.length && block[i] !== '"') {
+        if (block[i] === "\\") {
+          i++;
+          switch (block[i]) {
+            case "n": str += "\n"; break;
+            case "t": str += "\t"; break;
+            case "r": str += "\r"; break;
+            case "\\": str += "\\"; break;
+            case '"': str += '"'; break;
+            default: str += block[i];
+          }
+        } else {
+          str += block[i];
+        }
+        i++;
+      }
+      i++; // skip closing "
+      return str;
+    }
+
+    return null;
+  }
+}
+
+// ── Step 3: Compare and report ──────────────────────────────────────────
+
+function compareSets(upstreamCases, rustCases) {
+  const upstreamCodes = new Set(upstreamCases.map((t) => normalize(t.code)));
+  const rustCodes = new Set(rustCases.map((t) => normalize(t.code)));
+
+  const missing = [];
+  for (const t of upstreamCases) {
+    const norm = normalize(t.code);
+    if (norm && !rustCodes.has(norm)) {
+      missing.push(t);
+    }
+  }
+
+  const extra = [];
+  for (const t of rustCases) {
+    const norm = normalize(t.code);
+    if (norm && !upstreamCodes.has(norm)) {
+      extra.push(t);
+    }
+  }
+
+  return { missing, extra };
+}
+
+function truncate(str, maxLen = 120) {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen) + "...";
+}
+
+function printReport(upstreamResult, rustResult) {
+  const validComparison = compareSets(
+    upstreamResult.valid,
+    rustResult.valid,
+  );
+  const invalidComparison = compareSets(
+    upstreamResult.invalid,
+    rustResult.invalid,
+  );
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        {
+          rule: ruleName,
+          plugin: pluginName,
+          upstream: {
+            valid: upstreamResult.valid.length,
+            invalid: upstreamResult.invalid.length,
+          },
+          oxlint: {
+            valid: rustResult.valid.length,
+            invalid: rustResult.invalid.length,
+          },
+          missingValid: validComparison.missing.map((t) => t.code),
+          missingInvalid: invalidComparison.missing.map((t) => t.code),
+          extraValid: validComparison.extra.map((t) => t.code),
+          extraInvalid: invalidComparison.extra.map((t) => t.code),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`\nComparing test cases for ${pluginName}/${ruleName}...\n`);
+
+  console.log(
+    `Upstream (Node.js evaluated): ${upstreamResult.valid.length} valid, ${upstreamResult.invalid.length} invalid`,
+  );
+  console.log(
+    `Oxlint (Rust file):           ${rustResult.valid.length} valid, ${rustResult.invalid.length} invalid`,
+  );
+
+  if (
+    validComparison.missing.length === 0 &&
+    invalidComparison.missing.length === 0
+  ) {
+    console.log(
+      "\nAll upstream test cases are present in the oxlint rule file.",
+    );
+  }
+
+  if (validComparison.missing.length > 0) {
+    console.log(
+      `\nMissing valid cases (${validComparison.missing.length}):`,
+    );
+    for (const [i, t] of validComparison.missing.entries()) {
+      console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
+    }
+  }
+
+  if (invalidComparison.missing.length > 0) {
+    console.log(
+      `\nMissing invalid cases (${invalidComparison.missing.length}):`,
+    );
+    for (const [i, t] of invalidComparison.missing.entries()) {
+      console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
+    }
+  }
+
+  if (validComparison.extra.length > 0) {
+    console.log(
+      `\nExtra valid cases in oxlint not in upstream (${validComparison.extra.length}):`,
+    );
+    for (const [i, t] of validComparison.extra.entries()) {
+      console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
+    }
+  }
+
+  if (invalidComparison.extra.length > 0) {
+    console.log(
+      `\nExtra invalid cases in oxlint not in upstream (${invalidComparison.extra.length}):`,
+    );
+    for (const [i, t] of invalidComparison.extra.entries()) {
+      console.log(`  ${i + 1}. ${truncate(normalize(t.code))}`);
+    }
+  }
+
+  console.log();
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+async function main() {
+  // Download and evaluate the upstream test file
+  const { body, url } = await downloadTestFile(ruleName, plugin);
+  const upstreamResult = evaluateTestFile(body, url);
+
+  if (!upstreamResult) {
+    console.error("Failed to evaluate upstream test file.");
+    process.exit(1);
+  }
+
+  if (
+    upstreamResult.valid.length === 0 &&
+    upstreamResult.invalid.length === 0
+  ) {
+    console.error(
+      "Warning: No test cases captured from upstream file. " +
+        "The test file may use an unsupported pattern.",
+    );
+  }
+
+  // Find and parse the Rust rule file
+  const rustFile = findRustRuleFile(ruleName, plugin);
+  let rustResult;
+  if (rustFile) {
+    console.error(`Reading Rust file: ${rustFile}`);
+    rustResult = extractRustTestCases(rustFile);
+  } else {
+    console.error(
+      `No Rust rule file found for ${pluginName}/${toSnakeCase(toKebabCase(ruleName))}.rs`,
+    );
+    rustResult = { valid: [], invalid: [] };
+  }
+
+  printReport(upstreamResult, rustResult);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tasks/rulegen/mock-rule-tester.cjs
+++ b/tasks/rulegen/mock-rule-tester.cjs
@@ -1,0 +1,230 @@
+/**
+ * mock-rule-tester.cjs
+ *
+ * Hooks into Node's module resolution to intercept `require('eslint')`,
+ * `require('@typescript-eslint/rule-tester')`, and related imports so that
+ * evaluating an upstream test file captures the fully-resolved test arrays.
+ *
+ * Usage (from compare-tests.mjs):
+ *   node --require ./mock-rule-tester.cjs <test-file>
+ *
+ * After evaluation the captured data is written to stdout as JSON.
+ */
+
+"use strict";
+
+const Module = require("module");
+const path = require("path");
+
+// ── Global capture store ────────────────────────────────────────────────
+// Populated by MockRuleTester.run()
+global.__capturedTests = null;
+
+// ── Mock RuleTester ─────────────────────────────────────────────────────
+
+class MockRuleTester {
+  constructor(_options) {}
+
+  run(_name, _rule, tests) {
+    const valid = (tests.valid || []).map((t) =>
+      typeof t === "string" ? { code: t } : t,
+    );
+    const invalid = (tests.invalid || []).map((t) =>
+      typeof t === "string" ? { code: t } : t,
+    );
+    global.__capturedTests = { valid, invalid };
+  }
+}
+
+// Also act as a named export when destructured
+MockRuleTester.RuleTester = MockRuleTester;
+
+// ── Noop helpers commonly imported by test files ────────────────────────
+
+const noopFn = () => {};
+
+/**
+ * Tagged template literal that just concatenates the parts — used by
+ * typescript-eslint's `noFormat` and similar helpers.
+ */
+function taggedIdentity(strings, ...values) {
+  let result = "";
+  for (let i = 0; i < strings.length; i++) {
+    result += strings[i];
+    if (i < values.length) result += String(values[i]);
+  }
+  return result;
+}
+
+/**
+ * Factory that returns a new MockRuleTester — used by typescript-eslint's
+ * `createRuleTester()` and similar helpers.
+ */
+function createMockRuleTester() {
+  return new MockRuleTester();
+}
+
+const noopObj = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (prop === "__esModule") return true;
+      if (prop === "default") return noopObj;
+      if (prop === "RuleTester") return MockRuleTester;
+      // Tagged template literal helpers (noFormat, dedent, etc.)
+      if (prop === "noFormat" || prop === "dedent") return taggedIdentity;
+      // Factory functions that create rule testers
+      if (prop === "createRuleTester" || prop === "createRuleTesterWithTypes")
+        return createMockRuleTester;
+      // getFixturesRootDir returns a valid directory path
+      if (prop === "getFixturesRootDir")
+        return () => path.join(require("os").tmpdir(), "oxc-fixtures-mock");
+      // Return a function-like proxy for anything else
+      return typeof prop === "string" ? noopFn : undefined;
+    },
+  },
+);
+
+// ── Module resolution hook ──────────────────────────────────────────────
+
+const originalResolveFilename = Module._resolveFilename;
+
+const INTERCEPTED = new Set([
+  "eslint",
+  "eslint/use-at-your-own-risk",
+  "@typescript-eslint/rule-tester",
+  "@typescript-eslint/utils",
+  "@typescript-eslint/utils/ts-eslint",
+  "@typescript-eslint/utils/eslint-utils",
+  "@typescript-eslint/parser",
+  "@typescript-eslint/typescript-estree",
+]);
+
+Module._resolveFilename = function (request, parent, isMain, options) {
+  // Intercept known packages
+  if (INTERCEPTED.has(request)) {
+    // Return a path that we control – we register a fake module below
+    return `__mock__/${request}`;
+  }
+
+  // Intercept relative paths that look like ESLint fixture testers
+  // e.g. "../../fixtures/testers/rule-tester" in eslint's own test files
+  if (
+    request.includes("fixtures/testers/rule-tester") ||
+    request.includes("fixtures/testers/RuleTester")
+  ) {
+    return "__mock__/eslint";
+  }
+
+  // Intercept direct rule-tester imports (ESLint internal)
+  // e.g. "../../../lib/rule-tester/rule-tester" — exports the class directly
+  if (request.includes("lib/rule-tester")) {
+    return "__mock__/rule-tester-direct";
+  }
+
+  // Intercept relative imports to rule source files
+  // e.g. "../../../lib/rules/no-empty-function" — the test imports the rule itself
+  if (
+    request.includes("/lib/rules/") ||
+    request.includes("/src/rules/") ||
+    request.includes("/rules/")
+  ) {
+    return "__mock__/rule-source";
+  }
+
+  // Intercept vitest/mocha/jest globals that some files import
+  if (
+    request === "vitest" ||
+    request === "mocha" ||
+    request === "jest" ||
+    request === "node:test"
+  ) {
+    return `__mock__/${request}`;
+  }
+
+  // Catch-all for any unresolvable module: return a noop mock
+  // This prevents crashes from test helpers, fixtures, etc.
+  try {
+    return originalResolveFilename.call(this, request, parent, isMain, options);
+  } catch (err) {
+    if (err.code === "MODULE_NOT_FOUND") {
+      return "__mock__/fallback";
+    }
+    throw err;
+  }
+};
+
+// ── Register fake modules in the cache ──────────────────────────────────
+
+function registerMock(id, exports) {
+  const m = new Module(id);
+  m.loaded = true;
+  m.exports = exports;
+  Module._cache[id] = m;
+}
+
+// eslint — needs { RuleTester }
+const eslintMock = {
+  RuleTester: MockRuleTester,
+  Linter: class {},
+  Rule: {},
+};
+registerMock("__mock__/eslint", eslintMock);
+registerMock("__mock__/eslint/use-at-your-own-risk", noopObj);
+
+// Direct rule-tester import (module.exports = class RuleTester)
+registerMock("__mock__/rule-tester-direct", MockRuleTester);
+
+// Rule source — returns a noop rule object (the test file imports the rule
+// but we only care about the test cases passed to RuleTester.run())
+const noopRule = {
+  meta: { type: "problem", schema: [], messages: {} },
+  create: () => ({}),
+};
+registerMock("__mock__/rule-source", noopRule);
+
+// Fallback for any unresolvable module
+registerMock("__mock__/fallback", noopObj);
+
+// @typescript-eslint packages
+const tsRuleTesterMock = {
+  RuleTester: MockRuleTester,
+  noFormat: taggedIdentity,
+  dedent: taggedIdentity,
+  noopRuleTesterFn: noopFn,
+};
+registerMock("__mock__/@typescript-eslint/rule-tester", tsRuleTesterMock);
+registerMock("__mock__/@typescript-eslint/utils", noopObj);
+registerMock("__mock__/@typescript-eslint/utils/ts-eslint", {
+  ...noopObj,
+  RuleTester: MockRuleTester,
+  ESLintUtils: noopObj,
+});
+registerMock("__mock__/@typescript-eslint/utils/eslint-utils", noopObj);
+registerMock("__mock__/@typescript-eslint/parser", noopObj);
+registerMock("__mock__/@typescript-eslint/typescript-estree", noopObj);
+
+// vitest / mocha / jest stubs
+const testFrameworkMock = {
+  describe: (name, fn) => fn(),
+  it: (name, fn) => {},
+  test: (name, fn) => {},
+  expect: () =>
+    new Proxy(
+      {},
+      {
+        get() {
+          return noopFn;
+        },
+      },
+    ),
+  beforeAll: noopFn,
+  afterAll: noopFn,
+  beforeEach: noopFn,
+  afterEach: noopFn,
+  vi: { fn: noopFn, mock: noopFn },
+};
+registerMock("__mock__/vitest", testFrameworkMock);
+registerMock("__mock__/mocha", testFrameworkMock);
+registerMock("__mock__/jest", testFrameworkMock);
+registerMock("__mock__/node:test", testFrameworkMock);

--- a/tasks/rulegen/mock-rule-tester.cjs
+++ b/tasks/rulegen/mock-rule-tester.cjs
@@ -26,12 +26,8 @@ class MockRuleTester {
   constructor(_options) {}
 
   run(_name, _rule, tests) {
-    const valid = (tests.valid || []).map((t) =>
-      typeof t === "string" ? { code: t } : t,
-    );
-    const invalid = (tests.invalid || []).map((t) =>
-      typeof t === "string" ? { code: t } : t,
-    );
+    const valid = (tests.valid || []).map((t) => (typeof t === "string" ? { code: t } : t));
+    const invalid = (tests.invalid || []).map((t) => (typeof t === "string" ? { code: t } : t));
     global.__capturedTests = { valid, invalid };
   }
 }


### PR DESCRIPTION
DISCLAIMER: Fully written by Claude Code / Opus 4.6. I'm opening this now because I think it's really useful and wanted to share it before I had to hop off for the day. I have not reviewed the code in detail, nor have I audited for safety. It _should_ probably be safe (and definitely isn't going to cause problems in CI, it doesn't do anything that would touch that), but I would recommend looking it over to make sure. No reason to blindly trust AI-generated code, frankly.

This *only* works for ESLint and TS ESLint rules for now. The main difference from the existing tooling we have is that this will actually run the tests in Node to find tests that are dynamically-generated, which our rulegen tooling is not presently capable of.

For now, this only compares cases to find differences. It also does do some basic work to deal with differences caused by whitespace/indentation, but I'm not sure how robust it is yet as I've only done basic spot-checks.

It does not handle anything around config options for a given test currently (nor does it handle settings but that is a low priority to handle for now, I think).

<details>

<summary>Output for ban-ts-comment</summary>

```
node tasks/rulegen/compare-tests.mjs ban-ts-comment typescript
Downloading https://raw.githubusercontent.com/typescript-eslint/typescript-eslint/main/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts ...
Reading Rust file: /Users/connorshea/code/oxc/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs

Comparing test cases for typescript/ban-ts-comment...

Upstream (Node.js evaluated): 11 valid, 8 invalid
Oxlint (Rust file):           51 valid, 52 invalid

Missing valid cases (1):
  1. /*
 @ts-check running with long description in a block
*/

Missing invalid cases (2):
  1. if (false) {
  // @ts-check: Unreachable code error
  console.log('hello');
}
  2. // @ts-check 👨‍👩‍👧‍👦

Extra valid cases in oxlint not in upstream (41):
  1. // just a comment containing @ts-expect-error somewhere
  2. /*
@ts-expect-error running with long description in a block
*/
  3. /* @ts-expect-error not on the last line
*/
  4. /**
 * @ts-expect-error not on the last line
 */
  5. /* not on the last line
* @ts-expect-error
*/
  6. /* @ts-expect-error
* not on the last line */
  7. // @ts-expect-error
  8. // @ts-expect-error here is why the error is expected
  9. /*
* @ts-expect-error here is why the error is expected */
  10. // @ts-expect-error exactly 21 characters
  11. /*
* @ts-expect-error exactly 21 characters*/
  12. // @ts-expect-error: TS1234 because xyz
  13. /*
* @ts-expect-error: TS1234 because xyz */
  14. // @ts-expect-error 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦
  15. // just a comment containing @ts-ignore somewhere
  16. // @ts-ignore
  17. // @ts-ignore I think that I am exempted from any need to follow the rules!
  18. /*
 @ts-ignore running with long description in a block
*/
  19. /*
 @ts-ignore
*/
  20. /* @ts-ignore not on the last line
*/
  21. /**
 * @ts-ignore not on the last line
 */
  22. /* not on the last line
* @ts-expect-error
*/
  23. /* @ts-ignore
* not on the last line */
  24. // @ts-ignore: TS1234 because xyz
  25. // @ts-ignore 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦
  26. /*
* @ts-ignore here is why the error is expected */
  27. // @ts-ignore exactly 21 characters
  28. /*
* @ts-ignore exactly 21 characters*/
  29. /*
* @ts-ignore: TS1234 because xyz */
  30. // just a comment containing @ts-nocheck somewhere
  31. // @ts-nocheck
  32. // @ts-nocheck no doubt, people will put nonsense here from time to time just to get the rule to stop reporting, perhaps...
  33. /*
    @ts-nocheck running with long description in a block
*/
  34. // @ts-nocheck: TS1234 because xyz
  35. // @ts-nocheck 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦
  36. //// @ts-nocheck - pragma comments may contain 2 or 3 leading slashes
  37. /**
 @ts-nocheck
*/
  38. /*
 @ts-nocheck
*/
  39. /** @ts-nocheck */
  40. /* @ts-nocheck */
  41. /*
    @ts-check running with long description in a block
*/

Extra invalid cases in oxlint not in upstream (46):
  1. // @ts-expect-error
  2. /* @ts-expect-error */
  3. /*
 @ts-expect-error */
  4. /** on the last line
 @ts-expect-error */
  5. /** on the last line
 * @ts-expect-error */
  6. /**
 * @ts-expect-error: TODO */
  7. /**
 * @ts-expect-error: TS1234 because xyz */
  8. /**
 * @ts-expect-error: TS1234 */
  9. /**
 * @ts-expect-error    : TS1234 */
  10. /** @ts-expect-error */
  11. // @ts-expect-error: Suppress next line
  12. /////@ts-expect-error: Suppress next line
  13. if (false) {
    // @ts-expect-error: Unreachable code error
    console.log('hello');
}
  14. // @ts-expect-error
  15. // @ts-expect-error: TODO
  16. // @ts-expect-error: TS1234 because xyz
  17. // @ts-expect-error: TS1234
  18. // @ts-expect-error    : TS1234 because xyz
  19. // @ts-ignore
  20. // @ts-ignore
  21. // @ts-ignore
  22. /* @ts-ignore */
  23. /*
 @ts-ignore */
  24. /** on the last line
 @ts-ignore */
  25. /** on the last line
 * @ts-ignore */
  26. /** @ts-ignore */
  27. /**
 * @ts-ignore: TODO */
  28. /**
 * @ts-ignore: TS1234 because xyz */
  29. // @ts-ignore: Suppress next line
  30. /////@ts-ignore: Suppress next line
  31. if (false) {
    // @ts-ignore: Unreachable code error
    console.log('hello');
}
  32. // @ts-ignore
  33. // @ts-ignore
  34. // @ts-ignore    .
  35. // @ts-ignore: TS1234 because xyz
  36. // @ts-ignore: TS1234
  37. // @ts-ignore    : TS1234 because xyz
  38. // @ts-nocheck
  39. // @ts-nocheck
  40. // @ts-nocheck: Suppress next line
  41. if (false) {
    // @ts-nocheck: Unreachable code error
    console.log('hello');
}
  42. // @ts-nocheck
  43. // @ts-nocheck: TS1234 because xyz
  44. // @ts-nocheck: TS1234
  45. // @ts-nocheck    : TS1234 because xyz
  46. if (false) {
    // @ts-check: Unreachable code error
    console.log('hello');
}
```