### PR TITLE
test(linter): Regenerate/update tests for various typescript rules

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -78,23 +78,23 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        r"let a: readonly any[] = [];",
-        r"let a = new Array();",
-        r"// some other comment",
-        r"// TODO: this is a comment that mentions tslint",
-        r"/* another comment that mentions tslint */",
-        r"someCode(); // This is a comment that just happens to mention tslint",
+        "let a: readonly any[] = [];",
+        "let a = new Array();",
+        "// some other comment",
+        "// TODO: this is a comment that mentions tslint",
+        "/* another comment that mentions tslint */",
+        "someCode(); // This is a comment that just happens to mention tslint",
     ];
 
     let fail = vec![
-        r"/* tslint:disable */",
-        r"/* tslint:enable */",
-        r"/* tslint:disable:rule1 rule2 rule3... */",
-        r"/* tslint:enable:rule1 rule2 rule3... */",
-        r"// tslint:disable-next-line",
-        r"someCode(); // tslint:disable-line",
-        r"// tslint:disable-next-line:rule1 rule2 rule3...",
-        r"const woah = doSomeStuff();
+        "/* tslint:disable */",
+        "/* tslint:enable */",
+        "/* tslint:disable:rule1 rule2 rule3... */",
+        "/* tslint:enable:rule1 rule2 rule3... */",
+        "// tslint:disable-next-line",
+        "someCode(); // tslint:disable-line",
+        "// tslint:disable-next-line:rule1 rule2 rule3...",
+        "const woah = doSomeStuff();
         // tslint:disable-line
         console.log(woah);
         ",
@@ -102,22 +102,22 @@ fn test() {
 
     let fix = vec![
         (
-            r"const woah = doSomeStuff();
+            "const woah = doSomeStuff();
         // tslint:disable-line
         console.log(woah);",
-            r"const woah = doSomeStuff();
+            "const woah = doSomeStuff();
                 console.log(woah);",
             None,
         ),
         (
-            r"const woah = doSomeStuff();
+            "const woah = doSomeStuff();
         /* tslint:disable-line */
         console.log(woah);",
-            r"const woah = doSomeStuff();
+            "const woah = doSomeStuff();
                 console.log(woah);",
             None,
         ),
-        (r"/* tslint:disable-line */", r"", None),
+        ("/* tslint:disable-line */", "", None),
         // Issue: <https://github.com/oxc-project/oxc/issues/8090>
         (r"/*tslint:disable*/É", r"É", None),
     ];

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -434,44 +434,116 @@ fn test() {
         ("const a: Foo = Foo<string>();", None),
         (
             "
-			class Foo {
-			  a = new Foo<string>();
-			}
-			    ",
+            class Foo {
+              a = new Foo<string>();
+            }
+                ",
             None,
         ),
         (
             "
-			function foo(a: Foo = new Foo<string>()) {}
-			    ",
+            class Foo {
+              accessor a = new Foo<string>();
+            }
+                ",
             None,
         ),
         (
             "
-			function foo({ a }: Foo = new Foo<string>()) {}
-			    ",
+            function foo(a: Foo = new Foo<string>()) {}
+                ",
             None,
         ),
         (
             "
-			function foo([a]: Foo = new Foo<string>()) {}
-			    ",
+            function foo({ a }: Foo = new Foo<string>()) {}
+                ",
             None,
         ),
         (
             "
-			class A {
-			  constructor(a: Foo = new Foo<string>()) {}
-			}
-			    ",
+            function foo([a]: Foo = new Foo<string>()) {}
+                ",
             None,
         ),
         (
             "
-			const a = function (a: Foo = new Foo<string>()) {};
-			    ",
+            class A {
+              constructor(a: Foo = new Foo<string>()) {}
+            }
+                ",
             None,
         ),
+        (
+            "
+            const a = function (a: Foo = new Foo<string>()) {};
+                ",
+            None,
+        ),
+        // TODO: Fix the rule so these pass.
+        // (
+        //     "
+        //     const a: Float32Array<ArrayBufferLike> = new Float32Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Float64Array<ArrayBufferLike> = new Float64Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Int16Array<ArrayBufferLike> = new Int16Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Int8Array<ArrayBufferLike> = new Int8Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Uint16Array<ArrayBufferLike> = new Uint16Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Uint32Array<ArrayBufferLike> = new Uint32Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Uint8Array<ArrayBufferLike> = new Uint8Array();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     const a: Uint8ClampedArray<ArrayBufferLike> = new Uint8ClampedArray();
+        //     export {};
+        //         ",
+        //     None,
+        // ),
+        // TODO: Fix?
+        // (
+        //     "
+        //     const foo: Foo<string> = new Foo();
+        //           ",
+        //     None,
+        // ), // { "parserOptions": { "isolatedDeclarations": true, }, },
         ("const a = new Foo();", Some(serde_json::json!(["type-annotation"]))),
         ("const a: Foo<string> = new Foo();", Some(serde_json::json!(["type-annotation"]))),
         ("const a: Foo<string> = new Foo<string>();", Some(serde_json::json!(["type-annotation"]))),
@@ -484,54 +556,62 @@ fn test() {
         ("const a = new (class C<T> {})<string>();", Some(serde_json::json!(["type-annotation"]))),
         (
             "
-			class Foo {
-			  a: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              a: Foo<string> = new Foo();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo(a: Foo<string> = new Foo()) {}
-			      ",
+            class Foo {
+              accessor a: Foo<string> = new Foo();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo({ a }: Foo<string> = new Foo()) {}
-			      ",
+            function foo(a: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo([a]: Foo<string> = new Foo()) {}
-			      ",
+            function foo({ a }: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class A {
-			  constructor(a: Foo<string> = new Foo()) {}
-			}
-			      ",
+            function foo([a]: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			const a = function (a: Foo<string> = new Foo()) {};
-			      ",
+            class A {
+              constructor(a: Foo<string> = new Foo()) {}
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			const [a = new Foo<string>()] = [];
-			      ",
+            const a = function (a: Foo<string> = new Foo()) {};
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function a([a = new Foo<string>()]) {}
-			      ",
+            const [a = new Foo<string>()] = [];
+                  ",
+            Some(serde_json::json!(["type-annotation"])),
+        ),
+        (
+            "
+            function a([a = new Foo<string>()]) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
     ];
@@ -547,56 +627,81 @@ fn test() {
         ("const a: Foo/* comment */ <string> = new Foo /* another */();", None),
         (
             "const a: Foo<string> = new
-			 Foo
-			 ();",
+             Foo
+             ();",
             None,
         ),
         (
             "
-			class Foo {
-			  a: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              a: Foo<string> = new Foo();
+            }
+                  ",
             None,
         ),
         (
             "
-			class Foo {
-			  [a]: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              [a]: Foo<string> = new Foo();
+            }
+                  ",
+            None,
+        ),
+        // TODO: Fix these.
+        // (
+        //     "
+        //     class Foo {
+        //       accessor a: Foo<string> = new Foo();
+        //     }
+        //           ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     class Foo {
+        //       accessor a = new Foo<string>();
+        //     }
+        //           ",
+        //     Some(serde_json::json!(["type-annotation"])),
+        // ),
+        // (
+        //     "
+        //     class Foo {
+        //       accessor [a]: Foo<string> = new Foo();
+        //     }
+        //           ",
+        //     None,
+        // ),
+        (
+            "
+            function foo(a: Foo<string> = new Foo()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo(a: Foo<string> = new Foo()) {}
-			      ",
+            function foo({ a }: Foo<string> = new Foo()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo({ a }: Foo<string> = new Foo()) {}
-			      ",
+            function foo([a]: Foo<string> = new Foo()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo([a]: Foo<string> = new Foo()) {}
-			      ",
+            class A {
+              constructor(a: Foo<string> = new Foo()) {}
+            }
+                  ",
             None,
         ),
         (
             "
-			class A {
-			  constructor(a: Foo<string> = new Foo()) {}
-			}
-			      ",
-            None,
-        ),
-        (
-            "
-			const a = function (a: Foo<string> = new Foo()) {};
-			      ",
+            const a = function (a: Foo<string> = new Foo()) {};
+                  ",
             None,
         ),
         ("const a = new Foo<string>();", Some(serde_json::json!(["type-annotation"]))),
@@ -605,8 +710,8 @@ fn test() {
         ("const a = new Map< string, number >();", Some(serde_json::json!(["type-annotation"]))),
         (
             "const a = new
-			 Foo<string>
-			 ();",
+             Foo<string>
+             ();",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
@@ -619,60 +724,68 @@ fn test() {
         ),
         (
             "
-			class Foo {
-			  a = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              a = new Foo<string>();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class Foo {
-			  [a] = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              [a] = new Foo<string>();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class Foo {
-			  [a + b] = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              [a + b] = new Foo<string>();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo(a = new Foo<string>()) {}
-			      ",
+            function foo(a = new Foo<string>()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo({ a } = new Foo<string>()) {}
-			      ",
+            function foo({ a } = new Foo<string>()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo([a] = new Foo<string>()) {}
-			      ",
+            function foo([a] = new Foo<string>()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class A {
-			  constructor(a = new Foo<string>()) {}
-			}
-			      ",
+            class A {
+              constructor(a = new Foo<string>()) {}
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			const a = function (a = new Foo<string>()) {};
-			      ",
+            const a = function (a = new Foo<string>()) {};
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
+        // (
+        //     "
+        //     class Float32Array<T> {}
+        //     const a: Float32Array<ArrayBufferLike> = new Float32Array();
+        //     export {};
+        //           ",
+        //     None,
+        // ),
     ];
 
     let fix = vec![
@@ -706,86 +819,126 @@ fn test() {
         ),
         (
             "const a: Foo<string> = new
-			 Foo
-			 ();",
+             Foo
+             ();",
             "const a = new
-			 Foo<string>
-			 ();",
+             Foo<string>
+             ();",
             None,
         ),
         (
             "
-			class Foo {
-			  a: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              a: Foo<string> = new Foo();
+            }
+                  ",
             "
-			class Foo {
-			  a = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              a = new Foo<string>();
+            }
+                  ",
             None,
         ),
         (
             "
-			class Foo {
-			  [a]: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              [a]: Foo<string> = new Foo();
+            }
+                  ",
             "
-			class Foo {
-			  [a] = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              [a] = new Foo<string>();
+            }
+                  ",
+            None,
+        ),
+        // TODO: Fix these
+        // (
+        //     "
+        //     class Foo {
+        //       accessor a: Foo<string> = new Foo();
+        //     }
+        //           ",
+        //     "
+        //     class Foo {
+        //       accessor a = new Foo<string>();
+        //     }
+        //           ",
+        //     None,
+        // ),
+        // (
+        //     "
+        //     class Foo {
+        //       accessor a = new Foo<string>();
+        //     }
+        //           ",
+        //     "
+        //     class Foo {
+        //       accessor a: Foo<string> = new Foo();
+        //     }
+        //           ",
+        //     Some(serde_json::json!(["type-annotation"])),
+        // ),
+        // (
+        //     "
+        //     class Foo {
+        //       accessor [a]: Foo<string> = new Foo();
+        //     }
+        //           ",
+        //     "
+        //     class Foo {
+        //       accessor [a] = new Foo<string>();
+        //     }
+        //           ",
+        //     None,
+        // ),
+        (
+            "
+            function foo(a: Foo<string> = new Foo()) {}
+                  ",
+            "
+            function foo(a = new Foo<string>()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo(a: Foo<string> = new Foo()) {}
-			      ",
+            function foo({ a }: Foo<string> = new Foo()) {}
+                  ",
             "
-			function foo(a = new Foo<string>()) {}
-			      ",
+            function foo({ a } = new Foo<string>()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo({ a }: Foo<string> = new Foo()) {}
-			      ",
+            function foo([a]: Foo<string> = new Foo()) {}
+                  ",
             "
-			function foo({ a } = new Foo<string>()) {}
-			      ",
+            function foo([a] = new Foo<string>()) {}
+                  ",
             None,
         ),
         (
             "
-			function foo([a]: Foo<string> = new Foo()) {}
-			      ",
+            class A {
+              constructor(a: Foo<string> = new Foo()) {}
+            }
+                  ",
             "
-			function foo([a] = new Foo<string>()) {}
-			      ",
+            class A {
+              constructor(a = new Foo<string>()) {}
+            }
+                  ",
             None,
         ),
         (
             "
-			class A {
-			  constructor(a: Foo<string> = new Foo()) {}
-			}
-			      ",
+            const a = function (a: Foo<string> = new Foo()) {};
+                  ",
             "
-			class A {
-			  constructor(a = new Foo<string>()) {}
-			}
-			      ",
-            None,
-        ),
-        (
-            "
-			const a = function (a: Foo<string> = new Foo()) {};
-			      ",
-            "
-			const a = function (a = new Foo<string>()) {};
-			      ",
+            const a = function (a = new Foo<string>()) {};
+                  ",
             None,
         ),
         (
@@ -810,11 +963,11 @@ fn test() {
         ),
         (
             "const a = new
-			 Foo<string>
-			 ();",
+             Foo<string>
+             ();",
             "const a: Foo<string> = new
-			 Foo
-			 ();",
+             Foo
+             ();",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
@@ -829,90 +982,90 @@ fn test() {
         ),
         (
             "
-			class Foo {
-			  a = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              a = new Foo<string>();
+            }
+                  ",
             "
-			class Foo {
-			  a: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              a: Foo<string> = new Foo();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class Foo {
-			  [a] = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              [a] = new Foo<string>();
+            }
+                  ",
             "
-			class Foo {
-			  [a]: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              [a]: Foo<string> = new Foo();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class Foo {
-			  [a + b] = new Foo<string>();
-			}
-			      ",
+            class Foo {
+              [a + b] = new Foo<string>();
+            }
+                  ",
             "
-			class Foo {
-			  [a + b]: Foo<string> = new Foo();
-			}
-			      ",
+            class Foo {
+              [a + b]: Foo<string> = new Foo();
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo(a = new Foo<string>()) {}
-			      ",
+            function foo(a = new Foo<string>()) {}
+                  ",
             "
-			function foo(a: Foo<string> = new Foo()) {}
-			      ",
+            function foo(a: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo({ a } = new Foo<string>()) {}
-			      ",
+            function foo({ a } = new Foo<string>()) {}
+                  ",
             "
-			function foo({ a }: Foo<string> = new Foo()) {}
-			      ",
+            function foo({ a }: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			function foo([a] = new Foo<string>()) {}
-			      ",
+            function foo([a] = new Foo<string>()) {}
+                  ",
             "
-			function foo([a]: Foo<string> = new Foo()) {}
-			      ",
+            function foo([a]: Foo<string> = new Foo()) {}
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			class A {
-			  constructor(a = new Foo<string>()) {}
-			}
-			      ",
+            class A {
+              constructor(a = new Foo<string>()) {}
+            }
+                  ",
             "
-			class A {
-			  constructor(a: Foo<string> = new Foo()) {}
-			}
-			      ",
+            class A {
+              constructor(a: Foo<string> = new Foo()) {}
+            }
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
             "
-			const a = function (a = new Foo<string>()) {};
-			      ",
+            const a = function (a = new Foo<string>()) {};
+                  ",
             "
-			const a = function (a: Foo<string> = new Foo()) {};
-			      ",
+            const a = function (a: Foo<string> = new Foo()) {};
+                  ",
             Some(serde_json::json!(["type-annotation"])),
         ),
         (
@@ -925,6 +1078,19 @@ fn test() {
         (
             "const baz /* note: map */ : Map<number, number> = new Map();",
             "const baz /* note: map */ = new Map<number, number>();",
+            None,
+        ),
+        (
+            "
+            class Float32Array<T> {}
+            const a: Float32Array<ArrayBufferLike> = new Float32Array();
+            export {};
+                  ",
+            "
+            class Float32Array<T> {}
+            const a = new Float32Array<ArrayBufferLike>();
+            export {};
+                  ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -533,28 +533,28 @@ fn test() {
         ("interface Foo {}", None),
         (
             "
-			interface Foo {
-			  bar: string;
-			}
-			    ",
+            interface Foo {
+              bar: string;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  bar: string;
-			  [key: string]: any;
-			}
-			    ",
+            interface Foo {
+              bar: string;
+              [key: string]: any;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [key: string]: any;
-			  bar: string;
-			}
-			    ",
+            interface Foo {
+              [key: string]: any;
+              bar: string;
+            }
+                ",
             None,
         ),
         ("type Foo = { [key: string]: string | Foo };", None),
@@ -563,248 +563,248 @@ fn test() {
         ("type Foo = { [key in string]: Foo };", None),
         (
             "
-			interface Foo {
-			  [key: string]: Foo;
-			}
-			    ",
+            interface Foo {
+              [key: string]: Foo;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [key: string]: Foo<T>;
-			}
-			    ",
+            interface Foo<T> {
+              [key: string]: Foo<T>;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [key: string]: Foo<T> | string;
-			}
-			    ",
+            interface Foo<T> {
+              [key: string]: Foo<T> | string;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [s: string]: Foo & {};
-			}
-			    ",
+            interface Foo {
+              [s: string]: Foo & {};
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [s: string]: Foo | string;
-			}
-			    ",
+            interface Foo {
+              [s: string]: Foo | string;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [s: string]: Foo extends T ? string : number;
-			}
-			    ",
+            interface Foo<T> {
+              [s: string]: Foo extends T ? string : number;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [s: string]: T extends Foo ? string : number;
-			}
-			    ",
+            interface Foo<T> {
+              [s: string]: T extends Foo ? string : number;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [s: string]: T extends true ? Foo : number;
-			}
-			    ",
+            interface Foo<T> {
+              [s: string]: T extends true ? Foo : number;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo<T> {
-			  [s: string]: T extends true ? string : Foo;
-			}
-			    ",
+            interface Foo<T> {
+              [s: string]: T extends true ? string : Foo;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [s: string]: Foo[number];
-			}
-			    ",
+            interface Foo {
+              [s: string]: Foo[number];
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [s: string]: {}[Foo];
-			}
-			    ",
+            interface Foo {
+              [s: string]: {}[Foo];
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo1;
-			}
-			    ",
+            interface Foo2 {
+              [key: string]: Foo1;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo1;
-			}
-			    ",
+            interface Foo3 {
+              [key: string]: Foo1;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Record<string, Foo1>;
-			}
-			    ",
+            interface Foo3 {
+              [key: string]: Record<string, Foo1>;
+            }
+                ",
             None,
         ),
         (
             "
-			type Foo1 = {
-			  [key: string]: Foo2;
-			};
+            type Foo1 = {
+              [key: string]: Foo2;
+            };
 
-			type Foo2 = {
-			  [key: string]: Foo3;
-			};
+            type Foo2 = {
+              [key: string]: Foo3;
+            };
 
-			type Foo3 = {
-			  [key: string]: Foo1;
-			};
-			    ",
+            type Foo3 = {
+              [key: string]: Foo1;
+            };
+                ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			type Foo2 = {
-			  [key: string]: Foo3;
-			};
+            type Foo2 = {
+              [key: string]: Foo3;
+            };
 
-			interface Foo3 {
-			  [key: string]: Foo1;
-			}
-			    ",
+            interface Foo3 {
+              [key: string]: Foo1;
+            }
+                ",
             None,
         ),
         (
             "
-			type Foo1 = {
-			  [key: string]: Foo2;
-			};
+            type Foo1 = {
+              [key: string]: Foo2;
+            };
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo1;
-			}
-			    ",
+            interface Foo3 {
+              [key: string]: Foo1;
+            }
+                ",
             None,
         ),
         (
             "
-			type ExampleUnion = boolean | number;
+            type ExampleUnion = boolean | number;
 
-			type ExampleRoot = ExampleUnion | ExampleObject;
+            type ExampleRoot = ExampleUnion | ExampleObject;
 
-			interface ExampleObject {
-			  [key: string]: ExampleRoot;
-			}
-			    ",
+            interface ExampleObject {
+              [key: string]: ExampleRoot;
+            }
+                ",
             None,
         ),
         (
             "
-			type Bar<K extends string = never> = {
-			  [k in K]: Bar;
-			};
-			    ",
+            type Bar<K extends string = never> = {
+              [k in K]: Bar;
+            };
+                ",
             None,
         ),
         (
             "
-			type Bar<K extends string = never> = {
-			  [k in K]: Foo;
-			};
+            type Bar<K extends string = never> = {
+              [k in K]: Foo;
+            };
 
-			type Foo = Bar;
-			    ",
+            type Foo = Bar;
+                ",
             None,
         ),
         ("type Foo = {};", None),
         (
             "
-			type Foo = {
-			  bar: string;
-			  [key: string]: any;
-			};
-			    ",
+            type Foo = {
+              bar: string;
+              [key: string]: any;
+            };
+                ",
             None,
         ),
         (
             "
-			type Foo = {
-			  bar: string;
-			};
-			    ",
+            type Foo = {
+              bar: string;
+            };
+                ",
             None,
         ),
         (
             "
-			type Foo = {
-			  [key: string]: any;
-			  bar: string;
-			};
-			    ",
+            type Foo = {
+              [key: string]: any;
+              bar: string;
+            };
+                ",
             None,
         ),
         (
             "
-			type Foo = Generic<{
-			  [key: string]: any;
-			  bar: string;
-			}>;
-			    ",
+            type Foo = Generic<{
+              [key: string]: any;
+              bar: string;
+            }>;
+                ",
             None,
         ),
         ("function foo(arg: { [key: string]: any; bar: string }) {}", None),
@@ -834,19 +834,19 @@ fn test() {
         ("type T = { [key in Foo]: key | number };", None),
         (
             "
-			function foo(e: { readonly [key in PropertyKey]-?: key }) {}
-			      ",
+            function foo(e: { readonly [key in PropertyKey]-?: key }) {}
+                  ",
             None,
         ),
         (
             "
-			function f(): {
-			  // intentionally not using a Record to preserve optionals
-			  [k in keyof ParseResult]: unknown;
-			} {
-			  return {};
-			}
-			      ",
+            function f(): {
+              // intentionally not using a Record to preserve optionals
+              [k in keyof ParseResult]: unknown;
+            } {
+              return {};
+            }
+                  ",
             None,
         ),
         (
@@ -871,66 +871,66 @@ fn test() {
     let fail = vec![
         (
             "
-			interface Foo {
-			  [key: string]: any;
-			}
-			      ",
+            interface Foo {
+              [key: string]: any;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  readonly [key: string]: any;
-			}
-			      ",
+            interface Foo {
+              readonly [key: string]: any;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo<A> {
-			  [key: string]: A;
-			}
-			      ",
+            interface Foo<A> {
+              [key: string]: A;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo<A = any> {
-			  [key: string]: A;
-			}
-			      ",
+            interface Foo<A = any> {
+              [key: string]: A;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface B extends A {
-			  [index: number]: unknown;
-			}
-			      ",
+            interface B extends A {
+              [index: number]: unknown;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo<A> {
-			  readonly [key: string]: A;
-			}
-			      ",
+            interface Foo<A> {
+              readonly [key: string]: A;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo<A, B> {
-			  [key: A]: B;
-			}
-			      ",
+            interface Foo<A, B> {
+              [key: A]: B;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo<A, B> {
-			  readonly [key: A]: B;
-			}
-			      ",
+            interface Foo<A, B> {
+              readonly [key: A]: B;
+            }
+                  ",
             None,
         ),
         ("type Foo = { [key: string]: any };", None),
@@ -949,126 +949,126 @@ fn test() {
         ("type Foo = { [key: string]: string } | Foo;", None),
         (
             "
-			interface Foo<T> {
-			  [k: string]: T;
-			}
-			      ",
+            interface Foo<T> {
+              [k: string]: T;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [k: string]: A.Foo;
-			}
-			      ",
+            interface Foo {
+              [k: string]: A.Foo;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [k: string]: { [key: string]: Foo };
-			}
-			      ",
+            interface Foo {
+              [k: string]: { [key: string]: Foo };
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [key: string]: { foo: Foo };
-			}
-			      ",
+            interface Foo {
+              [key: string]: { foo: Foo };
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [key: string]: Foo[];
-			}
-			      ",
+            interface Foo {
+              [key: string]: Foo[];
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [key: string]: () => Foo;
-			}
-			      ",
+            interface Foo {
+              [key: string]: () => Foo;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo {
-			  [s: string]: [Foo];
-			}
-			      ",
+            interface Foo {
+              [s: string]: [Foo];
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ",
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ",
             None,
         ),
         (
             "
-			interface Foo1 {
-			  [key: string]: Record<string, Foo2>;
-			}
+            interface Foo1 {
+              [key: string]: Record<string, Foo2>;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ",
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ",
             None,
         ),
         (
             "
-			type Foo1 = {
-			  [key: string]: { foo2: Foo2 };
-			};
+            type Foo1 = {
+              [key: string]: { foo2: Foo2 };
+            };
 
-			type Foo2 = {
-			  [key: string]: Foo3;
-			};
+            type Foo2 = {
+              [key: string]: Foo3;
+            };
 
-			type Foo3 = {
-			  [key: string]: Record<string, Foo1>;
-			};
-			      ",
+            type Foo3 = {
+              [key: string]: Record<string, Foo1>;
+            };
+                  ",
             None,
         ),
         (
             "
-			type Foos<K extends string = never> = {
-			  [k in K]: { foo: Foo };
-			};
+            type Foos<K extends string = never> = {
+              [k in K]: { foo: Foo };
+            };
 
-			type Foo = Foos;
-			      ",
+            type Foo = Foos;
+                  ",
             None,
         ),
         (
             "
-			type Foos<K extends string = never> = {
-			  [k in K]: Foo[];
-			};
+            type Foos<K extends string = never> = {
+              [k in K]: Foo[];
+            };
 
-			type Foo = Foos;
-			      ",
+            type Foo = Foos;
+                  ",
             None,
         ),
         ("type Foo = Generic<Record<string, any>>;", Some(serde_json::json!(["index-signature"]))),
@@ -1087,54 +1087,54 @@ fn test() {
         ("type T = { [key in string]: number };", None),
         (
             "
-			function foo(e: { [key in PropertyKey]?: string }) {}
-			      ",
+            function foo(e: { [key in PropertyKey]?: string }) {}
+                  ",
             None,
         ),
         (
             "
-			function foo(e: { [key in PropertyKey]+?: string }) {}
-			      ",
+            function foo(e: { [key in PropertyKey]+?: string }) {}
+                  ",
             None,
         ),
         (
             "
-			function foo(e: { [key in PropertyKey]-?: string }) {}
-			      ",
+            function foo(e: { [key in PropertyKey]-?: string }) {}
+                  ",
             None,
         ),
         (
             "
-			function foo(e: { readonly [key in PropertyKey]-?: string }) {}
-			      ",
+            function foo(e: { readonly [key in PropertyKey]-?: string }) {}
+                  ",
             None,
         ),
         (
             "
-			type Options = [
-			  { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
-			    allow?: TypeOrValueSpecifier[];
-			  },
-			];
-			      ",
+            type Options = [
+              { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
+                allow?: TypeOrValueSpecifier[];
+              },
+            ];
+                  ",
             None,
         ),
         (
             "
-			export type MakeRequired<Base, Key extends keyof Base> = {
-			  [K in Key]-?: NonNullable<Base[Key]>;
-			} & Omit<Base, Key>;
-			      ",
+            export type MakeRequired<Base, Key extends keyof Base> = {
+              [K in Key]-?: NonNullable<Base[Key]>;
+            } & Omit<Base, Key>;
+                  ",
             None,
         ),
         (
             "
-			function f(): {
-			  [k in (keyof ParseResult)]: unknown;
-			} {
-			  return {};
-			}
-			      ",
+            function f(): {
+              [k in (keyof ParseResult)]: unknown;
+            } {
+              return {};
+            }
+                  ",
             None,
         ),
         // (
@@ -1151,81 +1151,81 @@ fn test() {
         // ),
         (
             "
-			type Foo = {
-			  [k in string];
-			};
-			      ",
+            type Foo = {
+              [k in string];
+            };
+                  ",
             None,
         ),
         // export default interface cannot be converted to export default type
         // because TypeScript doesn't allow "export default type"
         (
             "
-			export default interface SchedulerService {
-			  [key: string]: unknown;
-			}
-			      ",
+            export default interface SchedulerService {
+              [key: string]: unknown;
+            }
+                  ",
             None,
         ),
     ];
 
     let fix = vec![
         ("
-			interface Foo {
-			  [key: string]: any;
-			}
-			      ", "
-			type Foo = Record<string, any>;
-			      ", None),
+            interface Foo {
+              [key: string]: any;
+            }
+                  ", "
+            type Foo = Record<string, any>;
+                  ", None),
 ("
-			interface Foo {
-			  readonly [key: string]: any;
-			}
-			      ", "
-			type Foo = Readonly<Record<string, any>>;
-			      ", None),
+            interface Foo {
+              readonly [key: string]: any;
+            }
+                  ", "
+            type Foo = Readonly<Record<string, any>>;
+                  ", None),
 ("
-			interface Foo<A> {
-			  [key: string]: A;
-			}
-			      ", "
-			type Foo<A> = Record<string, A>;
-			      ", None),
+            interface Foo<A> {
+              [key: string]: A;
+            }
+                  ", "
+            type Foo<A> = Record<string, A>;
+                  ", None),
 ("
-			interface Foo<A = any> {
-			  [key: string]: A;
-			}
-			      ", "
-			type Foo<A = any> = Record<string, A>;
-			      ", None),
+            interface Foo<A = any> {
+              [key: string]: A;
+            }
+                  ", "
+            type Foo<A = any> = Record<string, A>;
+                  ", None),
 ("
-			export interface Bar {
-			  [key: string]: any;
-			}
-			      ", "
-			export type Bar = Record<string, any>;
-			      ", None),
+            export interface Bar {
+              [key: string]: any;
+            }
+                  ", "
+            export type Bar = Record<string, any>;
+                  ", None),
 ("
-			interface Foo<A> {
-			  readonly [key: string]: A;
-			}
-			      ", "
-			type Foo<A> = Readonly<Record<string, A>>;
-			      ", None),
+            interface Foo<A> {
+              readonly [key: string]: A;
+            }
+                  ", "
+            type Foo<A> = Readonly<Record<string, A>>;
+                  ", None),
 ("
-			interface Foo<A, B> {
-			  [key: A]: B;
-			}
-			      ", "
-			type Foo<A, B> = Record<A, B>;
-			      ", None),
+            interface Foo<A, B> {
+              [key: A]: B;
+            }
+                  ", "
+            type Foo<A, B> = Record<A, B>;
+                  ", None),
 ("
-			interface Foo<A, B> {
-			  readonly [key: A]: B;
-			}
-			      ", "
-			type Foo<A, B> = Readonly<Record<A, B>>;
-			      ", None),
+            interface Foo<A, B> {
+              readonly [key: A]: B;
+            }
+                  ", "
+            type Foo<A, B> = Readonly<Record<A, B>>;
+                  ", None),
 ("type Foo = { [key: string]: any };", "type Foo = Record<string, any>;", None),
 ("type Foo = { readonly [key: string]: any };", "type Foo = Readonly<Record<string, any>>;", None),
 ("type Foo = Generic<{ [key: string]: any }>;", "type Foo = Generic<Record<string, any>>;", None),
@@ -1241,143 +1241,143 @@ fn test() {
 ("type Foo = { [key: string]: { [key: string]: Foo } };", "type Foo = { [key: string]: Record<string, Foo> };", None),
 ("type Foo = { [key: string]: string } | Foo;", "type Foo = Record<string, string> | Foo;", None),
 ("
-			interface Foo<T> {
-			  [k: string]: T;
-			}
-			      ", "
-			type Foo<T> = Record<string, T>;
-			      ", None),
+            interface Foo<T> {
+              [k: string]: T;
+            }
+                  ", "
+            type Foo<T> = Record<string, T>;
+                  ", None),
 ("
-			interface Foo {
-			  [k: string]: A.Foo;
-			}
-			      ", "
-			type Foo = Record<string, A.Foo>;
-			      ", None),
+            interface Foo {
+              [k: string]: A.Foo;
+            }
+                  ", "
+            type Foo = Record<string, A.Foo>;
+                  ", None),
 ("
-			interface Foo {
-			  [k: string]: { [key: string]: Foo };
-			}
-			      ", "
-			interface Foo {
-			  [k: string]: Record<string, Foo>;
-			}
-			      ", None),
+            interface Foo {
+              [k: string]: { [key: string]: Foo };
+            }
+                  ", "
+            interface Foo {
+              [k: string]: Record<string, Foo>;
+            }
+                  ", None),
 ("
-			interface Foo {
-			  [key: string]: { foo: Foo };
-			}
-			      ", "
-			type Foo = Record<string, { foo: Foo }>;
-			      ", None),
+            interface Foo {
+              [key: string]: { foo: Foo };
+            }
+                  ", "
+            type Foo = Record<string, { foo: Foo }>;
+                  ", None),
 ("
-			interface Foo {
-			  [key: string]: Foo[];
-			}
-			      ", "
-			type Foo = Record<string, Foo[]>;
-			      ", None),
+            interface Foo {
+              [key: string]: Foo[];
+            }
+                  ", "
+            type Foo = Record<string, Foo[]>;
+                  ", None),
 ("
-			interface Foo {
-			  [key: string]: () => Foo;
-			}
-			      ", "
-			type Foo = Record<string, () => Foo>;
-			      ", None),
+            interface Foo {
+              [key: string]: () => Foo;
+            }
+                  ", "
+            type Foo = Record<string, () => Foo>;
+                  ", None),
 ("
-			interface Foo {
-			  [s: string]: [Foo];
-			}
-			      ", "
-			type Foo = Record<string, [Foo]>;
-			      ", None),
+            interface Foo {
+              [s: string]: [Foo];
+            }
+                  ", "
+            type Foo = Record<string, [Foo]>;
+                  ", None),
 ("
-			interface Foo1 {
-			  [key: string]: Foo2;
-			}
+            interface Foo1 {
+              [key: string]: Foo2;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ", "
-			type Foo1 = Record<string, Foo2>;
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ", "
+            type Foo1 = Record<string, Foo2>;
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ", None),
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ", None),
 ("
-			interface Foo1 {
-			  [key: string]: Record<string, Foo2>;
-			}
+            interface Foo1 {
+              [key: string]: Record<string, Foo2>;
+            }
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ", "
-			type Foo1 = Record<string, Record<string, Foo2>>;
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ", "
+            type Foo1 = Record<string, Record<string, Foo2>>;
 
-			interface Foo2 {
-			  [key: string]: Foo3;
-			}
+            interface Foo2 {
+              [key: string]: Foo3;
+            }
 
-			interface Foo3 {
-			  [key: string]: Foo2;
-			}
-			      ", None),
+            interface Foo3 {
+              [key: string]: Foo2;
+            }
+                  ", None),
 ("
-			type Foo1 = {
-			  [key: string]: { foo2: Foo2 };
-			};
+            type Foo1 = {
+              [key: string]: { foo2: Foo2 };
+            };
 
-			type Foo2 = {
-			  [key: string]: Foo3;
-			};
+            type Foo2 = {
+              [key: string]: Foo3;
+            };
 
-			type Foo3 = {
-			  [key: string]: Record<string, Foo1>;
-			};
-			      ", "
-			type Foo1 = Record<string, { foo2: Foo2 }>;
+            type Foo3 = {
+              [key: string]: Record<string, Foo1>;
+            };
+                  ", "
+            type Foo1 = Record<string, { foo2: Foo2 }>;
 
-			type Foo2 = Record<string, Foo3>;
+            type Foo2 = Record<string, Foo3>;
 
-			type Foo3 = Record<string, Record<string, Foo1>>;
-			      ", None),
+            type Foo3 = Record<string, Record<string, Foo1>>;
+                  ", None),
 ("
-			type Foos<K extends string = never> = {
-			  [k in K]: { foo: Foo };
-			};
+            type Foos<K extends string = never> = {
+              [k in K]: { foo: Foo };
+            };
 
-			type Foo = Foos;
-			      ", "
-			type Foos<K extends string = never> = Record<K, { foo: Foo }>;
+            type Foo = Foos;
+                  ", "
+            type Foos<K extends string = never> = Record<K, { foo: Foo }>;
 
-			type Foo = Foos;
-			      ", None),
+            type Foo = Foos;
+                  ", None),
 ("
-			type Foos<K extends string = never> = {
-			  [k in K]: Foo[];
-			};
+            type Foos<K extends string = never> = {
+              [k in K]: Foo[];
+            };
 
-			type Foo = Foos;
-			      ", "
-			type Foos<K extends string = never> = Record<K, Foo[]>;
+            type Foo = Foos;
+                  ", "
+            type Foos<K extends string = never> = Record<K, Foo[]>;
 
-			type Foo = Foos;
-			      ", None),
+            type Foo = Foos;
+                  ", None),
 ("type Foo = Generic<Record<string, any>>;", "type Foo = Generic<{ [key: string]: any }>;", Some(serde_json::json!(["index-signature"]))),
 ("type Foo = Record<number, any>;", "type Foo = { [key: number]: any };", Some(serde_json::json!(["index-signature"]))),
 ("type Foo = Record<symbol, any>;", "type Foo = { [key: symbol]: any };", Some(serde_json::json!(["index-signature"]))),
@@ -1387,78 +1387,78 @@ fn test() {
 ("type T = { +readonly [key in string]: number };", "type T = Readonly<Record<string, number>>;", None),
 ("type T = { [key in string]: number };", "type T = Record<string, number>;", None),
 ("
-			function foo(e: { [key in PropertyKey]?: string }) {}
-			      ", "
-			function foo(e: Partial<Record<PropertyKey, string>>) {}
-			      ", None),
+            function foo(e: { [key in PropertyKey]?: string }) {}
+                  ", "
+            function foo(e: Partial<Record<PropertyKey, string>>) {}
+                  ", None),
 ("
-			function foo(e: { [key in PropertyKey]+?: string }) {}
-			      ", "
-			function foo(e: Partial<Record<PropertyKey, string>>) {}
-			      ", None),
+            function foo(e: { [key in PropertyKey]+?: string }) {}
+                  ", "
+            function foo(e: Partial<Record<PropertyKey, string>>) {}
+                  ", None),
 ("
-			function foo(e: { [key in PropertyKey]-?: string }) {}
-			      ", "
-			function foo(e: Required<Record<PropertyKey, string>>) {}
-			      ", None),
-("
-			function foo(e: { readonly [key in PropertyKey]-?: string }) {}
-			      ", "
-			function foo(e: Readonly<Required<Record<PropertyKey, string>>>) {}
-			      ", None),
-("
-			type Options = [
-			  { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
-			    allow?: TypeOrValueSpecifier[];
-			  },
-			];
-			      ", "
-			type Options = [
-			  Partial<Record<(typeof optionTesters)[number]['option'], boolean>> & {
-			    allow?: TypeOrValueSpecifier[];
-			  },
-			];
-			      ", None),
-("
-			export type MakeRequired<Base, Key extends keyof Base> = {
-			  [K in Key]-?: NonNullable<Base[Key]>;
-			} & Omit<Base, Key>;
-			      ", "
-			export type MakeRequired<Base, Key extends keyof Base> = Required<Record<Key, NonNullable<Base[Key]>>> & Omit<Base, Key>;
-			      ", None),
-("
-			function f(): {
-			  [k in (keyof ParseResult)]: unknown;
-			} {
-			  return {};
-			}
-			      ", "
-			function f(): Record<keyof ParseResult, unknown> {
-			  return {};
-			}
-			      ", None),
+            function foo(e: { [key in PropertyKey]-?: string }) {}
+                  ", "
+            function foo(e: Required<Record<PropertyKey, string>>) {}
+                  ", None),
+        ("
+            function foo(e: { readonly [key in PropertyKey]-?: string }) {}
+                  ", "
+            function foo(e: Readonly<Required<Record<PropertyKey, string>>>) {}
+                  ", None),
+        ("
+            type Options = [
+              { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
+                allow?: TypeOrValueSpecifier[];
+              },
+            ];
+                  ", "
+            type Options = [
+              Partial<Record<(typeof optionTesters)[number]['option'], boolean>> & {
+                allow?: TypeOrValueSpecifier[];
+              },
+            ];
+                  ", None),
+        ("
+            export type MakeRequired<Base, Key extends keyof Base> = {
+              [K in Key]-?: NonNullable<Base[Key]>;
+            } & Omit<Base, Key>;
+                  ", "
+            export type MakeRequired<Base, Key extends keyof Base> = Required<Record<Key, NonNullable<Base[Key]>>> & Omit<Base, Key>;
+                  ", None),
+        ("
+            function f(): {
+              [k in (keyof ParseResult)]: unknown;
+            } {
+              return {};
+            }
+                  ", "
+            function f(): Record<keyof ParseResult, unknown> {
+              return {};
+            }
+                  ", None),
 // ("
-// 			interface Foo {
-// 			  [key: string]: Bar;
-// 			}
-//
-// 			interface Bar {
-// 			  [key: string];
-// 			}
-// 			      ", "
-// 			type Foo = Record<string, Bar>;
-//
-// 			interface Bar {
-// 			  [key: string];
-// 			}
-// 			      ", None),
-("
-			type Foo = {
-			  [k in string];
-			};
-			      ", "
-			type Foo = Record<string, any>;
-			      ", None)
+//             interface Foo {
+//               [key: string]: Bar;
+//             }
+
+//             interface Bar {
+//               [key: string];
+//             }
+//                   ", "
+//             type Foo = Record<string, Bar>;
+
+//             interface Bar {
+//               [key: string];
+//             }
+//                   ", None),
+        ("
+            type Foo = {
+              [k in string];
+            };
+                  ", "
+            type Foo = Record<string, any>;
+                  ", None)
     ];
     Tester::new(
         ConsistentIndexedObjectStyle::NAME,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -257,10 +257,10 @@ fn test() {
         ("interface A {}", Some(serde_json::json!(["interface"]))),
         (
             "
-			interface A extends B {
-			  x: number;
-			}
-			      ",
+            interface A extends B {
+              x: number;
+            }
+                  ",
             Some(serde_json::json!(["interface"])),
         ),
         ("type U = string;", Some(serde_json::json!(["interface"]))),
@@ -268,10 +268,10 @@ fn test() {
         ("interface T { x: \"interface\" | \"type\"; }", Some(serde_json::json!(["interface"]))),
         (
             "
-			type Record<T, U> = {
-			  [K in T]: U;
-			};
-			      ",
+            type Record<T, U> = {
+              [K in T]: U;
+            };
+                  ",
             Some(serde_json::json!(["interface"])),
         ),
         ("type T = { x: number };", Some(serde_json::json!(["type"]))),
@@ -279,10 +279,10 @@ fn test() {
         ("type A = { x: number } & B<T1> & C<T2>;", Some(serde_json::json!(["type"]))),
         (
             "
-			export type W<T> = {
-			  x: T;
-			};
-			      ",
+            export type W<T> = {
+              x: T;
+            };
+                  ",
             Some(serde_json::json!(["type"])),
         ),
     ];
@@ -293,10 +293,10 @@ fn test() {
         ("type T=                         { x: number; };", Some(serde_json::json!(["interface"]))),
         (
             "
-			export type W<T> = {
-			  x: T;
-			};
-			      ",
+            export type W<T> = {
+              x: T;
+            };
+                  ",
             Some(serde_json::json!(["interface"])),
         ),
         ("interface T { x: number; }", Some(serde_json::json!(["type"]))),
@@ -307,77 +307,77 @@ fn test() {
         ("interface A extends B<T1>, C<T2> { x: number; };", Some(serde_json::json!(["type"]))),
         (
             "
-			export interface W<T> {
-			  x: T;
-			}
-			      ",
+            export interface W<T> {
+              x: T;
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			namespace JSX {
-			  interface Array<T> {
-			    foo(x: (x: number) => T): T[];
-			  }
-			}
-			      ",
+            namespace JSX {
+              interface Array<T> {
+                foo(x: (x: number) => T): T[];
+              }
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			global {
-			  interface Array<T> {
-			    foo(x: (x: number) => T): T[];
-			  }
-			}
-			      ",
+            global {
+              interface Array<T> {
+                foo(x: (x: number) => T): T[];
+              }
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			declare global {
-			  interface Array<T> {
-			    foo(x: (x: number) => T): T[];
-			  }
-			}
-			      ",
+            declare global {
+              interface Array<T> {
+                foo(x: (x: number) => T): T[];
+              }
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			declare global {
-			  namespace Foo {
-			    interface Bar {}
-			  }
-			}
-			      ",
+            declare global {
+              namespace Foo {
+                interface Bar {}
+              }
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			export default interface Test {
-			  bar(): string;
-			  foo(): number;
-			}
-			      ",
+            export default interface Test {
+              bar(): string;
+              foo(): number;
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         (
             "
-			export declare type Test = {
-			  foo: string;
-			  bar: string;
-			};
-			      ",
+            export declare type Test = {
+              foo: string;
+              bar: string;
+            };
+                  ",
             Some(serde_json::json!(["interface"])),
         ),
         (
             "
-			export declare interface Test {
-			  foo: string;
-			  bar: string;
-			}
-			      ",
+            export declare interface Test {
+              foo: string;
+              bar: string;
+            }
+                  ",
             Some(serde_json::json!(["type"])),
         ),
         // Issue: <https://github.com/oxc-project/oxc/issues/7552>

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -711,19 +711,19 @@ fn test() {
         ("return;", None, None, None),
         (
             "
-        	function test(): void {
-        	  return;
-        	}
-        	",
+            function test(): void {
+              return;
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	var fn = function (): number {
-        	  return 1;
-        	};
+            var fn = function (): number {
+              return 1;
+            };
             ",
             None,
             None,
@@ -732,18 +732,18 @@ fn test() {
         ("var arrowFn = (): string => 'test';", None, None, None),
         (
             "
-        	class Test {
-        	  constructor() {}
-        	  get prop(): number {
-        	    return 1;
-        	  }
-        	  set prop(_foo) {}
-        	  method(): void {
-        	    return;
-        	  }
-        	  arrow = (): string => 'arrow';
-        	}
-        	",
+            class Test {
+              constructor() {}
+              get prop(): number {
+                return 1;
+              }
+              set prop(_foo) {}
+              method(): void {
+                return;
+              }
+              arrow = (): string => 'arrow';
+            }
+            ",
             None,
             None,
             None,
@@ -782,10 +782,10 @@ fn test() {
         ),
         (
             "
-        	var funcExpr: Foo = function () {
-        	  return 'test';
-        	};
-        	",
+            var funcExpr: Foo = function () {
+              return 'test';
+            };
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -804,72 +804,72 @@ fn test() {
         ),
         (
             "
-        	const x = {
-        	  foo: () => {},
-        	} as Foo;
-        	",
+            const x = {
+              foo: () => {},
+            } as Foo;
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
         ),
         (
             "
-        	const x = <Foo>{
-        	  foo: () => {},
-        	};
-        	",
-            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
-            None,
-            Some(PathBuf::from("test.ts")),
-        ),
-        (
-            "
-        	const x: Foo = {
-        	  foo: () => {},
-        	};
-        	",
-            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
-            None,
-            None,
-        ),
-        (
-            "
-        	const x = {
-        	  foo: { bar: () => {} },
-        	} as Foo;
-        	",
-            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
-            None,
-            None,
-        ),
-        (
-            "
-        	const x = <Foo>{
-        	  foo: { bar: () => {} },
-        	};
-        	",
+            const x = <Foo>{
+              foo: () => {},
+            };
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             Some(PathBuf::from("test.ts")),
         ),
         (
             "
-        	const x: Foo = {
-        	  foo: { bar: () => {} },
-        	};
-        	",
+            const x: Foo = {
+              foo: () => {},
+            };
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
         ),
         (
             "
-        	type MethodType = () => void;
+            const x = {
+              foo: { bar: () => {} },
+            } as Foo;
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            const x = <Foo>{
+              foo: { bar: () => {} },
+            };
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            Some(PathBuf::from("test.ts")),
+        ),
+        (
+            "
+            const x: Foo = {
+              foo: { bar: () => {} },
+            };
+            ",
+            Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
+            None,
+            None,
+        ),
+        (
+            "
+            type MethodType = () => void;
 
-        	class App {
-        	  private method: MethodType = () => {};
-        	}
-        	",
+            class App {
+              private method: MethodType = () => {};
+            }
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -906,11 +906,11 @@ fn test() {
         ),
         (
             "
-        	const myObj = {
-        	  set myProp(val) {
-        	    this.myProp = val;
-        	  },
-        	};
+            const myObj = {
+              set myProp(val) {
+                this.myProp = val;
+              },
+            };
             ",
             None,
             None,
@@ -930,197 +930,197 @@ fn test() {
         ),
         (
             "
-        	() => {
-        	  return (): void => {};
-        	};
-        	",
+            () => {
+              return (): void => {};
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	() => {
-        	  return function (): void {};
-        	};
-        	",
+            () => {
+              return function (): void {};
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	() => {
-        	  const foo = 'foo';
-        	  return function (): string {
-        	    return foo;
-        	  };
-        	};
-        	",
+            () => {
+              const foo = 'foo';
+              return function (): string {
+                return foo;
+              };
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  return (): void => {};
-        	}
-        	",
+            function fn() {
+              return (): void => {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  return function (): void {};
-        	}
-        	",
+            function fn() {
+              return function (): void {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  const bar = () => (): number => 1;
-        	  return function (): void {};
-        	}
-        	",
+            function fn() {
+              const bar = () => (): number => 1;
+              return function (): void {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn(arg: boolean) {
-        	  if (arg) {
-        	    return () => (): number => 1;
-        	  } else {
-        	    return function (): string {
-        	      return 'foo';
-        	    };
-        	  }
+            function fn(arg: boolean) {
+              if (arg) {
+                return () => (): number => 1;
+              } else {
+                return function (): string {
+                  return 'foo';
+                };
+              }
 
-        	  return function (): void {};
-        	}
-        	",
+              return function (): void {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function FunctionDeclaration() {
-        	  return function FunctionExpression_Within_FunctionDeclaration() {
-        	    return function FunctionExpression_Within_FunctionExpression() {
-        	      return () => {
-        	        // ArrowFunctionExpression_Within_FunctionExpression
-        	        return () =>
-        	          // ArrowFunctionExpression_Within_ArrowFunctionExpression
-        	          (): number =>
-        	            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
-        	      };
-        	    };
-        	  };
-        	}
-        	",
+            function FunctionDeclaration() {
+              return function FunctionExpression_Within_FunctionDeclaration() {
+                return function FunctionExpression_Within_FunctionExpression() {
+                  return () => {
+                    // ArrowFunctionExpression_Within_FunctionExpression
+                    return () =>
+                      // ArrowFunctionExpression_Within_ArrowFunctionExpression
+                      (): number =>
+                        1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+                  };
+                };
+              };
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	() => () => {
-        	  return (): void => {
-        	    return;
-        	  };
-        	};
-        	",
+            () => () => {
+              return (): void => {
+                return;
+              };
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	declare function foo(arg: () => void): void;
-        	foo(() => 1);
-        	foo(() => {});
-        	foo(() => null);
-        	foo(() => true);
-        	foo(() => '');
-        	",
+            declare function foo(arg: () => void): void;
+            foo(() => 1);
+            foo(() => {});
+            foo(() => null);
+            foo(() => true);
+            foo(() => '');
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "
-        	declare function foo(arg: () => void): void;
-        	foo?.(() => 1);
-        	foo?.bar(() => {});
-        	foo?.bar?.(() => null);
-        	foo.bar?.(() => true);
-        	foo?.(() => '');
-        	",
+            declare function foo(arg: () => void): void;
+            foo?.(() => 1);
+            foo?.bar(() => {});
+            foo?.bar?.(() => null);
+            foo.bar?.(() => true);
+            foo?.(() => '');
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "
-        	class Accumulator {
-        	  private count: number = 0;
+            class Accumulator {
+              private count: number = 0;
 
-        	  public accumulate(fn: () => number): void {
-        	    this.count += fn();
-        	  }
-        	}
+              public accumulate(fn: () => number): void {
+                this.count += fn();
+              }
+            }
 
-        	new Accumulator().accumulate(() => 1);
-        	",
+            new Accumulator().accumulate(() => 1);
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "
-        	declare function foo(arg: { meth: () => number }): void;
-        	foo({
-        	  meth() {
-        	    return 1;
-        	  },
-        	});
-        	foo({
-        	  meth: function () {
-        	    return 1;
-        	  },
-        	});
-        	foo({
-        	  meth: () => {
-        	    return 1;
-        	  },
-        	});
-        	",
+            declare function foo(arg: { meth: () => number }): void;
+            foo({
+              meth() {
+                return 1;
+              },
+            });
+            foo({
+              meth: function () {
+                return 1;
+              },
+            });
+            foo({
+              meth: () => {
+                return 1;
+              },
+            });
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "
-        	const func1 = (value: number) => ({ type: 'X', value }) as const;
-        	const func2 = (value: number) => ({ type: 'X', value }) as const;
-        	const func3 = (value: number) => x as const;
-        	const func4 = (value: number) => x as const;
-        	",
+            const func1 = (value: number) => ({ type: 'X', value }) as const;
+            const func2 = (value: number) => ({ type: 'X', value }) as const;
+            const func3 = (value: number) => x as const;
+            const func4 = (value: number) => x as const;
+            ",
             Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
             None,
             None,
         ),
         (
             "
-        	interface R {
+            interface R {
                 type: string;
                 value: number;
                 }
@@ -1190,127 +1190,127 @@ fn test() {
         ),
         (
             "
-        	function log<A>(a: A): A {
-        	  return a;
-        	}
-        	",
+            function log<A>(a: A): A {
+              return a;
+            }
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	function log(a: string) {
-        	  return a;
-        	}
-        	",
+            function log(a: string) {
+              return a;
+            }
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	const log = function <A>(a: A): A {
-        	  return a;
-        	};
-        	",
+            const log = function <A>(a: A): A {
+              return a;
+            };
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	const log = function (a: A): string {
-        	  return a;
-        	};
-        	",
+            const log = function (a: A): string {
+              return a;
+            };
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	function test1() {
-        	  return;
-        	}
+            function test1() {
+              return;
+            }
 
-        	const foo = function test2() {
-        	  return;
-        	};
-        	",
+            const foo = function test2() {
+              return;
+            };
+            ",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
         (
             "
-        	const test1 = function () {
-        	  return;
-        	};
-        	const foo = function () {
-        	  return function test2() {};
-        	};
-        	",
+            const test1 = function () {
+              return;
+            };
+            const foo = function () {
+              return function test2() {};
+            };
+            ",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
         (
             "
-        	const test1 = () => {
-        	  return;
-        	};
-        	export const foo = {
-        	  test2() {
-        	    return 0;
-        	  },
-        	};
-        	",
+            const test1 = () => {
+              return;
+            };
+            export const foo = {
+              test2() {
+                return 0;
+              },
+            };
+            ",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
         (
             "
-        	class Test {
-        	  constructor() {}
-        	  get prop() {
-        	    return 1;
-        	  }
-        	  set prop(_foo) {}
-        	  method() {
-        	    return;
-        	  }
-        	  arrow = () => 'arrow';
-        	  private method() {
-        	    return;
-        	  }
-        	}
-        	",
+            class Test {
+              constructor() {}
+              get prop() {
+                return 1;
+              }
+              set prop(_foo) {}
+              method() {
+                return;
+              }
+              arrow = () => 'arrow';
+              private method() {
+                return;
+              }
+            }
+            ",
             Some(serde_json::json!([ { "allowedNames": ["prop", "method", "arrow"],  }, ])),
             None,
             None,
         ),
         (
             "
-        	const x = {
-        	  arrowFn: () => {
-        	    return;
-        	  },
-        	  fn: function () {
-        	    return;
-        	  },
-        	};
-        	",
+            const x = {
+              arrowFn: () => {
+                return;
+              },
+              fn: function () {
+                return;
+              },
+            };
+            ",
             Some(serde_json::json!([ { "allowedNames": ["arrowFn", "fn"],  }, ])),
             None,
             None,
         ),
         (
             "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	",
+            type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+            const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true, "allowHigherOrderFunctions": true }, ]),
             ),
@@ -1319,9 +1319,9 @@ fn test() {
         ),
         (
             "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	",
+            type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+            const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true, "allowHigherOrderFunctions": false }, ]),
             ),
@@ -1330,18 +1330,18 @@ fn test() {
         ),
         (
             "
-        	interface Foo {
-        	  foo: string;
-        	  arrowFn: () => string;
-        	}
+            interface Foo {
+              foo: string;
+              arrowFn: () => string;
+            }
 
-        	function foo(): Foo {
-        	  return {
-        	    foo: 'foo',
-        	    arrowFn: () => 'test',
-        	  };
-        	}
-        	",
+            function foo(): Foo {
+              return {
+                foo: 'foo',
+                arrowFn: () => 'test',
+              };
+            }
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true, "allowHigherOrderFunctions": true }, ]),
             ),
@@ -1350,10 +1350,10 @@ fn test() {
         ),
         (
             "
-        	type Foo = (arg1: string) => string;
-        	type Bar<T> = (arg2: string) => T;
-        	const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
-        	",
+            type Foo = (arg1: string) => string;
+            type Bar<T> = (arg2: string) => T;
+            const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true, "allowHigherOrderFunctions": true }, ]),
             ),
@@ -1362,40 +1362,40 @@ fn test() {
         ),
         (
             "
-        	let foo = function (): number {
-        	  return 1;
-        	};
-        	",
+            let foo = function (): number {
+              return 1;
+            };
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	const foo = (function () {
-        	  return 1;
-        	})();
-        	",
+            const foo = (function () {
+              return 1;
+            })();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	const foo = (() => {
-        	  return 1;
-        	})();
-        	",
+            const foo = (() => {
+              return 1;
+            })();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	const foo = ((arg: number): number => {
-        	  return arg;
-        	})(0);
-        	",
+            const foo = ((arg: number): number => {
+              return arg;
+            })(0);
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
@@ -1408,20 +1408,20 @@ fn test() {
         ),
         (
             "
-        	let foo = (() => (): string => {
-        	  return 'foo';
-        	})()();
-        	",
+            let foo = (() => (): string => {
+              return 'foo';
+            })()();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	let foo = (() => (): string => {
-        	  return 'foo';
-        	})();
-        	",
+            let foo = (() => (): string => {
+              return 'foo';
+            })();
+            ",
             Some(
                 serde_json::json!([ { "allowIIFEs": true, "allowHigherOrderFunctions": false }, ]),
             ),
@@ -1430,82 +1430,82 @@ fn test() {
         ),
         (
             "
-        	let foo = (() => (): string => {
-        	  return 'foo';
-        	})()();
-        	",
+            let foo = (() => (): string => {
+              return 'foo';
+            })()();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true, "allowHigherOrderFunctions": true }, ])),
             None,
             None,
         ),
         (
             "
-        	let foo = (() => (): void => {})()();
-        	",
+            let foo = (() => (): void => {})()();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	let foo = (() => (() => {})())();
-        	",
+            let foo = (() => (() => {})())();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	class Bar {
-        	  bar: Foo = {
-        	    foo: x => x + 1,
-        	  };
-        	}
-        	",
+            class Bar {
+              bar: Foo = {
+                foo: x => x + 1,
+              };
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	class Bar {
-        	  bar: Foo[] = [
-        	    {
-        	      foo: x => x + 1,
-        	    },
-        	  ];
-        	}
-        	",
+            class Bar {
+              bar: Foo[] = [
+                {
+                  foo: x => x + 1,
+                },
+              ];
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	type CallBack = () => void;
+            type CallBack = () => void;
 
-        	function f(gotcha: CallBack = () => {}): void {}
-        	",
+            function f(gotcha: CallBack = () => {}): void {}
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
         ),
         (
             "
-        	type CallBack = () => void;
+            type CallBack = () => void;
 
-        	const f = (gotcha: CallBack = () => {}): void => {};
-        	",
+            const f = (gotcha: CallBack = () => {}): void => {};
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
         ),
         (
             "
-        	type ObjectWithCallback = { callback: () => void };
+            type ObjectWithCallback = { callback: () => void };
 
-        	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
-        	",
+            const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1514,7 +1514,7 @@ fn test() {
             "export function define(): (callback: (() => void)) => void {
                 return () => {xxxxxxx }
             }
-        	",
+            ",
             None,
             None,
             None,
@@ -1530,69 +1530,69 @@ fn test() {
     let fail = vec![
         (
             "
-        	function test(a: number, b: number) {
-        	  return;
-        	}
-        	",
+            function test(a: number, b: number) {
+              return;
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	function test() {
-        	  return;
-        	}
-        	",
+            function test() {
+              return;
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	var fn = function () {
-        	  return 1;
-        	};
-        	",
+            var fn = function () {
+              return 1;
+            };
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	var arrowFn = () => 'test';
-        	",
+            var arrowFn = () => 'test';
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	class Test {
-        	  constructor() {}
-        	  get prop() {
-        	    return 1;
-        	  }
-        	  set prop(_foo) {}
-        	  method() {
-        	    return;
-        	  }
-        	  arrow = () => 'arrow';
-        	  private method() {
-        	    return;
-        	  }
-        	}
-        	",
+            class Test {
+              constructor() {}
+              get prop() {
+                return 1;
+              }
+              set prop(_foo) {}
+              method() {
+                return;
+              }
+              arrow = () => 'arrow';
+              private method() {
+                return;
+              }
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	function test() {
-        	  return;
-        	}
-        	",
+            function test() {
+              return;
+            }
+            ",
             Some(serde_json::json!([{ "allowExpressions": true }])),
             None,
             None,
@@ -1623,15 +1623,15 @@ fn test() {
         ),
         (
             "
-        	class Foo {
-        	  public a = () => {};
-        	  public b = function () {};
-        	  public c = function test() {};
+            class Foo {
+              public a = () => {};
+              public b = function () {};
+              public c = function test() {};
 
-        	  static d = () => {};
-        	  static e = function () {};
-        	}
-        	",
+              static d = () => {};
+              static e = function () {};
+            }
+            ",
             Some(serde_json::json!([{ "allowExpressions": true }])),
             None,
             None,
@@ -1644,45 +1644,45 @@ fn test() {
         ),
         (
             "
-        	function foo(): any {
-        	  const bar = () => () => console.log('aa');
-        	}
-        	",
+            function foo(): any {
+              const bar = () => () => console.log('aa');
+            }
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true }, ])),
             None,
             None,
         ),
         (
             "
-        	let anyValue: any;
-        	function foo(): any {
-        	  anyValue = () => () => console.log('aa');
-        	}
-        	",
+            let anyValue: any;
+            function foo(): any {
+              anyValue = () => () => console.log('aa');
+            }
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true }, ])),
             None,
             None,
         ),
         (
             "
-        	class Foo {
-        	  foo(): any {
-        	    const bar = () => () => {
-        	      return console.log('foo');
-        	    };
-        	  }
-        	}
-        	",
+            class Foo {
+              foo(): any {
+                const bar = () => () => {
+                  return console.log('foo');
+                };
+              }
+            }
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true }, ])),
             None,
             None,
         ),
         (
             "
-        	var funcExpr = function () {
-        	  return 'test';
-        	};
-        	",
+            var funcExpr = function () {
+              return 'test';
+            };
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1695,22 +1695,22 @@ fn test() {
         ),
         (
             "
-        	interface Foo {}
-        	const x = {
-        	  foo: () => {},
-        	} as Foo;
-        	",
+            interface Foo {}
+            const x = {
+              foo: () => {},
+            } as Foo;
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
         ),
         (
             "
-        	interface Foo {}
-        	const x: Foo = {
-        	  foo: () => {},
-        	};
-        	",
+            interface Foo {}
+            const x: Foo = {
+              foo: () => {},
+            };
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
@@ -1747,14 +1747,14 @@ fn test() {
         ),
         (
             "
-        	function foo(): any {
-        	  class Foo {
-        	    foo = () => () => {
-        	      return console.log('foo');
-        	    };
-        	  }
-        	}
-        	",
+            function foo(): any {
+              class Foo {
+                foo = () => () => {
+                  return console.log('foo');
+                };
+              }
+            }
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1773,124 +1773,124 @@ fn test() {
         ),
         (
             "
-        	() => {
-        	  return () => {};
-        	};
-        	",
+            () => {
+              return () => {};
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	() => {
-        	  return function () {};
-        	};
-        	",
+            () => {
+              return function () {};
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  return () => {};
-        	}
-        	",
+            function fn() {
+              return () => {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  return function () {};
-        	}
-        	",
+            function fn() {
+              return function () {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn() {
-        	  const bar = () => (): number => 1;
-        	  const baz = () => () => 'baz';
-        	  return function (): void {};
-        	}
-        	",
+            function fn() {
+              const bar = () => (): number => 1;
+              const baz = () => () => 'baz';
+              return function (): void {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function fn(arg: boolean) {
-        	  if (arg) return 'string';
-        	  return function (): void {};
-        	}
-        	",
+            function fn(arg: boolean) {
+              if (arg) return 'string';
+              return function (): void {};
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	function FunctionDeclaration() {
-        	  return function FunctionExpression_Within_FunctionDeclaration() {
-        	    return function FunctionExpression_Within_FunctionExpression() {
-        	      return () => {
-        	        // ArrowFunctionExpression_Within_FunctionExpression
-        	        return () =>
-        	          // ArrowFunctionExpression_Within_ArrowFunctionExpression
-        	          () =>
-        	            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
-        	      };
-        	    };
-        	  };
-        	}
-        	",
+            function FunctionDeclaration() {
+              return function FunctionExpression_Within_FunctionDeclaration() {
+                return function FunctionExpression_Within_FunctionExpression() {
+                  return () => {
+                    // ArrowFunctionExpression_Within_FunctionExpression
+                    return () =>
+                      // ArrowFunctionExpression_Within_ArrowFunctionExpression
+                      () =>
+                        1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+                  };
+                };
+              };
+            }
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	() => () => {
-        	  return () => {
-        	    return;
-        	  };
-        	};
-        	",
+            () => () => {
+              return () => {
+                return;
+              };
+            };
+            ",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
             "
-        	declare function foo(arg: () => void): void;
-        	foo(() => 1);
-        	foo(() => {});
-        	foo(() => null);
-        	foo(() => true);
-        	foo(() => '');
-        	",
+            declare function foo(arg: () => void): void;
+            foo(() => 1);
+            foo(() => {});
+            foo(() => null);
+            foo(() => true);
+            foo(() => '');
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
         ),
         (
             "
-        	class Accumulator {
-        	  private count: number = 0;
+            class Accumulator {
+              private count: number = 0;
 
-        	  public accumulate(fn: () => number): void {
-        	    this.count += fn();
-        	  }
-        	}
+              public accumulate(fn: () => number): void {
+                this.count += fn();
+              }
+            }
 
-        	new Accumulator().accumulate(() => 1);
-        	",
+            new Accumulator().accumulate(() => 1);
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false }, ])),
             None,
             None,
@@ -1903,32 +1903,32 @@ fn test() {
         ),
         (
             "
-        	declare function foo(arg: { meth: () => number }): void;
-        	foo({
-        	  meth() {
-        	    return 1;
-        	  },
-        	});
-        	foo({
-        	  meth: function () {
-        	    return 1;
-        	  },
-        	});
-        	foo({
-        	  meth: () => {
-        	    return 1;
-        	  },
-        	});
-        	",
+            declare function foo(arg: { meth: () => number }): void;
+            foo({
+              meth() {
+                return 1;
+              },
+            });
+            foo({
+              meth: function () {
+                return 1;
+              },
+            });
+            foo({
+              meth: () => {
+                return 1;
+              },
+            });
+            ",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false } ])),
             None,
             None,
         ),
         (
             "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	",
+            type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+            const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": false, "allowHigherOrderFunctions": true } ]),
             ),
@@ -1937,9 +1937,9 @@ fn test() {
         ),
         (
             "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	",
+            type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+            const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+            ",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": false, "allowHigherOrderFunctions": false } ]),
             ),
@@ -1948,9 +1948,9 @@ fn test() {
         ),
         (
             "
-        	const func1 = (value: number) => ({ type: 'X', value }) as any;
-        	const func2 = (value: number) => ({ type: 'X', value }) as Action;
-        	",
+            const func1 = (value: number) => ({ type: 'X', value }) as any;
+            const func2 = (value: number) => ({ type: 'X', value }) as Action;
+            ",
             Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true } ])),
             None,
             None,
@@ -1971,9 +1971,9 @@ fn test() {
         ),
         (
             "
-        	const log = (message: string) => {
+            const log = (message: string) => {
               void console.log(message);
-        	};
+            };
             ",
             Some(
                 serde_json::json!([{ "allowConciseArrowFunctionExpressionsStartingWithVoid": true }]),
@@ -1989,106 +1989,106 @@ fn test() {
         ),
         (
             "
-        	function log<A>(a: A) {
-        	  return a;
-        	}
-        	",
+            function log<A>(a: A) {
+              return a;
+            }
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	const log = function <A>(a: A) {
-        	  return a;
-        	};
-        	",
+            const log = function <A>(a: A) {
+              return a;
+            };
+            ",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
         ),
         (
             "
-        	function hoge() {
-        	  return;
-        	}
-        	const foo = () => {
-        	  return;
-        	};
-        	const baz = function () {
-        	  return;
-        	};
-        	let [test, test2] = function () {
-        	  return;
-        	};
-        	class X {
-        	  [test] = function () {
-        	    return;
-        	  };
-        	}
-        	const x = {
-        	  1: function () {
-        	    return;
-        	  },
-        	};
-        	",
+            function hoge() {
+              return;
+            }
+            const foo = () => {
+              return;
+            };
+            const baz = function () {
+              return;
+            };
+            let [test, test2] = function () {
+              return;
+            };
+            class X {
+              [test] = function () {
+                return;
+              };
+            }
+            const x = {
+              1: function () {
+                return;
+              },
+            };
+            ",
             Some(serde_json::json!([ { "allowedNames": ["test", "1"] }, ])),
             None,
             None,
         ),
         (
             "
-        	const ignoredName = 'notIgnoredName';
-        	class Foo {
-        	  [ignoredName]() {}
-        	}
-        	",
+            const ignoredName = 'notIgnoredName';
+            class Foo {
+              [ignoredName]() {}
+            }
+            ",
             Some(serde_json::json!([{ "allowedNames": ["ignoredName"] }])),
             None,
             None,
         ),
         (
             "
-        	class Bar {
-        	  bar = [
-        	    {
-        	      foo: x => x + 1,
-        	    },
-        	  ];
-        	}
-        	",
+            class Bar {
+              bar = [
+                {
+                  foo: x => x + 1,
+                },
+              ];
+            }
+            ",
             None,
             None,
             None,
         ),
         (
             "
-        	const foo = (function () {
-        	  return 'foo';
-        	})();
-        	",
+            const foo = (function () {
+              return 'foo';
+            })();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": false }, ])),
             None,
             None,
         ),
         (
             "
-        	const foo = (function () {
-        	  return () => {
-        	    return 1;
-        	  };
-        	})();
-        	",
+            const foo = (function () {
+              return () => {
+                return 1;
+              };
+            })();
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
         ),
         (
             "
-        	let foo = function () {
-        	  return 'foo';
-        	};
-        	",
+            let foo = function () {
+              return 'foo';
+            };
+            ",
             Some(serde_json::json!([ { "allowIIFEs": true }, ])),
             None,
             None,
@@ -2101,30 +2101,30 @@ fn test() {
         ),
         (
             "
-        	type CallBack = () => void;
+            type CallBack = () => void;
 
-        	function f(gotcha: CallBack = () => {}): void {}
-        	",
+            function f(gotcha: CallBack = () => {}): void {}
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
         ),
         (
             "
-        	type CallBack = () => void;
+            type CallBack = () => void;
 
-        	const f = (gotcha: CallBack = () => {}): void => {};
-        	",
+            const f = (gotcha: CallBack = () => {}): void => {};
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
         ),
         (
             "
-        	type ObjectWithCallback = { callback: () => void };
+            type ObjectWithCallback = { callback: () => void };
 
-        	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
-        	",
+            const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+            ",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -71,99 +71,95 @@ fn test() {
 
     let pass = vec![
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container.aaa;
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container.aaa;
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container.delete;
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container.delete;
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[7];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container[7];
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[-7];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container[-7];
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['-Infinity'];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container['-Infinity'];
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['+Infinity'];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container['+Infinity'];
+                ",
         "
-        	const value = 1;
-        	delete value;
-        	    ",
+            const value = 1;
+            delete value;
+                ",
         "
-        	const value = 1;
-        	delete -value;
-        	    ",
+            const value = 1;
+            delete -value;
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['aaa'];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container['aaa'];
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['delete'];
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container['delete'];
+                ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['NaN'];
-        	    ",
-        "
-        	const container = {};
-        	delete container[('aaa')]
-        	    ",
+            const container: { [i: string]: 0 } = {};
+            delete container['NaN'];
+                ",
     ];
 
     let fail = vec![
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container['aa' + 'b'];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container['aa' + 'b'];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[+7];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[+7];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[-Infinity];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[-Infinity];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[+Infinity];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[+Infinity];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[NaN];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[NaN];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	const name = 'name';
-        	delete container[name];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            const name = 'name';
+            delete container[name];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	const getName = () => 'aaa';
-        	delete container[getName()];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            const getName = () => 'aaa';
+            delete container[getName()];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	const name = { foo: { bar: 'bar' } };
-        	delete container[name.foo.bar];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            const name = { foo: { bar: 'bar' } };
+            delete container[name.foo.bar];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[+'Infinity'];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[+'Infinity'];
+                  ",
         "
-        	const container: { [i: string]: 0 } = {};
-        	delete container[typeof 1];
-        	      ",
+            const container: { [i: string]: 0 } = {};
+            delete container[typeof 1];
+                  ",
     ];
 
     Tester::new(NoDynamicDelete::NAME, NoDynamicDelete::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -94,59 +94,59 @@ fn test() {
     let pass = vec![
         (
             "
-			interface Foo {
-			  name: string;
-			}
-			    ",
+            interface Foo {
+              name: string;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  name: string;
-			}
+            interface Foo {
+              name: string;
+            }
 
-			interface Bar {
-			  age: number;
-			}
+            interface Bar {
+              age: number;
+            }
 
-			// valid because extending multiple interfaces can be used instead of a union type
-			interface Baz extends Foo, Bar {}
-			    ",
+            // valid because extending multiple interfaces can be used instead of a union type
+            interface Baz extends Foo, Bar {}
+                ",
             None,
         ),
         (
             "
-			interface Foo {
-			  name: string;
-			}
+            interface Foo {
+              name: string;
+            }
 
-			interface Bar extends Foo {}
-			      ",
+            interface Bar extends Foo {}
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": true }])),
         ),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			class Bar {}
-			      ",
+            class Bar {}
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": true }])),
         ),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			class Bar {}
-			      ",
+            class Bar {}
+                  ",
             Some(serde_json::json!([{ "allow_single_extends": true }])),
         ),
     ];
@@ -156,93 +156,93 @@ fn test() {
         ("interface Foo extends {}", None),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			class Baz {}
-			      ",
+            class Baz {}
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": false }])),
         ),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			class Bar {}
-			      ",
+            class Bar {}
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": false }])),
         ),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			const bar = class Bar {};
-			      ",
+            const bar = class Bar {};
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": false }])),
         ),
         (
             "
-			interface Foo {
-			  props: string;
-			}
+            interface Foo {
+              props: string;
+            }
 
-			interface Bar extends Foo {}
+            interface Bar extends Foo {}
 
-			const bar = class Bar {};
-			      ",
+            const bar = class Bar {};
+                  ",
             Some(serde_json::json!([{ "allow_single_extends": false }])),
         ),
         (
             "
-			interface Foo {
-			  name: string;
-			}
+            interface Foo {
+              name: string;
+            }
 
-			interface Bar extends Foo {}
-			      ",
+            interface Bar extends Foo {}
+                  ",
             Some(serde_json::json!([{ "allowSingleExtends": false }])),
         ),
         ("interface Foo extends Array<number> {}", None),
         ("interface Foo extends Array<number | {}> {}", None),
         (
             "
-			interface Bar {
-			  bar: string;
-			}
-			interface Foo extends Array<Bar> {}
-			      ",
+            interface Bar {
+              bar: string;
+            }
+            interface Foo extends Array<Bar> {}
+                  ",
             None,
         ),
         (
             "
-			type R = Record<string, unknown>;
-			interface Foo extends R {}
-			      ",
+            type R = Record<string, unknown>;
+            interface Foo extends R {}
+                  ",
             None,
         ),
         (
             "
-			interface Foo<T> extends Bar<T> {}
-			      ",
+            interface Foo<T> extends Bar<T> {}
+                  ",
             None,
         ),
         (
             "
-			declare module FooBar {
-			  type Baz = typeof baz;
-			  export interface Bar extends Baz {}
-			}
-			      ",
+            declare module FooBar {
+              type Baz = typeof baz;
+              export interface Bar extends Baz {}
+            }
+                  ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -279,48 +279,48 @@ fn test() {
     let pass = vec![
         (
             "
-			interface Base {
-			  name: string;
-			}
-			    ",
+            interface Base {
+              name: string;
+            }
+                ",
             None,
         ),
         (
             "
-			interface Base {
-			  name: string;
-			}
+            interface Base {
+              name: string;
+            }
 
-			interface Derived {
-			  age: number;
-			}
+            interface Derived {
+              age: number;
+            }
 
-			// valid because extending multiple interfaces can be used instead of a union type
-			interface Both extends Base, Derived {}
-			    ",
+            // valid because extending multiple interfaces can be used instead of a union type
+            interface Both extends Base, Derived {}
+                ",
             None,
         ),
         ("interface Base {}", Some(serde_json::json!([{ "allowInterfaces": "always" }]))),
         (
             "
-			interface Base {
-			  name: string;
-			}
+            interface Base {
+              name: string;
+            }
 
-			interface Derived extends Base {}
-			      ",
+            interface Derived extends Base {}
+                  ",
             Some(serde_json::json!([{ "allowInterfaces": "with-single-extends" }])),
         ),
         (
             "
-			interface Base {
-			  props: string;
-			}
+            interface Base {
+              props: string;
+            }
 
-			interface Derived extends Base {}
+            interface Derived extends Base {}
 
-			class Derived {}
-			      ",
+            class Derived {}
+                  ",
             Some(serde_json::json!([{ "allowInterfaces": "with-single-extends" }])),
         ),
         ("let value: object;", None),
@@ -341,76 +341,76 @@ fn test() {
         ("interface Base {}", Some(serde_json::json!([{ "allowInterfaces": "never" }]))),
         (
             "
-			interface Base {
-			  props: string;
-			}
+            interface Base {
+              props: string;
+            }
 
-			interface Derived extends Base {}
+            interface Derived extends Base {}
 
-			class Other {}
-			      ",
+            class Other {}
+                  ",
             None,
         ),
         (
             "
-			interface Base {
-			  props: string;
-			}
+            interface Base {
+              props: string;
+            }
 
-			interface Derived extends Base {}
+            interface Derived extends Base {}
 
-			class Derived {}
-			      ",
+            class Derived {}
+                  ",
             None,
         ),
         (
             "
-			interface Base {
-			  props: string;
-			}
+            interface Base {
+              props: string;
+            }
 
-			interface Derived extends Base {}
+            interface Derived extends Base {}
 
-			const derived = class Derived {};
-			      ",
+            const derived = class Derived {};
+                  ",
             None,
         ),
         (
             "
-			interface Base {
-			  name: string;
-			}
+            interface Base {
+              name: string;
+            }
 
-			interface Derived extends Base {}
-			      ",
+            interface Derived extends Base {}
+                  ",
             None,
         ),
         ("interface Base extends Array<number> {}", None),
         ("interface Base extends Array<number | {}> {}", None),
         (
             "
-			interface Derived {
-			  property: string;
-			}
-			interface Base extends Array<Derived> {}
-			      ",
+            interface Derived {
+              property: string;
+            }
+            interface Base extends Array<Derived> {}
+                  ",
             None,
         ),
         (
             "
-			type R = Record<string, unknown>;
-			interface Base extends R {}
-			      ",
+            type R = Record<string, unknown>;
+            interface Base extends R {}
+                  ",
             None,
         ),
         ("interface Base<T> extends Derived<T> {}", None),
         (
             "
-			declare namespace BaseAndDerived {
-			  type Base = typeof base;
-			  export interface Derived extends Base {}
-			}
-			      ",
+            declare namespace BaseAndDerived {
+              type Base = typeof base;
+              export interface Derived extends Base {}
+            }
+                  ",
             None,
         ),
         ("type Base = {};", None),
@@ -419,10 +419,10 @@ fn test() {
         ("let value: {};", Some(serde_json::json!([{ "allowObjectTypes": "never" }]))),
         (
             "
-			let value: {
-			  /* ... */
-			};
-			      ",
+            let value: {
+              /* ... */
+            };
+                  ",
             None,
         ),
         ("type MyUnion<T> = T | {};", None),

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -186,22 +186,22 @@ fn test() {
     let pass = vec![
         (
             "
-			class Foo {
-			  public prop = 1;
-			  constructor() {}
-			}
+            class Foo {
+              public prop = 1;
+              constructor() {}
+            }
             ",
             None,
         ),
         (
             "
-			export class CClass extends BaseClass {
-			  public static helper(): void {}
-			  private static privateHelper(): boolean {
-			    return true;
-			  }
-			  constructor() {}
-			}
+            export class CClass extends BaseClass {
+              public static helper(): void {}
+              private static privateHelper(): boolean {
+                return true;
+              }
+              constructor() {}
+            }
             ",
             None,
         ),
@@ -210,36 +210,36 @@ fn test() {
         ("class Foo { constructor() {} }", Some(json!([{ "allowConstructorOnly": true }]))),
         (
             "
-			export class Bar {
-			  public static helper(): void {}
-			  private static privateHelper(): boolean {
-			    return true;
-			  }
-			}
-			      ",
+            export class Bar {
+              public static helper(): void {}
+              private static privateHelper(): boolean {
+                return true;
+              }
+            }
+                  ",
             Some(json!([{ "allowStaticOnly": true }])),
         ),
         (
             "
-			export default class {
-			  hello() {
-			    return 'I am foo!';
-			  }
-			}
-		    ",
+            export default class {
+              hello() {
+                return 'I am foo!';
+              }
+            }
+            ",
             None,
         ),
         ("@FooDecorator class Foo {} ", Some(json!([{ "allowWithDecorator": true }]))),
         (
             "
-			@FooDecorator
-			class Foo {
-			  constructor(foo: Foo) {
-			    foo.subscribe(a => {
-			      console.log(a);
-			    });
-			  }
-			}
+            @FooDecorator
+            class Foo {
+              constructor(foo: Foo) {
+                foo.subscribe(a => {
+                  console.log(a);
+                });
+              }
+            }
             ",
             Some(json!([{ "allowWithDecorator": true }])),
         ),
@@ -251,67 +251,67 @@ fn test() {
         ("class Foo {}", None),
         (
             "
-			class Foo {
-			  public prop = 1;
-			  constructor() {
-			    class Bar {
-			      static PROP = 2;
-			    }
-			  }
-			}
-			export class Bar {
-			  public static helper(): void {}
-			  private static privateHelper(): boolean {
-			    return true;
-			  }
-			}
-			      ",
+            class Foo {
+              public prop = 1;
+              constructor() {
+                class Bar {
+                  static PROP = 2;
+                }
+              }
+            }
+            export class Bar {
+              public static helper(): void {}
+              private static privateHelper(): boolean {
+                return true;
+              }
+            }
+                  ",
             None,
         ),
         ("class Foo { constructor() {} }", None),
         (
             "
-			export class AClass {
-			  public static helper(): void {}
-			  private static privateHelper(): boolean {
-			    return true;
-			  }
-			  constructor() {
-			    class nestedClass {}
-			  }
-			}
-			      ",
+            export class AClass {
+              public static helper(): void {}
+              private static privateHelper(): boolean {
+                return true;
+              }
+              constructor() {
+                class nestedClass {}
+              }
+            }
+                  ",
             None,
         ),
         ("export default class { static hello() {} }", None),
         (
             "
-			@FooDecorator
-			class Foo {}
+            @FooDecorator
+            class Foo {}
             ",
             Some(json!([{ "allowWithDecorator": false }])),
         ),
         (
             "
-			@FooDecorator({
+            @FooDecorator({
               wowThisDecoratorIsQuiteLarge: true,
               itShouldNotBeIncludedIn: 'the diagnostic span',
             })
-			class Foo {}
+            class Foo {}
             ",
             Some(json!([{ "allowWithDecorator": false }])),
         ),
         (
             "
-			@FooDecorator
-			class Foo {
-			  constructor(foo: Foo) {
-			    foo.subscribe(a => {
-			      console.log(a);
-			    });
-			  }
-			}
-			",
+            @FooDecorator
+            class Foo {
+              constructor(foo: Foo) {
+                foo.subscribe(a => {
+                  console.log(a);
+                });
+              }
+            }
+            ",
             Some(json!([{ "allowWithDecorator": false }])),
         ),
         ("abstract class Foo {}", None),

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -148,7 +148,6 @@ fn test() {
         "import { type T, U } from 'mod';",
         "import { T, type U } from 'mod';",
         "import type T from 'mod';",
-        // "import type T, { U } from 'mod';", ts error 1363
         "import T, { type U } from 'mod';",
         "import type * as T from 'mod';",
         "import 'mod';",
@@ -162,15 +161,15 @@ fn test() {
     ];
 
     let fix = vec![
-        ("import { type A } from 'mod';", "import type { A } from 'mod';", None),
-        ("import { type A as AA } from 'mod';", "import type { A as AA } from 'mod';", None),
-        ("import { type A, type B } from 'mod';", "import type { A, B } from 'mod';", None),
+        ("import { type A } from 'mod';", "import type { A } from 'mod';"),
+        ("import { type A as AA } from 'mod';", "import type { A as AA } from 'mod';"),
+        ("import { type A, type B } from 'mod';", "import type { A, B } from 'mod';"),
         (
             "import { type A as AA, type B as BB } from 'mod';",
             "import type { A as AA, B as BB } from 'mod';",
-            None,
         ),
     ];
+
     Tester::new(NoImportTypeSideEffects::NAME, NoImportTypeSideEffects::PLUGIN, pass, fail)
         .expect_fix(fix)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -363,46 +363,46 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        (r"const a = 10n", None),
-        (r"const a = -10n", None),
-        (r"const a = BigInt(10)", None),
-        (r"const a = -BigInt(10)", None),
-        (r"const a = BigInt?.(10)", None),
-        (r"const a = -BigInt?.(10)", None),
-        (r"const a = false", None),
-        (r"const a = true", None),
-        (r"const a = Boolean(null)", None),
-        (r"const a = Boolean?.(null)", None),
-        (r"const a = !0", None),
-        (r"const a = 10", None),
-        (r"const a = +10", None),
-        (r"const a = -10", None),
-        (r#"const a = Number("1")"#, None),
-        (r#"const a = +Number("1")"#, None),
-        (r#"const a = -Number("1")"#, None),
-        (r#"const a = Number?.("1")"#, None),
-        (r#"const a = +Number?.("1")"#, None),
-        (r#"const a = -Number?.("1")"#, None),
-        (r"const a = Infinity", None),
-        (r"const a = +Infinity", None),
-        (r"const a = -Infinity", None),
-        (r"const a = NaN", None),
-        (r"const a = +NaN", None),
-        (r"const a = -NaN", None),
-        (r"const a = null", None),
-        (r"const a = /a/", None),
-        (r#"const a = RegExp("a")"#, None),
-        (r#"const a = RegExp?.("a")"#, None),
-        (r#"const a = new RegExp("a")"#, None),
-        (r#"const a = "str""#, None),
-        (r"const a = 'str'", None),
-        (r"const a = `str`", None),
-        (r"const a = String(1)", None),
-        (r"const a = String?.(1)", None),
-        (r#"const a = Symbol("a")"#, None),
-        (r#"const a = Symbol?.("a")"#, None),
-        (r"const a = undefined", None),
-        (r"const a = void someValue", None),
+        ("const a = 10n;", None),
+        ("const a = -10n;", None),
+        ("const a = BigInt(10);", None),
+        ("const a = -BigInt(10);", None),
+        ("const a = BigInt?.(10);", None),
+        ("const a = -BigInt?.(10);", None),
+        ("const a = false;", None),
+        ("const a = true;", None),
+        ("const a = Boolean(null);", None),
+        ("const a = Boolean?.(null);", None),
+        ("const a = !0;", None),
+        ("const a = 10;", None),
+        ("const a = +10;", None),
+        ("const a = -10;", None),
+        ("const a = Number('1');", None),
+        ("const a = +Number('1');", None),
+        ("const a = -Number('1');", None),
+        ("const a = Number?.('1');", None),
+        ("const a = +Number?.('1');", None),
+        ("const a = -Number?.('1');", None),
+        ("const a = Infinity;", None),
+        ("const a = +Infinity;", None),
+        ("const a = -Infinity;", None),
+        ("const a = NaN;", None),
+        ("const a = +NaN;", None),
+        ("const a = -NaN;", None),
+        ("const a = null;", None),
+        ("const a = /a/;", None),
+        ("const a = RegExp('a');", None),
+        ("const a = RegExp?.('a');", None),
+        ("const a = new RegExp('a');", None),
+        (r#"const a = "str";"#, None), // Single and double-quotes both work.
+        ("const a = 'str';", None),
+        ("const a = `str`;", None),
+        ("const a = String(1);", None),
+        ("const a = String?.(1);", None),
+        ("const a = Symbol('a');", None),
+        ("const a = Symbol?.('a');", None),
+        ("const a = undefined;", None),
+        ("const a = void someValue;", None),
         ("const fn = (a = 5, b = true, c = 'foo') => {};", None),
         ("const fn = function (a = 5, b = true, c = 'foo') {};", None),
         ("function fn(a = 5, b = true, c = 'foo') {}", None),
@@ -413,10 +413,19 @@ fn test() {
               a = 5;
               b = true;
               c = 'foo';
-            }",
+            }
+                ",
             None,
         ),
         ("class Foo { readonly a: number = 5; }", None),
+        (
+            "
+            class Foo {
+              accessor a = 5;
+            }
+                ",
+            None,
+        ),
         ("const a: any = 5;", None),
         ("const fn = function (a: any = 5, b: any = true, c: any = 'foo') {};", None),
         (
@@ -437,7 +446,16 @@ fn test() {
               a: number = 5;
               b: boolean = true;
               c: string = 'foo';
-            }",
+            }
+                  ",
+            Some(serde_json::json!([{ "ignoreProperties": true }])),
+        ),
+        (
+            "
+            class Foo {
+              accessor a: number = 5;
+            }
+                  ",
             Some(serde_json::json!([{ "ignoreProperties": true }])),
         ),
         (
@@ -446,73 +464,94 @@ fn test() {
               a?: number = 5;
               b?: boolean = true;
               c?: string = 'foo';
-            }",
+            }
+                  ",
             None,
         ),
         ("class Foo { constructor(public a = true) {} }", None),
     ];
 
     let fail = vec![
-        (r"const a: bigint = 10n", None),
-        (r"const a: bigint = -10n", None),
-        (r"const a: bigint = BigInt(10)", None),
-        (r"const a: bigint = -BigInt(10)", None),
-        (r"const a: bigint = BigInt?.(10)", None),
-        (r"const a: bigint = -BigInt?.(10)", None),
-        (r"const a: boolean = false", None),
-        (r"const a: boolean = true", None),
-        (r"const a: boolean = Boolean(null)", None),
-        (r"const a: boolean = Boolean?.(null)", None),
-        (r"const a: boolean = !0", None),
-        (r"const a: number = 10", None),
-        (r"const a: number = +10", None),
-        (r"const a: number = -10", None),
-        (r#"const a: number = Number("1")"#, None),
-        (r#"const a: number = +Number("1")"#, None),
-        (r#"const a: number = -Number("1")"#, None),
-        (r#"const a: number = Number?.("1")"#, None),
-        (r#"const a: number = +Number?.("1")"#, None),
-        (r#"const a: number = -Number?.("1")"#, None),
-        (r"const a: number = Infinity", None),
-        (r"const a: number = +Infinity", None),
-        (r"const a: number = -Infinity", None),
-        (r"const a: number = NaN", None),
-        (r"const a: number = +NaN", None),
-        (r"const a: number = -NaN", None),
-        (r"const a: null = null", None),
-        (r"const a: RegExp = /a/", None),
-        (r#"const a: RegExp = RegExp("a")"#, None),
-        (r#"const a: RegExp = RegExp?.("a")"#, None),
-        (r#"const a: RegExp = new RegExp("a")"#, None),
-        (r#"const a: string = "str""#, None),
-        (r"const a: string = 'str'", None),
-        (r"const a: string = `str`", None),
-        (r"const a: string = String(1)", None),
-        (r"const a: string = String?.(1)", None),
-        (r#"const a: symbol = Symbol("a")"#, None),
-        (r#"const a: symbol = Symbol?.("a")"#, None),
-        (r"const a: undefined = undefined", None),
-        (r"const a: undefined = void someValue", None),
+        ("const a: bigint = 10n;", None),
+        ("const a: bigint = -10n;", None),
+        ("const a: bigint = BigInt(10);", None),
+        ("const a: bigint = -BigInt(10);", None),
+        ("const a: bigint = BigInt?.(10);", None),
+        ("const a: bigint = -BigInt?.(10);", None),
+        ("const a: boolean = false;", None),
+        ("const a: boolean = true;", None),
+        ("const a: boolean = Boolean(null);", None),
+        ("const a: boolean = Boolean?.(null);", None),
+        ("const a: boolean = !0;", None),
+        ("const a: number = 10;", None),
+        ("const a: number = +10;", None),
+        ("const a: number = -10;", None),
+        ("const a: number = Number('1');", None),
+        ("const a: number = +Number('1');", None),
+        ("const a: number = -Number('1');", None),
+        ("const a: number = Number?.('1');", None),
+        ("const a: number = +Number?.('1');", None),
+        ("const a: number = -Number?.('1');", None),
+        ("const a: number = Infinity;", None),
+        ("const a: number = +Infinity;", None),
+        ("const a: number = -Infinity;", None),
+        ("const a: number = NaN;", None),
+        ("const a: number = +NaN;", None),
+        ("const a: number = -NaN;", None),
+        ("const a: null = null;", None),
+        ("const a: RegExp = /a/;", None),
+        ("const a: RegExp = RegExp('a');", None),
+        ("const a: RegExp = RegExp?.('a');", None),
+        ("const a: RegExp = new RegExp('a');", None),
+        (r#"const a: string = "str";"#, None), // This one exists to ensure single and double quotes both work.
+        ("const a: string = 'str';", None),
+        ("const a: string = `str`;", None),
+        ("const a: string = String(1);", None),
+        ("const a: string = String?.(1);", None),
+        ("const a: symbol = Symbol('a');", None),
+        ("const a: symbol = Symbol?.('a');", None),
+        ("const a: undefined = undefined;", None),
+        ("const a: undefined = void someValue;", None),
         (
-            "const fn = (a: number = 5) => {};",
-            Some(serde_json::json!([{ "ignoreParameters": false }])),
+            "const fn = (a?: number = 5) => {};",
+            Some(serde_json::json!([ { "ignoreParameters": false, }, ])),
         ),
-        ("class A { a!: number = 1; }", Some(serde_json::json!([{ "ignoreProperties": false }]))),
+        (
+            "
+            class A {
+              a!: number = 1;
+            }
+                  ",
+            Some(serde_json::json!([ { "ignoreProperties": false, }, ])),
+        ),
         (
             "const fn = (a: number = 5, b: boolean = true, c: string = 'foo') => {};",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
         (
-            "class Foo {
+            "
+            class Foo {
               a: number = 5;
               b: boolean = true;
               c: string = 'foo';
             }",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
         (
-            "class Foo { constructor(public a: boolean = true) {} }",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            "
+            class Foo {
+              constructor(public a: boolean = true) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
+        ),
+        (
+            "
+            class Foo {
+              accessor a: number = 5;
+            }
+                  ",
+            None,
         ),
     ];
 
@@ -556,65 +595,70 @@ fn test() {
         ("const a: symbol = Symbol?.('a');", "const a = Symbol?.('a');", None),
         ("const a: undefined = undefined;", "const a = undefined;", None),
         ("const a: undefined = void someValue;", "const a = void someValue;", None),
+        // (
+        //     "const fn = (a?: number = 5) => {};",
+        //     "const fn = (a = 5) => {};",
+        //     Some(serde_json::json!([ { "ignoreParameters": false, }, ])),
+        // ),
         (
             "
-			class A {
-			  a!: number = 1;
-			}
-			      ",
+            class A {
+              a!: number = 1;
+            }
+                  ",
             "
-			class A {
-			  a = 1;
-			}
-			      ",
-            Some(serde_json::json!([{ "ignoreProperties": false }])),
+            class A {
+              a = 1;
+            }
+                  ",
+            Some(serde_json::json!([ { "ignoreProperties": false, }, ])),
         ),
         (
             "const fn = (a: number = 5, b: boolean = true, c: string = 'foo') => {};",
             "const fn = (a = 5, b = true, c = 'foo') => {};",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
         (
             "
-			class Foo {
-			  a: number = 5;
-			  b: boolean = true;
-			  c: string = 'foo';
-			}
-			      ",
+            class Foo {
+              a: number = 5;
+              b: boolean = true;
+              c: string = 'foo';
+            }
+                  ",
             "
-			class Foo {
-			  a = 5;
-			  b = true;
-			  c = 'foo';
-			}
-			      ",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            class Foo {
+              a = 5;
+              b = true;
+              c = 'foo';
+            }
+                  ",
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
         (
             "
-			class Foo {
-			  constructor(public a: boolean = true) {}
-			}
-			      ",
+            class Foo {
+              constructor(public a: boolean = true) {}
+            }
+                  ",
             "
-			class Foo {
-			  constructor(public a = true) {}
-			}
-			      ",
-            Some(serde_json::json!([{ "ignoreParameters": false, "ignoreProperties": false }])),
+            class Foo {
+              constructor(public a = true) {}
+            }
+                  ",
+            Some(serde_json::json!([ { "ignoreParameters": false, "ignoreProperties": false, }, ])),
         ),
         (
             "
-			class Foo {
-			  accessor a: number = 5;
-			}
-			      ",
+            class Foo {
+              accessor a: number = 5;
+            }
+                  ",
             "
-			class Foo {
-			  accessor a = 5;
-			}
-			      ",
+            class Foo {
+              accessor a = 5;
+            }
+                  ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -122,49 +122,49 @@ fn test() {
         "foo() ?? bar!;",
         "(foo ?? bar)!;",
         "
-        	      let x: string;
-        	      x! ?? '';
-        	    ",
+                  let x: string;
+                  x! ?? '';
+                ",
         "
-        	      let x: string;
-        	      x ?? '';
-        	    ",
+                  let x: string;
+                  x ?? '';
+                ",
         "
-        	      let x!: string;
-        	      x ?? '';
-        	    ",
+                  let x!: string;
+                  x ?? '';
+                ",
         "
-        	      let x: string;
-        	      foo(x);
-        	      x! ?? '';
-        	    ",
+                  let x: string;
+                  foo(x);
+                  x! ?? '';
+                ",
         "
-        	      let x: string;
-        	      x! ?? '';
-        	      x = foo();
-        	    ",
+                  let x: string;
+                  x! ?? '';
+                  x = foo();
+                ",
         "
-        	      let x: string;
-        	      foo(x);
-        	      x! ?? '';
-        	      x = foo();
-        	    ",
+                  let x: string;
+                  foo(x);
+                  x! ?? '';
+                  x = foo();
+                ",
         "
-        	      let x = foo();
-        	      x ?? '';
-        	    ",
+                  let x = foo();
+                  x ?? '';
+                ",
         "
-        	      function foo() {
-        	        let x: string;
-        	        return x ?? '';
-        	      }
-        	    ",
+                  function foo() {
+                    let x: string;
+                    return x ?? '';
+                  }
+                ",
         "
-        	      let x: string;
-        	      function foo() {
-        	        return x ?? '';
-        	      }
-        	    ",
+                  let x: string;
+                  function foo() {
+                    return x ?? '';
+                  }
+                ",
     ];
 
     let fail = vec![
@@ -177,40 +177,40 @@ fn test() {
         "foo()! ?? bar;",
         "foo()! ?? bar!;",
         "
-        	let x!: string;
-        	x! ?? '';
-        	      ",
+            let x!: string;
+            x! ?? '';
+                  ",
         "
-        	let x: string;
-        	x = foo();
-        	x! ?? '';
-        	      ",
+            let x: string;
+            x = foo();
+            x! ?? '';
+                  ",
         "
-        	let x: string;
-        	x = foo();
-        	x! ?? '';
-        	x = foo();
-        	      ",
+            let x: string;
+            x = foo();
+            x! ?? '';
+            x = foo();
+                  ",
         "
-        	let x = foo();
-        	x! ?? '';
-        	      ",
+            let x = foo();
+            x! ?? '';
+                  ",
         "
-        	function foo() {
-        	  let x!: string;
-        	  return x! ?? '';
-        	}
-        	      ",
+            function foo() {
+              let x!: string;
+              return x! ?? '';
+            }
+                  ",
         "
-        	let x!: string;
-        	function foo() {
-        	  return x! ?? '';
-        	}
-        	      ",
+            let x!: string;
+            function foo() {
+              return x! ?? '';
+            }
+                  ",
         "
-        	let x = foo();
-        	x  ! ?? '';
-        	      ",
+            let x = foo();
+            x  ! ?? '';
+                  ",
     ];
 
     Tester::new(

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -83,25 +83,31 @@ fn test() {
         "x!?.y.z;",
         "x.y.z!?.();",
         "
-        	x!
-        	.y
-        	      ",
+            x!
+            .y
+                  ",
         "
-        	x!
-        	// comment
-        	.y
-        	      ",
+            x!
+            // comment
+            .y
+                  ",
         "
-        	x!
-        	 // comment
-        	    . /* comment */
-        	      y
-        	      ",
+            x!
+             // comment
+                . /* comment */
+                  y
+                  ",
         "
-        	x!
-        	 // comment
-        	     /* comment */ ['y']
-        	      ",
+            x!
+             // comment
+                 /* comment */ ['y']
+                  ",
+        "
+            document.querySelector('input')!.files = new FileList();
+                  ",
+        "
+            hoge.files = document.querySelector('input')!.files;
+                  ",
     ];
 
     Tester::new(NoNonNullAssertion::NAME, NoNonNullAssertion::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -214,10 +214,10 @@ fn test() {
         ("var lib3 = load?.('not_an_import');", None),
         (
             "
-			import { createRequire } from 'module';
-			const require = createRequire();
-			require('remark-preset-prettier');
-			    ",
+            import { createRequire } from 'module';
+            const require = createRequire();
+            require('remark-preset-prettier');
+                ",
             None,
         ),
         (
@@ -251,60 +251,60 @@ fn test() {
         ("import foo = require('foo');", Some(serde_json::json!([{ "allowAsImport": true }]))),
         (
             "
-			let require = bazz;
-			trick(require('foo'));
-			      ",
+            let require = bazz;
+            trick(require('foo'));
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			const foo = require('./foo.json') as Foo;
-			      ",
+            let require = bazz;
+            const foo = require('./foo.json') as Foo;
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			const foo: Foo = require('./foo.json').default;
-			      ",
+            let require = bazz;
+            const foo: Foo = require('./foo.json').default;
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			const foo = <Foo>require('./foo.json');
-			      ",
+            let require = bazz;
+            const foo = <Foo>require('./foo.json');
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			const configValidator = new Validator(require('./a.json'));
-			configValidator.addSchema(require('./a.json'));
-			      ",
+            let require = bazz;
+            const configValidator = new Validator(require('./a.json'));
+            configValidator.addSchema(require('./a.json'));
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			require('foo');
-			      ",
+            let require = bazz;
+            require('foo');
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			let require = bazz;
-			require?.('foo');
-			      ",
+            let require = bazz;
+            require?.('foo');
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         (
             "
-			import { createRequire } from 'module';
-			const require = createRequire();
-			require('remark-preset-prettier');
-			      ",
+            import { createRequire } from 'module';
+            const require = createRequire();
+            require('remark-preset-prettier');
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
     ];
@@ -314,9 +314,9 @@ fn test() {
         ("let lib2 = require('lib2');", None),
         (
             "
-			var lib5 = require('lib5'),
-			  lib6 = require('lib6');
-			      ",
+            var lib5 = require('lib5'),
+              lib6 = require('lib6');
+                  ",
             None,
         ),
         ("import lib8 = require('lib8');", None),
@@ -324,9 +324,9 @@ fn test() {
         ("let lib2 = require?.('lib2');", None),
         (
             "
-			var lib5 = require?.('lib5'),
-			  lib6 = require?.('lib6');
-			      ",
+            var lib5 = require?.('lib5'),
+              lib6 = require?.('lib6');
+                  ",
             None,
         ),
         ("const pkg = require('./package.json');", None),
@@ -367,9 +367,9 @@ fn test() {
         ),
         (
             "
-			const configValidator = new Validator(require('./a.json'));
-			configValidator.addSchema(require('./a.json'));
-			      ",
+            const configValidator = new Validator(require('./a.json'));
+            configValidator.addSchema(require('./a.json'));
+                  ",
             Some(serde_json::json!([{ "allowAsImport": true }])),
         ),
         ("require('foo');", Some(serde_json::json!([{ "allowAsImport": true }]))),

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -100,70 +100,70 @@ fn test() {
     let pass = vec![
         (
             "
-			interface Foo {}
-			class Bar implements Foo {}
-			    ",
+            interface Foo {}
+            class Bar implements Foo {}
+                ",
             None,
         ),
         (
             "
-         			namespace Foo {}
-         			namespace Foo {}
-         			    ",
+                     namespace Foo {}
+                     namespace Foo {}
+                         ",
             None,
         ),
         (
             "
-         			enum Foo {}
-         			namespace Foo {}
-         			    ",
+                     enum Foo {}
+                     namespace Foo {}
+                         ",
             None,
         ),
         (
             "
-         			namespace Fooo {}
-         			function Foo() {}
-         			    ",
+                     namespace Fooo {}
+                     function Foo() {}
+                         ",
             None,
         ),
         (
             "
-         			const Foo = class {};
-         			    ",
+                     const Foo = class {};
+                         ",
             None,
         ),
         (
             "
-         			interface Foo {
-         			  props: string;
-         			}
+                     interface Foo {
+                       props: string;
+                     }
 
-         			function bar() {
-         			  return class Foo {};
-         			}
-         			    ",
+                     function bar() {
+                       return class Foo {};
+                     }
+                         ",
             None,
         ),
         (
             "
-         			interface Foo {
-         			  props: string;
-         			}
+                     interface Foo {
+                       props: string;
+                     }
 
-         			(function bar() {
-         			  class Foo {}
-         			})();
-         			    ",
+                     (function bar() {
+                       class Foo {}
+                     })();
+                         ",
             None,
         ),
         (
             "
-         			declare global {
-         			  interface Foo {}
-         			}
+                     declare global {
+                       interface Foo {}
+                     }
 
-         			class Foo {}
-         			    ",
+                     class Foo {}
+                         ",
             None,
         ),
     ];
@@ -171,25 +171,25 @@ fn test() {
     let fail = vec![
         (
             "
-			interface Foo {}
-			class Foo {}
-			      ",
+            interface Foo {}
+            class Foo {}
+                  ",
             None,
         ),
         (
             "
-         			class Foo {}
-         			interface Foo {}
-         			      ",
+                     class Foo {}
+                     interface Foo {}
+                           ",
             None,
         ),
         (
             "
-         			declare global {
-         			  interface Foo {}
-         			  class Foo {}
-         			}
-         			      ",
+                     declare global {
+                       interface Foo {}
+                       class Foo {}
+                     }
+                           ",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -113,15 +113,15 @@ fn test() {
         "let value: Function[];",
         "let value: Function | number;",
         "
-			        class Weird implements Function {
-			          // ...
-			        }
-			      ",
+                    class Weird implements Function {
+                      // ...
+                    }
+                  ",
         "
-			        interface Weird extends Function {
-			          // ...
-			        }
-			      ",
+                    interface Weird extends Function {
+                      // ...
+                    }
+                  ",
     ];
 
     Tester::new(NoUnsafeFunctionType::NAME, NoUnsafeFunctionType::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -151,17 +151,17 @@ fn test() {
         "type Void = {};",
         "class MyClass extends Number {}",
         "
-        	      type Number = 0 | 1;
-        	      let value: Number;
-        	    ",
+                  type Number = 0 | 1;
+                  let value: Number;
+                ",
         "
-        	      type Bigint = 0 | 1;
-        	      let value: Bigint;
-        	    ",
+                  type Bigint = 0 | 1;
+                  let value: Bigint;
+                ",
         "
-        	      type T<Symbol> = Symbol;
-        	      type U<UU> = UU extends T<infer Function> ? Function : never;
-        	    ",
+                  type T<Symbol> = Symbol;
+                  type U<UU> = UU extends T<infer Function> ? Function : never;
+                ",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -100,51 +100,51 @@ fn test() {
 
     let pass = vec![
         "
-			enum Direction {}
-			    ",
+            enum Direction {}
+                ",
         "
-			enum Direction {
-			  Up = 1,
-			}
-			    ",
+            enum Direction {
+              Up = 1,
+            }
+                ",
         "
-			enum Direction {
-			  Up = 1,
-			  Down = 2,
-			}
-			    ",
+            enum Direction {
+              Up = 1,
+              Down = 2,
+            }
+                ",
         "
-			enum Direction {
-			  Up = 'Up',
-			  Down = 'Down',
-			}
-			    ",
+            enum Direction {
+              Up = 'Up',
+              Down = 'Down',
+            }
+                ",
     ];
 
     let fail = vec![
         "
-			enum Direction {
-			  Up,
-			}
-			      ",
+            enum Direction {
+              Up,
+            }
+                  ",
         "
-			enum Direction {
-			  Up,
-			  Down,
-			}
-			      ",
+            enum Direction {
+              Up,
+              Down,
+            }
+                  ",
         "
-			enum Direction {
-			  Up = 'Up',
-			  Down,
-			}
-			      ",
+            enum Direction {
+              Up = 'Up',
+              Down,
+            }
+                  ",
         "
-			enum Direction {
-			  Up,
-			  Down = 'Down',
-			}
-			      ",
+            enum Direction {
+              Up,
+              Down = 'Down',
+            }
+                  ",
     ];
 
     // Each test case provides 3 suggestions: index, index+1, and member name as string

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -128,234 +128,329 @@ fn test() {
     let pass = vec![
         (
             "
-        	enum ValidRegex {
-                A = /test/,
+            enum ValidRegex {
+              A = /test/,
             }
-        	    ",
+                ",
             None,
         ),
         (
             "
-        	enum ValidString {
-        	  A = 'test',
-        	}
-        	    ",
+            enum ValidString {
+              A = 'test',
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidLiteral {
-        	  A = `test`,
-        	}
-        	    ",
+            enum ValidLiteral {
+              A = `test`,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidNumber {
-        	  A = 42,
-        	}
-        	    ",
+            enum ValidNumber {
+              A = 42,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidNumber {
-        	  A = -42,
-        	}
-        	    ",
+            enum ValidNumber {
+              A = -42,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidNumber {
-        	  A = +42,
-        	}
-        	    ",
+            enum ValidNumber {
+              A = +42,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidNull {
-        	  A = null,
-        	}
-        	    ",
+            enum ValidNull {
+              A = null,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidPlain {
-        	  A,
-        	}
-        	    ",
+            enum ValidPlain {
+              A,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidQuotedKey {
-        	  'a',
-        	}
-        	    ",
+            enum ValidQuotedKey {
+              'a',
+            }
+                ",
             None,
         ),
         (
             "
-        	enum ValidQuotedKeyWithAssignment {
-        	  'a' = 1,
-        	}
-        	    ",
+            enum ValidQuotedKeyWithAssignment {
+              'a' = 1,
+            }
+                ",
             None,
         ),
         (
             "
-        	enum Foo {
-        	  A = 1 << 0,
-        	  B = 1 >> 0,
-        	  C = 1 >>> 0,
-        	  D = 1 | 0,
-        	  E = 1 & 0,
-        	  F = 1 ^ 0,
-        	  G = ~1,
-        	}
-        	      ",
+            enum Foo {
+              A = 1 << 0,
+              B = 1 >> 0,
+              C = 1 >>> 0,
+              D = 1 | 0,
+              E = 1 & 0,
+              F = 1 ^ 0,
+              G = ~1,
+            }
+                  ",
             Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
         ),
+        // TODO: Fix these to allow `|`.
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 >> 0,
+        //       C = A | B,
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 >> 0,
+        //       C = Foo.A | Foo.B,
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 >> 0,
+        //       C = Foo['A'] | B,
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 << 1,
+        //       C = 1 << 2,
+        //       D = A | B | C,
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 << 1,
+        //       C = 1 << 2,
+        //       D = Foo.A | Foo.B | Foo.C,
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 << 1,
+        //       C = 1 << 2,
+        //       D = Foo.A | (Foo.B & ~Foo.C),
+        //     }
+        //           ",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
+        // TODO: Fix
+        // (
+        //     "
+        //     enum Foo {
+        //       A = 1 << 0,
+        //       B = 1 << 1,
+        //       C = 1 << 2,
+        //       D = Foo.A | -Foo.B,
+        //     }",
+        //     Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        // ),
     ];
 
     let fail = vec![
         (
             "
-        	enum InvalidObject {
-        	  A = {},
-        	}
-        	      ",
+            enum InvalidObject {
+              A = {},
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidArray {
-        	  A = [],
-        	}
-        	      ",
+            enum InvalidArray {
+              A = [],
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidTemplateLiteral {
-        	  A = `foo ${0}`,
-        	}
-        	      ",
+            enum InvalidTemplateLiteral {
+              A = `foo ${0}`,
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidConstructor {
-        	  A = new Set(),
-        	}
-        	      ",
+            enum InvalidConstructor {
+              A = new Set(),
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidExpression {
-        	  A = 2 + 2,
-        	}
-        	      ",
+            enum InvalidExpression {
+              A = 2 + 2,
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidExpression {
-        	  A = delete 2,
-        	  B = -a,
-        	  C = void 2,
-        	  D = ~2,
-        	  E = !0,
-        	}
-        	      ",
+            enum InvalidExpression {
+              A = delete 2,
+              B = -a,
+              C = void 2,
+              D = ~2,
+              E = !0,
+            }
+                  ",
             None,
         ),
         (
             "
-        	const variable = 'Test';
-        	enum InvalidVariable {
-        	  A = 'TestStr',
-        	  B = 2,
-        	  C,
-        	  V = variable,
-        	}
-        	      ",
+            const variable = 'Test';
+            enum InvalidVariable {
+              A = 'TestStr',
+              B = 2,
+              C,
+              V = variable,
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum InvalidEnumMember {
-        	  A = 'TestStr',
-        	  B = A,
-        	}
-        	      ",
+            enum InvalidEnumMember {
+              A = 'TestStr',
+              B = A,
+            }
+                  ",
             None,
         ),
         (
             "
-        	const Valid = { A: 2 };
-        	enum InvalidObjectMember {
-        	  A = 'TestStr',
-        	  B = Valid.A,
-        	}
-        	      ",
+            const Valid = { A: 2 };
+            enum InvalidObjectMember {
+              A = 'TestStr',
+              B = Valid.A,
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum Valid {
-        	  A,
-        	}
-        	enum InvalidEnumMember {
-        	  A = 'TestStr',
-        	  B = Valid.A,
-        	}
-        	      ",
+            enum Valid {
+              A,
+            }
+            enum InvalidEnumMember {
+              A = 'TestStr',
+              B = Valid.A,
+            }
+                  ",
             None,
         ),
         (
             "
-        	const obj = { a: 1 };
-        	enum InvalidSpread {
-        	  A = 'TestStr',
-        	  B = { ...a },
-        	}
-        	      ",
+            const obj = { a: 1 };
+            enum InvalidSpread {
+              A = 'TestStr',
+              B = { ...a },
+            }
+                  ",
             None,
         ),
         (
             "
-        	enum Foo {
-        	  A = 1 << 0,
-        	  B = 1 >> 0,
-        	  C = 1 >>> 0,
-        	  D = 1 | 0,
-        	  E = 1 & 0,
-        	  F = 1 ^ 0,
-        	  G = ~1,
-        	}
-        	      ",
+            enum Foo {
+              A = 1 << 0,
+              B = 1 >> 0,
+              C = 1 >>> 0,
+              D = 1 | 0,
+              E = 1 & 0,
+              F = 1 ^ 0,
+              G = ~1,
+            }
+                  ",
             Some(serde_json::json!([{ "allowBitwiseExpressions": false }])),
         ),
         (
             "
-        	const x = 1;
-        	enum Foo {
-        	  A = x << 0,
-        	  B = x >> 0,
-        	  C = x >>> 0,
-        	  D = x | 0,
-        	  E = x & 0,
-        	  F = x ^ 0,
-        	  G = ~x,
-        	}
-        	      ",
+            const x = 1;
+            enum Foo {
+              A = x << 0,
+              B = x >> 0,
+              C = x >>> 0,
+              D = x | 0,
+              E = x & 0,
+              F = x ^ 0,
+              G = ~x,
+            }
+                  ",
             Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        ),
+        (
+            "
+            const x = 1;
+            enum Foo {
+              A = 1 << 0,
+              B = x >> Foo.A,
+              C = x >> A,
+            }
+                  ",
+            Some(serde_json::json!([{ "allowBitwiseExpressions": true }])),
+        ),
+        (
+            "
+            enum Foo {
+              A,
+              B = +A,
+            }
+                  ",
+            None,
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -211,109 +211,109 @@ fn test() {
     let pass = vec![
         (
             r#"
-        	        // <reference path="foo" />
-        	        // <reference types="bar" />
-        	        // <reference lib="baz" />
-        	        import * as foo from 'foo';
-        	        import * as bar from 'bar';
-        	        import * as baz from 'baz';
-        	      "#,
-            Some(serde_json::json!([{ "path": "never", "types": "never", "lib": "never" }])),
+                    // <reference path="foo" />
+                    // <reference types="bar" />
+                    // <reference lib="baz" />
+                    import * as foo from 'foo';
+                    import * as bar from 'bar';
+                    import * as baz from 'baz';
+                  "#,
+            Some(serde_json::json!([{ "lib": "never", "path": "never", "types": "never" }])),
         ),
         (
             r#"
-        	        // <reference path="foo" />
-        	        // <reference types="bar" />
-        	        // <reference lib="baz" />
-        	        import foo = require('foo');
-        	        import bar = require('bar');
-        	        import baz = require('baz');
-        	      "#,
-            Some(serde_json::json!([{ "path": "never", "types": "never", "lib": "never" }])),
+                    // <reference path="foo" />
+                    // <reference types="bar" />
+                    // <reference lib="baz" />
+                    import foo = require('foo');
+                    import bar = require('bar');
+                    import baz = require('baz');
+                  "#,
+            Some(serde_json::json!([{ "lib": "never", "path": "never", "types": "never" }])),
         ),
         (
             r#"
-        	        /// <reference path="foo" />
-        	        /// <reference types="bar" />
-        	        /// <reference lib="baz" />
-        	        import * as foo from 'foo';
-        	        import * as bar from 'bar';
-        	        import * as baz from 'baz';
-        	      "#,
-            Some(serde_json::json!([{ "path": "always", "types": "always", "lib": "always" }])),
+                    /// <reference path="foo" />
+                    /// <reference types="bar" />
+                    /// <reference lib="baz" />
+                    import * as foo from 'foo';
+                    import * as bar from 'bar';
+                    import * as baz from 'baz';
+                  "#,
+            Some(serde_json::json!([{ "lib": "always", "path": "always", "types": "always" }])),
         ),
         (
             r#"
-        	        /// <reference path="foo" />
-        	        /// <reference types="bar" />
-        	        /// <reference lib="baz" />
-        	        import foo = require('foo');
-        	        import bar = require('bar');
-        	        import baz = require('baz');
-        	      "#,
-            Some(serde_json::json!([{ "path": "always", "types": "always", "lib": "always" }])),
+                    /// <reference path="foo" />
+                    /// <reference types="bar" />
+                    /// <reference lib="baz" />
+                    import foo = require('foo');
+                    import bar = require('bar');
+                    import baz = require('baz');
+                  "#,
+            Some(serde_json::json!([{ "lib": "always", "path": "always", "types": "always" }])),
         ),
         (
             r#"
-        	        /// <reference path="foo" />
-        	        /// <reference types="bar" />
-        	        /// <reference lib="baz" />
-        	        import foo = foo;
-        	        import bar = bar;
-        	        import baz = baz;
-        	      "#,
-            Some(serde_json::json!([{ "path": "always", "types": "always", "lib": "always" }])),
+                    /// <reference path="foo" />
+                    /// <reference types="bar" />
+                    /// <reference lib="baz" />
+                    import foo = foo;
+                    import bar = bar;
+                    import baz = baz;
+                  "#,
+            Some(serde_json::json!([{ "lib": "always", "path": "always", "types": "always" }])),
         ),
         (
             r#"
-        	        /// <reference path="foo" />
-        	        /// <reference types="bar" />
-        	        /// <reference lib="baz" />
-        	        import foo = foo.foo;
-        	        import bar = bar.bar.bar.bar;
-        	        import baz = baz.baz;
-        	      "#,
-            Some(serde_json::json!([{ "path": "always", "types": "always", "lib": "always" }])),
+                    /// <reference path="foo" />
+                    /// <reference types="bar" />
+                    /// <reference lib="baz" />
+                    import foo = foo.foo;
+                    import bar = bar.bar.bar.bar;
+                    import baz = baz.baz;
+                  "#,
+            Some(serde_json::json!([{ "lib": "always", "path": "always", "types": "always" }])),
         ),
-        (r"import * as foo from 'foo';", Some(serde_json::json!([{ "path": "never" }]))),
-        (r"import foo = require('foo');", Some(serde_json::json!([{ "path": "never" }]))),
-        (r"import * as foo from 'foo';", Some(serde_json::json!([{ "types": "never" }]))),
-        (r"import foo = require('foo');", Some(serde_json::json!([{ "types": "never" }]))),
-        (r"import * as foo from 'foo';", Some(serde_json::json!([{ "lib": "never" }]))),
-        (r"import foo = require('foo');", Some(serde_json::json!([{ "lib": "never" }]))),
-        (r"import * as foo from 'foo';", Some(serde_json::json!([{ "types": "prefer-import" }]))),
-        (r"import foo = require('foo');", Some(serde_json::json!([{ "types": "prefer-import" }]))),
+        ("import * as foo from 'foo';", Some(serde_json::json!([{ "path": "never" }]))),
+        ("import foo = require('foo');", Some(serde_json::json!([{ "path": "never" }]))),
+        ("import * as foo from 'foo';", Some(serde_json::json!([{ "types": "never" }]))),
+        ("import foo = require('foo');", Some(serde_json::json!([{ "types": "never" }]))),
+        ("import * as foo from 'foo';", Some(serde_json::json!([{ "lib": "never" }]))),
+        ("import foo = require('foo');", Some(serde_json::json!([{ "lib": "never" }]))),
+        ("import * as foo from 'foo';", Some(serde_json::json!([{ "types": "prefer-import" }]))),
+        ("import foo = require('foo');", Some(serde_json::json!([{ "types": "prefer-import" }]))),
         (
             r#"
-        	        /// <reference types="foo" />
-        	        import * as bar from 'bar';
-        	      "#,
+                    /// <reference types="foo" />
+                    import * as bar from 'bar';
+                  "#,
             Some(serde_json::json!([{ "types": "prefer-import" }])),
         ),
         (
             r#"
-        	        /*
-        	        /// <reference types="foo" />
-        	        */
-        	        import * as foo from 'foo';
-        	      "#,
-            Some(serde_json::json!([{ "path": "never", "types": "never", "lib": "never" }])),
+                    /*
+                    /// <reference types="foo" />
+                    */
+                    import * as foo from 'foo';
+                  "#,
+            Some(serde_json::json!([{ "lib": "never", "path": "never", "types": "never" }])),
         ),
     ];
 
     let fail = vec![
         (
             r#"
-			/// <reference types="foo" />
-			import * as foo from 'foo';
-			      "#,
+            /// <reference types="foo" />
+            import * as foo from 'foo';
+                  "#,
             Some(serde_json::json!([{ "types": "prefer-import" }])),
         ),
         (
             r#"
-        	/// <reference types="foo" />
-        	import foo = require('foo');
-        	      "#,
+            /// <reference types="foo" />
+            import foo = require('foo');
+                  "#,
             Some(serde_json::json!([{ "types": "prefer-import" }])),
         ),
         (r#"/// <reference path="foo" />"#, Some(serde_json::json!([{ "path": "never" }]))),

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow_restricted_names.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint(no-shadow-restricted-names): Shadowing of global properties such as `undefined` is not allowed.
    ╭─[no_shadow_restricted_names.tsx:1:10]
  1 │ function NaN(NaN) { var NaN; !function NaN(NaN) { try {} catch(NaN) {} }; }

--- a/crates/oxc_linter/src/snapshots/eslint_no_unmodified_loop_condition.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unmodified_loop_condition.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(no-unmodified-loop-condition): 'foo' is not modified in this loop.

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:3:7]
+   ╭─[consistent_generic_constructors.tsx:3:16]
  2 │             class Foo {
  3 │               a: Foo<string> = new Foo();
    ·                ─────────────
@@ -76,7 +76,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:3:9]
+   ╭─[consistent_generic_constructors.tsx:3:18]
  2 │             class Foo {
  3 │               [a]: Foo<string> = new Foo();
    ·                  ─────────────
@@ -85,7 +85,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:2:18]
+   ╭─[consistent_generic_constructors.tsx:2:27]
  1 │ 
  2 │             function foo(a: Foo<string> = new Foo()) {}
    ·                           ─────────────
@@ -94,7 +94,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:2:22]
+   ╭─[consistent_generic_constructors.tsx:2:31]
  1 │ 
  2 │             function foo({ a }: Foo<string> = new Foo()) {}
    ·                               ─────────────
@@ -103,7 +103,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:2:20]
+   ╭─[consistent_generic_constructors.tsx:2:29]
  1 │ 
  2 │             function foo([a]: Foo<string> = new Foo()) {}
    ·                             ─────────────
@@ -112,7 +112,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:3:19]
+   ╭─[consistent_generic_constructors.tsx:3:28]
  2 │             class A {
  3 │               constructor(a: Foo<string> = new Foo()) {}
    ·                            ─────────────
@@ -121,7 +121,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
-   ╭─[consistent_generic_constructors.tsx:2:25]
+   ╭─[consistent_generic_constructors.tsx:2:34]
  1 │ 
  2 │             const a = function (a: Foo<string> = new Foo()) {};
    ·                                  ─────────────
@@ -158,7 +158,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:2:8]
+   ╭─[consistent_generic_constructors.tsx:2:17]
  1 │ const a = new
  2 │              Foo<string>
    ·                 ────────
@@ -181,7 +181,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:3:17]
+   ╭─[consistent_generic_constructors.tsx:3:26]
  2 │             class Foo {
  3 │               a = new Foo<string>();
    ·                          ────────
@@ -190,7 +190,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:3:19]
+   ╭─[consistent_generic_constructors.tsx:3:28]
  2 │             class Foo {
  3 │               [a] = new Foo<string>();
    ·                            ────────
@@ -199,7 +199,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:3:23]
+   ╭─[consistent_generic_constructors.tsx:3:32]
  2 │             class Foo {
  3 │               [a + b] = new Foo<string>();
    ·                                ────────
@@ -208,7 +208,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:2:28]
+   ╭─[consistent_generic_constructors.tsx:2:37]
  1 │ 
  2 │             function foo(a = new Foo<string>()) {}
    ·                                     ────────
@@ -217,7 +217,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:2:32]
+   ╭─[consistent_generic_constructors.tsx:2:41]
  1 │ 
  2 │             function foo({ a } = new Foo<string>()) {}
    ·                                         ────────
@@ -226,7 +226,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:2:30]
+   ╭─[consistent_generic_constructors.tsx:2:39]
  1 │ 
  2 │             function foo([a] = new Foo<string>()) {}
    ·                                       ────────
@@ -235,7 +235,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:3:29]
+   ╭─[consistent_generic_constructors.tsx:3:38]
  2 │             class A {
  3 │               constructor(a = new Foo<string>()) {}
    ·                                      ────────
@@ -244,7 +244,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the generic type to the type annotation
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
-   ╭─[consistent_generic_constructors.tsx:2:35]
+   ╭─[consistent_generic_constructors.tsx:2:44]
  1 │ 
  2 │             const a = function (a = new Foo<string>()) {};
    ·                                            ────────

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_indexed_object_style.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_indexed_object_style.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [key: string]: any;
    ·               ───────────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               readonly [key: string]: any;
    ·               ────────────────────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<A> {
  3 │               [key: string]: A;
    ·               ─────────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<A = any> {
  3 │               [key: string]: A;
    ·               ─────────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface B extends A {
  3 │               [index: number]: unknown;
    ·               ─────────────────────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<A> {
  3 │               readonly [key: string]: A;
    ·               ──────────────────────────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<A, B> {
  3 │               [key: A]: B;
    ·               ────────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<A, B> {
  3 │               readonly [key: A]: B;
    ·               ─────────────────────
@@ -173,7 +173,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo<T> {
  3 │               [k: string]: T;
    ·               ───────────────
@@ -182,7 +182,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [k: string]: A.Foo;
    ·               ───────────────────
@@ -191,7 +191,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:21]
+   ╭─[consistent_indexed_object_style.tsx:3:30]
  2 │             interface Foo {
  3 │               [k: string]: { [key: string]: Foo };
    ·                              ──────────────────
@@ -200,7 +200,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [key: string]: { foo: Foo };
    ·               ────────────────────────────
@@ -209,7 +209,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [key: string]: Foo[];
    ·               ─────────────────────
@@ -218,7 +218,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [key: string]: () => Foo;
    ·               ─────────────────────────
@@ -227,7 +227,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo {
  3 │               [s: string]: [Foo];
    ·               ───────────────────
@@ -236,7 +236,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo1 {
  3 │               [key: string]: Foo2;
    ·               ────────────────────
@@ -245,7 +245,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             interface Foo1 {
  3 │               [key: string]: Record<string, Foo2>;
    ·               ────────────────────────────────────
@@ -254,7 +254,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             type Foo1 = {
  3 │               [key: string]: { foo2: Foo2 };
    ·               ──────────────────────────────
@@ -263,7 +263,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:7:6]
+   ╭─[consistent_indexed_object_style.tsx:7:15]
  6 │             type Foo2 = {
  7 │               [key: string]: Foo3;
    ·               ────────────────────
@@ -272,7 +272,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-    ╭─[consistent_indexed_object_style.tsx:11:6]
+    ╭─[consistent_indexed_object_style.tsx:11:15]
  10 │             type Foo3 = {
  11 │               [key: string]: Record<string, Foo1>;
     ·               ────────────────────────────────────
@@ -281,7 +281,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:42]
+   ╭─[consistent_indexed_object_style.tsx:2:51]
  1 │     
  2 │ ╭─▶             type Foos<K extends string = never> = {
  3 │ │                 [k in K]: { foo: Foo };
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:42]
+   ╭─[consistent_indexed_object_style.tsx:2:51]
  1 │     
  2 │ ╭─▶             type Foos<K extends string = never> = {
  3 │ │                 [k in K]: Foo[];
@@ -378,7 +378,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:20]
+   ╭─[consistent_indexed_object_style.tsx:2:29]
  1 │ 
  2 │             function foo(e: { [key in PropertyKey]?: string }) {}
    ·                             ─────────────────────────────────
@@ -387,7 +387,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:20]
+   ╭─[consistent_indexed_object_style.tsx:2:29]
  1 │ 
  2 │             function foo(e: { [key in PropertyKey]+?: string }) {}
    ·                             ──────────────────────────────────
@@ -396,7 +396,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:20]
+   ╭─[consistent_indexed_object_style.tsx:2:29]
  1 │ 
  2 │             function foo(e: { [key in PropertyKey]-?: string }) {}
    ·                             ──────────────────────────────────
@@ -405,7 +405,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:20]
+   ╭─[consistent_indexed_object_style.tsx:2:29]
  1 │ 
  2 │             function foo(e: { readonly [key in PropertyKey]-?: string }) {}
    ·                             ───────────────────────────────────────────
@@ -414,7 +414,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             type Options = [
  3 │               { [Type in (typeof optionTesters)[number]['option']]?: boolean } & {
    ·               ────────────────────────────────────────────────────────────────
@@ -423,7 +423,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:61]
+   ╭─[consistent_indexed_object_style.tsx:2:70]
  1 │     
  2 │ ╭─▶             export type MakeRequired<Base, Key extends keyof Base> = {
  3 │ │                 [K in Key]-?: NonNullable<Base[Key]>;
@@ -433,7 +433,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:18]
+   ╭─[consistent_indexed_object_style.tsx:2:27]
  1 │     
  2 │ ╭─▶             function f(): {
  3 │ │                 [k in (keyof ParseResult)]: unknown;
@@ -443,7 +443,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:2:15]
+   ╭─[consistent_indexed_object_style.tsx:2:24]
  1 │     
  2 │ ╭─▶             type Foo = {
  3 │ │                 [k in string];
@@ -453,7 +453,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a record type such as `Record<string, unknown>` instead of an index signature.
 
   ⚠ typescript-eslint(consistent-indexed-object-style): A record is preferred over an index signature.
-   ╭─[consistent_indexed_object_style.tsx:3:6]
+   ╭─[consistent_indexed_object_style.tsx:3:15]
  2 │             export default interface SchedulerService {
  3 │               [key: string]: unknown;
    ·               ───────────────────────

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_definitions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_definitions.snap
@@ -24,17 +24,17 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `type T=                         { x: number; };` with `interface T { x: number; }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `interface` instead of `type`.
-   ╭─[consistent_type_definitions.tsx:2:11]
+   ╭─[consistent_type_definitions.tsx:2:20]
  1 │ 
  2 │             export type W<T> = {
    ·                    ────
  3 │               x: T;
    ╰────
   help: Replace `type W<T> = {
-        			  x: T;
-        			};` with `interface W<T> {
-        			  x: T;
-        			}`.
+                      x: T;
+                    };` with `interface W<T> {
+                      x: T;
+                    }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
    ╭─[consistent_type_definitions.tsx:1:1]
@@ -79,59 +79,59 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `interface A extends B<T1>, C<T2> { x: number; }` with `type A = { x: number; } & B<T1> & C<T2>`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:2:11]
+   ╭─[consistent_type_definitions.tsx:2:20]
  1 │ 
  2 │             export interface W<T> {
    ·                    ─────────
  3 │               x: T;
    ╰────
   help: Replace `interface W<T> {
-        			  x: T;
-        			}` with `type W<T> = {
-        			  x: T;
-        			}`.
+                      x: T;
+                    }` with `type W<T> = {
+                      x: T;
+                    }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:3:6]
+   ╭─[consistent_type_definitions.tsx:3:15]
  2 │             namespace JSX {
  3 │               interface Array<T> {
    ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Replace `interface Array<T> {
-        			    foo(x: (x: number) => T): T[];
-        			  }` with `type Array<T> = {
-        			    foo(x: (x: number) => T): T[];
-        			  }`.
+                        foo(x: (x: number) => T): T[];
+                      }` with `type Array<T> = {
+                        foo(x: (x: number) => T): T[];
+                      }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:3:6]
+   ╭─[consistent_type_definitions.tsx:3:15]
  2 │             global {
  3 │               interface Array<T> {
    ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Replace `interface Array<T> {
-        			    foo(x: (x: number) => T): T[];
-        			  }` with `type Array<T> = {
-        			    foo(x: (x: number) => T): T[];
-        			  }`.
+                        foo(x: (x: number) => T): T[];
+                      }` with `type Array<T> = {
+                        foo(x: (x: number) => T): T[];
+                      }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:3:6]
+   ╭─[consistent_type_definitions.tsx:3:15]
  2 │             declare global {
  3 │               interface Array<T> {
    ·               ─────────
  4 │                 foo(x: (x: number) => T): T[];
    ╰────
   help: Replace `interface Array<T> {
-        			    foo(x: (x: number) => T): T[];
-        			  }` with `type Array<T> = {
-        			    foo(x: (x: number) => T): T[];
-        			  }`.
+                        foo(x: (x: number) => T): T[];
+                      }` with `type Array<T> = {
+                        foo(x: (x: number) => T): T[];
+                      }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:4:8]
+   ╭─[consistent_type_definitions.tsx:4:17]
  3 │               namespace Foo {
  4 │                 interface Bar {}
    ·                 ─────────
@@ -140,65 +140,65 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `interface Bar {}` with `type Bar = {}`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:2:19]
+   ╭─[consistent_type_definitions.tsx:2:28]
  1 │ 
  2 │             export default interface Test {
    ·                            ─────────
  3 │               bar(): string;
    ╰────
   help: Replace `export default interface Test {
-        			  bar(): string;
-        			  foo(): number;
-        			}` with `type Test = {
-        			  bar(): string;
-        			  foo(): number;
-        			}
+                      bar(): string;
+                      foo(): number;
+                    }` with `type Test = {
+                      bar(): string;
+                      foo(): number;
+                    }
         export default Test`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:2:19]
+   ╭─[consistent_type_definitions.tsx:2:28]
  1 │ 
  2 │             export default interface Test {
    ·                            ─────────
  3 │               bar(): string;
    ╰────
   help: Replace `interface Test {
-        			  bar(): string;
-        			  foo(): number;
-        			}` with `type Test = {
-        			  bar(): string;
-        			  foo(): number;
-        			}`.
+                      bar(): string;
+                      foo(): number;
+                    }` with `type Test = {
+                      bar(): string;
+                      foo(): number;
+                    }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `interface` instead of `type`.
-   ╭─[consistent_type_definitions.tsx:2:19]
+   ╭─[consistent_type_definitions.tsx:2:28]
  1 │ 
  2 │             export declare type Test = {
    ·                            ────
  3 │               foo: string;
    ╰────
   help: Replace `type Test = {
-        			  foo: string;
-        			  bar: string;
-        			};` with `interface Test {
-        			  foo: string;
-        			  bar: string;
-        			}`.
+                      foo: string;
+                      bar: string;
+                    };` with `interface Test {
+                      foo: string;
+                      bar: string;
+                    }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `type` instead of `interface`.
-   ╭─[consistent_type_definitions.tsx:2:19]
+   ╭─[consistent_type_definitions.tsx:2:28]
  1 │ 
  2 │             export declare interface Test {
    ·                            ─────────
  3 │               foo: string;
    ╰────
   help: Replace `interface Test {
-        			  foo: string;
-        			  bar: string;
-        			}` with `type Test = {
-        			  foo: string;
-        			  bar: string;
-        			}`.
+                      foo: string;
+                      bar: string;
+                    }` with `type Test = {
+                      foo: string;
+                      bar: string;
+                    }`.
 
   ⚠ typescript-eslint(consistent-type-definitions): Use `interface` instead of `type`.
    ╭─[consistent_type_definitions.tsx:1:10]

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function test(a: number, b: number) {
    ·             ─────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function test() {
    ·             ─────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:19]
+   ╭─[explicit_function_return_type.tsx:2:22]
  1 │ 
  2 │             var fn = function () {
    ·                      ─────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:27]
+   ╭─[explicit_function_return_type.tsx:2:30]
  1 │ 
  2 │             var arrowFn = () => 'test';
    ·                              ──
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │               constructor() {}
  4 │               get prop() {
    ·               ────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:8:12]
+   ╭─[explicit_function_return_type.tsx:8:15]
  7 │               set prop(_foo) {}
  8 │               method() {
    ·               ──────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:11:12]
+    ╭─[explicit_function_return_type.tsx:11:15]
  10 │               }
  11 │               arrow = () => 'arrow';
     ·               ────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:12:12]
+    ╭─[explicit_function_return_type.tsx:12:15]
  11 │               arrow = () => 'arrow';
  12 │               private method() {
     ·               ──────────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function test() {
    ·             ─────────────
@@ -112,7 +112,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:12]
+   ╭─[explicit_function_return_type.tsx:3:15]
  2 │             class Foo {
  3 │               public a = () => {};
    ·               ───────────
@@ -121,7 +121,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │               public a = () => {};
  4 │               public b = function () {};
    ·               ────────────────────
@@ -130,7 +130,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:12]
+   ╭─[explicit_function_return_type.tsx:5:15]
  4 │               public b = function () {};
  5 │               public c = function test() {};
    ·               ────────────────────────
@@ -139,7 +139,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:7:12]
+   ╭─[explicit_function_return_type.tsx:7:15]
  6 │ 
  7 │               static d = () => {};
    ·               ───────────
@@ -148,7 +148,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:8:12]
+   ╭─[explicit_function_return_type.tsx:8:15]
  7 │               static d = () => {};
  8 │               static e = function () {};
    ·               ────────────────────
@@ -164,7 +164,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:33]
+   ╭─[explicit_function_return_type.tsx:3:36]
  2 │             function foo(): any {
  3 │               const bar = () => () => console.log('aa');
    ·                                    ──
@@ -173,7 +173,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:32]
+   ╭─[explicit_function_return_type.tsx:4:35]
  3 │             function foo(): any {
  4 │               anyValue = () => () => console.log('aa');
    ·                                   ──
@@ -182,7 +182,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:35]
+   ╭─[explicit_function_return_type.tsx:4:38]
  3 │               foo(): any {
  4 │                 const bar = () => () => {
    ·                                      ──
@@ -191,7 +191,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:25]
+   ╭─[explicit_function_return_type.tsx:2:28]
  1 │ 
  2 │             var funcExpr = function () {
    ·                            ─────────
@@ -207,7 +207,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │             const x = {
  4 │               foo: () => {},
    ·               ─────
@@ -216,7 +216,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │             const x: Foo = {
  4 │               foo: () => {},
    ·               ─────
@@ -260,7 +260,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:29]
+   ╭─[explicit_function_return_type.tsx:4:32]
  3 │               class Foo {
  4 │                 foo = () => () => {
    ·                                ──
@@ -283,7 +283,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:22]
+   ╭─[explicit_function_return_type.tsx:3:25]
  2 │             () => {
  3 │               return () => {};
    ·                         ──
@@ -292,7 +292,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:19]
+   ╭─[explicit_function_return_type.tsx:3:22]
  2 │             () => {
  3 │               return function () {};
    ·                      ─────────
@@ -301,7 +301,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:22]
+   ╭─[explicit_function_return_type.tsx:3:25]
  2 │             function fn() {
  3 │               return () => {};
    ·                         ──
@@ -310,7 +310,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:19]
+   ╭─[explicit_function_return_type.tsx:3:22]
  2 │             function fn() {
  3 │               return function () {};
    ·                      ─────────
@@ -319,7 +319,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:33]
+   ╭─[explicit_function_return_type.tsx:4:36]
  3 │               const bar = () => (): number => 1;
  4 │               const baz = () => () => 'baz';
    ·                                    ──
@@ -328,7 +328,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function fn(arg: boolean) {
    ·             ───────────
@@ -337,7 +337,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:9:23]
+    ╭─[explicit_function_return_type.tsx:9:26]
   8 │                       // ArrowFunctionExpression_Within_ArrowFunctionExpression
   9 │                       () =>
     ·                          ──
@@ -346,7 +346,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:22]
+   ╭─[explicit_function_return_type.tsx:3:25]
  2 │             () => () => {
  3 │               return () => {
    ·                         ──
@@ -355,7 +355,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:17]
+   ╭─[explicit_function_return_type.tsx:3:20]
  2 │             declare function foo(arg: () => void): void;
  3 │             foo(() => 1);
    ·                    ──
@@ -364,7 +364,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:17]
+   ╭─[explicit_function_return_type.tsx:4:20]
  3 │             foo(() => 1);
  4 │             foo(() => {});
    ·                    ──
@@ -373,7 +373,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:17]
+   ╭─[explicit_function_return_type.tsx:5:20]
  4 │             foo(() => {});
  5 │             foo(() => null);
    ·                    ──
@@ -382,7 +382,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:6:17]
+   ╭─[explicit_function_return_type.tsx:6:20]
  5 │             foo(() => null);
  6 │             foo(() => true);
    ·                    ──
@@ -391,7 +391,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:7:17]
+   ╭─[explicit_function_return_type.tsx:7:20]
  6 │             foo(() => true);
  7 │             foo(() => '');
    ·                    ──
@@ -400,7 +400,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:10:42]
+    ╭─[explicit_function_return_type.tsx:10:45]
   9 │ 
  10 │             new Accumulator().accumulate(() => 1);
     ·                                             ──
@@ -416,7 +416,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │             foo({
  4 │               meth() {
    ·               ────
@@ -425,7 +425,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:9:12]
+    ╭─[explicit_function_return_type.tsx:9:15]
   8 │             foo({
   9 │               meth: function () {
     ·               ───────────────
@@ -434,7 +434,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:14:12]
+    ╭─[explicit_function_return_type.tsx:14:15]
  13 │             foo({
  14 │               meth: () => {
     ·               ──────
@@ -443,7 +443,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:56]
+   ╭─[explicit_function_return_type.tsx:3:59]
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                           ──
@@ -452,7 +452,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:40]
+   ╭─[explicit_function_return_type.tsx:3:43]
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                           ──
@@ -461,7 +461,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:48]
+   ╭─[explicit_function_return_type.tsx:3:51]
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                   ──
@@ -470,7 +470,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:56]
+   ╭─[explicit_function_return_type.tsx:3:59]
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                           ──
@@ -479,7 +479,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:40]
+   ╭─[explicit_function_return_type.tsx:2:43]
  1 │ 
  2 │             const func1 = (value: number) => ({ type: 'X', value }) as any;
    ·                                           ──
@@ -488,7 +488,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:40]
+   ╭─[explicit_function_return_type.tsx:3:43]
  2 │             const func1 = (value: number) => ({ type: 'X', value }) as any;
  3 │             const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ·                                           ──
@@ -511,7 +511,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:40]
+   ╭─[explicit_function_return_type.tsx:2:43]
  1 │ 
  2 │             const log = (message: string) => {
    ·                                           ──
@@ -527,7 +527,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function log<A>(a: A) {
    ·             ────────────
@@ -536,7 +536,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:22]
+   ╭─[explicit_function_return_type.tsx:2:25]
  1 │ 
  2 │             const log = function <A>(a: A) {
    ·                         ────────────
@@ -545,7 +545,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:10]
+   ╭─[explicit_function_return_type.tsx:2:13]
  1 │ 
  2 │             function hoge() {
    ·             ─────────────
@@ -554,7 +554,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:25]
+   ╭─[explicit_function_return_type.tsx:5:28]
  4 │             }
  5 │             const foo = () => {
    ·                            ──
@@ -563,7 +563,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:8:22]
+   ╭─[explicit_function_return_type.tsx:8:25]
  7 │             };
  8 │             const baz = function () {
    ·                         ─────────
@@ -572,7 +572,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:11:30]
+    ╭─[explicit_function_return_type.tsx:11:33]
  10 │             };
  11 │             let [test, test2] = function () {
     ·                                 ─────────
@@ -581,7 +581,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:15:12]
+    ╭─[explicit_function_return_type.tsx:15:15]
  14 │             class X {
  15 │               [test] = function () {
     ·               ──────────────────
@@ -590,7 +590,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:20:12]
+    ╭─[explicit_function_return_type.tsx:20:15]
  19 │             const x = {
  20 │               1: function () {
     ·               ────────────
@@ -599,7 +599,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:12]
+   ╭─[explicit_function_return_type.tsx:4:15]
  3 │             class Foo {
  4 │               [ignoredName]() {}
    ·               ─────────────
@@ -608,7 +608,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:16]
+   ╭─[explicit_function_return_type.tsx:5:19]
  4 │                 {
  5 │                   foo: x => x + 1,
    ·                   ─────
@@ -617,7 +617,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:23]
+   ╭─[explicit_function_return_type.tsx:2:26]
  1 │ 
  2 │             const foo = (function () {
    ·                          ─────────
@@ -626,7 +626,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:22]
+   ╭─[explicit_function_return_type.tsx:3:25]
  2 │             const foo = (function () {
  3 │               return () => {
    ·                         ──
@@ -635,7 +635,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:20]
+   ╭─[explicit_function_return_type.tsx:2:23]
  1 │ 
  2 │             let foo = function () {
    ·                       ─────────
@@ -651,7 +651,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:43]
+   ╭─[explicit_function_return_type.tsx:4:46]
  3 │ 
  4 │             function f(gotcha: CallBack = () => {}): void {}
    ·                                              ──
@@ -660,7 +660,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:43]
+   ╭─[explicit_function_return_type.tsx:4:46]
  3 │ 
  4 │             const f = (gotcha: CallBack = () => {}): void => {};
    ·                                              ──
@@ -669,7 +669,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:4:52]
+   ╭─[explicit_function_return_type.tsx:4:55]
  3 │ 
  4 │             const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
    ·                                                       ──────────

--- a/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container['aa' + 'b'];
    ·             ────────────────────────────
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[+7];
    ·             ────────────────────
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[-Infinity];
    ·             ───────────────────────────
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[+Infinity];
    ·             ───────────────────────────
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[NaN];
    ·             ─────────────────────
@@ -43,7 +43,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:4:10]
+   ╭─[no_dynamic_delete.tsx:4:13]
  3 │             const name = 'name';
  4 │             delete container[name];
    ·             ──────────────────────
@@ -51,7 +51,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:4:10]
+   ╭─[no_dynamic_delete.tsx:4:13]
  3 │             const getName = () => 'aaa';
  4 │             delete container[getName()];
    ·             ───────────────────────────
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:4:10]
+   ╭─[no_dynamic_delete.tsx:4:13]
  3 │             const name = { foo: { bar: 'bar' } };
  4 │             delete container[name.foo.bar];
    ·             ──────────────────────────────
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[+'Infinity'];
    ·             ─────────────────────────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
-   ╭─[no_dynamic_delete.tsx:3:10]
+   ╭─[no_dynamic_delete.tsx:3:13]
  2 │             const container: { [i: string]: 0 } = {};
  3 │             delete container[typeof 1];
    ·             ──────────────────────────

--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_interface.snap
@@ -14,7 +14,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:6:4]
+   ╭─[no_empty_interface.tsx:6:13]
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
@@ -22,7 +22,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:6:4]
+   ╭─[no_empty_interface.tsx:6:13]
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:6:4]
+   ╭─[no_empty_interface.tsx:6:13]
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
@@ -38,7 +38,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:6:4]
+   ╭─[no_empty_interface.tsx:6:13]
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:6:4]
+   ╭─[no_empty_interface.tsx:6:13]
  5 │ 
  6 │             interface Bar extends Foo {}
    ·             ────────────────────────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:5:4]
+   ╭─[no_empty_interface.tsx:5:13]
  4 │             }
  5 │             interface Foo extends Array<Bar> {}
    ·             ───────────────────────────────────
@@ -74,7 +74,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:3:4]
+   ╭─[no_empty_interface.tsx:3:13]
  2 │             type R = Record<string, unknown>;
  3 │             interface Foo extends R {}
    ·             ──────────────────────────
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:2:4]
+   ╭─[no_empty_interface.tsx:2:13]
  1 │ 
  2 │             interface Foo<T> extends Bar<T> {}
    ·             ──────────────────────────────────
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(no-empty-interface): an interface declaring no members is equivalent to its supertype
-   ╭─[no_empty_interface.tsx:4:13]
+   ╭─[no_empty_interface.tsx:4:22]
  3 │               type Baz = typeof baz;
  4 │               export interface Bar extends Baz {}
    ·                      ────────────────────────────

--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_object_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_object_type.snap
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:6:35]
+   ╭─[no_empty_object_type.tsx:6:44]
  5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:6:35]
+   ╭─[no_empty_object_type.tsx:6:44]
  5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:6:35]
+   ╭─[no_empty_object_type.tsx:6:44]
  5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:6:35]
+   ╭─[no_empty_object_type.tsx:6:44]
  5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
@@ -74,7 +74,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:5:42]
+   ╭─[no_empty_object_type.tsx:5:51]
  4 │             }
  5 │             interface Base extends Array<Derived> {}
    ·                                                   ──
@@ -83,7 +83,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:3:29]
+   ╭─[no_empty_object_type.tsx:3:38]
  2 │             type R = Record<string, unknown>;
  3 │             interface Base extends R {}
    ·                                      ──
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
-   ╭─[no_empty_object_type.tsx:4:44]
+   ╭─[no_empty_object_type.tsx:4:53]
  3 │               type Base = typeof base;
  4 │               export interface Derived extends Base {}
    ·                                                     ──
@@ -136,7 +136,7 @@ source: crates/oxc_linter/src/tester.rs
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use the empty object type literal.
-   ╭─[no_empty_object_type.tsx:2:15]
+   ╭─[no_empty_object_type.tsx:2:24]
  1 │     
  2 │ ╭─▶             let value: {
  3 │ │                 /* ... */

--- a/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extraneous_class.snap
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Delete this class
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
-   ╭─[no_extraneous_class.tsx:5:14]
+   ╭─[no_extraneous_class.tsx:5:23]
  4 │               constructor() {
  5 │                 class Bar {
    ·                       ───
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only static properties.
-    ╭─[no_extraneous_class.tsx:10:17]
+    ╭─[no_extraneous_class.tsx:10:26]
   9 │             }
  10 │             export class Bar {
     ·                          ───
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Try replacing this class with a standalone function or deleting it entirely
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
-   ╭─[no_extraneous_class.tsx:8:8]
+   ╭─[no_extraneous_class.tsx:8:17]
  7 │               constructor() {
  8 │                 class nestedClass {}
    ·                 ────────────────────
@@ -51,7 +51,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Try using standalone functions instead of static methods
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
-   ╭─[no_extraneous_class.tsx:3:4]
+   ╭─[no_extraneous_class.tsx:3:13]
  2 │             @FooDecorator
  3 │             class Foo {}
    ·             ────────────
@@ -60,7 +60,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Set "allowWithDecorator": true in your config to allow empty decorated classes
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected empty class.
-   ╭─[no_extraneous_class.tsx:6:4]
+   ╭─[no_extraneous_class.tsx:6:13]
  5 │             })
  6 │             class Foo {}
    ·             ────────────
@@ -69,7 +69,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Set "allowWithDecorator": true in your config to allow empty decorated classes
 
   ⚠ typescript-eslint(no-extraneous-class): Unexpected class with only a constructor.
-   ╭─[no_extraneous_class.tsx:3:10]
+   ╭─[no_extraneous_class.tsx:3:19]
  2 │             @FooDecorator
  3 │             class Foo {
    ·                   ───

--- a/crates/oxc_linter/src/snapshots/typescript_no_inferrable_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_inferrable_types.snap
@@ -4,295 +4,296 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = 10n
+ 1 │ const a: bigint = 10n;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = -10n
+ 1 │ const a: bigint = -10n;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = BigInt(10)
+ 1 │ const a: bigint = BigInt(10);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = -BigInt(10)
+ 1 │ const a: bigint = -BigInt(10);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = BigInt?.(10)
+ 1 │ const a: bigint = BigInt?.(10);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: bigint = -BigInt?.(10)
+ 1 │ const a: bigint = -BigInt?.(10);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: boolean = false
+ 1 │ const a: boolean = false;
    ·        ─────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: boolean = true
+ 1 │ const a: boolean = true;
    ·        ─────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: boolean = Boolean(null)
+ 1 │ const a: boolean = Boolean(null);
    ·        ─────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: boolean = Boolean?.(null)
+ 1 │ const a: boolean = Boolean?.(null);
    ·        ─────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: boolean = !0
+ 1 │ const a: boolean = !0;
    ·        ─────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = 10
+ 1 │ const a: number = 10;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = +10
+ 1 │ const a: number = +10;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = -10
+ 1 │ const a: number = -10;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = Number("1")
+ 1 │ const a: number = Number('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = +Number("1")
+ 1 │ const a: number = +Number('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = -Number("1")
+ 1 │ const a: number = -Number('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = Number?.("1")
+ 1 │ const a: number = Number?.('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = +Number?.("1")
+ 1 │ const a: number = +Number?.('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = -Number?.("1")
+ 1 │ const a: number = -Number?.('1');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = Infinity
+ 1 │ const a: number = Infinity;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = +Infinity
+ 1 │ const a: number = +Infinity;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = -Infinity
+ 1 │ const a: number = -Infinity;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = NaN
+ 1 │ const a: number = NaN;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = +NaN
+ 1 │ const a: number = +NaN;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: number = -NaN
+ 1 │ const a: number = -NaN;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: null = null
+ 1 │ const a: null = null;
    ·        ──────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: RegExp = /a/
+ 1 │ const a: RegExp = /a/;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: RegExp = RegExp("a")
+ 1 │ const a: RegExp = RegExp('a');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: RegExp = RegExp?.("a")
+ 1 │ const a: RegExp = RegExp?.('a');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: RegExp = new RegExp("a")
+ 1 │ const a: RegExp = new RegExp('a');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: string = "str"
+ 1 │ const a: string = "str";
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: string = 'str'
+ 1 │ const a: string = 'str';
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: string = `str`
+ 1 │ const a: string = `str`;
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: string = String(1)
+ 1 │ const a: string = String(1);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: string = String?.(1)
+ 1 │ const a: string = String?.(1);
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: symbol = Symbol("a")
+ 1 │ const a: symbol = Symbol('a');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: symbol = Symbol?.("a")
+ 1 │ const a: symbol = Symbol?.('a');
    ·        ────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: undefined = undefined
+ 1 │ const a: undefined = undefined;
    ·        ───────────
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:1:8]
- 1 │ const a: undefined = void someValue
+ 1 │ const a: undefined = void someValue;
    ·        ───────────
    ╰────
   help: Remove the type annotation
 
-  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
-   ╭─[no_inferrable_types.tsx:1:14]
- 1 │ const fn = (a: number = 5) => {};
-   ·              ────────
-   ╰────
-  help: Remove the type annotation
-
-  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
+  × TS(1015): A parameter cannot have a question mark and an initializer.
    ╭─[no_inferrable_types.tsx:1:13]
- 1 │ class A { a!: number = 1; }
-   ·             ────────
+ 1 │ const fn = (a?: number = 5) => {};
+   ·             ─
+   ╰────
+
+  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
+   ╭─[no_inferrable_types.tsx:3:17]
+ 2 │             class A {
+ 3 │               a!: number = 1;
+   ·                 ────────
+ 4 │             }
    ╰────
   help: Remove the type annotation
 
@@ -318,35 +319,46 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
-   ╭─[no_inferrable_types.tsx:2:16]
- 1 │ class Foo {
- 2 │               a: number = 5;
-   ·                ────────
- 3 │               b: boolean = true;
-   ╰────
-  help: Remove the type annotation
-
-  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:3:16]
- 2 │               a: number = 5;
- 3 │               b: boolean = true;
-   ·                ─────────
- 4 │               c: string = 'foo';
+ 2 │             class Foo {
+ 3 │               a: number = 5;
+   ·                ────────
+ 4 │               b: boolean = true;
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
    ╭─[no_inferrable_types.tsx:4:16]
- 3 │               b: boolean = true;
- 4 │               c: string = 'foo';
-   ·                ────────
- 5 │             }
+ 3 │               a: number = 5;
+ 4 │               b: boolean = true;
+   ·                ─────────
+ 5 │               c: string = 'foo';
    ╰────
   help: Remove the type annotation
 
   ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
-   ╭─[no_inferrable_types.tsx:1:33]
- 1 │ class Foo { constructor(public a: boolean = true) {} }
-   ·                                 ─────────
+   ╭─[no_inferrable_types.tsx:5:16]
+ 4 │               b: boolean = true;
+ 5 │               c: string = 'foo';
+   ·                ────────
+ 6 │             }
+   ╰────
+  help: Remove the type annotation
+
+  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
+   ╭─[no_inferrable_types.tsx:3:35]
+ 2 │             class Foo {
+ 3 │               constructor(public a: boolean = true) {}
+   ·                                   ─────────
+ 4 │             }
+   ╰────
+  help: Remove the type annotation
+
+  ⚠ typescript-eslint(no-inferrable-types): Type can be trivially inferred from the initializer
+   ╭─[no_inferrable_types.tsx:3:25]
+ 2 │             class Foo {
+ 3 │               accessor a: number = 5;
+   ·                         ────────
+ 4 │             }
    ╰────
   help: Remove the type annotation

--- a/crates/oxc_linter/src/snapshots/typescript_no_non_null_asserted_nullish_coalescing.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_non_null_asserted_nullish_coalescing.snap
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:10]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:13]
  2 │             let x!: string;
  3 │             x! ?? '';
    ·             ──
@@ -68,7 +68,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:10]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:13]
  3 │             x = foo();
  4 │             x! ?? '';
    ·             ──
@@ -77,7 +77,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:10]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:13]
  3 │             x = foo();
  4 │             x! ?? '';
    ·             ──
@@ -86,7 +86,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:10]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:13]
  2 │             let x = foo();
  3 │             x! ?? '';
    ·             ──
@@ -95,7 +95,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:19]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:22]
  3 │               let x!: string;
  4 │               return x! ?? '';
    ·                      ──
@@ -104,7 +104,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:19]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:4:22]
  3 │             function foo() {
  4 │               return x! ?? '';
    ·                      ──
@@ -113,7 +113,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The nullish coalescing operator is designed to handle undefined and null - using a non-null assertion is not needed.
 
   ⚠ typescript-eslint(no-non-null-asserted-nullish-coalescing): 'Disallow non-null assertions in the left operand of a nullish coalescing operator
-   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:10]
+   ╭─[no_non_null_asserted_nullish_coalescing.tsx:3:13]
  2 │             let x = foo();
  3 │             x  ! ?? '';
    ·             ────

--- a/crates/oxc_linter/src/snapshots/typescript_no_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_non_null_assertion.snap
@@ -150,7 +150,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
 
   ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
-   ╭─[no_non_null_assertion.tsx:2:10]
+   ╭─[no_non_null_assertion.tsx:2:13]
  1 │ 
  2 │             x!
    ·             ──
@@ -159,7 +159,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
 
   ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
-   ╭─[no_non_null_assertion.tsx:2:10]
+   ╭─[no_non_null_assertion.tsx:2:13]
  1 │ 
  2 │             x!
    ·             ──
@@ -168,7 +168,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
 
   ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
-   ╭─[no_non_null_assertion.tsx:2:10]
+   ╭─[no_non_null_assertion.tsx:2:13]
  1 │ 
  2 │             x!
    ·             ──
@@ -177,10 +177,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
 
   ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
-   ╭─[no_non_null_assertion.tsx:2:10]
+   ╭─[no_non_null_assertion.tsx:2:13]
  1 │ 
  2 │             x!
    ·             ──
  3 │              // comment
+   ╰────
+  help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
+
+  ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
+   ╭─[no_non_null_assertion.tsx:2:13]
+ 1 │ 
+ 2 │             document.querySelector('input')!.files = new FileList();
+   ·             ────────────────────────────────
+ 3 │                   
+   ╰────
+  help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.
+
+  ⚠ typescript-eslint(no-non-null-assertion): Forbidden non-null assertion.
+   ╭─[no_non_null_assertion.tsx:2:26]
+ 1 │ 
+ 2 │             hoge.files = document.querySelector('input')!.files;
+   ·                          ────────────────────────────────
+ 3 │                   
    ╰────
   help: Consider using the optional chain operator `?.` instead. This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator.

--- a/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
@@ -17,7 +17,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:2:15]
+   ╭─[no_require_imports.ts:2:24]
  1 │ 
  2 │             var lib5 = require('lib5'),
    ·                        ───────────────
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:3:13]
+   ╭─[no_require_imports.ts:3:22]
  2 │             var lib5 = require('lib5'),
  3 │               lib6 = require('lib6');
    ·                      ───────────────
@@ -56,7 +56,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:2:15]
+   ╭─[no_require_imports.ts:2:24]
  1 │ 
  2 │             var lib5 = require?.('lib5'),
    ·                        ─────────────────
@@ -65,7 +65,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:3:13]
+   ╭─[no_require_imports.ts:3:22]
  2 │             var lib5 = require?.('lib5'),
  3 │               lib6 = require?.('lib6');
    ·                      ─────────────────
@@ -186,7 +186,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:2:42]
+   ╭─[no_require_imports.ts:2:51]
  1 │ 
  2 │             const configValidator = new Validator(require('./a.json'));
    ·                                                   ───────────────────
@@ -195,7 +195,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:3:30]
+   ╭─[no_require_imports.ts:3:39]
  2 │             const configValidator = new Validator(require('./a.json'));
  3 │             configValidator.addSchema(require('./a.json'));
    ·                                       ───────────────────

--- a/crates/oxc_linter/src/snapshots/typescript_no_unsafe_declaration_merging.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unsafe_declaration_merging.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(no-unsafe-declaration-merging): Unsafe declaration merging between classes and interfaces.
-   ╭─[no_unsafe_declaration_merging.tsx:2:14]
+   ╭─[no_unsafe_declaration_merging.tsx:2:23]
  1 │ 
  2 │             interface Foo {}
    ·                       ───
@@ -14,23 +14,23 @@ source: crates/oxc_linter/src/tester.rs
   help: The TypeScript compiler doesn't check whether properties are initialized, which can lead to TypeScript not detecting code that will cause runtime errors.
 
   ⚠ typescript-eslint(no-unsafe-declaration-merging): Unsafe declaration merging between classes and interfaces.
-   ╭─[no_unsafe_declaration_merging.tsx:2:19]
+   ╭─[no_unsafe_declaration_merging.tsx:2:28]
  1 │ 
- 2 │                     class Foo {}
-   ·                           ───
- 3 │                     interface Foo {}
-   ·                               ───
- 4 │                           
+ 2 │                      class Foo {}
+   ·                            ───
+ 3 │                      interface Foo {}
+   ·                                ───
+ 4 │                            
    ╰────
   help: The TypeScript compiler doesn't check whether properties are initialized, which can lead to TypeScript not detecting code that will cause runtime errors.
 
   ⚠ typescript-eslint(no-unsafe-declaration-merging): Unsafe declaration merging between classes and interfaces.
-   ╭─[no_unsafe_declaration_merging.tsx:3:25]
- 2 │                     declare global {
- 3 │                       interface Foo {}
-   ·                                 ───
- 4 │                       class Foo {}
-   ·                             ───
- 5 │                     }
+   ╭─[no_unsafe_declaration_merging.tsx:3:34]
+ 2 │                      declare global {
+ 3 │                        interface Foo {}
+   ·                                  ───
+ 4 │                        class Foo {}
+   ·                              ───
+ 5 │                      }
    ╰────
   help: The TypeScript compiler doesn't check whether properties are initialized, which can lead to TypeScript not detecting code that will cause runtime errors.

--- a/crates/oxc_linter/src/snapshots/typescript_no_unsafe_function_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unsafe_function_type.snap
@@ -24,7 +24,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Prefer explicitly defining any function parameters and return type.
 
   ⚠ typescript-eslint(no-unsafe-function-type): The `Function` type accepts any function-like value.
-   ╭─[no_unsafe_function_type.tsx:2:35]
+   ╭─[no_unsafe_function_type.tsx:2:44]
  1 │ 
  2 │                     class Weird implements Function {
    ·                                            ────────
@@ -33,7 +33,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Prefer explicitly defining any function parameters and return type.
 
   ⚠ typescript-eslint(no-unsafe-function-type): The `Function` type accepts any function-like value.
-   ╭─[no_unsafe_function_type.tsx:2:36]
+   ╭─[no_unsafe_function_type.tsx:2:45]
  1 │ 
  2 │                     interface Weird extends Function {
    ·                                             ────────

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_enum_initializers.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_enum_initializers.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Up" should be explicitly defined.
-   ╭─[prefer_enum_initializers.tsx:3:6]
+   ╭─[prefer_enum_initializers.tsx:3:15]
  2 │             enum Direction {
  3 │               Up,
    ·               ──
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Up" should be explicitly defined.
-   ╭─[prefer_enum_initializers.tsx:3:6]
+   ╭─[prefer_enum_initializers.tsx:3:15]
  2 │             enum Direction {
  3 │               Up,
    ·               ──
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Down" should be explicitly defined.
-   ╭─[prefer_enum_initializers.tsx:4:6]
+   ╭─[prefer_enum_initializers.tsx:4:15]
  3 │               Up,
  4 │               Down,
    ·               ────
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Down" should be explicitly defined.
-   ╭─[prefer_enum_initializers.tsx:4:6]
+   ╭─[prefer_enum_initializers.tsx:4:15]
  3 │               Up = 'Up',
  4 │               Down,
    ·               ────
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(prefer-enum-initializers): The value of the member "Up" should be explicitly defined.
-   ╭─[prefer_enum_initializers.tsx:3:6]
+   ╭─[prefer_enum_initializers.tsx:3:15]
  2 │             enum Direction {
  3 │               Up,
    ·               ──

--- a/crates/oxc_linter/src/snapshots/typescript_prefer_literal_enum_member.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_prefer_literal_enum_member.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidObject {
  3 │               A = {},
    ·               ──────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidArray {
  3 │               A = [],
    ·               ──────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidTemplateLiteral {
  3 │               A = `foo ${0}`,
    ·               ──────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidConstructor {
  3 │               A = new Set(),
    ·               ─────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidExpression {
  3 │               A = 2 + 2,
    ·               ─────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum InvalidExpression {
  3 │               A = delete 2,
    ·               ────────────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:4:12]
+   ╭─[prefer_literal_enum_member.tsx:4:15]
  3 │               A = delete 2,
  4 │               B = -a,
    ·               ──────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:5:12]
+   ╭─[prefer_literal_enum_member.tsx:5:15]
  4 │               B = -a,
  5 │               C = void 2,
    ·               ──────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:6:12]
+   ╭─[prefer_literal_enum_member.tsx:6:15]
  5 │               C = void 2,
  6 │               D = ~2,
    ·               ──────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:7:12]
+   ╭─[prefer_literal_enum_member.tsx:7:15]
  6 │               D = ~2,
  7 │               E = !0,
    ·               ──────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:7:12]
+   ╭─[prefer_literal_enum_member.tsx:7:15]
  6 │               C,
  7 │               V = variable,
    ·               ────────────
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:4:12]
+   ╭─[prefer_literal_enum_member.tsx:4:15]
  3 │               A = 'TestStr',
  4 │               B = A,
    ·               ─────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:5:12]
+   ╭─[prefer_literal_enum_member.tsx:5:15]
  4 │               A = 'TestStr',
  5 │               B = Valid.A,
    ·               ───────────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:7:12]
+   ╭─[prefer_literal_enum_member.tsx:7:15]
  6 │               A = 'TestStr',
  7 │               B = Valid.A,
    ·               ───────────
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:5:12]
+   ╭─[prefer_literal_enum_member.tsx:5:15]
  4 │               A = 'TestStr',
  5 │               B = { ...a },
    ·               ────────────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:3:12]
+   ╭─[prefer_literal_enum_member.tsx:3:15]
  2 │             enum Foo {
  3 │               A = 1 << 0,
    ·               ──────────
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:4:12]
+   ╭─[prefer_literal_enum_member.tsx:4:15]
  3 │               A = 1 << 0,
  4 │               B = 1 >> 0,
    ·               ──────────
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:5:12]
+   ╭─[prefer_literal_enum_member.tsx:5:15]
  4 │               B = 1 >> 0,
  5 │               C = 1 >>> 0,
    ·               ───────────
@@ -165,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:6:12]
+   ╭─[prefer_literal_enum_member.tsx:6:15]
  5 │               C = 1 >>> 0,
  6 │               D = 1 | 0,
    ·               ─────────
@@ -174,7 +174,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:7:12]
+   ╭─[prefer_literal_enum_member.tsx:7:15]
  6 │               D = 1 | 0,
  7 │               E = 1 & 0,
    ·               ─────────
@@ -183,7 +183,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:8:12]
+   ╭─[prefer_literal_enum_member.tsx:8:15]
  7 │               E = 1 & 0,
  8 │               F = 1 ^ 0,
    ·               ─────────
@@ -192,7 +192,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-    ╭─[prefer_literal_enum_member.tsx:9:12]
+    ╭─[prefer_literal_enum_member.tsx:9:15]
   8 │               F = 1 ^ 0,
   9 │               G = ~1,
     ·               ──────
@@ -201,7 +201,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:4:12]
+   ╭─[prefer_literal_enum_member.tsx:4:15]
  3 │             enum Foo {
  4 │               A = x << 0,
    ·               ──────────
@@ -210,7 +210,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:5:12]
+   ╭─[prefer_literal_enum_member.tsx:5:15]
  4 │               A = x << 0,
  5 │               B = x >> 0,
    ·               ──────────
@@ -219,7 +219,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:6:12]
+   ╭─[prefer_literal_enum_member.tsx:6:15]
  5 │               B = x >> 0,
  6 │               C = x >>> 0,
    ·               ───────────
@@ -228,7 +228,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:7:12]
+   ╭─[prefer_literal_enum_member.tsx:7:15]
  6 │               C = x >>> 0,
  7 │               D = x | 0,
    ·               ─────────
@@ -237,7 +237,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-   ╭─[prefer_literal_enum_member.tsx:8:12]
+   ╭─[prefer_literal_enum_member.tsx:8:15]
  7 │               D = x | 0,
  8 │               E = x & 0,
    ·               ─────────
@@ -246,7 +246,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-    ╭─[prefer_literal_enum_member.tsx:9:12]
+    ╭─[prefer_literal_enum_member.tsx:9:15]
   8 │               E = x & 0,
   9 │               F = x ^ 0,
     ·               ─────────
@@ -255,10 +255,37 @@ source: crates/oxc_linter/src/tester.rs
   help: Require all enum members to be literal values.
 
   ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
-    ╭─[prefer_literal_enum_member.tsx:10:12]
+    ╭─[prefer_literal_enum_member.tsx:10:15]
   9 │               F = x ^ 0,
  10 │               G = ~x,
     ·               ──────
  11 │             }
     ╰────
+  help: Require all enum members to be literal values.
+
+  ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
+   ╭─[prefer_literal_enum_member.tsx:5:15]
+ 4 │               A = 1 << 0,
+ 5 │               B = x >> Foo.A,
+   ·               ──────────────
+ 6 │               C = x >> A,
+   ╰────
+  help: Require all enum members to be literal values.
+
+  ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
+   ╭─[prefer_literal_enum_member.tsx:6:15]
+ 5 │               B = x >> Foo.A,
+ 6 │               C = x >> A,
+   ·               ──────────
+ 7 │             }
+   ╰────
+  help: Require all enum members to be literal values.
+
+  ⚠ typescript-eslint(prefer-literal-enum-member): Explicit enum value must only be a literal value (string, number, boolean, etc).
+   ╭─[prefer_literal_enum_member.tsx:4:15]
+ 3 │               A,
+ 4 │               B = +A,
+   ·               ──────
+ 5 │             }
+   ╰────
   help: Require all enum members to be literal values.

--- a/crates/oxc_linter/src/snapshots/typescript_triple_slash_reference.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_triple_slash_reference.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ typescript-eslint(triple-slash-reference): Do not use a triple slash reference for foo, use `import` style instead.
-   ╭─[triple_slash_reference.tsx:2:4]
+   ╭─[triple_slash_reference.tsx:2:13]
  1 │ 
  2 │             /// <reference types="foo" />
    ·             ─────────────────────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use of triple-slash reference type directives is generally discouraged in favor of ECMAScript Module imports.
 
   ⚠ typescript-eslint(triple-slash-reference): Do not use a triple slash reference for foo, use `import` style instead.
-   ╭─[triple_slash_reference.tsx:2:10]
+   ╭─[triple_slash_reference.tsx:2:13]
  1 │ 
  2 │             /// <reference types="foo" />
    ·             ─────────────────────────────


### PR DESCRIPTION
- Update spacing in tests for 16 typescript rules, to better match the rulegen format we have now and make it easier to compare with regenerated rule tests in the future.
- Regenerate tests for `typescript/no-inferrable-types` rule, mostly just spacing changes with a minor handful of new rules. One new test that failed and got commented-out.
- Regenerate `typescript/no-import-type-side-effects` rule tests.
- Regenerate `typescript/prefer-literal-enum-members` rule tests.
- Regenerate `typescript/consistent-generic-constructors` rule tests.
- Regenerate `typescript/no-non-null-assertion` rule tests.
- Regenerate `typescript/triple-slash-reference` rule tests.
- Regenerate two unrelated insta snapshots because they kept giving warnings about using the old format.

The updated rule tests were updated exclusively with tests that passed, or otherwise tests that got commented-out due to failing right now. We may want to go back and fix the rule behaviors where relevant.

The goal for the updated spacing is to decrease the diff noise when evaluating which rules need updates to add new tests when regenerating, as we use spaces for all generated tests. The indentation changes were done manually using VS Code's "Convert Indentation to Spaces" command after determining which files it was relevant for. The regenerations were done using the `update-rule-tests` just command.