### PR TITLE
chore(linter): Fix the name of `ignore_spaces` in the `jest/valid-title` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -74,7 +74,7 @@ pub struct ValidTitleConfig {
     /// A list of disallowed words, which will not be allowed in titles.
     disallowed_words: Vec<CompactStr>,
     /// Whether to ignore leading and trailing spaces in titles.
-    ignore_space: bool,
+    ignore_spaces: bool,
     /// Patterns for titles that must not match.
     must_not_match_patterns: FxHashMap<MatchKind, CompiledMatcherAndMessage>,
     /// Patterns for titles that must be matched for the title to be valid.
@@ -159,7 +159,7 @@ impl Rule for ValidTitle {
         let ignore_type_of_test_name = get_as_bool("ignoreTypeOfTestName");
         let ignore_type_of_describe_name = get_as_bool("ignoreTypeOfDescribeName");
         let allow_arguments = get_as_bool("allowArguments");
-        let ignore_space = get_as_bool("ignoreSpaces");
+        let ignore_spaces = get_as_bool("ignoreSpaces");
         let disallowed_words = config
             .and_then(|v| v.get("disallowedWords"))
             .and_then(|v| v.as_array())
@@ -179,7 +179,7 @@ impl Rule for ValidTitle {
             ignore_type_of_describe_name,
             allow_arguments,
             disallowed_words,
-            ignore_space,
+            ignore_spaces,
             must_not_match_patterns,
             must_match_patterns,
         })))
@@ -420,7 +420,7 @@ fn validate_title(
     }
 
     let trimmed_title = title.trim();
-    if !valid_title.ignore_space && trimmed_title != title {
+    if !valid_title.ignore_spaces && trimmed_title != title {
         ctx.diagnostic_with_fix(accidental_space_diagnostic(span), |fixer| {
             let inner_span = span.shrink(1);
             let raw_text = fixer.source_range(inner_span);


### PR DESCRIPTION
This isn't really a problem currently, but will be in the future if/when the config option is used for the JsonSchema on the rule. The name of the option we actually accept (and also the one from the original rule) is ignoreSpaces. So it needs to be pluralized.