### PR TITLE
fix(linter): Add a few new DOM props for `react/no-unknown-property`.

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
@@ -189,7 +189,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <div onLoad={this.load} />
    ·      ──────
    ╰────
-  help: Property 'onLoad' is only allowed on: link, source, picture, script, iframe, img, object
+  help: Property 'onLoad' is only allowed on: source, body, img, link, script, picture, object, iframe
 
   ⚠ eslint-plugin-react(no-unknown-property): Invalid property found
    ╭─[no_unknown_property.tsx:1:6]


### PR DESCRIPTION
These are all valid and did not exist on the list of known properties. This also means the rule does a better job matching what attributes are valid in accordance with the original rule. I found these by going through the commit history upstream.

- `onBeforeToggle` is part of the popover spec: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforetoggle_event
- `shadowrootmode`, `shadowrootclonable`, `shadowrootdelegatesfocus`, and `shadowrootserializable` are related to shadow roots. https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode
- `transform-origin` is for SVGs: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/transform-origin
- `onLoad` is allowed for the body element.
- `closedby` is a prop on the `dialog` element (it is intentionally not capitalized in React, for whatever reason): https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby