### PR TITLE
feat(oxlint)!: `no-shadow-restricted-names` report `globalThis` by default

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
@@ -1,28 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
-   ╭─[no_shadow_restricted_names.tsx:1:5]
- 1 │ var undefined = 5;
-   ·     ─────────
-   ╰────
-  help: Rename 'undefined' to avoid shadowing the global property.
-
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
-   ╭─[no_shadow_restricted_names.tsx:1:10]
- 1 │ function NaN(){}
-   ·          ───
-   ╰────
-  help: Rename 'NaN' to avoid shadowing the global property.
-
-  ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
-   ╭─[no_shadow_restricted_names.tsx:1:14]
- 1 │ try {} catch(eval){}
-   ·              ────
-   ╰────
-  help: Rename 'eval' to avoid shadowing the global property.
-
   ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }


### PR DESCRIPTION
upstream PR: https://github.com/eslint/eslint/pull/20027

found here: https://github.com/oxc-project/eslint-plugin-oxlint/actions/runs/22040552727/job/63680629647?pr=632

updated the test via `just new-rule no-shadow-restricted-names`, there is a simpler command, but it works :) 

note: this is a default rule in oxlint: https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-shadow-restricted-names.html
