### PR TITLE
test(linter): Add missing test cases for `typescript/no-duplicate-enum-values` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -141,135 +141,260 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        (
-            "
-			enum E {
-			  A,
-			  B,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 1,
-			  B,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 1,
-			  B = 2,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'B',
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'B',
-			  C,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'B',
-			  C = 2,
-			  D = 1 + 1,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 3,
-			  B = 2,
-			  C,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'B',
-			  C = 2,
-			  D = foo(),
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = '',
-			  B = 0,
-			}
-			    ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 0,
-			  B = -0,
-			  C = NaN,
-			}
-			    ",
-            None,
-        ),
+        "
+            enum E {
+              A,
+              B,
+            }
+        ",
+        "
+            enum E {
+              A = 1,
+              B,
+            }
+        ",
+        "
+            enum E {
+              A = 1,
+              B = 2,
+            }
+        ",
+        "
+            enum E {
+              A = -1,
+              B = -2,
+            }
+        ",
+        "
+            enum E {
+              A = +1,
+              B = +2,
+            }
+        ",
+        "
+            enum E {
+              A = +1,
+              B = -1,
+            }
+        ",
+        "
+            enum E {
+              A = 1,
+              B = -1,
+            }
+        ",
+        "
+            enum E {
+              A = -0,
+              B = +0,
+            }
+        ",
+        "
+            enum E {
+              A = -0,
+              B = 0,
+            }
+        ",
+        "
+            enum E {
+              A = 1,
+              B = '1',
+            }
+        ",
+        "
+            enum E {
+              A = -1,
+              B = '-1',
+            }
+        ",
+        "
+            enum E {
+              A = 'A',
+              B = 'B',
+            }
+        ",
+        "
+            enum E {
+              A = 'A',
+              B = 'B',
+              C,
+            }
+        ",
+        "
+            enum E {
+              A = 'A',
+              B = 'B',
+              C = 2,
+              D = 1 + 1,
+            }
+        ",
+        "
+            enum E {
+              A = 3,
+              B = 2,
+              C,
+            }
+        ",
+        "
+            enum E {
+              A = 'A',
+              B = 'B',
+              C = 2,
+              D = foo(),
+            }
+        ",
+        "
+            enum E {
+              A = '',
+              B = 0,
+            }
+        ",
+        "
+            enum E {
+              A = 0,
+              B = -0,
+              C = NaN,
+            }
+        ",
+        "
+            enum E {
+              A = NaN,
+              B = NaN,
+            }
+        ",
+        "
+            enum E {
+              A = NaN,
+              B = -NaN,
+            }
+        ",
+        "
+            enum E {
+              A = 'NaN',
+              B = NaN,
+            }
+        ",
+        "
+            enum E {
+              A = -+-0,
+              B = +-+0,
+            }
+        ",
+        "
+            enum E {
+              A = -'',
+              B = 0,
+            }
+        ",
+        "
+            enum E {
+              A = Infinity,
+              B = Infinity,
+            }
+        ",
+        "
+            const A = 'A';
+            enum E {
+              A = 'A',
+              B = `${A}`,
+            }
+        ",
     ];
 
     let fail = vec![
-        (
-            "
-			enum E {
-			  A = 1,
-			  B = 1,
-			}
-			      ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'A',
-			}
-			      ",
-            None,
-        ),
-        (
-            "
-			enum E {
-			  A = 'A',
-			  B = 'A',
-			  C = 1,
-			  D = 1,
-			}
-			      ",
-            None,
-        ),
+        "
+            enum E {
+              A = 1,
+              B = 1,
+            }
+        ",
+        // "
+        //     enum E {
+        //       A = -1,
+        //       B = -1,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = +1,
+        //       B = +1,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = +0,
+        //       B = 0,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = -0,
+        //       B = -0,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = +'0',
+        //       B = 0,
+        //     }
+        // ",
+        "
+            enum E {
+              A = 0x10,
+              B = 16,
+            }
+        ",
+        // "
+        //     enum E {
+        //       A = +'1e2',
+        //       B = 100,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = +'',
+        //       B = 0,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = -+1,
+        //       B = +-1,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = -`0`,
+        //       B = -0,
+        //     }
+        // ",
+        "
+            enum E {
+              A = 'A',
+              B = 'A',
+            }
+        ",
+        "
+            enum E {
+              A = 'A',
+              B = 'A',
+              C = 1,
+              D = 1,
+            }
+        ",
+        // TODO: Fix the following cases where there is a raw template literal.
+        // "
+        //     enum E {
+        //       A = 'A',
+        //       B = `A`,
+        //     }
+        // ",
+        // "
+        //     enum E {
+        //       A = `A`,
+        //       B = `A`,
+        //     }
+        // ",
     ];
 
     Tester::new(NoDuplicateEnumValues::NAME, NoDuplicateEnumValues::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/typescript_no_duplicate_enum_values.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_duplicate_enum_values.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(no-duplicate-enum-values): Duplicate enum value `1`
-   ╭─[no_duplicate_enum_values.tsx:3:10]
+   ╭─[no_duplicate_enum_values.tsx:3:19]
  2 │             enum E {
  3 │               A = 1,
    ·                   ┬
@@ -15,8 +15,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Give B a unique value
 
+  ⚠ typescript-eslint(no-duplicate-enum-values): Duplicate enum value `16`
+   ╭─[no_duplicate_enum_values.tsx:3:19]
+ 2 │             enum E {
+ 3 │               A = 0x10,
+   ·                   ──┬─
+   ·                     ╰── 16 is first used as an initializer here
+ 4 │               B = 16,
+   ·                   ─┬
+   ·                    ╰── and is re-used here
+ 5 │             }
+   ╰────
+  help: Give B a unique value
+
   ⚠ typescript-eslint(no-duplicate-enum-values): Duplicate enum value `'A'`
-   ╭─[no_duplicate_enum_values.tsx:3:10]
+   ╭─[no_duplicate_enum_values.tsx:3:19]
  2 │             enum E {
  3 │               A = 'A',
    ·                   ─┬─
@@ -29,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Give B a unique value
 
   ⚠ typescript-eslint(no-duplicate-enum-values): Duplicate enum value `'A'`
-   ╭─[no_duplicate_enum_values.tsx:3:10]
+   ╭─[no_duplicate_enum_values.tsx:3:19]
  2 │             enum E {
  3 │               A = 'A',
    ·                   ─┬─
@@ -42,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Give B a unique value
 
   ⚠ typescript-eslint(no-duplicate-enum-values): Duplicate enum value `1`
-   ╭─[no_duplicate_enum_values.tsx:5:10]
+   ╭─[no_duplicate_enum_values.tsx:5:19]
  4 │               B = 'A',
  5 │               C = 1,
    ·                   ┬


### PR DESCRIPTION
Some of these are probably excessive to support, but others definitely need to be fixed. That's not my problem though, someone else will need to handle it :)