### PR TITLE
refactor(formatter,oxfmt): Simplify sort_imports options parsing

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/group_config.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/group_config.rs
@@ -11,6 +11,26 @@ pub enum GroupEntry {
     Custom(String),
 }
 
+impl GroupEntry {
+    /// Parse a group entry string.
+    ///
+    /// - `"unknown"`: `GroupEntry::Unknown`
+    /// - Valid predefined name: `GroupEntry::Predefined(..)`
+    /// - Anything else: `GroupEntry::Custom(..)`
+    ///
+    /// NOTE: This does NOT validate whether custom group names are actually defined.
+    /// That validation should be done at the config layer.
+    pub fn parse(name: &str) -> Self {
+        if name == "unknown" {
+            return Self::Unknown;
+        }
+        if let Some(group_name) = GroupName::parse(name) {
+            return Self::Predefined(group_name);
+        }
+        Self::Custom(name.to_string())
+    }
+}
+
 /// Represents a group name pattern for matching imports.
 /// A group name consists of 1 selector and N modifiers.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -42,6 +42,26 @@ pub struct SortImportsOptions {
     pub newline_boundary_overrides: Vec<Option<bool>>,
 }
 
+impl SortImportsOptions {
+    /// Validate option combinations.
+    ///
+    /// # Errors
+    /// Returns an error message if incompatible options are set.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.partition_by_newline && self.newline_boundary_overrides.iter().any(Option::is_some)
+        {
+            return Err("`partitionByNewline` and per-group `{ \"newlinesBetween\" }` markers cannot be used together".to_string());
+        }
+        if self.partition_by_newline && self.newlines_between {
+            return Err(
+                "`partitionByNewline: true` and `newlinesBetween: true` cannot be used together"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 impl Default for SortImportsOptions {
     fn default() -> Self {
         Self {

--- a/crates/oxc_formatter/tests/ir_transform/mod.rs
+++ b/crates/oxc_formatter/tests/ir_transform/mod.rs
@@ -1,8 +1,8 @@
 mod sort_imports;
 
 use oxc_formatter::{
-    CustomGroupDefinition, FormatOptions, GroupEntry, GroupName, ImportModifier, ImportSelector,
-    QuoteStyle, Semicolons, SortImportsOptions, SortOrder,
+    CustomGroupDefinition, FormatOptions, GroupEntry, ImportModifier, ImportSelector, QuoteStyle,
+    Semicolons, SortImportsOptions, SortOrder,
 };
 use serde::Deserialize;
 
@@ -88,16 +88,6 @@ struct ParsedGroups {
     newline_boundary_overrides: Vec<Option<bool>>,
 }
 
-fn parse_group_name(name: &str) -> GroupEntry {
-    if name == "unknown" {
-        GroupEntry::Unknown
-    } else if let Some(group_name) = GroupName::parse(name) {
-        GroupEntry::Predefined(group_name)
-    } else {
-        GroupEntry::Custom(name.to_string())
-    }
-}
-
 fn deserialize_groups<'de, D>(deserializer: D) -> Result<Option<ParsedGroups>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -120,9 +110,9 @@ where
                 newline_boundary_overrides.push(pending_override.take());
             }
             let group = match item {
-                Value::String(s) => vec![parse_group_name(&s)],
+                Value::String(s) => vec![GroupEntry::parse(&s)],
                 Value::Array(a) => {
-                    a.into_iter().filter_map(|v| v.as_str().map(parse_group_name)).collect()
+                    a.into_iter().filter_map(|v| v.as_str().map(GroupEntry::parse)).collect()
                 }
                 _ => continue,
             };

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -30,9 +30,9 @@ use oxc::{
 };
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, FormatOptions,
-    Formatter, GroupEntry, GroupName, IndentStyle, IndentWidth, LineEnding, LineWidth,
-    QuoteProperties, QuoteStyle, Semicolons, SortImportsOptions, SortOrder, TrailingCommas,
-    default_groups, default_internal_patterns, get_parse_options,
+    Formatter, GroupEntry, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteProperties,
+    QuoteStyle, Semicolons, SortImportsOptions, SortOrder, TrailingCommas, default_groups,
+    default_internal_patterns, get_parse_options,
 };
 use oxc_linter::{
     ConfigStore, ConfigStoreBuilder, ContextSubHost, ExternalPluginStore, LintOptions, Linter,
@@ -530,20 +530,7 @@ impl Oxc {
                 groups: sort_imports_config.groups.as_ref().map_or_else(default_groups, |groups| {
                     groups
                         .iter()
-                        .map(|group| {
-                            group
-                                .iter()
-                                .map(|name| {
-                                    if name == "unknown" {
-                                        GroupEntry::Unknown
-                                    } else if let Some(gn) = GroupName::parse(name) {
-                                        GroupEntry::Predefined(gn)
-                                    } else {
-                                        GroupEntry::Custom(name.clone())
-                                    }
-                                })
-                                .collect()
-                        })
+                        .map(|group| group.iter().map(|name| GroupEntry::parse(name)).collect())
                         .collect()
                 }),
                 custom_groups: vec![],


### PR DESCRIPTION
Introduce `GroupEntry::parse()` to reduce redundants.