### PR TITLE
docs(contributing): change the find out more link in the CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,4 @@ We encourage the use of AI tools to assist with development, but all contributio
 
 ---
 
-You may checkout the complete contributing guide on the [website](https://oxc.rs/docs/contribute/development.html).
+Please see the complete contributing guide on the [website](https://oxc.rs/docs/contribute/introduction.html).


### PR DESCRIPTION
Hello,

This PR addresses the Move the link for learning more about Contributing to the introduction page. #19236 . 

In [CONTRIBUTING.md](https://github.com/oxc-project/oxc/blob/main/CONTRIBUTING.md), the link to the contribution guide currently points to the [Getting Started](https://oxc.rs/docs/contribute/development.html) page. It may be more helpful to link to the [Introduction page](https://oxc.rs/docs/contribute/introduction.html) instead, as it provides broader context about the project and makes it clearer the contribution guide covers several pages. The Introduction page, also, includes a link to the rules and policies on making a PR. 

Please let me know if you have any questions or concerns. Thank you again for all the great work. 