### PR TITLE
test(linter): Update indentation in tests for unicorn rules

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
@@ -253,30 +253,30 @@ fn test() {
         ",
         // Since the variable is references from function parameter, it will not be checked here
         r"
-          	const index = foo.indexOf('bar');
-          	function foo (index) {
-          		if (index < 0) {}
-          	}
+              const index = foo.indexOf('bar');
+              function foo (index) {
+                  if (index < 0) {}
+              }
         ",
         // To prevent false positives, it will not check if the index is not declared via const
         r"
-          	let index = foo.indexOf('bar');
+              let index = foo.indexOf('bar');
 
-          	index < 0
+              index < 0
         ",
         // To prevent false positives, it will not check if the index is not declared via const
         r"
-          	var index = foo.indexOf('bar');
-          	index < 0
+              var index = foo.indexOf('bar');
+              index < 0
         ",
         // To prevent false positives, it will not check if the index is not declared via const
         r"
-          	let index;
+              let index;
 
-          	// do stuff
+              // do stuff
 
-          	index = arr.findLastIndex(element => element > 10);
-          	index < 0;
+              index = arr.findLastIndex(element => element > 10);
+              index < 0;
         ",
         r"const indexOf = 'indexOf'; const index = foo[indexOf](foo); index < 0;",
         r"const index = foo.indexOf?.(foo); index < 0;",
@@ -297,55 +297,55 @@ fn test() {
         r"const index = foo.findIndex('bar'); if (index > -1) {}",
         r"const index = foo.findLastIndex('bar'); if (index > -1) {}",
         r"
-        	const index = foo.indexOf(bar);
+            const index = foo.indexOf(bar);
 
-        	function foo () {
-        		if (index < 0) {}
-        	}
+            function foo () {
+                if (index < 0) {}
+            }
         ",
         r"
-        	const index1 = foo.indexOf('1'),
-        		index2 = foo.indexOf('2');
-        	index1 < 0;
-        	index2 >= 0;
+            const index1 = foo.indexOf('1'),
+                index2 = foo.indexOf('2');
+            index1 < 0;
+            index2 >= 0;
         ",
         r"
-              	const index = foo.indexOf('1');
-              	((
-              		/* comment 1 */
-              		((
-              			/* comment 2 */
-              			index
-              			/* comment 3 */
-              		))
-              		/* comment 4 */
-              		<
-              		/* comment 5 */
-              		((
-              			/* comment 6 */
-              			0
-              			/* comment 7 */
-              		))
-              		/* comment 8 */
-              	));
+                  const index = foo.indexOf('1');
+                  ((
+                      /* comment 1 */
+                      ((
+                          /* comment 2 */
+                          index
+                          /* comment 3 */
+                      ))
+                      /* comment 4 */
+                      <
+                      /* comment 5 */
+                      ((
+                          /* comment 6 */
+                          0
+                          /* comment 7 */
+                      ))
+                      /* comment 8 */
+                  ));
               ",
         r"
-        	const index = foo.indexOf('1');
-        	((
-        		/* comment 1 */
-        		((
-        			/* comment 2 */
-        			index
-        			/* comment 3 */
-        		))
-        		/* comment 4 */
-        		>
-        		((
-        			/* comment 5 */
-        			- /* comment 6 */ (( /* comment 7 */ 1 /* comment 8 */ ))
-        			/* comment 9 */
-        		))
-        	));
+            const index = foo.indexOf('1');
+            ((
+                /* comment 1 */
+                ((
+                    /* comment 2 */
+                    index
+                    /* comment 3 */
+                ))
+                /* comment 4 */
+                >
+                ((
+                    /* comment 5 */
+                    - /* comment 6 */ (( /* comment 7 */ 1 /* comment 8 */ ))
+                    /* comment 9 */
+                ))
+            ));
         ",
         r"const index = _.indexOf([1, 2, 1, 2], 2); index < 0;",
     ];

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -121,13 +121,13 @@ declare_oxc_lint!(
     ///
     /// ```js
     /// function doFoo(foo) {
-    /// 	{
-    /// 		function doBar(bar) {
-    /// 			return bar;
-    /// 		}
-    /// 	}
+    ///   {
+    ///     function doBar(bar) {
+    ///       return bar;
+    ///     }
+    ///   }
     ///
-    /// 	return foo;
+    ///   return foo;
     /// }
     /// ```
     ///
@@ -135,11 +135,11 @@ declare_oxc_lint!(
     ///
     /// ```jsx
     /// function doFoo(FooComponent) {
-    /// 	function Bar() {
-    /// 		return <FooComponent/>;
-    /// 	}
+    ///   function Bar() {
+    ///     return <FooComponent/>;
+    ///   }
     ///
-    /// 	return Bar;
+    ///   return Bar;
     /// };
     /// ```
     ///
@@ -147,9 +147,9 @@ declare_oxc_lint!(
     ///
     /// ```js
     /// (function () {
-    /// 	function doFoo(bar) {
-    /// 		return bar;
-    /// 	}
+    ///   function doFoo(bar) {
+    ///       return bar;
+    ///   }
     /// })();
     /// ```
     ConsistentFunctionScoping,

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -188,16 +188,16 @@ fn test() {
             const m = Map();
         ",
         r"
-        	const {Map} = require('immutable');
-        	const foo = Map();
+            const {Map} = require('immutable');
+            const foo = Map();
         ",
         r"
-        	const {String} = require('guitar');
-        	const lowE = new String();
+            const {String} = require('guitar');
+            const lowE = new String();
         ",
         r"
-        	import {String} from 'guitar';
-        	const lowE = new String();
+            import {String} from 'guitar';
+            const lowE = new String();
         ",
         "new Foo();Bar();",
         "Foo();new Bar();",
@@ -253,25 +253,25 @@ fn test() {
         "const foo = new String()",
         "const foo = new Symbol()",
         r"
-			function varCheck() {
-				{
-					var WeakMap = function() {};
-				}
-				// This should not reported
-				return WeakMap()
-			}
-			function constCheck() {
-				{
-					const Array = function() {};
-				}
-				return Array()
-			}
-			function letCheck() {
-				{
-					let Map = function() {};
-				}
-				return Map()
-			}
+            function varCheck() {
+                {
+                    var WeakMap = function() {};
+                }
+                // This should not reported
+                return WeakMap()
+            }
+            function constCheck() {
+                {
+                    const Array = function() {};
+                }
+                return Array()
+            }
+            function letCheck() {
+                {
+                    let Map = function() {};
+                }
+                return Map()
+            }
         ",
     ];
 

--- a/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
@@ -474,17 +474,17 @@ fn test() {
         ",
         r"
             class Foo {
-        		get bar() {
-        			return this.bar;
-        		}
-        	}
+                get bar() {
+                    return this.bar;
+                }
+            }
         ",
         r"
             const foo = {
-        		get bar() {
-        			return this.bar.baz;
-        		}
-        	};
+                get bar() {
+                    return this.bar.baz;
+                }
+            };
         ",
         r"
             const foo = {

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -171,12 +171,12 @@ fn test() {
         ("export default class{}"),
         ("export default class {}"),
         ("let Foo, Foo_, foo, foo_
-			export default class {}"),
+            export default class {}"),
         ("let Foo, Foo_, foo, foo_
-			export default (class{})"),
+            export default (class{})"),
         ("export default (class extends class {} {})"),
         ("let Exports, Exports_, exports, exports_
-			exports = class {}"),
+            exports = class {}"),
         ("module.exports = class {}"),
         ("export default function () {}"),
         ("export default function* () {}"),
@@ -186,13 +186,13 @@ fn test() {
         ("export default async function   *   () {}"),
         ("export default async function * /* comment */ () {}"),
         ("export default async function * // comment
-			() {}"),
+            () {}"),
         ("let Foo, Foo_, foo, foo_
-			export default async function * () {}"),
+            export default async function * () {}"),
         ("let Foo, Foo_, foo, foo_
-			export default (async function * () {})"),
+            export default (async function * () {})"),
         ("let Exports, Exports_, exports, exports_
-			exports = function() {}"),
+            exports = function() {}"),
         ("module.exports = function() {}"),
         ("export default () => {}"),
         ("export default async () => {}"),
@@ -202,23 +202,23 @@ fn test() {
         ("export default (( () => {} ))"),
         ("/* comment 1 */ export /* comment 2 */ default /* comment 3 */  () => {}"),
         ("// comment 1
-			export
-			// comment 2
-			default
-			// comment 3
-			() => {}"),
+            export
+            // comment 2
+            default
+            // comment 3
+            () => {}"),
         ("let Foo, Foo_, foo, foo_
-			export default async () => {}"),
+            export default async () => {}"),
         ("let Exports, Exports_, exports, exports_
-			exports = (( () => {} ))"),
+            exports = (( () => {} ))"),
         ("// comment 1
-			module
-			// comment 2
-			.exports
-			// comment 3
-			=
-			// comment 4
-			() => {};"),
+            module
+            // comment 2
+            .exports
+            // comment 3
+            =
+            // comment 4
+            () => {};"),
         ("(( exports = (( () => {} )) ))"),
         ("(( module.exports = (( () => {} )) ))"),
         ("(( exports = (( () => {} )) ));"),

--- a/crates/oxc_linter/src/rules/unicorn/no_array_callback_reference.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_callback_reference.rs
@@ -279,21 +279,21 @@ fn test() {
         "foo.map(function bar() {})",
         "foo.map(function (a) {}.bind(bar))",
         "async function foo() {
-				const clientId = 20
-				const client = await oidc.Client.find(clientId)
-			}",
+                const clientId = 20
+                const client = await oidc.Client.find(clientId)
+            }",
         "const results = collection
-				.find({
-					$and: [cursorQuery, params.query]
-				}, {
-					projection: params.projection
-				})
-				.sort($sort)
-				.limit(params.limit + 1)
-				.toArray()",
+                .find({
+                    $and: [cursorQuery, params.query]
+                }, {
+                    projection: params.projection
+                })
+                .sort($sort)
+                .limit(params.limit + 1)
+                .toArray()",
         "const EventsStore = types.model('EventsStore', {
-				events: types.optional(types.map(Event), {}),
-			})",
+                events: types.optional(types.map(Event), {}),
+            })",
         "foo.map(_ ? () => {} : _ ? () => {} : () => {})",
         "foo.reduce(_ ? () => {} : _ ? () => {} : () => {})",
         "foo.every(_ ? Boolean : _ ? Boolean : Boolean)",
@@ -306,29 +306,29 @@ fn test() {
         "foo.map(lib.fn)",
         "foo.reduce(lib.fn)",
         "foo.map(
-				_
-					? String // This one should be ignored
-					: callback
-			);",
+                _
+                    ? String // This one should be ignored
+                    : callback
+            );",
         "foo.forEach(
-				_
-					? callbackA
-					: _
-							? callbackB
-							: callbackC
-			);",
+                _
+                    ? callbackA
+                    : _
+                            ? callbackB
+                            : callbackC
+            );",
         "async function * foo () {
-				foo.map((0, bar));
-				foo.map(yield bar);
-				foo.map(yield* bar);
-				foo.map(() => bar);
-				foo.map(bar &&= baz);
-				foo.map(bar || baz);
-				foo.map(bar + bar);
-				foo.map(+ bar);
-				foo.map(++ bar);
-				foo.map(new Function(''));
-			}",
+                foo.map((0, bar));
+                foo.map(yield bar);
+                foo.map(yield* bar);
+                foo.map(() => bar);
+                foo.map(bar &&= baz);
+                foo.map(bar || baz);
+                foo.map(bar + bar);
+                foo.map(+ bar);
+                foo.map(++ bar);
+                foo.map(new Function(''));
+            }",
     ];
 
     Tester::new(NoArrayCallbackReference::NAME, NoArrayCallbackReference::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reduce.rs
@@ -340,19 +340,19 @@ fn test() {
         (r#"array.reduce((str, item) => str += item, "")"#, None),
         (
             r"
-			array.reduce((obj, item) => {
-				obj[item] = null;
-				return obj;
-			}, {})
-			",
+            array.reduce((obj, item) => {
+                obj[item] = null;
+                return obj;
+            }, {})
+            ",
             None,
         ),
         (r"array.reduce((obj, item) => ({ [item]: null }), {})", None),
         (
             r#"
-			const hyphenate = (str, char) => `${str}-${char}`;
-			["a", "b", "c"].reduce(hyphenate);
-			"#,
+            const hyphenate = (str, char) => `${str}-${char}`;
+            ["a", "b", "c"].reduce(hyphenate);
+            "#,
             None,
         ),
         (r"[].reduce.call(array, (s, i) => s + i)", None),
@@ -366,13 +366,13 @@ fn test() {
         (r"Array.prototype.reduce.apply(array, [sum]);", None),
         (
             r"
-			array.reduce((total, item) => {
-				return total + doComplicatedThings(item);
-				function doComplicatedThings(item) {
-					return item + 1;
-				}
-			}, 0);
-			",
+            array.reduce((total, item) => {
+                return total + doComplicatedThings(item);
+                function doComplicatedThings(item) {
+                    return item + 1;
+                }
+            }, 0);
+            ",
             None,
         ),
         // Option: allowSimpleOperations
@@ -402,28 +402,28 @@ fn test() {
         ),
         (
             r"
-				array.reduce((total, item) => {
-					return (total / item) * 100;
-				}, 0);
-		",
+                array.reduce((total, item) => {
+                    return (total / item) * 100;
+                }, 0);
+        ",
             Some(json!([{ "allowSimpleOperations": false }])),
         ),
         (r#"array.reduceRight((str, item) => str += item, "")"#, None),
         (
             r"
-			array.reduceRight((obj, item) => {
-				obj[item] = null;
-				return obj;
-			}, {})
-			",
+            array.reduceRight((obj, item) => {
+                obj[item] = null;
+                return obj;
+            }, {})
+            ",
             None,
         ),
         (r"array.reduceRight((obj, item) => ({ [item]: null }), {})", None),
         (
             r#"
-			const hyphenate = (str, char) => `${str}-${char}`;
-			["a", "b", "c"].reduceRight(hyphenate);
-			"#,
+            const hyphenate = (str, char) => `${str}-${char}`;
+            ["a", "b", "c"].reduceRight(hyphenate);
+            "#,
             None,
         ),
         (r"[].reduceRight.call(array, (s, i) => s + i)", None),
@@ -437,13 +437,13 @@ fn test() {
         (r"Array.prototype.reduceRight.apply(array, [sum]);", None),
         (
             r"
-			array.reduceRight((total, item) => {
-				return total + doComplicatedThings(item);
-				function doComplicatedThings(item) {
-					return item + 1;
-				}
-			}, 0);
-			",
+            array.reduceRight((total, item) => {
+                return total + doComplicatedThings(item);
+                function doComplicatedThings(item) {
+                    return item + 1;
+                }
+            }, 0);
+            ",
             None,
         ),
         // Option: allowSimpleOperations
@@ -473,10 +473,10 @@ fn test() {
         ),
         (
             r"
-				array.reduceRight((total, item) => {
-					return (total / item) * 100;
-				}, 0);
-		",
+                array.reduceRight((total, item) => {
+                    return (total / item) * 100;
+                }, 0);
+        ",
             Some(json!([{ "allowSimpleOperations": false }])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -148,7 +148,7 @@ fn test() {
         r#"document[CONSTANTS_COOKIE] = "foo=bar""#,
         r#"document[cookie] = "foo=bar""#,
         r#"const CONSTANTS_COOKIE = "cookie";
-			document[CONSTANTS_COOKIE] = "foo=bar";"#,
+            document[CONSTANTS_COOKIE] = "foo=bar";"#,
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/no_immediate_mutation.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_immediate_mutation.rs
@@ -642,507 +642,507 @@ fn test() {
 
     let pass = vec![
         "const array = [1, 2];
-			array.notPush(3, 4);",
+            array.notPush(3, 4);",
         "const array = [1, 2];
-			; // Not next to each other
-			array.push(3, 4);",
+            ; // Not next to each other
+            array.push(3, 4);",
         "const array = [1, 2],
-				otherVariable = 1;
-			array.push(3, 4);",
+                otherVariable = 1;
+            array.push(3, 4);",
         "const array = [1, 2];
-			array.push();",
+            array.push();",
         "const {array} = [1, 2];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const [array] = [1, 2];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const foo = [1, 2];
-			bar.push(3, 4);",
+            bar.push(3, 4);",
         "const array = [1, 2];
-			array.push(array[0]);",
+            array.push(array[0]);",
         "const array = [1, 2];
-			array.push(((foo) => foo(array.length))());",
+            array.push(((foo) => foo(array.length))());",
         "let array;
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const array = foo;
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const array = [1, 2];
-			array.push?.(3, 4);",
+            array.push?.(3, 4);",
         "const array = [1, 2];
-			array?.push(3, 4);",
+            array?.push(3, 4);",
         "let array;
-			array ??= [1, 2];
-			array.push(3, 4);",
+            array ??= [1, 2];
+            array.push(3, 4);",
         "let foo;
-			foo = [1, 2];
-			bar.push(3, 4);",
+            foo = [1, 2];
+            bar.push(3, 4);",
         "let foo, bar;
-			foo = bar = [1, 2];
-			bar.push(3, 4);",
+            foo = bar = [1, 2];
+            bar.push(3, 4);",
         "const foo = new Foo();
-			foo.bar = [1, 2];
-			foo.bar.push(3, 4);",
+            foo.bar = [1, 2];
+            foo.bar.push(3, 4);",
         "const object = [];
-			object.bar = 2;",
+            object.bar = 2;",
         "const [object] = {foo: 1};
-			object.bar = 2;",
+            object.bar = 2;",
         "const {object} = {foo: 1};
-			object.bar = 2;",
+            object.bar = 2;",
         "const object = {foo: 1};
-			object.bar += 2;",
+            object.bar += 2;",
         "const object = {foo: 1};
-			object.bar = object.baz = 2;",
+            object.bar = object.baz = 2;",
         "const foo = {};
-			bar.bar = 2;",
+            bar.bar = 2;",
         "const object = {foo: 1};
-			anotherObject.baz = object.bar = 2;",
+            anotherObject.baz = object.bar = 2;",
         "const object = {foo: 1};
-			object[object.foo] = 2;",
+            object[object.foo] = 2;",
         "var object;
-			object.bar = 2;",
+            object.bar = 2;",
         "const object = foo;
-			object.bar = 2;",
+            object.bar = 2;",
         "let object;
-			object ??= {foo: 1};
-			object.bar = 2;",
+            object ??= {foo: 1};
+            object.bar = 2;",
         "let foo;
-			foo = {foo: 1};
-			bar.bar = 2;",
+            foo = {foo: 1};
+            bar.bar = 2;",
         "let foo, bar;
-			foo = bar = {foo: 1};
-			bar.bar = 2;",
+            foo = bar = {foo: 1};
+            bar.bar = 2;",
         "const foo = new Foo();
-			foo.bar = {foo: 1};
-			foo.bar.bar = 2;",
+            foo.bar = {foo: 1};
+            foo.bar.bar = 2;",
         "const object = [];
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "const [object] = {foo: 1};
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "const {object} = {foo: 1};
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "const object = {foo: 1};
-			Object.assign?.(object, bar);",
+            Object.assign?.(object, bar);",
         "const object = {foo: 1};
-			Object?.assign(object, bar);",
+            Object?.assign(object, bar);",
         "const object = {foo: 1};
-			Object.assign();",
+            Object.assign();",
         "const object = {foo: 1};
-			Object.assign(object);",
+            Object.assign(object);",
         "const object = {foo: 1};
-			Object.assign(...object);",
+            Object.assign(...object);",
         "const object = {foo: 1};
-			Object.assign(object, ...spread);",
+            Object.assign(object, ...spread);",
         "const object = {foo: 1};
-			Object.assign(object, ...spread, bar);",
+            Object.assign(object, ...spread, bar);",
         "const object = {foo: 1};
-			Object.assign(object, ...bar);",
+            Object.assign(object, ...bar);",
         "const object = {foo: 1};
-			NotObject.notAssign(object, bar);",
+            NotObject.notAssign(object, bar);",
         "const foo = {foo: 1};
-			Object.assign(bar, bar);",
+            Object.assign(bar, bar);",
         "let object;
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "const object = {foo: 1};
-			Object.assign(object, object.foo);",
+            Object.assign(object, object.foo);",
         "const object = {foo: 1};
-			Object.assign(object, {baz(){return object}});",
+            Object.assign(object, {baz(){return object}});",
         "let object;
-			object ??= {foo: 1};
-			Object.assign(object, bar);",
+            object ??= {foo: 1};
+            Object.assign(object, bar);",
         "let foo;
-			foo = {foo: 1};
-			bar.assign(object, baz);",
+            foo = {foo: 1};
+            bar.assign(object, baz);",
         "let foo, bar;
-			foo = bar = {foo: 1};
-			Object.assign(bar, baz);",
+            foo = bar = {foo: 1};
+            Object.assign(bar, baz);",
         "const foo = new Foo();
-			foo.bar = {foo: 1};
-			Object.assign(foo.bar, baz);",
+            foo.bar = {foo: 1};
+            Object.assign(foo.bar, baz);",
         "const set = new Set([1, 2]);
-			set.notAdd(3);",
+            set.notAdd(3);",
         "const set = new NotSet([1, 2]);
-			set.notAdd(3);",
+            set.notAdd(3);",
         "const set = new Set([1, 2]);
-			; // Not next to each other
-			set.add(3);",
+            ; // Not next to each other
+            set.add(3);",
         "const set = new Set([1, 2]),
-				otherVariable = 1;
-			set.add(3);",
+                otherVariable = 1;
+            set.add(3);",
         "const set = new Set([1, 2]);
-			set.add();",
+            set.add();",
         "const set = new Set([1, 2]);
-			set.add(3, 4);",
+            set.add(3, 4);",
         "const set = new Set([1, 2]);
-			set.add(...bar);",
+            set.add(...bar);",
         "const {set} = new Set([1, 2]);
-			set.add(3);",
+            set.add(3);",
         "const [set] = new Set([1, 2]);
-			set.add(3);",
+            set.add(3);",
         "const foo = new Set([1, 2]);
-			bar.add(3);",
+            bar.add(3);",
         "const set = new Set([1, 2]);
-			set.add(set.size);",
+            set.add(set.size);",
         "const set = new Set([1, 2]);
-			set.add(((foo) => foo(set.size))());",
+            set.add(((foo) => foo(set.size))());",
         "let set;
-			set.add(3);",
+            set.add(3);",
         "const set = foo;
-			set.add(3);",
+            set.add(3);",
         "const set = new Set([1, 2]);
-			set.add?.(3);",
+            set.add?.(3);",
         "const set = new Set([1, 2]);
-			set?.add(3);",
+            set?.add(3);",
         "let set;
-			set ??= new Set([1, 2]);
-			set.add(3);",
+            set ??= new Set([1, 2]);
+            set.add(3);",
         "let foo;
-			foo ??= new Set([1, 2]);
-			bar.add(3);",
+            foo ??= new Set([1, 2]);
+            bar.add(3);",
         "let foo, bar;
-			foo = bar = new Set([1, 2]);
-			bar.add(3);",
+            foo = bar = new Set([1, 2]);
+            bar.add(3);",
         "const foo = new Foo();
-			foo.bar = new Set([1, 2]);
-			foo.bar.add(3);",
+            foo.bar = new Set([1, 2]);
+            foo.bar.add(3);",
         r#"const map = new Map([["foo", 1]]);
-			map.notSet("bar", 2);"#,
+            map.notSet("bar", 2);"#,
         r#"const map = new NotMap([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         // Shadowed Set/Map/Object should not trigger
         "const Set = CustomSet; const s = new Set(); s.add(1);",
         r#"const Map = CustomMap; const m = new Map(); m.set("a", 1);"#,
         "const Object = CustomObject; const o = {}; Object.assign(o, x);",
         r#"const map = new Map([["foo", 1]]);
-			; // Not next to each other
-			map.set("bar", 2);"#,
+            ; // Not next to each other
+            map.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]),
-				otherVariable = 1;
-			map.set("bar", 2);"#,
+                otherVariable = 1;
+            map.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set();"#,
+            map.set();"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar");"#,
+            map.set("bar");"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", 2, extraArgument);"#,
+            map.set("bar", 2, extraArgument);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set(..."bar", ..."2");"#,
+            map.set(..."bar", ..."2");"#,
         r#"const {map} = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const [map] = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const foo = new Map([["foo", 1]]);
-			bar.set("bar", 2);"#,
+            bar.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set(map.size, 2);"#,
+            map.set(map.size, 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", map.size);"#,
+            map.set("bar", map.size);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", ((foo) => foo(map.size))());"#,
+            map.set("bar", ((foo) => foo(map.size))());"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set(((foo) => foo(map.size))(), 2);"#,
+            map.set(((foo) => foo(map.size))(), 2);"#,
         r#"let map;
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = foo;
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set?.("bar", 2);"#,
+            map.set?.("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map?.set("bar", 2);"#,
+            map?.set("bar", 2);"#,
         r#"let map;
-			map ??= new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map ??= new Map([["foo", 1]]);
+            map.set("bar", 2);"#,
         r#"let foo;
-			foo = new Map([["foo", 1]]);
-			bar.set("bar", 2);"#,
+            foo = new Map([["foo", 1]]);
+            bar.set("bar", 2);"#,
         r#"let foo, bar;
-			foo = bar = new Map([["foo", 1]]);
-			bar.set("bar", 2);"#,
+            foo = bar = new Map([["foo", 1]]);
+            bar.set("bar", 2);"#,
         r#"const foo = new Foo();
-			foo.bar = new Map([["foo", 1]]);
-			foo.bar.set("bar", 2);"#,
+            foo.bar = new Map([["foo", 1]]);
+            foo.bar.set("bar", 2);"#,
     ];
 
     let fail = vec![
         "const array = [1, 2];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "let array;
-			array = [1, 2];
-			array.push(3, 4);",
+            array = [1, 2];
+            array.push(3, 4);",
         "const array = [3, 4];
-			array.unshift(1, 2);",
+            array.unshift(1, 2);",
         "const array = [];
-			array.push(3, 4,);",
+            array.push(3, 4,);",
         "const array = [];
-			array.unshift(1, 2,);",
+            array.unshift(1, 2,);",
         "const array = [1, 2,];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const array = [3, 4,];
-			array.unshift(1, 2);",
+            array.unshift(1, 2);",
         "const otherVariable = 1,
-				array = [1, 2,];
-			array.push(3, 4);",
+                array = [1, 2,];
+            array.push(3, 4);",
         "const array = [1, 2];
-			array.push( (( 0, 3 )), (( 0, 4 )) );",
+            array.push( (( 0, 3 )), (( 0, 4 )) );",
         "const array = [1, 2]; array.push(3, 4); foo()",
         "const array = [1, 2]; array.push(3, 4);",
         "const array = [1, 2];
-			array.push(3, 4); // comment",
+            array.push(3, 4); // comment",
         "const array = [1, 2];
-			array.push(3, 4);
-			array.unshift(1, 2);",
+            array.push(3, 4);
+            array.unshift(1, 2);",
         "const array = [1, 2];
-			array.push(...bar);",
+            array.push(...bar);",
         "const array = [1, 2];
-			array.unshift(...bar);",
+            array.unshift(...bar);",
         "const array = [1, 2];
-			array.unshift(foo());",
+            array.unshift(foo());",
         "const array = [1, 2];
-			array.unshift(...foo());",
+            array.unshift(...foo());",
         "const array = [1, 2];
-			array.unshift([foo()]);",
+            array.unshift([foo()]);",
         "const array = [1, 2];
-			array.push(
-				3,
-				4,
-			);",
+            array.push(
+                3,
+                4,
+            );",
         "const array = [1, 2];
-			array.push(((array) => foo(array.length))());",
+            array.push(((array) => foo(array.length))());",
         "let array= [1, 2];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "var array = [1, 2];
-			array.push(3, 4);",
+            array.push(3, 4);",
         "const array = [1]
-			array.push(2);
-			[0].map()",
+            array.push(2);
+            [0].map()",
         "const array = [1]
-			;(( array.push(2) ))
-			;[0].map()",
+            ;(( array.push(2) ))
+            ;[0].map()",
         "const array = [1]
-			array.push(2);
-			notNeeded.map()",
+            array.push(2);
+            notNeeded.map()",
         "const array = [1]
-			array.push(2);
-			array.push(3);
-			[0].map()",
+            array.push(2);
+            array.push(3);
+            [0].map()",
         "const array = [1]
-			array.push(2);
-			array.push(3);
-			notNeeded.map()",
+            array.push(2);
+            array.push(3);
+            notNeeded.map()",
         "if(1) {
-				const array = [1]
-				array.push(2);
-				[0].map()
-			}",
+                const array = [1]
+                array.push(2);
+                [0].map()
+            }",
         "let array
-			array = [1, 2]
-			array.push(3, 4)
-			;[0].map()",
+            array = [1, 2]
+            array.push(3, 4)
+            ;[0].map()",
         "const object = {foo: 1};
-			object.bar = 2;",
+            object.bar = 2;",
         "let object;
-			object = {foo: 1};
-			object.bar = 2;",
+            object = {foo: 1};
+            object.bar = 2;",
         "const object = {foo: 1};
-			object[bar] = 2;",
+            object[bar] = 2;",
         "const object = {foo: 1};
-			object[(( 0, bar ))] = (( baz ));",
+            object[(( 0, bar ))] = (( baz ));",
         "const object = {};
-			object.bar = 2;",
+            object.bar = 2;",
         "const object = {foo: 1,};
-			object.bar = 2;",
+            object.bar = 2;",
         "const otherVariable = 1,
-				object = {foo: 1};
-			object.bar = 2;",
+                object = {foo: 1};
+            object.bar = 2;",
         "const object = {foo: 1}; object.bar = 2; foo()",
         "const object = {foo: 1}; object.bar = 2;",
         "const object = {foo: 1};
-			object.bar = 2; // comment",
+            object.bar = 2; // comment",
         "const object = {foo: 1};
-			object.bar = 2;
-			object.baz = 2;",
+            object.bar = 2;
+            object.baz = 2;",
         "const object = {foo: 1};
-			object.bar = anotherObject.baz = 2;",
+            object.bar = anotherObject.baz = 2;",
         "const object = {foo: 1};
-			object.bar = (object) => object.foo;",
+            object.bar = (object) => object.foo;",
         "const object = {foo: 1};
-			object.object = 2;",
+            object.object = 2;",
         "const object = {foo: 1}
-			object.bar = 2
-			;[0].map()",
+            object.bar = 2
+            ;[0].map()",
         "const object = {foo: 1}
-			object.bar = 2
-			;notNeeded.map()",
+            object.bar = 2
+            ;notNeeded.map()",
         "let object
-			object = {foo: 1}
-			object.bar = 2
-			;[0].map()",
+            object = {foo: 1}
+            object.bar = 2
+            ;[0].map()",
         "const object = {foo: 1};
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "let object;
-			object = {foo: 1};
-			Object.assign(object, bar);",
+            object = {foo: 1};
+            Object.assign(object, bar);",
         "const object = {foo: 1};
-			Object.assign(object, {bar: 2});",
+            Object.assign(object, {bar: 2});",
         "const object = {foo: 1};
-			Object.assign(object, {bar, baz,});",
+            Object.assign(object, {bar, baz,});",
         "const object = {foo: 1,};
-			Object.assign(object, {bar, baz,});",
+            Object.assign(object, {bar, baz,});",
         "const object = {};
-			Object.assign(object, {bar, baz,});",
+            Object.assign(object, {bar, baz,});",
         "const object = {};
-			Object.assign(object, {});",
+            Object.assign(object, {});",
         "const object = {};
-			Object.assign((( object )), (( 0, bar)));",
+            Object.assign((( object )), (( 0, bar)));",
         "const object = {};
-			Object.assign((( object )), (( {bar: 2} )));",
+            Object.assign((( object )), (( {bar: 2} )));",
         "const otherVariable = 1,
-				object = {foo: 1};
-			Object.assign(object, bar);",
+                object = {foo: 1};
+            Object.assign(object, bar);",
         "const object = {foo: 1}; object.bar = 2; foo()",
         "const object = {foo: 1}; object.bar = 2;",
         "const object = {foo: 1};
-			Object.assign(object, bar) // comment",
+            Object.assign(object, bar) // comment",
         "const object = {foo: 1};
-			Object.assign(object, bar)
-			Object.assign(object, {baz})",
+            Object.assign(object, bar)
+            Object.assign(object, {baz})",
         "const object = {foo: 1};
-			Object.assign(object, {baz(object){return object}})",
+            Object.assign(object, {baz(object){return object}})",
         "const object = {foo: 1};
-			Object.assign(object, bar());",
+            Object.assign(object, bar());",
         "let object = {foo: 1};
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "var object = {foo: 1};
-			Object.assign(object, bar);",
+            Object.assign(object, bar);",
         "const object = {foo: 1};
-			Object.assign(object, bar, baz);",
+            Object.assign(object, bar, baz);",
         "const object = {foo: 1};
-			Object.assign(object, {}, baz);",
+            Object.assign(object, {}, baz);",
         "const object = {foo: 1};
-			Object.assign(object, bar, ...baz, {bar: 2});",
+            Object.assign(object, bar, ...baz, {bar: 2});",
         "const object = {foo: 1}
-			Object.assign(object, bar)
-			;[0].map()",
+            Object.assign(object, bar)
+            ;[0].map()",
         "const object = {foo: 1}
-			Object.assign(object, bar)
-			;notNeeded.map()",
+            Object.assign(object, bar)
+            ;notNeeded.map()",
         "let object
-			object = {foo: 1}
-			Object.assign(object, bar)
-			;[0].map()",
+            object = {foo: 1}
+            Object.assign(object, bar)
+            ;[0].map()",
         "const set = new Set([1, 2]);
-			set.add(3);",
+            set.add(3);",
         "let set;
-			set = new Set([1, 2]);
-			set.add(3);",
+            set = new Set([1, 2]);
+            set.add(3);",
         "const weakSet = new WeakSet([a, b]);
-			weakSet.add(c);",
+            weakSet.add(c);",
         "const set = new Set([]);
-			set.add(3);",
+            set.add(3);",
         "const set = new Set();
-			set.add(3);",
+            set.add(3);",
         "const set = new Set;
-			set.add(3);",
+            set.add(3);",
         "const set = (( new Set ));
-			set.add(3);",
+            set.add(3);",
         "const set = new (( Set ));
-			set.add(3);",
+            set.add(3);",
         "const otherVariable = 1,
-				set = new Set;
-			set.add(3);",
+                set = new Set;
+            set.add(3);",
         "const set = new Set([1, 2]);
-			set.add( ((0, 3)), );",
+            set.add( ((0, 3)), );",
         "const set = new Set([1, 2]); set.add(3); foo()",
         "const set = new Set([1, 2]); set.add(3);",
         "const set = new Set([1, 2]);
-			set.add(3); // comment",
+            set.add(3); // comment",
         "const set = new Set([1, 2]);
-			set.add(foo());",
+            set.add(foo());",
         "const set = new Set([1, 2]);
-			set
-				.add(
-					3,
-			);",
+            set
+                .add(
+                    3,
+            );",
         "let set = new Set([1, 2]);
-			set.add(3);",
+            set.add(3);",
         "var set = new Set([1, 2]);
-			set.add(3);",
+            set.add(3);",
         "const set = new Set([1, 2])
-			set.add(3);
-			[0].map()",
+            set.add(3);
+            [0].map()",
         "const set = new Set([1, 2])
-			set.add(3);
-			notNeeded.map()",
+            set.add(3);
+            notNeeded.map()",
         "const set = new Set
-			set.add(3);
-			[0].map()",
+            set.add(3);
+            [0].map()",
         "const set = new Set
-			set.add(3);
-			notNeeded.map()",
+            set.add(3);
+            notNeeded.map()",
         "let set
-			set = new Set([1, 2])
-			set.add(3)
-			;[0].map()",
+            set = new Set([1, 2])
+            set.add(3)
+            ;[0].map()",
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"let map;
-			map = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map = new Map([["foo", 1]]);
+            map.set("bar", 2);"#,
         "const weakMap = new WeakMap([[foo, 1]]);
-			weakMap.set(bar, 2);",
+            weakMap.set(bar, 2);",
         r#"const map = new Map([]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = new Map();
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = new Map;
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = (( new Map ));
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = new (( Map ));
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const otherVariable = 1,
-				map = new Map;
-			map.set("bar", 2);"#,
+                map = new Map;
+            map.set("bar", 2);"#,
         r#"const map = new Map([["foo",1]]);
-			map.set( ((0, "bar")), ((0, 2)), );"#,
+            map.set( ((0, "bar")), ((0, 2)), );"#,
         r#"const map = new Map([["foo", 1]]);    map.set("bar", 2);    foo()"#,
         r#"const map = new Map([["foo", 1]]);    map.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", 2); // comment"#,
+            map.set("bar", 2); // comment"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set("bar", foo());"#,
+            map.set("bar", foo());"#,
         r#"const map = new Map([["foo", 1]]);
-			map.set(bar(), 2);"#,
+            map.set(bar(), 2);"#,
         r#"const map = new Map([["foo", 1]]);
-			map
-				.set(
-					"bar",
-					2,
-			);"#,
+            map
+                .set(
+                    "bar",
+                    2,
+            );"#,
         r#"let map = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"var map = new Map([["foo", 1]]);
-			map.set("bar", 2);"#,
+            map.set("bar", 2);"#,
         r#"const map = new Map([["foo", 1]])
-			map.set("bar", 2);
-			[0].map()"#,
+            map.set("bar", 2);
+            [0].map()"#,
         r#"const map = new Map([["foo", 1]])
-			map.set("bar", 2);
-			notNeeded.map()"#,
+            map.set("bar", 2);
+            notNeeded.map()"#,
         r#"const map = new Map
-			map.set("bar", 2);
-			[0].map()"#,
+            map.set("bar", 2);
+            [0].map()"#,
         r#"const map = new Map
-			map.set("bar", 2);
-			notNeeded.map()"#,
+            map.set("bar", 2);
+            notNeeded.map()"#,
         r#"let map
-			map = new Map([["foo", 1]])
-			map.set("bar", 2)
-			;[0].map()"#,
+            map = new Map([["foo", 1]])
+            map.set("bar", 2)
+            ;[0].map()"#,
         "const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>();
-			cellOutputMappers.set('display_data', translateDisplayDataOutput);",
+            cellOutputMappers.set('display_data', translateDisplayDataOutput);",
         "const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>([]);
-			cellOutputMappers.set('display_data', translateDisplayDataOutput);",
+            cellOutputMappers.set('display_data', translateDisplayDataOutput);",
         "const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>;
-			cellOutputMappers.set('display_data', translateDisplayDataOutput);",
+            cellOutputMappers.set('display_data', translateDisplayDataOutput);",
     ];
 
     Tester::new(NoImmediateMutation::NAME, NoImmediateMutation::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
@@ -365,31 +365,31 @@ fn test() {
         ("function foo(){return[]instanceof Array}", None),
         (
             "(
-				// comment
-				((
-					// comment
-					(
-						// comment
-						foo
-						// comment
-					)
-					// comment
-				))
-				// comment
-			)
-			// comment before instanceof
+                // comment
+                ((
+                    // comment
+                    (
+                        // comment
+                        foo
+                        // comment
+                    )
+                    // comment
+                ))
+                // comment
+            )
+            // comment before instanceof
             instanceof
-			// comment after instanceof
-			(
-				// comment
-				(
-					// comment
-					Array
-					// comment
-				)
-					// comment
-			)
-				// comment",
+            // comment after instanceof
+            (
+                // comment
+                (
+                    // comment
+                    Array
+                    // comment
+                )
+                    // comment
+            )
+                // comment",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -140,34 +140,34 @@ fn test() {
         "!foo == bar",
         "!foo != bar",
         "
-						function x() {
-							return!foo === bar;
-						}
-					",
+                        function x() {
+                            return!foo === bar;
+                        }
+                    ",
         "
-						function x() {
-							return!
-								foo === bar;
-							throw!
-								foo === bar;
-						}
-					",
+                        function x() {
+                            return!
+                                foo === bar;
+                            throw!
+                                foo === bar;
+                        }
+                    ",
         "
-						foo
-						!(a) === b
-					",
+                        foo
+                        !(a) === b
+                    ",
         "
-						foo
-						![a, b].join('') === c
-					",
+                        foo
+                        ![a, b].join('') === c
+                    ",
         "
-						foo
-						! [a, b].join('') === c
-					",
+                        foo
+                        ! [a, b].join('') === c
+                    ",
         "
-						foo
-						!/* comment */[a, b].join('') === c
-					",
+                        foo
+                        !/* comment */[a, b].join('') === c
+                    ",
     ];
 
     let fix = vec![
@@ -177,71 +177,71 @@ fn test() {
         ("!foo != bar", "foo == bar"),
         (
             "
-						function x() {
-							return!foo === bar;
-						}
-					",
+                        function x() {
+                            return!foo === bar;
+                        }
+                    ",
             "
-						function x() {
-							return foo !== bar;
-						}
-					",
+                        function x() {
+                            return foo !== bar;
+                        }
+                    ",
         ),
         (
             "
-						function x() {
-							return!
-								foo === bar;
-							throw!
-								foo === bar;
-						}
-					",
+                        function x() {
+                            return!
+                                foo === bar;
+                            throw!
+                                foo === bar;
+                        }
+                    ",
             "
-						function x() {
-							return foo !== bar;
-							throw foo !== bar;
-						}
-					",
+                        function x() {
+                            return foo !== bar;
+                            throw foo !== bar;
+                        }
+                    ",
         ),
         (
             "
-						foo
-						!(a) === b
-					",
+                        foo
+                        !(a) === b
+                    ",
             "
-						foo
-						;(a) !== b
-					",
+                        foo
+                        ;(a) !== b
+                    ",
         ),
         (
             "
-						foo
-						![a, b].join('') === c
-					",
+                        foo
+                        ![a, b].join('') === c
+                    ",
             "
-						foo
-						;[a, b].join('') !== c
-					",
+                        foo
+                        ;[a, b].join('') !== c
+                    ",
         ),
         (
             "
-						foo
-						! [a, b].join('') === c
-					",
+                        foo
+                        ! [a, b].join('') === c
+                    ",
             "
-						foo
-						;[a, b].join('') !== c
-					",
+                        foo
+                        ;[a, b].join('') !== c
+                    ",
         ),
         (
             "
-						foo
-						!/* comment */[a, b].join('') === c
-					",
+                        foo
+                        !/* comment */[a, b].join('') === c
+                    ",
             "
-						foo
-						;[a, b].join('') !== c
-					",
+                        foo
+                        ;[a, b].join('') !== c
+                    ",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -79,9 +79,9 @@ fn test() {
     let fail = vec![
         "const array = new Array(1)",
         "const zero = 0;
-			const array = new Array(zero);",
+            const array = new Array(zero);",
         "const length = 1;
-			const array = new Array(length);",
+            const array = new Array(length);",
         "const array = new Array(1.5)",
         r#"const array = new Array(Number("1"))"#,
         r#"const array = new Array("1")"#,
@@ -89,7 +89,7 @@ fn test() {
         r#"const array = new Array(("1"))"#,
         "const array = new Array((0, 1))",
         r#"const foo = []
-			new Array("bar").forEach(baz)"#,
+            new Array("bar").forEach(baz)"#,
         "new Array(0xff)",
         "new Array(Math.PI | foo)",
         "new Array(Math.min(foo, bar))",
@@ -140,9 +140,9 @@ fn test() {
         "const array = new Array(foo)",
         "const array = new Array(length)",
         "const foo = []
-			new Array(bar).forEach(baz)",
+            new Array(bar).forEach(baz)",
         "const foo = []
-			new Array(...bar).forEach(baz)",
+            new Array(...bar).forEach(baz)",
     ];
 
     Tester::new(NoNewArray::NAME, NoNewArray::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -390,23 +390,23 @@ fn test() {
         ("() => { return null as any as typeof Array }", "() => { return  }", None),
         (
             r"const newDecorations = enabled ?
-	this._debugService.getModel().getBreakpoints().map(breakpoint => {
-		const parsed = test()
-		if (!parsed ) {
-			return null;
-		}
-		return { handle: parsed.handle};
-	}).filter(x => !!x) as INotebookDeltaDecoration[]
-	: [];",
+    this._debugService.getModel().getBreakpoints().map(breakpoint => {
+        const parsed = test()
+        if (!parsed ) {
+            return null;
+        }
+        return { handle: parsed.handle};
+    }).filter(x => !!x) as INotebookDeltaDecoration[]
+    : [];",
             r"const newDecorations = enabled ?
-	this._debugService.getModel().getBreakpoints().map(breakpoint => {
-		const parsed = test()
-		if (!parsed ) {
-			return ;
-		}
-		return { handle: parsed.handle};
-	}).filter(x => !!x) as INotebookDeltaDecoration[]
-	: [];",
+    this._debugService.getModel().getBreakpoints().map(breakpoint => {
+        const parsed = test()
+        if (!parsed ) {
+            return ;
+        }
+        return { handle: parsed.handle};
+    }).filter(x => !!x) as INotebookDeltaDecoration[]
+    : [];",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -229,16 +229,16 @@ fn test() {
         "
         await Promise.all([(x,y)])
         [0].toString()
-		",
+        ",
         "Promise.all([promise,],)",
         "
-		foo
-		Promise.all([(0, promise),],)
-		",
+        foo
+        Promise.all([(0, promise),],)
+        ",
         "
         foo
         Promise.all([[array][0],],)
-		",
+        ",
         "Promise.all([promise]).then()",
         "Promise.all([1]).then()",
         "Promise.all([1.]).then()",

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -32,9 +32,9 @@ declare_oxc_lint!(
     /// ```javascript
     /// const foo = this;
     /// class Bar {
-    /// 	method() {
-    /// 		foo.baz();
-    /// 	}
+    ///     method() {
+    ///         foo.baz();
+    ///     }
     /// }
     ///
     /// new Bar().method();
@@ -43,12 +43,12 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// class Bar {
-    /// 	constructor(fooInstance) {
-    /// 		this.fooInstance = fooInstance;
-    /// 	}
-    /// 	method() {
-    /// 		this.fooInstance.baz();
-    /// 	}
+    ///     constructor(fooInstance) {
+    ///         this.fooInstance = fooInstance;
+    ///     }
+    ///     method() {
+    ///         this.fooInstance.baz();
+    ///     }
     /// }
     ///
     /// new Bar(this).method();

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
@@ -227,97 +227,97 @@ fn test() {
         "class MyError {constructor() {Error.captureStackTrace(this, MyError)}}",
         "class MyError extends NotABuiltinError {constructor() {Error.captureStackTrace(this, MyError)}}",
         "class MyError extends Error {
-				notConstructor() {
-					Error.captureStackTrace(this, MyError)
-				}
-			}",
+                notConstructor() {
+                    Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class MyError extends Error {
-				constructor() {
-					function foo() {
-						Error.captureStackTrace(this, MyError)
-					}
-				}
-			}",
+                constructor() {
+                    function foo() {
+                        Error.captureStackTrace(this, MyError)
+                    }
+                }
+            }",
         "class MyError extends Error {
-				constructor(MyError) {
-					Error.captureStackTrace(this, MyError)
-				}
-			}",
+                constructor(MyError) {
+                    Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class MyError extends Error {
-				static {
-					Error.captureStackTrace(this, MyError)
-					function foo() {
-						Error.captureStackTrace(this, MyError)
-					}
-				}
-			}",
+                static {
+                    Error.captureStackTrace(this, MyError)
+                    function foo() {
+                        Error.captureStackTrace(this, MyError)
+                    }
+                }
+            }",
         "class MyError extends Error {
-				constructor() {
-					class NotAErrorSubclass {
-						constructor() {
-							Error.captureStackTrace(this, new.target)
-						}
-					}
-				}
-			}",
+                constructor() {
+                    class NotAErrorSubclass {
+                        constructor() {
+                            Error.captureStackTrace(this, new.target)
+                        }
+                    }
+                }
+            }",
         "class Error {}
-			class MyError extends Error {
-				constructor() {
-					Error.captureStackTrace(this, MyError)
-				}
-			}",
+            class MyError extends Error {
+                constructor() {
+                    Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class Error {}
-			class MyError extends RangeError {
-				constructor() {
-					Error.captureStackTrace(this, MyError)
-				}
-			}",
+            class MyError extends RangeError {
+                constructor() {
+                    Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class MyError extends Error {
-				constructor(): void;
-				static {
-					Error.captureStackTrace(this, MyError)
-					function foo() {
-						Error.captureStackTrace(this, MyError)
-					}
-				}
-			}",
+                constructor(): void;
+                static {
+                    Error.captureStackTrace(this, MyError)
+                    function foo() {
+                        Error.captureStackTrace(this, MyError)
+                    }
+                }
+            }",
     ];
 
     let fail = vec![
         "class MyError extends Error {
-				constructor() {
-					const foo = () => {
-						Error.captureStackTrace(this, MyError)
-					}
-				}
-			}",
+                constructor() {
+                    const foo = () => {
+                        Error.captureStackTrace(this, MyError)
+                    }
+                }
+            }",
         "class MyError extends Error {
-				constructor() {
-					if (a) Error.captureStackTrace(this, MyError)
-				}
-			}",
+                constructor() {
+                    if (a) Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class MyError extends Error {
-				constructor() {
-					const x = () => Error.captureStackTrace(this, MyError)
-				}
-			}",
+                constructor() {
+                    const x = () => Error.captureStackTrace(this, MyError)
+                }
+            }",
         "class MyError extends Error {
-				constructor() {
-					void Error.captureStackTrace(this, MyError)
-				}
-			}",
+                constructor() {
+                    void Error.captureStackTrace(this, MyError)
+                }
+            }",
         "export default class extends Error {
-				constructor() {
-					Error.captureStackTrace(this, new.target)
-				}
-			}",
+                constructor() {
+                    Error.captureStackTrace(this, new.target)
+                }
+            }",
         "export default (
-				class extends Error {
-					constructor() {
-						Error.captureStackTrace(this, new.target)
-					}
-				}
-			)",
+                class extends Error {
+                    constructor() {
+                        Error.captureStackTrace(this, new.target)
+                    }
+                }
+            )",
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -537,16 +537,16 @@ fn test() {
         (
             r"
             async function * foo() {
-				yield* Promise.resolve(bar);
-			}
+                yield* Promise.resolve(bar);
+            }
         ",
             None,
         ),
         (
             r"
             async function * foo() {
-				yield* Promise.reject(bar);
-			}
+                yield* Promise.reject(bar);
+            }
         ",
             None,
         ),
@@ -635,25 +635,25 @@ fn test() {
         ),
         (
             r"
-			(async function() {
-				return Promise.resolve(bar);
-			});
-		",
-            None,
-        ),
-        (
-            r"
-			async function * foo() {
-				return Promise.resolve(bar);
-			}
+            (async function() {
+                return Promise.resolve(bar);
+            });
         ",
             None,
         ),
         (
             r"
-		    (async function*() {
-		    	return Promise.resolve(bar);
-		    });
+            async function * foo() {
+                return Promise.resolve(bar);
+            }
+        ",
+            None,
+        ),
+        (
+            r"
+            (async function*() {
+                return Promise.resolve(bar);
+            });
         ",
             None,
         ),
@@ -661,102 +661,102 @@ fn test() {
         (r"async () => Promise.reject(bar);", None),
         (
             r"
-			async () => {
-				return Promise.reject(bar);
-			};
-		",
+            async () => {
+                return Promise.reject(bar);
+            };
+        ",
             None,
         ),
         (
             r"
-			async function foo() {
-				return Promise.reject(bar);
-		    }
-		",
+            async function foo() {
+                return Promise.reject(bar);
+            }
+        ",
             None,
         ),
         (
             r"
-			(async function() {
-				return Promise.reject(bar);
-			});
-		",
+            (async function() {
+                return Promise.reject(bar);
+            });
+        ",
             None,
         ),
         (
             r"
-			async function * foo() {
-				return Promise.reject(bar);
-			}
-		",
+            async function * foo() {
+                return Promise.reject(bar);
+            }
+        ",
             None,
         ),
         (
             r"
-			(async function*() {
-				return Promise.reject(bar);
-			});
-		",
+            (async function*() {
+                return Promise.reject(bar);
+            });
+        ",
             None,
         ),
         // Async generator yielding Promise.resolve
         (
             r"
-				async function * foo() {
-					yield Promise.resolve(bar);
-				}
-			",
+                async function * foo() {
+                    yield Promise.resolve(bar);
+                }
+            ",
             None,
         ),
         (
             r"
-				(async function * () {
-					yield Promise.resolve(bar);
-				});
-				",
+                (async function * () {
+                    yield Promise.resolve(bar);
+                });
+                ",
             None,
         ),
         (
             // Async generator yielding Promise.reject
             r"
-				async function * foo() {
-					yield Promise.reject(bar);
-				}
-				",
+                async function * foo() {
+                    yield Promise.reject(bar);
+                }
+                ",
             None,
         ),
         (
             r"
-				(async function * () {
-					yield Promise.reject(bar);
-				});
-				",
+                (async function * () {
+                    yield Promise.reject(bar);
+                });
+                ",
             None,
         ),
         (r"async () => Promise.resolve();", None),
         (
             r"
-				async function foo() {
-					return Promise.resolve();
-				}
-				",
+                async function foo() {
+                    return Promise.resolve();
+                }
+                ",
             None,
         ),
         (r"async () => Promise.reject();", None),
         (
             r"
-				async function foo() {
-					return Promise.reject();
-				}
-				",
+                async function foo() {
+                    return Promise.reject();
+                }
+                ",
             None,
         ),
         (
             r"
-				async function * foo() {
-					yield Promise.resolve();
-				}
-				",
+                async function * foo() {
+                    yield Promise.resolve();
+                }
+                ",
             None,
         ),
         // Multiple arguments
@@ -765,10 +765,10 @@ fn test() {
         // Sequence expressions
         (
             r"async
-				async function * foo() {
-					yield Promise.resolve((bar, baz));
-				}
-		",
+                async function * foo() {
+                    yield Promise.resolve((bar, baz));
+                }
+        ",
             None,
         ),
         (r"async () => Promise.resolve((bar, baz))", None),
@@ -777,22 +777,22 @@ fn test() {
         // Try statements
         (
             r"
-				async function foo() {
-					try {
-						return Promise.resolve(1);
-					} catch {}
-				}
-		",
+                async function foo() {
+                    try {
+                        return Promise.resolve(1);
+                    } catch {}
+                }
+        ",
             None,
         ),
         (
             r"
-				async function foo() {
-					try {
-						return Promise.reject(1);
-					} catch {}
-				}
-				",
+                async function foo() {
+                    try {
+                        return Promise.reject(1);
+                    } catch {}
+                }
+                ",
             None,
         ),
         // Spread arguments
@@ -822,16 +822,16 @@ fn test() {
         (
             r"
             async function * foo() {
-     			(yield Promise.reject(bar));
-     		}
+                 (yield Promise.reject(bar));
+             }
         ",
             None,
         ),
         (
             r"
             async function * foo() {
-     			((yield Promise.reject(bar)));
-     		}
+                 ((yield Promise.reject(bar)));
+             }
         ",
             None,
         ),
@@ -958,22 +958,22 @@ fn test() {
     let fix = vec![
         (
             r"
-				const main = async foo => {
-					if (foo > 4) {
-						return Promise.reject(new Error('🤪'));
-					}
+                const main = async foo => {
+                    if (foo > 4) {
+                        return Promise.reject(new Error('🤪'));
+                    }
 
-					return Promise.resolve(result);
-				};
+                    return Promise.resolve(result);
+                };
         ",
             r"
-				const main = async foo => {
-					if (foo > 4) {
-						throw new Error('🤪');
-					}
+                const main = async foo => {
+                    if (foo > 4) {
+                        throw new Error('🤪');
+                    }
 
-					return result;
-				};
+                    return result;
+                };
         ",
             None,
         ),
@@ -981,66 +981,66 @@ fn test() {
         ("async () => Promise.resolve(bar);", "async () => bar;", None),
         (
             r"
-				async () => {
-					return Promise.resolve(bar);
-				};
+                async () => {
+                    return Promise.resolve(bar);
+                };
         ",
             r"
-				async () => {
-					return bar;
-				};
-        ",
-            None,
-        ),
-        (
-            r"
-				async function foo() {
-					return Promise.resolve(bar);
-				}
-        ",
-            r"
-				async function foo() {
-					return bar;
-				}
+                async () => {
+                    return bar;
+                };
         ",
             None,
         ),
         (
             r"
-				(async function() {
-					return Promise.resolve(bar);
-				});
+                async function foo() {
+                    return Promise.resolve(bar);
+                }
         ",
             r"
-				(async function() {
-					return bar;
-				});
-        ",
-            None,
-        ),
-        (
-            r"
-				async function * foo() {
-					return Promise.resolve(bar);
-				}
-        ",
-            r"
-				async function * foo() {
-					return bar;
-				}
+                async function foo() {
+                    return bar;
+                }
         ",
             None,
         ),
         (
             r"
-				(async function*() {
-					return Promise.resolve(bar);
-				});
+                (async function() {
+                    return Promise.resolve(bar);
+                });
         ",
             r"
-				(async function*() {
-					return bar;
-				});
+                (async function() {
+                    return bar;
+                });
+        ",
+            None,
+        ),
+        (
+            r"
+                async function * foo() {
+                    return Promise.resolve(bar);
+                }
+        ",
+            r"
+                async function * foo() {
+                    return bar;
+                }
+        ",
+            None,
+        ),
+        (
+            r"
+                (async function*() {
+                    return Promise.resolve(bar);
+                });
+        ",
+            r"
+                (async function*() {
+                    return bar;
+                });
         ",
             None,
         ),
@@ -1048,120 +1048,120 @@ fn test() {
         ("async () => Promise.reject(bar);", "async () => { throw bar; };", None),
         (
             r"
-				async () => {
-					return Promise.reject(bar);
-				};
+                async () => {
+                    return Promise.reject(bar);
+                };
         ",
             r"
-				async () => {
-					throw bar;
-				};
-        ",
-            None,
-        ),
-        (
-            r"
-				async function foo() {
-					return Promise.reject(bar);
-				}
-        ",
-            r"
-				async function foo() {
-					throw bar;
-				}
+                async () => {
+                    throw bar;
+                };
         ",
             None,
         ),
         (
             r"
-				(async function() {
-					return Promise.reject(bar);
-				});
+                async function foo() {
+                    return Promise.reject(bar);
+                }
         ",
             r"
-				(async function() {
-					throw bar;
-				});
-        ",
-            None,
-        ),
-        (
-            r"
-				async function * foo() {
-					return Promise.reject(bar);
-				}
-        ",
-            r"
-				async function * foo() {
-					throw bar;
-				}
+                async function foo() {
+                    throw bar;
+                }
         ",
             None,
         ),
         (
             r"
-				(async function*() {
-					return Promise.reject(bar);
-				});
+                (async function() {
+                    return Promise.reject(bar);
+                });
         ",
             r"
-				(async function*() {
-					throw bar;
-				});
+                (async function() {
+                    throw bar;
+                });
+        ",
+            None,
+        ),
+        (
+            r"
+                async function * foo() {
+                    return Promise.reject(bar);
+                }
+        ",
+            r"
+                async function * foo() {
+                    throw bar;
+                }
+        ",
+            None,
+        ),
+        (
+            r"
+                (async function*() {
+                    return Promise.reject(bar);
+                });
+        ",
+            r"
+                (async function*() {
+                    throw bar;
+                });
         ",
             None,
         ),
         // Async generator yielding Promise.resolve
         (
             r"
-				async function * foo() {
-					yield Promise.resolve(bar);
-				}
+                async function * foo() {
+                    yield Promise.resolve(bar);
+                }
         ",
             r"
-				async function * foo() {
-					yield bar;
-				}
+                async function * foo() {
+                    yield bar;
+                }
         ",
             None,
         ),
         (
             r"
-				(async function * () {
-					yield Promise.resolve(bar);
-				});
+                (async function * () {
+                    yield Promise.resolve(bar);
+                });
         ",
             r"
-				(async function * () {
-					yield bar;
-				});
+                (async function * () {
+                    yield bar;
+                });
         ",
             None,
         ),
         // Async generator yielding Promise.reject
         (
             r"
-				async function * foo() {
-					yield Promise.reject(bar);
-				}
+                async function * foo() {
+                    yield Promise.reject(bar);
+                }
         ",
             r"
-				async function * foo() {
-					throw bar;
-				}
+                async function * foo() {
+                    throw bar;
+                }
         ",
             None,
         ),
         (
             r"
-				(async function * () {
-					yield Promise.reject(bar);
-				});
+                (async function * () {
+                    yield Promise.reject(bar);
+                });
         ",
             r"
-				(async function * () {
-					throw bar;
-				});
+                (async function * () {
+                    throw bar;
+                });
         ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -29,20 +29,20 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// switch (foo) {
-    /// 	case 1:
-    /// 	default:
-    /// 		handleDefaultCase();
-    /// 		break;
+    ///     case 1:
+    ///     default:
+    ///         handleDefaultCase();
+    ///         break;
     /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// switch (foo) {
-    ///	case 1:
-    ///	case 2:
-    ///		handleCase1And2();
-    ///		break;
+    ///     case 1:
+    ///     case 2:
+    ///         handleCase1And2();
+    ///         break;
     /// }
     /// ```
     NoUselessSwitchCase,

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -567,15 +567,15 @@ fn test() {
         (r"function foo([bar = undefined] = []) {}", None),
         (
             r"
-			foo(
-				undefined,
-				bar,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-			)
-		",
+            foo(
+                undefined,
+                bar,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+            )
+        ",
             None,
         ),
         ("function foo([bar = undefined] = []) {}", None),
@@ -682,21 +682,21 @@ fn test() {
         (
             r"
             function foo():undefined {
-					function nested() {
-						return undefined;
-					}
+                    function nested() {
+                        return undefined;
+                    }
 
-					return nested();
-				}
+                    return nested();
+                }
         ",
             r"
             function foo():undefined {
-					function nested() {
-						return;
-					}
+                    function nested() {
+                        return;
+                    }
 
-					return nested();
-				}
+                    return nested();
+                }
         ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
@@ -325,13 +325,13 @@ fn test() {
         "foo = array.filter(bar); const first = foo[+0];",
         "const {foo} = array.filter(bar), first = foo[0];",
         "const foo = array.filter(bar);
-			doSomething(foo);
-			const first = foo[0];",
+            doSomething(foo);
+            const first = foo[0];",
         // "var foo = array.filter(bar);
         // 	var foo = array.filter(bar);
         // 	const first = foo[0];",
         "export const foo = array.filter(bar);
-			const first = foo[0];",
+            const first = foo[0];",
         "const foo = array.find(bar); const [first] = foo;",
         "const foo = array.find(bar); [first] = foo;",
         "const foo = array.filter(bar); const [first] = notFoo;",
@@ -350,7 +350,7 @@ fn test() {
         "const foo = array.filter(bar); const [...first] = foo;",
         "const foo = array.filter(bar); [...first] = foo;",
         "const foo = array.filter(bar);
-			function a([bar] = foo) {}",
+            function a([bar] = foo) {}",
         "const foo = array.filter; const first = foo[0]",
         "const foo = filter(bar); const first = foo[0]",
         // r#"const foo = array["filter"](bar); const first = foo[0]"#,
@@ -442,15 +442,15 @@ fn test() {
         "array.filter(foo, thisArgument).shift()",
         "array?.filter(foo, thisArgument).shift()",
         "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.shift()
-				// comment 4
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .shift()
+                // comment 4
+                ;",
         "const [foo] = array.filter(bar)",
         "const [items] = array.filter(bar)",
         "const [foo] = array.filter(bar, thisArgument)",
@@ -465,18 +465,18 @@ fn test() {
         "let a = 1, [{foo}] = array.filter(bar)",
         "for (let [i] = array.filter(bar); i< 10; i++) {}",
         "const [
-				// comment 1
-				item
-				]
-				// comment 2
-				= array
-				// comment 3
-				.filter(
-					// comment 4
-					x => x === '🦄'
-				)
-				// comment 5
-				;",
+                // comment 1
+                item
+                ]
+                // comment 2
+                = array
+                // comment 3
+                .filter(
+                    // comment 4
+                    x => x === '🦄'
+                )
+                // comment 5
+                ;",
         "const [foo = baz] = array.filter(bar)",
         "const [foo = (bar)] = array.filter(bar)",
         "const [foo = a ? b : c] = array.filter(bar)",
@@ -492,8 +492,8 @@ fn test() {
         "[foo, ] = array.filter(bar)",
         "for ([i] = array.filter(bar); i< 10; i++) {}",
         "let foo
-			const bar = []
-			;[foo] = array.filter(bar)",
+            const bar = []
+            ;[foo] = array.filter(bar)",
         "[foo = baz] = array.filter(bar)",
         "[{foo} = baz] = array.filter(bar)",
         ";([{foo} = baz] = array.filter(bar))",
@@ -509,115 +509,115 @@ fn test() {
         "const foo = array.filter(bar); const [{propOfFirst = unicorn}] = foo;",
         "const foo = array.filter(bar); [{propOfFirst = unicorn}] = foo;",
         "const items = array.filter(bar);
-			const first = items[0];
-			console.log(items[0]);
-			function foo() { return items[0]; }",
+            const first = items[0];
+            console.log(items[0]);
+            function foo() { return items[0]; }",
         "const item = {}; const items = array.filter(bar); console.log(items[0]);",
         "let items = array.filter(bar); console.log(items[0]);",
         "const item = 1;
-			function f() {
-				const items = array.filter(bar);
-				console.log(items[0]);
-			}",
+            function f() {
+                const items = array.filter(bar);
+                console.log(items[0]);
+            }",
         "const items = array.filter(bar);
-			function f() {
-				const item = 1;
-				const item_ = 2;
-				console.log(items[0]);
-			}",
+            function f() {
+                const item = 1;
+                const item_ = 2;
+                console.log(items[0]);
+            }",
         "const items = array.filter(bar);
-			function f() {
-				console.log(items[0], item);
-			}",
+            function f() {
+                console.log(items[0], item);
+            }",
         "const items = array.filter(bar);
-			console.log(items[0]);
-			function f(item) {
-				return item;
-			}",
+            console.log(items[0]);
+            function f(item) {
+                return item;
+            }",
         "function f() {
-				const items = array.filter(bar);
-				console.log(items[0]);
-			}
-			function f2(item) {
-				return item;
-			}",
+                const items = array.filter(bar);
+                console.log(items[0]);
+            }
+            function f2(item) {
+                return item;
+            }",
         "const packages = array.filter(bar);
-			console.log(packages[0]);",
+            console.log(packages[0]);",
         "const symbols = array.filter(bar);
-			console.log(symbols[0]);",
+            console.log(symbols[0]);",
         "const foo = array.filter(bar); const [first = bar] = foo;",
         "const foo = array.filter(bar); [first = bar] = foo;",
         "let foo = array.filter(bar);foo[0](foo[0])[foo[0]];",
         "let baz;
-			const foo = array.filter(bar);
-			const [bar] = foo;
-			[{bar}] = foo;
-			function getValueOfFirst() {
-				return foo[0].value;
-			}
-			function getPropertyOfFirst(property) {
-				return foo[0][property];
-			}",
+            const foo = array.filter(bar);
+            const [bar] = foo;
+            [{bar}] = foo;
+            function getValueOfFirst() {
+                return foo[0].value;
+            }
+            function getPropertyOfFirst(property) {
+                return foo[0][property];
+            }",
         "const quz = array.filter(fn);
-			const [foo] = array.filter(quz[0]);
-			[{bar: baz}] = foo[
-				array.filter(fn)[0]
-			].filter(
-				array.filter(fn).shift()
-			);",
+            const [foo] = array.filter(quz[0]);
+            [{bar: baz}] = foo[
+                array.filter(fn)[0]
+            ].filter(
+                array.filter(fn).shift()
+            );",
         "const quz = array.find(fn);
-			const [foo] = array.filter(quz);
-			({bar: baz} = foo[
-				array.filter(fn)[0]
-			].find(
-				array.filter(fn).shift()
-			));",
+            const [foo] = array.filter(quz);
+            ({bar: baz} = foo[
+                array.filter(fn)[0]
+            ].find(
+                array.filter(fn).shift()
+            ));",
         "array.filter(foo).pop()",
         "array.filter(foo, thisArgument).pop()",
         "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.pop()
-				// comment 4
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .pop()
+                // comment 4
+                ;",
         "array.filter(foo).at(-1)",
         "array.filter(foo, thisArgument).at(-1)",
         "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.at(
-					// comment 4
-					-1
-					// comment 5
-				)
-				// comment 6
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .at(
+                    // comment 4
+                    -1
+                    // comment 5
+                )
+                // comment 6
+                ;",
         "array.filter(foo).at(0)",
         "array?.filter(foo).at(0)",
         "array.filter(foo, thisArgument).at(0)",
         "array?.filter(foo, thisArgument).at(0)",
         "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.at(
-					// comment 4
-					0
-					// comment 5
-				)
-				// comment 6
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .at(
+                    // comment 4
+                    0
+                    // comment 5
+                )
+                // comment 6
+                ;",
         // oxc-project/oxc#12399
         "array.filter(foo).pop!()",
         "array.filter(foo)?.pop()",
@@ -635,23 +635,23 @@ fn test() {
         ("array?.filter(foo, thisArgument).shift()", "array?.find(foo, thisArgument)"),
         (
             "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.shift()
-				// comment 4
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .shift()
+                // comment 4
+                ;",
             "const item = array
-				// comment 1
-				.find(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 4
-				;",
+                // comment 1
+                .find(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 4
+                ;",
         ),
         ("const [foo] = array.filter(bar)", "const foo = array.find(bar)"),
         ("const [items] = array.filter(bar)", "const items = array.find(bar)"),
@@ -674,28 +674,28 @@ fn test() {
         ),
         (
             "const [
-				// comment 1
-				item
-				]
-				// comment 2
-				= array
-				// comment 3
-				.filter(
-					// comment 4
-					x => x === '🦄'
-				)
-				// comment 5
-				;",
+                // comment 1
+                item
+                ]
+                // comment 2
+                = array
+                // comment 3
+                .filter(
+                    // comment 4
+                    x => x === '🦄'
+                )
+                // comment 5
+                ;",
             "const item
-				// comment 2
-				= array
-				// comment 3
-				.find(
-					// comment 4
-					x => x === '🦄'
-				)
-				// comment 5
-				;",
+                // comment 2
+                = array
+                // comment 3
+                .find(
+                    // comment 4
+                    x => x === '🦄'
+                )
+                // comment 5
+                ;",
         ),
         ("[foo] = array.filter(bar)", "foo = array.find(bar)"),
         ("[foo] = array.filter(bar, thisArgument)", "foo = array.find(bar, thisArgument)"),
@@ -710,11 +710,11 @@ fn test() {
         ),
         (
             "let foo
-			const bar = []
-			;[foo] = array.filter(bar)",
+            const bar = []
+            ;[foo] = array.filter(bar)",
             "let foo
-			const bar = []
-			;foo = array.find(bar)",
+            const bar = []
+            ;foo = array.find(bar)",
         ),
         (
             "const foo = array.filter(bar); const first = foo[0];",
@@ -744,13 +744,13 @@ fn test() {
         ),
         (
             "const items = array.filter(bar);
-			const first = items[0];
-			console.log(items[0]);
-			function foo() { return items[0]; }",
+            const first = items[0];
+            console.log(items[0]);
+            function foo() { return items[0]; }",
             "const item = array.find(bar);
-			const first = item;
-			console.log(item);
-			function foo() { return item; }",
+            const first = item;
+            console.log(item);
+            function foo() { return item; }",
         ),
         (
             "const item = {}; const items = array.filter(bar); console.log(items[0]);",
@@ -762,79 +762,79 @@ fn test() {
         ),
         (
             "const item = 1;
-			function f() {
-				const items = array.filter(bar);
-				console.log(items[0]);
-			}",
+            function f() {
+                const items = array.filter(bar);
+                console.log(items[0]);
+            }",
             "const item = 1;
-			function f() {
-				const item_ = array.find(bar);
-				console.log(item_);
-			}",
+            function f() {
+                const item_ = array.find(bar);
+                console.log(item_);
+            }",
         ),
         (
             "const items = array.filter(bar);
-			function f() {
-				const item = 1;
-				const item_ = 2;
-				console.log(items[0]);
-			}",
+            function f() {
+                const item = 1;
+                const item_ = 2;
+                console.log(items[0]);
+            }",
             "const item__ = array.find(bar);
-			function f() {
-				const item = 1;
-				const item_ = 2;
-				console.log(item__);
-			}",
+            function f() {
+                const item = 1;
+                const item_ = 2;
+                console.log(item__);
+            }",
         ),
         (
             "const items = array.filter(bar);
-			function f() {
-				console.log(items[0], item);
-			}",
+            function f() {
+                console.log(items[0], item);
+            }",
             "const item_ = array.find(bar);
-			function f() {
-				console.log(item_, item);
-			}",
+            function f() {
+                console.log(item_, item);
+            }",
         ),
         (
             "const items = array.filter(bar);
-			console.log(items[0]);
-			function f(item) {
-				return item;
-			}",
+            console.log(items[0]);
+            function f(item) {
+                return item;
+            }",
             "const item_ = array.find(bar);
-			console.log(item_);
-			function f(item) {
-				return item;
-			}",
+            console.log(item_);
+            function f(item) {
+                return item;
+            }",
         ),
         (
             "function f() {
-				const items = array.filter(bar);
-				console.log(items[0]);
-			}
-			function f2(item) {
-				return item;
-			}",
+                const items = array.filter(bar);
+                console.log(items[0]);
+            }
+            function f2(item) {
+                return item;
+            }",
             "function f() {
-				const item = array.find(bar);
-				console.log(item);
-			}
-			function f2(item) {
-				return item;
-			}",
+                const item = array.find(bar);
+                console.log(item);
+            }
+            function f2(item) {
+                return item;
+            }",
         ),
         (
             "const packages = array.filter(bar);
-			console.log(packages[0]);",
+            console.log(packages[0]);",
             "const package_ = array.find(bar);
-			console.log(package_);",
+            console.log(package_);",
         ),
         (
             "const symbols = array.filter(bar);
-			console.log(symbols[0]);",
+            console.log(symbols[0]);",
             "const symbol_ = array.find(bar);
-			console.log(symbol_);",
+            console.log(symbol_);",
         ),
         (
             "let foo = array.filter(bar);foo[0](foo[0])[foo[0]];",
@@ -842,105 +842,105 @@ fn test() {
         ),
         (
             "let baz;
-			const foo = array.filter(bar);
-			const [bar] = foo;
-			[{bar}] = foo;
-			function getValueOfFirst() {
-				return foo[0].value;
-			}
-			function getPropertyOfFirst(property) {
-				return foo[0][property];
-			}",
+            const foo = array.filter(bar);
+            const [bar] = foo;
+            [{bar}] = foo;
+            function getValueOfFirst() {
+                return foo[0].value;
+            }
+            function getPropertyOfFirst(property) {
+                return foo[0][property];
+            }",
             "let baz;
-			const foo = array.find(bar);
-			const bar = foo;
-			({bar} = foo);
-			function getValueOfFirst() {
-				return foo.value;
-			}
-			function getPropertyOfFirst(property) {
-				return foo[property];
-			}",
+            const foo = array.find(bar);
+            const bar = foo;
+            ({bar} = foo);
+            function getValueOfFirst() {
+                return foo.value;
+            }
+            function getPropertyOfFirst(property) {
+                return foo[property];
+            }",
         ),
         (
             "const quz = array.filter(fn);
-			const [foo] = array.filter(quz[0]);
-			[{bar: baz}] = foo[
-				array.filter(fn)[0]
-			].filter(
-				array.filter(fn).shift()
-			);",
+            const [foo] = array.filter(quz[0]);
+            [{bar: baz}] = foo[
+                array.filter(fn)[0]
+            ].filter(
+                array.filter(fn).shift()
+            );",
             "const quz = array.find(fn);
-			const [foo] = array.filter(quz);
-			({bar: baz} = foo[
-				array.filter(fn)[0]
-			].find(
-				array.filter(fn).shift()
-			));",
+            const [foo] = array.filter(quz);
+            ({bar: baz} = foo[
+                array.filter(fn)[0]
+            ].find(
+                array.filter(fn).shift()
+            ));",
         ),
         (
             "const quz = array.find(fn);
-			const [foo] = array.filter(quz);
-			({bar: baz} = foo[
-				array.filter(fn)[0]
-			].find(
-				array.filter(fn).shift()
-			));",
+            const [foo] = array.filter(quz);
+            ({bar: baz} = foo[
+                array.filter(fn)[0]
+            ].find(
+                array.filter(fn).shift()
+            ));",
             "const quz = array.find(fn);
-			const foo = array.find(quz);
-			({bar: baz} = foo[
-				array.find(fn)
-			].find(
-				array.find(fn)
-			));",
+            const foo = array.find(quz);
+            ({bar: baz} = foo[
+                array.find(fn)
+            ].find(
+                array.find(fn)
+            ));",
         ),
         ("array.filter(foo).pop()", "array.findLast(foo)"),
         ("array.filter(foo, thisArgument).pop()", "array.findLast(foo, thisArgument)"),
         (
             "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.pop()
-				// comment 4
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .pop()
+                // comment 4
+                ;",
             "const item = array
-				// comment 1
-				.findLast(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 4
-				;",
+                // comment 1
+                .findLast(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 4
+                ;",
         ),
         ("array.filter(foo).at(-1)", "array.findLast(foo)"),
         ("array.filter(foo, thisArgument).at(-1)", "array.findLast(foo, thisArgument)"),
         (
             "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.at(
-					// comment 4
-					-1
-					// comment 5
-				)
-				// comment 6
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .at(
+                    // comment 4
+                    -1
+                    // comment 5
+                )
+                // comment 6
+                ;",
             "const item = array
-				// comment 1
-				.findLast(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 6
-				;",
+                // comment 1
+                .findLast(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 6
+                ;",
         ),
         ("array.filter(foo).at(0)", "array.find(foo)"),
         ("array?.filter(foo).at(0)", "array?.find(foo)"),
@@ -948,27 +948,27 @@ fn test() {
         ("array?.filter(foo, thisArgument).at(0)", "array?.find(foo, thisArgument)"),
         (
             "const item = array
-				// comment 1
-				.filter(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 3
-				.at(
-					// comment 4
-					0
-					// comment 5
-				)
-				// comment 6
-				;",
+                // comment 1
+                .filter(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 3
+                .at(
+                    // comment 4
+                    0
+                    // comment 5
+                )
+                // comment 6
+                ;",
             "const item = array
-				// comment 1
-				.find(
-					// comment 2
-					x => x === '🦄'
-				)
-				// comment 6
-				;",
+                // comment 1
+                .find(
+                    // comment 2
+                    x => x === '🦄'
+                )
+                // comment 6
+                ;",
         ),
     ];
     Tester::new(PreferArrayFind::NAME, PreferArrayFind::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -466,11 +466,11 @@ fn test() {
         // "lodash.flatten(array)",
         // "underscore.flatten(array)",
         "before()
-			Array.prototype.concat.apply([], [array].concat(array))",
+            Array.prototype.concat.apply([], [array].concat(array))",
         "before()
-			Array.prototype.concat.apply([], +1)",
+            Array.prototype.concat.apply([], +1)",
         "before()
-			Array.prototype.concat.call([], +1)",
+            Array.prototype.concat.call([], +1)",
         "Array.prototype.concat.apply([], (0, array))",
         "Array.prototype.concat.call([], (0, array))",
         "async function a() { return [].concat(await getArray()); }",
@@ -478,21 +478,21 @@ fn test() {
         // "async function a() { return _.flatten(await getArray()); }",
         // "async function a() { return _.flatten((await getArray())); }",
         "before()
-			Array.prototype.concat.apply([], 1)",
+            Array.prototype.concat.apply([], 1)",
         "before()
-			Array.prototype.concat.call([], 1)",
+            Array.prototype.concat.call([], 1)",
         "before()
-			Array.prototype.concat.apply([], 1.)",
+            Array.prototype.concat.apply([], 1.)",
         "before()
-			Array.prototype.concat.call([], 1.)",
+            Array.prototype.concat.call([], 1.)",
         "before()
-			Array.prototype.concat.apply([], .1)",
+            Array.prototype.concat.apply([], .1)",
         "before()
-			Array.prototype.concat.call([], .1)",
+            Array.prototype.concat.call([], .1)",
         "before()
-			Array.prototype.concat.apply([], 1.0)",
+            Array.prototype.concat.apply([], 1.0)",
         "before()
-			Array.prototype.concat.call([], 1.0)",
+            Array.prototype.concat.call([], 1.0)",
         "[].concat(some./**/array)",
         "[/**/].concat(some./**/array)",
         "[/**/].concat(some.array)",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
@@ -238,129 +238,129 @@ fn test() {
         "class Foo {constructor() {notThis.bar = 1}}",
         "class Foo {constructor() {notThis.bar = 1 + 2}}",
         "class Foo {
-				constructor() {
-					if (something) { return; }
-					this.bar = 1;
-				}
-			}",
+                constructor() {
+                    if (something) { return; }
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				foo: string = 'foo';
-			}",
+                foo: string = 'foo';
+            }",
         "declare class Foo {
-				constructor(foo?: string);
-			}",
+                constructor(foo?: string);
+            }",
     ];
 
     let fail = vec![
         "class Foo {
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				constructor() {
-					;
-					this.bar = 1;
-				}
-			}",
+                constructor() {
+                    ;
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				constructor() {
-					this.bar = 1;
-					this.baz = 2;
-				}
-			}",
+                constructor() {
+                    this.bar = 1;
+                    this.baz = 2;
+                }
+            }",
         "class Foo {
-				constructor() {
-					this.bar = 1;
-					this.bar = 2;
-				}
-			}",
+                constructor() {
+                    this.bar = 1;
+                    this.bar = 2;
+                }
+            }",
         "class Foo {
-				bar;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                bar;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				#bar;
-				constructor() {
-					this.#bar = 1;
-				}
-			}",
+                #bar;
+                constructor() {
+                    this.#bar = 1;
+                }
+            }",
         "class Foo {
-				bar = 0;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                bar = 0;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				#bar = 0;
-				constructor() {
-					this.#bar = 1;
-				}
-			}",
+                #bar = 0;
+                constructor() {
+                    this.#bar = 1;
+                }
+            }",
         "class Foo {
-				[bar];
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                [bar];
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				[bar] = 0;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                [bar] = 0;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				static bar;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                static bar;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				static bar = 0;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                static bar = 0;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				static [bar];
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                static [bar];
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-				static [bar] = 1;
-				constructor() {
-					this.bar = 1;
-				}
-			}",
+                static [bar] = 1;
+                constructor() {
+                    this.bar = 1;
+                }
+            }",
         "class Foo {
-			constructor() {
-				this.bar = 1;
-			}}",
+            constructor() {
+                this.bar = 1;
+            }}",
         "class Foo {
-			constructor() {
-				this.bar = 1;
-			}
-			static}",
+            constructor() {
+                this.bar = 1;
+            }
+            static}",
         "class Foo {
-			constructor() {
-				this.bar = 1;
-			}
-			static// comment;
-			}",
+            constructor() {
+                this.bar = 1;
+            }
+            static// comment;
+            }",
         r#"class MyError extends Error {
-				constructor(message: string) {
-					this.name = "MyError";
-				}
-			}"#,
+                constructor(message: string) {
+                    this.name = "MyError";
+                }
+            }"#,
         r#"class MyError extends Error {
-				name: string;
-				constructor(message: string) {
-					this.name = "MyError";
-				}
-			}"#,
+                name: string;
+                constructor(message: string) {
+                    this.name = "MyError";
+                }
+            }"#,
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
@@ -428,84 +428,84 @@ fn test() {
         r#"element.classList.toggle("className", condition)"#,
         r#"element.classList.toggle("className")"#,
         "if (condition) {
-				element.classList.add('className');
-			} else if (other) {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else if (other) {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList.notAdd('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.notAdd('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList.remove('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList.add('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (condition) {
-				element.classList.add('className1');
-			} else {
-				element.classList.remove('className2');
-			}",
+                element.classList.add('className1');
+            } else {
+                element.classList.remove('className2');
+            }",
         "element.classList.add('className');
-			element.classList.remove('className');",
+            element.classList.remove('className');",
         "if (condition) {
-				element.classList.add?.('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add?.('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList?.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList?.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				a.add('className');
-			} else {
-				a.remove('className');
-			}",
+                a.add('className');
+            } else {
+                a.remove('className');
+            }",
         "if (condition) {
-				element.notClassList.add('className');
-			} else {
-				element.notClassList.remove('className');
-			}",
+                element.notClassList.add('className');
+            } else {
+                element.notClassList.remove('className');
+            }",
         "if (condition) {
-				element.classList.add('className');
-				foo();
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+                foo();
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				{
-					element.classList.add('className');
-				}
-			} else {
-				element.classList.remove('className');
-			}",
+                {
+                    element.classList.add('className');
+                }
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element1.classList.add('className');
-			} else {
-				element2.classList.remove('className');
-			}",
+                element1.classList.add('className');
+            } else {
+                element2.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList.add('className', extraArgument);
-			} else {
-				element.classList.remove('className', extraArgument);
-			}",
+                element.classList.add('className', extraArgument);
+            } else {
+                element.classList.remove('className', extraArgument);
+            }",
         "if (condition) {
-				element.classList.add();
-			} else {
-				element.classList.remove();
-			}",
+                element.classList.add();
+            } else {
+                element.classList.remove();
+            }",
         "if (condition) {
-				element.classList.remove('className');
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+                element.classList.add('className');
+            }",
         "condition ? element.classList.add(className1) : element.classList.remove(className2)",
         "condition ? element.classList.add?.(className) : element.classList.remove(className)",
         "condition ? element.classList?.add(className) : element.classList.remove(className)",
@@ -526,168 +526,168 @@ fn test() {
 
     let fail = vec![
         "if (condition) {
-				element.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition)
-				element.classList.add('className');
-			else
-				element.classList.remove('className');",
+                element.classList.add('className');
+            else
+                element.classList.remove('className');",
         "if (condition)
-				element.classList.add('className');
-			else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element?.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element?.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition)
-				element.classList.add('className');
-			else
-				element?.classList.remove('className');",
+                element.classList.add('className');
+            else
+                element?.classList.remove('className');",
         "if (condition) {
-				element.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (condition) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (condition) {
-				(( element )).classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                (( element )).classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (0, condition) {
-				element.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (0, condition) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (condition) {
-				element.classList.remove(((className)));
-			} else {
-				element.classList.add(((className)));
-			}",
+                element.classList.remove(((className)));
+            } else {
+                element.classList.add(((className)));
+            }",
         "foo
-			if (condition) {
-				(( element )).classList.add('className')
-			} else {
-				element.classList.remove('className')
-			}",
+            if (condition) {
+                (( element )).classList.add('className')
+            } else {
+                element.classList.remove('className')
+            }",
         "if (condition) {
-				(( element )).classList.add('className')
-			} else {
-				element.classList.remove('className')
-			}
-			[].forEach(foo);",
+                (( element )).classList.add('className')
+            } else {
+                element.classList.remove('className')
+            }
+            [].forEach(foo);",
         "if (element.classList.contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element?.classList.contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.classList.contains?.('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.classList?.contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.classList.notContains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.classList.contains('not-same-class-name')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.notClassList.contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (notSameElement.classList.contains('className')) {
-				element.classList.remove('className');
-			} else {
-				element.classList.add('className');
-			}",
+                element.classList.remove('className');
+            } else {
+                element.classList.add('className');
+            }",
         "if (element.classList.contains('className')) {
-				element.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "if (!element.classList.contains('className')) {
-				element.classList.add('className');
-			} else {
-				element.classList.remove('className');
-			}",
+                element.classList.add('className');
+            } else {
+                element.classList.remove('className');
+            }",
         "condition ? element.classList.add(className) : element.classList.remove(className)",
         "condition ? element?.classList.add(className) : element.classList.remove(className)",
         "condition ? element.classList.add(className) : element?.classList.remove(className)",
         "condition ? element.classList.remove(className) : element.classList.add(className)",
         "if (condition ? element.classList.add(className) : element.classList.remove(className));",
         "function foo() {
-				return!foo ? element.classList.add(className) : element.classList.remove(className)
-			}",
+                return!foo ? element.classList.add(className) : element.classList.remove(className)
+            }",
         "foo
-			condition ? (( element )).classList.add(className) : element.classList.remove(className);",
+            condition ? (( element )).classList.add(className) : element.classList.remove(className);",
         "element.classList.contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element?.classList.contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.classList.contains?.('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.classList?.contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.classList.notContains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.classList.contains('not-same-class-name')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.notClassList.contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "notSameElement.classList.contains('className')
-				? element.classList.remove('className')
-				: element.classList.add('className')",
+                ? element.classList.remove('className')
+                : element.classList.add('className')",
         "element.classList.contains('className')
-				? element.classList.add('className')
-				: element.classList.remove('className')",
+                ? element.classList.add('className')
+                : element.classList.remove('className')",
         "!element.classList.contains('className')
-				? element.classList.add('className')
-				: element.classList.remove('className')",
+                ? element.classList.add('className')
+                : element.classList.remove('className')",
         r#"element.classList[condition ? "add" : "remove"](className)"#,
         r#"element.classList[condition ? "remove": "add"](className)"#,
         r#"element?.classList[condition ? "add" : "remove"](className)"#,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -350,267 +350,267 @@ fn test() {
         "const abc = function({ bar } = { bar: 123 }) { }",
         "const abc = function({ bar = 123 } = {}) { }",
         "function abc(foo) {
-				foo = foo || bar();
-			}",
+                foo = foo || bar();
+            }",
         "function abc(foo) {
-				foo = foo || {bar};
-			}",
+                foo = foo || {bar};
+            }",
         "function abc(foo) {
-				const {bar} = foo || 123;
-			}",
+                const {bar} = foo || 123;
+            }",
         "function abc(foo, bar) {
-				bar = foo || 'bar';
-			}",
+                bar = foo || 'bar';
+            }",
         "function abc(foo, bar) {
-				foo = foo || 'bar';
-				baz();
-			}",
+                foo = foo || 'bar';
+                baz();
+            }",
         "function abc(foo) {
-				foo = foo && 'bar';
-			}",
+                foo = foo && 'bar';
+            }",
         "function abc(foo) {
-				foo = foo || 1 && 2 || 3;
-			}",
+                foo = foo || 1 && 2 || 3;
+            }",
         "function abc(foo) {
-				foo = !foo || 'bar';
-			}",
+                foo = !foo || 'bar';
+            }",
         "function abc(foo) {
-				foo = (foo && bar) || baz;
-			}",
+                foo = (foo && bar) || baz;
+            }",
         "function abc(foo = 123) {
-				foo = foo || 'bar';
-			}",
+                foo = foo || 'bar';
+            }",
         "function abc() {
-				let foo = 123;
-				foo = foo || 'bar';
-			}",
+                let foo = 123;
+                foo = foo || 'bar';
+            }",
         "function abc() {
-				let foo = 123;
-				const bar = foo || 'bar';
-			}",
+                let foo = 123;
+                const bar = foo || 'bar';
+            }",
         "const abc = (foo, bar) => {
-				bar = foo || 'bar';
-			};",
+                bar = foo || 'bar';
+            };",
         "const abc = function(foo, bar) {
-				bar = foo || 'bar';
-			}",
+                bar = foo || 'bar';
+            }",
         "const abc = function(foo) {
-				foo = foo || bar();
-			}",
+                foo = foo || bar();
+            }",
         "function abc(foo) {
-				function def(bar) {
-					foo = foo || 'bar';
-				}
-			}",
+                function def(bar) {
+                    foo = foo || 'bar';
+                }
+            }",
         "function abc(foo) {
-				const bar = foo = foo || 123;
-			}",
+                const bar = foo = foo || 123;
+            }",
         "function abc(foo) {
-				bar(foo = foo || 1);
-				baz(foo);
-			}",
+                bar(foo = foo || 1);
+                baz(foo);
+            }",
         "function abc(foo) {
-				console.log(foo);
-				foo = foo || 123;
-			}",
+                console.log(foo);
+                foo = foo || 123;
+            }",
         "function abc(foo) {
-				console.log(foo);
-				foo = foo || 'bar';
-			}",
+                console.log(foo);
+                foo = foo || 'bar';
+            }",
         "function abc(foo) {
-				const bar = foo || 'bar';
-				console.log(foo, bar);
-			}",
+                const bar = foo || 'bar';
+                console.log(foo, bar);
+            }",
         "function abc(foo) {
-				let bar = 123;
-				bar = foo;
-				foo = foo || 123;
-			}",
+                let bar = 123;
+                bar = foo;
+                foo = foo || 123;
+            }",
         "function abc(foo) {
-				bar();
-				foo = foo || 123;
-			}",
+                bar();
+                foo = foo || 123;
+            }",
         "const abc = (foo) => {
-				bar();
-				foo = foo || 123;
-			};",
+                bar();
+                foo = foo || 123;
+            };",
         "const abc = function(foo) {
-				bar();
-				foo = foo || 123;
-			};",
+                bar();
+                foo = foo || 123;
+            };",
         "function abc(foo) {
-				sideEffects();
-				foo = foo || 123;
-				function sideEffects() {
-					foo = 456;
-				}
-			}",
+                sideEffects();
+                foo = foo || 123;
+                function sideEffects() {
+                    foo = 456;
+                }
+            }",
         "function abc(foo) {
-				const bar = sideEffects();
-				foo = foo || 123;
-				function sideEffects() {
-					foo = 456;
-				}
-			}",
+                const bar = sideEffects();
+                foo = foo || 123;
+                function sideEffects() {
+                    foo = 456;
+                }
+            }",
         "function abc(foo) {
-				const bar = sideEffects() + 123;
-				foo = foo || 123;
-				function sideEffects() {
-					foo = 456;
-				}
-			}",
+                const bar = sideEffects() + 123;
+                foo = foo || 123;
+                function sideEffects() {
+                    foo = 456;
+                }
+            }",
         "function abc(foo) {
-				const bar = !sideEffects();
-				foo = foo || 123;
-				function sideEffects() {
-					foo = 456;
-				}
-			}",
+                const bar = !sideEffects();
+                foo = foo || 123;
+                function sideEffects() {
+                    foo = 456;
+                }
+            }",
         "function abc(foo) {
-				const bar = function() {
-					foo = 456;
-				}
-				foo = foo || 123;
-			}",
+                const bar = function() {
+                    foo = 456;
+                }
+                foo = foo || 123;
+            }",
         "function abc(...foo) {
-				foo = foo || 'bar';
-			}",
+                foo = foo || 'bar';
+            }",
         "function abc(foo = 'bar') {
-				foo = foo || 'baz';
-			}",
+                foo = foo || 'baz';
+            }",
         "function abc(foo, bar) {
-				const { baz, ...rest } = bar;
-				foo = foo || 123;
-			}",
+                const { baz, ...rest } = bar;
+                foo = foo || 123;
+            }",
         "function abc(foo, bar) {
-				const baz = foo?.bar;
-				foo = foo || 123;
-			}",
+                const baz = foo?.bar;
+                foo = foo || 123;
+            }",
         "function abc(foo, bar) {
-				import('foo');
-				foo = foo || 123;
-			}",
+                import('foo');
+                foo = foo || 123;
+            }",
     ];
 
     let fail = vec![
         r"function abc(foo) {
-	foo = foo || 123;
+    foo = foo || 123;
 }",
         r"function abc(foo) {
-	foo = foo || true;
+    foo = foo || true;
 }",
         r"function abc(foo) {
-	foo = foo || 123;
-	console.log(foo);
+    foo = foo || 123;
+    console.log(foo);
 }",
         r"function abc(foo) {
-	const bar = foo || 'bar';
+    const bar = foo || 'bar';
 }",
         r"function abc(foo) {
-	let bar = foo || 'bar';
+    let bar = foo || 'bar';
 }",
         r"const abc = function(foo) {
-	foo = foo || 123;
+    foo = foo || 123;
 }",
         r"const abc = (foo) => {
-	foo = foo || 'bar';
+    foo = foo || 'bar';
 };",
         r"const abc = foo => {
-	foo = foo || 'bar';
+    foo = foo || 'bar';
 };",
         r"const abc = (foo) => {
-	const bar = foo || 'bar';
+    const bar = foo || 'bar';
 };",
         r"function abc(foo) {
-	foo = foo || 'bar';
-	bar();
-	baz();
+    foo = foo || 'bar';
+    bar();
+    baz();
 }",
         r"function abc(foo) {
-	foo = foo ?? 123;
+    foo = foo ?? 123;
 }",
         r"function abc(foo) {
-	const bar = foo || 'bar';
-	console.log(bar);
+    const bar = foo || 'bar';
+    console.log(bar);
 }",
         r"const abc = function(foo) {
-	const bar = foo || 'bar';
-	console.log(bar);
+    const bar = foo || 'bar';
+    console.log(bar);
 }",
         r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
 };",
         r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	},
-	def(foo) { }
+    abc(foo) {
+        foo = foo || 123;
+    },
+    def(foo) { }
 };",
         r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
 }",
         r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
-	def(foo) { }
+    abc(foo) {
+        foo = foo || 123;
+    }
+    def(foo) { }
 }",
         r"function abc(foo) { foo = foo || 'bar'; }",
         r"function abc(foo) { foo = foo || 'bar';}",
         r"const abc = function(foo) { foo = foo || 'bar';}",
         r"function abc(foo) {
-	foo = foo || 'bar'; bar(); baz();
+    foo = foo || 'bar'; bar(); baz();
 }",
         r"function abc(foo) {
-	foo = foo || 'bar';
-	function def(bar) {
-		bar = bar || 'foo';
-	}
+    foo = foo || 'bar';
+    function def(bar) {
+        bar = bar || 'foo';
+    }
 }",
         r"function abc(foo) {
-	foo += 'bar';
-	function def(bar) {
-		bar = bar || 'foo';
-	}
-	function ghi(baz) {
-		const bay = baz || 'bar';
-	}
-	foo = foo || 'bar';
+    foo += 'bar';
+    function def(bar) {
+        bar = bar || 'foo';
+    }
+    function ghi(baz) {
+        const bay = baz || 'bar';
+    }
+    foo = foo || 'bar';
 }",
         r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	},
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    },
+    def(foo) {
+        foo = foo || 123;
+    }
 };",
         r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
+    def(foo) {
+        foo = foo || 123;
+    }
 }",
         r"function abc(foo) {
-	const noSideEffects = 123;
-	foo = foo || 123;
+    const noSideEffects = 123;
+    foo = foo || 123;
 }",
         r"const abc = function(foo) {
-	let bar = true;
-	bar = false;
+    let bar = true;
+    bar = false;
 
-	foo = foo || 123;
-	console.log(foo);
+    foo = foo || 123;
+    console.log(foo);
 }",
         r"function abc(foo) {
-	const bar = function() {};
-	foo = foo || 123;
+    const bar = function() {};
+    foo = foo || 123;
 }",
     ];
 
@@ -618,151 +618,151 @@ fn test() {
     let _fix = vec![
         (
             r"function abc(foo) {
-	foo = foo || 123;
+    foo = foo || 123;
 }",
             r"function abc(foo = 123) {
 }",
         ),
         (
             r"function abc(foo) {
-	foo = foo || true;
+    foo = foo || true;
 }",
             r"function abc(foo = true) {
 }",
         ),
         (
             r"function abc(foo) {
-	foo = foo || 123;
-	console.log(foo);
+    foo = foo || 123;
+    console.log(foo);
 }",
             r"function abc(foo = 123) {
-	console.log(foo);
+    console.log(foo);
 }",
         ),
         (
             r"function abc(foo) {
-	const bar = foo || 'bar';
+    const bar = foo || 'bar';
 }",
             r"function abc(bar = 'bar') {
 }",
         ),
         (
             r"function abc(foo) {
-	let bar = foo || 'bar';
+    let bar = foo || 'bar';
 }",
             r"function abc(bar = 'bar') {
 }",
         ),
         (
             r"const abc = function(foo) {
-	foo = foo || 123;
+    foo = foo || 123;
 }",
             r"const abc = function(foo = 123) {
 }",
         ),
         (
             r"const abc = (foo) => {
-	foo = foo || 'bar';
+    foo = foo || 'bar';
 };",
             r"const abc = (foo = 'bar') => {
 };",
         ),
         (
             r"const abc = foo => {
-	foo = foo || 'bar';
+    foo = foo || 'bar';
 };",
             r"const abc = (foo = 'bar') => {
 };",
         ),
         (
             r"const abc = (foo) => {
-	const bar = foo || 'bar';
+    const bar = foo || 'bar';
 };",
             r"const abc = (bar = 'bar') => {
 };",
         ),
         (
             r"function abc(foo) {
-	foo = foo || 'bar';
-	bar();
-	baz();
+    foo = foo || 'bar';
+    bar();
+    baz();
 }",
             r"function abc(foo = 'bar') {
-	bar();
-	baz();
+    bar();
+    baz();
 }",
         ),
         (
             r"function abc(foo) {
-	foo = foo ?? 123;
+    foo = foo ?? 123;
 }",
             r"function abc(foo = 123) {
 }",
         ),
         (
             r"function abc(foo) {
-	const bar = foo || 'bar';
-	console.log(bar);
+    const bar = foo || 'bar';
+    console.log(bar);
 }",
             r"function abc(bar = 'bar') {
-	console.log(bar);
+    console.log(bar);
 }",
         ),
         (
             r"const abc = function(foo) {
-	const bar = foo || 'bar';
-	console.log(bar);
+    const bar = foo || 'bar';
+    console.log(bar);
 }",
             r"const abc = function(bar = 'bar') {
-	console.log(bar);
+    console.log(bar);
 }",
         ),
         (
             r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
 };",
             r"foo = {
-	abc(foo = 123) {
-	}
+    abc(foo = 123) {
+    }
 };",
         ),
         (
             r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	},
-	def(foo) { }
+    abc(foo) {
+        foo = foo || 123;
+    },
+    def(foo) { }
 };",
             r"foo = {
-	abc(foo = 123) {
-	},
-	def(foo) { }
+    abc(foo = 123) {
+    },
+    def(foo) { }
 };",
         ),
         (
             r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
 }",
             r"class Foo {
-	abc(foo = 123) {
-	}
+    abc(foo = 123) {
+    }
 }",
         ),
         (
             r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
-	def(foo) { }
+    abc(foo) {
+        foo = foo || 123;
+    }
+    def(foo) { }
 }",
             r"class Foo {
-	abc(foo = 123) {
-	}
-	def(foo) { }
+    abc(foo = 123) {
+    }
+    def(foo) { }
 }",
         ),
         (r"function abc(foo) { foo = foo || 'bar'; }", r"function abc(foo = 'bar') { }"),
@@ -773,111 +773,111 @@ fn test() {
         ),
         (
             r"function abc(foo) {
-	foo = foo || 'bar'; bar(); baz();
+    foo = foo || 'bar'; bar(); baz();
 }",
             r"function abc(foo = 'bar') {
-	bar(); baz();
+    bar(); baz();
 }",
         ),
         (
             r"function abc(foo) {
-	foo = foo || 'bar';
-	function def(bar) {
-		bar = bar || 'foo';
-	}
+    foo = foo || 'bar';
+    function def(bar) {
+        bar = bar || 'foo';
+    }
 }",
             r"function abc(foo = 'bar') {
-	function def(bar) {
-		bar = bar || 'foo';
-	}
+    function def(bar) {
+        bar = bar || 'foo';
+    }
 }",
         ),
         (
             r"function abc(foo) {
-	foo += 'bar';
-	function def(bar) {
-		bar = bar || 'foo';
-	}
-	function ghi(baz) {
-		const bay = baz || 'bar';
-	}
-	foo = foo || 'bar';
+    foo += 'bar';
+    function def(bar) {
+        bar = bar || 'foo';
+    }
+    function ghi(baz) {
+        const bay = baz || 'bar';
+    }
+    foo = foo || 'bar';
 }",
             r"function abc(foo) {
-	foo += 'bar';
-	function def(bar = 'foo') {
-	}
-	function ghi(baz) {
-		const bay = baz || 'bar';
-	}
-	foo = foo || 'bar';
+    foo += 'bar';
+    function def(bar = 'foo') {
+    }
+    function ghi(baz) {
+        const bay = baz || 'bar';
+    }
+    foo = foo || 'bar';
 }",
         ),
         (
             r"foo = {
-	abc(foo) {
-		foo = foo || 123;
-	},
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    },
+    def(foo) {
+        foo = foo || 123;
+    }
 };",
             r"foo = {
-	abc(foo = 123) {
-	},
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo = 123) {
+    },
+    def(foo) {
+        foo = foo || 123;
+    }
 };",
         ),
         (
             r"class Foo {
-	abc(foo) {
-		foo = foo || 123;
-	}
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo) {
+        foo = foo || 123;
+    }
+    def(foo) {
+        foo = foo || 123;
+    }
 }",
             r"class Foo {
-	abc(foo = 123) {
-	}
-	def(foo) {
-		foo = foo || 123;
-	}
+    abc(foo = 123) {
+    }
+    def(foo) {
+        foo = foo || 123;
+    }
 }",
         ),
         (
             r"function abc(foo) {
-	const noSideEffects = 123;
-	foo = foo || 123;
+    const noSideEffects = 123;
+    foo = foo || 123;
 }",
             r"function abc(foo = 123) {
-	const noSideEffects = 123;
+    const noSideEffects = 123;
 }",
         ),
         (
             r"const abc = function(foo) {
-	let bar = true;
-	bar = false;
+    let bar = true;
+    bar = false;
 
-	foo = foo || 123;
-	console.log(foo);
+    foo = foo || 123;
+    console.log(foo);
 }",
             r"const abc = function(foo = 123) {
-	let bar = true;
-	bar = false;
+    let bar = true;
+    bar = false;
 
-	console.log(foo);
+    console.log(foo);
 }",
         ),
         (
             r"function abc(foo) {
-	const bar = function() {};
-	foo = foo || 123;
+    const bar = function() {};
+    foo = foo || 123;
 }",
             r"function abc(foo = 123) {
-	const bar = function() {};
+    const bar = function() {};
 }",
         ),
     ];

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -211,9 +211,9 @@ fn test() {
         "class Foo extends EventEmitter { someMethod() {} }",
         "const Foo = class extends EventEmitter {}",
         "class Foo extends EventEmitter {
-				addListener() {}
-				removeListener() {}
-			}",
+                addListener() {}
+                removeListener() {}
+            }",
         "new EventEmitter",
         "const emitter = new EventEmitter;",
         "for (const {EventEmitter} of []) {new EventEmitter}",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -266,12 +266,12 @@ fn test() {
         "let global = {}",
         "const global = {}",
         "function foo (window) {
-				window.foo();
-			}",
+                window.foo();
+            }",
         "var window = {};
-			function foo () {
-				window.foo();
-			}",
+            function foo () {
+                window.foo();
+            }",
         "foo.window",
         "foo.global",
         r#"import window from "xxx""#,
@@ -280,7 +280,7 @@ fn test() {
         r#"export { window }  from "xxx""#,
         r#"export * as window from "xxx";"#,
         "try {
-			} catch (window) {}",
+            } catch (window) {}",
         r#"window.name = "foo""#,
         "window.addEventListener",
         "window.innerWidth",
@@ -290,7 +290,7 @@ fn test() {
         r#"window.addEventListener("resize", () => {})"#,
         "window.onresize = function () {}",
         "const {window} = jsdom()
-			window.jQuery = jQuery;",
+            window.jQuery = jQuery;",
         "({ foo: window.name } =  {})",
         "[window.name] = []",
         "window[foo]",
@@ -312,28 +312,28 @@ fn test() {
         "window = 123",
         "obj.a = window",
         "function* gen() {
-			  yield window
-			}",
+              yield window
+            }",
         "async function gen() {
-			  await window
-			}",
+              await window
+            }",
         "window ? foo : bar",
         "foo ? window : bar",
         "foo ? bar : window",
         "function foo() {
-			  return window
-			}",
+              return window
+            }",
         "new window()",
         "const obj = {
-				foo: window.foo,
-				bar: window.bar,
-				window: window
-			}",
+                foo: window.foo,
+                bar: window.bar,
+                window: window
+            }",
         "function sequenceTest() {
-				let x, y;
-				x = (y = 10, y + 5, window);
-				console.log(x, y);
-			}",
+                let x, y;
+                x = (y = 10, y + 5, window);
+                console.log(x, y);
+            }",
         "window`Hello ${42} World`",
         "tag`Hello ${window.foo} World`",
         "var str = `hello ${window.foo} world!`",
@@ -341,30 +341,30 @@ fn test() {
         "++window",
         "++window.foo",
         "for (var attr in window) {
-			}",
+            }",
         "for (window.foo = 0; i < 10; window.foo++) {
-			}",
+            }",
         "for (const item of window.foo) {
-			}",
+            }",
         "for (const item of window) {
-			}",
+            }",
         "switch (window) {}",
         "switch (true) {
-				case window:
-					break;
-			}",
+                case window:
+                    break;
+            }",
         "switch (true) {
-				case window.foo:
-					break;
-			}",
+                case window.foo:
+                    break;
+            }",
         "while (window) {
-			}",
+            }",
         "do {} while (window) {}",
         "if (window) {}",
         "throw window",
         "var foo = window",
         "function foo (name = window) {
-			}",
+            }",
         "self.innerWidth",
         "self.innerHeight",
         "window.crypto",
@@ -401,55 +401,55 @@ fn test() {
         ("obj.a = window", "obj.a = globalThis"),
         (
             "function* gen() {
-			  yield window
-			}",
+              yield window
+            }",
             "function* gen() {
-			  yield globalThis
-			}",
+              yield globalThis
+            }",
         ),
         (
             "async function gen() {
-			  await window
-			}",
+              await window
+            }",
             "async function gen() {
-			  await globalThis
-			}",
+              await globalThis
+            }",
         ),
         ("window ? foo : bar", "globalThis ? foo : bar"),
         ("foo ? window : bar", "foo ? globalThis : bar"),
         ("foo ? bar : window", "foo ? bar : globalThis"),
         (
             "function foo() {
-			  return window
-			}",
+              return window
+            }",
             "function foo() {
-			  return globalThis
-			}",
+              return globalThis
+            }",
         ),
         ("new window()", "new globalThis()"),
         (
             "const obj = {
-				foo: window.foo,
-				bar: window.bar,
-				window: window
-			}",
+                foo: window.foo,
+                bar: window.bar,
+                window: window
+            }",
             "const obj = {
-				foo: globalThis.foo,
-				bar: globalThis.bar,
-				window: globalThis
-			}",
+                foo: globalThis.foo,
+                bar: globalThis.bar,
+                window: globalThis
+            }",
         ),
         (
             "function sequenceTest() {
-				let x, y;
-				x = (y = 10, y + 5, window);
-				console.log(x, y);
-			}",
+                let x, y;
+                x = (y = 10, y + 5, window);
+                console.log(x, y);
+            }",
             "function sequenceTest() {
-				let x, y;
-				x = (y = 10, y + 5, globalThis);
-				console.log(x, y);
-			}",
+                let x, y;
+                x = (y = 10, y + 5, globalThis);
+                console.log(x, y);
+            }",
         ),
         ("window`Hello ${42} World`", "globalThis`Hello ${42} World`"),
         ("tag`Hello ${window.foo} World`", "tag`Hello ${globalThis.foo} World`"),
@@ -459,54 +459,54 @@ fn test() {
         ("++window.foo", "++globalThis.foo"),
         (
             "for (var attr in window) {
-			}",
+            }",
             "for (var attr in globalThis) {
-			}",
+            }",
         ),
         (
             "for (window.foo = 0; i < 10; window.foo++) {
-			}",
+            }",
             "for (globalThis.foo = 0; i < 10; globalThis.foo++) {
-			}",
+            }",
         ),
         (
             "for (const item of window.foo) {
-			}",
+            }",
             "for (const item of globalThis.foo) {
-			}",
+            }",
         ),
         (
             "for (const item of window) {
-			}",
+            }",
             "for (const item of globalThis) {
-			}",
+            }",
         ),
         ("switch (window) {}", "switch (globalThis) {}"),
         (
             "switch (true) {
-				case window:
-					break;
-			}",
+                case window:
+                    break;
+            }",
             "switch (true) {
-				case globalThis:
-					break;
-			}",
+                case globalThis:
+                    break;
+            }",
         ),
         (
             "switch (true) {
-				case window.foo:
-					break;
-			}",
+                case window.foo:
+                    break;
+            }",
             "switch (true) {
-				case globalThis.foo:
-					break;
-			}",
+                case globalThis.foo:
+                    break;
+            }",
         ),
         (
             "while (window) {
-			}",
+            }",
             "while (globalThis) {
-			}",
+            }",
         ),
         ("do {} while (window) {}", "do {} while (globalThis) {}"),
         ("if (window) {}", "if (globalThis) {}"),
@@ -514,9 +514,9 @@ fn test() {
         ("var foo = window", "var foo = globalThis"),
         (
             "function foo (name = window) {
-			}",
+            }",
             "function foo (name = globalThis) {
-			}",
+            }",
         ),
         ("self.innerWidth", "globalThis.innerWidth"),
         ("self.innerHeight", "globalThis.innerHeight"),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -512,37 +512,37 @@ fn test() {
 
     let pass = vec![
         "window.addEventListener('click', e => {
-				console.log(e.key);
-			})",
+                console.log(e.key);
+            })",
         "window.addEventListener('click', () => {
-				console.log(keyCode, which, charCode);
-				console.log(window.keyCode);
-			})",
+                console.log(keyCode, which, charCode);
+                console.log(window.keyCode);
+            })",
         "foo.addEventListener('click', (e, r, fg) => {
-				function a() {
-					if (true) {
-						{
-							{
-								const e = {};
-								const { charCode } = e;
-								console.log(e.keyCode, charCode);
-							}
-						}
-					}
-				}
-			});",
+                function a() {
+                    if (true) {
+                        {
+                            {
+                                const e = {};
+                                const { charCode } = e;
+                                console.log(e.keyCode, charCode);
+                            }
+                        }
+                    }
+                }
+            });",
         "const e = {}
-			foo.addEventListener('click', function (event) {
-				function a() {
-					if (true) {
-						{
-							{
-								console.log(e.keyCode);
-							}
-						}
-					}
-				}
-			});",
+            foo.addEventListener('click', function (event) {
+                function a() {
+                    if (true) {
+                        {
+                            {
+                                console.log(e.keyCode);
+                            }
+                        }
+                    }
+                }
+            });",
         "const { keyCode } = e",
         "const { charCode } = e",
         "const {a, b, c} = event",
@@ -553,608 +553,608 @@ fn test() {
         "const { keyCode: key } = e",
         "const { keyCode: abc } = e",
         "foo.addEventListener('keydown', e => {
-				(function (abc) {
-					if (e.key === 'ArrowLeft') return true;
-					const { charCode } = abc;
-				}())
-			})",
+                (function (abc) {
+                    if (e.key === 'ArrowLeft') return true;
+                    const { charCode } = abc;
+                }())
+            })",
         "foo.addEventListener('keydown', e => {
-					if (e.key === 'ArrowLeft') return true;
-				})",
+                    if (e.key === 'ArrowLeft') return true;
+                })",
         "a.addEventListener('keyup', function (event) {
-					const key = event.key;
-				})",
+                    const key = event.key;
+                })",
         "a.addEventListener('keyup', function (event) {
-					const { key } = event;
-				})",
+                    const { key } = event;
+                })",
         "foo.addEventListener('click', e => {
-					const good = {};
-					good.keyCode = '34';
-				});",
+                    const good = {};
+                    good.keyCode = '34';
+                });",
         "foo.addEventListener('click', e => {
-					const good = {};
-					good.charCode = '34';
-				});",
+                    const good = {};
+                    good.charCode = '34';
+                });",
         "foo.addEventListener('click', e => {
-					const good = {};
-					good.which = '34';
-				});",
+                    const good = {};
+                    good.which = '34';
+                });",
         "foo.addEventListener('click', e => {
-					const {keyCode: a, charCode: b, charCode: c} = e;
-				});",
+                    const {keyCode: a, charCode: b, charCode: c} = e;
+                });",
         "add.addEventListener('keyup', event => {
-					f.addEventList('some', e => {
-						const {charCode} = e;
-						console.log(event.key)
-					})
-				})",
+                    f.addEventList('some', e => {
+                        const {charCode} = e;
+                        console.log(event.key)
+                    })
+                })",
         "foo.addEventListener('click', e => {
-					{
-						const e = {};
-						console.log(e.keyCode);
-					}
-				});",
+                    {
+                        const e = {};
+                        console.log(e.keyCode);
+                    }
+                });",
     ];
 
     let fail = vec![
         "window.addEventListener('click', e => {
-				console.log(e.keyCode);
-			})",
+                console.log(e.keyCode);
+            })",
         "window.addEventListener('click', ({keyCode}) => {
-				console.log(keyCode);
-			})",
+                console.log(keyCode);
+            })",
         "window.addEventListener('click', ({which}) => {
-				if (which === 23) {
-					console.log('Wrong!')
-				}
-			})",
+                if (which === 23) {
+                    console.log('Wrong!')
+                }
+            })",
         "window.addEventListener('click', ({which, another}) => {
-				if (which === 23) {
-					console.log('Wrong!')
-				}
-			})",
+                if (which === 23) {
+                    console.log('Wrong!')
+                }
+            })",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 27) {
-				}
-			});",
+                if (event.keyCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', event => {
-				if (event.keyCode === 65) {}
-			});",
+                if (event.keyCode === 65) {}
+            });",
         "foo.addEventListener('click', event => {
-				if (event.keyCode === 10) {}
-			});",
+                if (event.keyCode === 10) {}
+            });",
         "foo.addEventListener('click', event => {
-				if (!event.keyCode) {}
-			});",
+                if (!event.keyCode) {}
+            });",
         "foo.addEventListener('click', a => {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', (a, b, c) => {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(a, b, c) {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(b) {
-				if (b.keyCode === 27) {
-				}
-			});",
+                if (b.keyCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', e => {
-				const {keyCode, a, b} = e;
-			});",
+                const {keyCode, a, b} = e;
+            });",
         "foo.addEventListener('click', e => {
-				const {a: keyCode, a, b} = e;
-			});",
+                const {a: keyCode, a, b} = e;
+            });",
         "add.addEventListener('keyup', event => {
-				f.addEventList('some', e => {
-					const {keyCode} = event;
-					console.log(event.key)
-				})
-			})",
+                f.addEventList('some', e => {
+                    const {keyCode} = event;
+                    console.log(event.key)
+                })
+            })",
         "window.addEventListener('click', e => {
-				console.log(e.charCode);
-			})",
+                console.log(e.charCode);
+            })",
         "foo11111111.addEventListener('click', event => {
-				if (event.charCode === 27) {
-				}
-			});",
+                if (event.charCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', a => {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', (a, b, c) => {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(a, b, c) {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(b) {
-				if (b.charCode === 27) {
-				}
-			});",
+                if (b.charCode === 27) {
+                }
+            });",
         "foo.addEventListener('click', e => {
-				const {charCode, a, b} = e;
-			});",
+                const {charCode, a, b} = e;
+            });",
         "foo.addEventListener('click', e => {
-				const {a: charCode, a, b} = e;
-			});",
+                const {a: charCode, a, b} = e;
+            });",
         "window.addEventListener('click', e => {
-				console.log(e.which);
-			})",
+                console.log(e.which);
+            })",
         "foo.addEventListener('click', event => {
-				if (event.which === 27) {
-				}
-			});",
+                if (event.which === 27) {
+                }
+            });",
         "foo.addEventListener('click', a => {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
         "foo.addEventListener('click', (a, b, c) => {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(a, b, c) {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
         "foo.addEventListener('click', function(b) {
-				if (b.which === 27) {
-				}
-			});",
+                if (b.which === 27) {
+                }
+            });",
         "foo.addEventListener('click', e => {
-				const {which, a, b} = e;
-			});",
+                const {which, a, b} = e;
+            });",
         "foo.addEventListener('click', e => {
-				const {a: which, a, b} = e;
-			});",
+                const {a: which, a, b} = e;
+            });",
         "foo.addEventListener('click', function(b) {
-				if (b.which === 27) {
-				}
-				const {keyCode} = b;
-				if (keyCode === 32) return 4;
-			});",
+                if (b.which === 27) {
+                }
+                const {keyCode} = b;
+                if (keyCode === 32) return 4;
+            });",
         "foo.addEventListener('click', function(b) {
-				if (b.which > 27) {
-				}
-				const {keyCode} = b;
-				if (keyCode === 32) return 4;
-			});",
+                if (b.which > 27) {
+                }
+                const {keyCode} = b;
+                if (keyCode === 32) return 4;
+            });",
         "const e = {}
-			foo.addEventListener('click', (e, r, fg) => {
-				function a() {
-					if (true) {
-						{
-							{
-								const { charCode } = e;
-								console.log(e.keyCode, charCode);
-							}
-						}
-					}
-				}
-			});",
+            foo.addEventListener('click', (e, r, fg) => {
+                function a() {
+                    if (true) {
+                        {
+                            {
+                                const { charCode } = e;
+                                console.log(e.keyCode, charCode);
+                            }
+                        }
+                    }
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 13) {
-				}
-			});",
+                if (event.keyCode === 13) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 38) {
-				}
-			});",
+                if (event.keyCode === 38) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 40) {
-				}
-			});",
+                if (event.keyCode === 40) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 37) {
-				}
-			});",
+                if (event.keyCode === 37) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 39) {
-				}
-			});",
+                if (event.keyCode === 39) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 221) {
-				}
-			});",
+                if (event.keyCode === 221) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 186) {
-				}
-			});",
+                if (event.keyCode === 186) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 187) {
-				}
-			});",
+                if (event.keyCode === 187) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 188) {
-				}
-			});",
+                if (event.keyCode === 188) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 189) {
-				}
-			});",
+                if (event.keyCode === 189) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 190) {
-				}
-			});",
+                if (event.keyCode === 190) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 191) {
-				}
-			});",
+                if (event.keyCode === 191) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 219) {
-				}
-			});",
+                if (event.keyCode === 219) {
+                }
+            });",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 222) {
-				}
-			});",
+                if (event.keyCode === 222) {
+                }
+            });",
         "window.addEventListener('click', ({which, another}) => {
-				if (which === 23) {
-					console.log('Wrong!')
-				}
-			})",
+                if (which === 23) {
+                    console.log('Wrong!')
+                }
+            })",
         "foo123.addEventListener('click', event => {
-				if (event.keyCode === 27) {
-				}
-			});",
+                if (event.keyCode === 27) {
+                }
+            });",
     ];
 
     let fix = vec![
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 27) {
-				}
-			});",
+                if (event.keyCode === 27) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'Escape') {
-				}
-			});",
+                if (event.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', event => {
-				if (event.keyCode === 65) {}
-			});",
+                if (event.keyCode === 65) {}
+            });",
             "foo.addEventListener('click', event => {
-				if (event.key === 'A') {}
-			});",
+                if (event.key === 'A') {}
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', event => {
-				if (event.keyCode === 10) {}
-			});",
+                if (event.keyCode === 10) {}
+            });",
             r"foo.addEventListener('click', event => {
-				if (event.key === '\n') {}
-			});",
+                if (event.key === '\n') {}
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', a => {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', a => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.keyCode === 27) {
-				}
-			});",
+                if (a.keyCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(b) {
-				if (b.keyCode === 27) {
-				}
-			});",
+                if (b.keyCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(b) {
-				if (b.key === 'Escape') {
-				}
-			});",
+                if (b.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo11111111.addEventListener('click', event => {
-				if (event.charCode === 27) {
-				}
-			});",
+                if (event.charCode === 27) {
+                }
+            });",
             "foo11111111.addEventListener('click', event => {
-				if (event.key === 'Escape') {
-				}
-			});",
+                if (event.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', a => {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', a => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.charCode === 27) {
-				}
-			});",
+                if (a.charCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(b) {
-				if (b.charCode === 27) {
-				}
-			});",
+                if (b.charCode === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(b) {
-				if (b.key === 'Escape') {
-				}
-			});",
+                if (b.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', event => {
-				if (event.which === 27) {
-				}
-			});",
+                if (event.which === 27) {
+                }
+            });",
             "foo.addEventListener('click', event => {
-				if (event.key === 'Escape') {
-				}
-			});",
+                if (event.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', a => {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
             "foo.addEventListener('click', a => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
             "foo.addEventListener('click', (a, b, c) => {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.which === 27) {
-				}
-			});",
+                if (a.which === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(a, b, c) {
-				if (a.key === 'Escape') {
-				}
-			});",
+                if (a.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(b) {
-				if (b.which === 27) {
-				}
-			});",
+                if (b.which === 27) {
+                }
+            });",
             "foo.addEventListener('click', function(b) {
-				if (b.key === 'Escape') {
-				}
-			});",
+                if (b.key === 'Escape') {
+                }
+            });",
             None,
         ),
         (
             "foo.addEventListener('click', function(b) {
-				if (b.which === 27) {
-				}
-				const {keyCode} = b;
-				if (keyCode === 32) return 4;
-			});",
+                if (b.which === 27) {
+                }
+                const {keyCode} = b;
+                if (keyCode === 32) return 4;
+            });",
             "foo.addEventListener('click', function(b) {
-				if (b.key === 'Escape') {
-				}
-				const {keyCode} = b;
-				if (keyCode === 32) return 4;
-			});",
+                if (b.key === 'Escape') {
+                }
+                const {keyCode} = b;
+                if (keyCode === 32) return 4;
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 13) {
-				}
-			});",
+                if (event.keyCode === 13) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'Enter') {
-				}
-			});",
+                if (event.key === 'Enter') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 38) {
-				}
-			});",
+                if (event.keyCode === 38) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'ArrowUp') {
-				}
-			});",
+                if (event.key === 'ArrowUp') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 40) {
-				}
-			});",
+                if (event.keyCode === 40) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'ArrowDown') {
-				}
-			});",
+                if (event.key === 'ArrowDown') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 37) {
-				}
-			});",
+                if (event.keyCode === 37) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'ArrowLeft') {
-				}
-			});",
+                if (event.key === 'ArrowLeft') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 39) {
-				}
-			});",
+                if (event.keyCode === 39) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === 'ArrowRight') {
-				}
-			});",
+                if (event.key === 'ArrowRight') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 221) {
-				}
-			});",
+                if (event.keyCode === 221) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === ']') {
-				}
-			});",
+                if (event.key === ']') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 186) {
-				}
-			});",
+                if (event.keyCode === 186) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === ';') {
-				}
-			});",
+                if (event.key === ';') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 187) {
-				}
-			});",
+                if (event.keyCode === 187) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '=') {
-				}
-			});",
+                if (event.key === '=') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 188) {
-				}
-			});",
+                if (event.keyCode === 188) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === ',') {
-				}
-			});",
+                if (event.key === ',') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 189) {
-				}
-			});",
+                if (event.keyCode === 189) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '-') {
-				}
-			});",
+                if (event.key === '-') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 190) {
-				}
-			});",
+                if (event.keyCode === 190) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '.') {
-				}
-			});",
+                if (event.key === '.') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 191) {
-				}
-			});",
+                if (event.keyCode === 191) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '/') {
-				}
-			});",
+                if (event.key === '/') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 219) {
-				}
-			});",
+                if (event.keyCode === 219) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '[') {
-				}
-			});",
+                if (event.key === '[') {
+                }
+            });",
             None,
         ),
         (
             "foo123.addEventListener('click', event => {
-				if (event.keyCode === 222) {
-				}
-			});",
+                if (event.keyCode === 222) {
+                }
+            });",
             "foo123.addEventListener('click', event => {
-				if (event.key === '\\'') {
-				}
-			});",
+                if (event.key === '\\'') {
+                }
+            });",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -387,13 +387,13 @@ fn test() {
         r"Math.LOG10E * Math.log((( 0,x )))",
         r"Math.log((( 0,x ))) / Math.LN10",
         r"
-			function foo(x) {
-				return (
-					Math.log(x)
-						/ Math.LN10
-				);
-			}
-		",
+            function foo(x) {
+                return (
+                    Math.log(x)
+                        / Math.LN10
+                );
+            }
+        ",
         // Prefer `Math.log2(x)`
         r"Math.log(x) * Math.LOG2E",
         r"Math.LOG2E * Math.log(x)",
@@ -402,13 +402,13 @@ fn test() {
         r"Math.LOG2E * Math.log((( 0,x )))",
         r"Math.log((( 0,x ))) / Math.LN2",
         r"
-			function foo(x) {
-				return (
-					Math.log(x)
-						/ Math.LN2
-				);
-			}
-		",
+            function foo(x) {
+                return (
+                    Math.log(x)
+                        / Math.LN2
+                );
+            }
+        ",
         // TODO: Fix this
         // "Math.sqrt((( a ** 2 )) + (( b ** 2 + c ** 2 )) + (( d )) * (( d )) + (( e )) ** (( 2 )))",
     ];

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -278,28 +278,28 @@ fn test() {
         (
             r#"const parseInt = function() {};
 function inner() {
-	return parseInt("10", 2);
+    return parseInt("10", 2);
 }"#,
             None,
         ),
         (
             r#"const parseFloat = function() {};
 function inner() {
-	return parseFloat("10.5");
+    return parseFloat("10.5");
 }"#,
             None,
         ),
         (
             r"const isNaN = function() {};
 function inner() {
-	return isNaN(10);
+    return isNaN(10);
 }",
             None,
         ),
         (
             r"const isFinite = function() {};
 function inner() {
-	return isFinite(10);
+    return isFinite(10);
 }",
             None,
         ),
@@ -346,11 +346,11 @@ function inner() {
         (r"class Foo {#NaN = 1}", None),
         (
             r"NaN: for (const foo of bar) {
-	if (a) {
-		continue NaN;
-	} else {
-		break NaN;
-	}
+    if (a) {
+        continue NaN;
+    } else {
+        break NaN;
+    }
 }",
             None,
         ),
@@ -372,8 +372,8 @@ function inner() {
         (r#"const foo = "-Infinity";"#, None),
         (
             r"function foo () {
-	const Infinity = 2
-	return Infinity
+    const Infinity = 2
+    return Infinity
 }",
             None,
         ),
@@ -387,15 +387,15 @@ function inner() {
         (r"class Foo2 {NaN = 1}", None),
         (
             r"export enum NumberSymbol {
-	Decimal,
-	NaN,
+    Decimal,
+    NaN,
 }",
             None,
         ),
         (r"declare var NaN: number;", None),
         (
             r"interface NumberConstructor {
-	readonly NaN: number;
+    readonly NaN: number;
 }",
             None,
         ),
@@ -495,13 +495,13 @@ function inner() {
     let fix = vec![
         (
             r#"const a = parseInt("10", 2);
-			const b = parseFloat("10.5");
-			const c = isNaN(10);
-			const d = isFinite(10);"#,
+            const b = parseFloat("10.5");
+            const c = isNaN(10);
+            const d = isFinite(10);"#,
             r#"const a = Number.parseInt("10", 2);
-			const b = Number.parseFloat("10.5");
-			const c = Number.isNaN(10);
-			const d = Number.isFinite(10);"#,
+            const b = Number.parseFloat("10.5");
+            const c = Number.isNaN(10);
+            const d = Number.isFinite(10);"#,
             None::<serde_json::Value>,
         ),
         ("const foo = NaN;", "const foo = Number.NaN;", None),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -364,25 +364,25 @@ fn test() {
         ("pairs.reduce(object => ({...object, [((key))] : ((value))}), {});", None),
         (
             "((
-				(( pairs ))
-				.reduce(
-					((
-						(object,) => ((
-							((
-								Object
-							)).assign(
-								((
-									object
-								)),
-								(({
-									[ ((key)) ] : ((value)),
-								}))
-							)
-						))
-					)),
-					Object.create(((null)),)
-				)
-			));",
+                (( pairs ))
+                .reduce(
+                    ((
+                        (object,) => ((
+                            ((
+                                Object
+                            )).assign(
+                                ((
+                                    object
+                                )),
+                                (({
+                                    [ ((key)) ] : ((value)),
+                                }))
+                            )
+                        ))
+                    )),
+                    Object.create(((null)),)
+                )
+            ));",
             None,
         ),
         ("pairs.reduce(object => ({...object, 0: value}), {});", None),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
@@ -172,18 +172,18 @@ fn test() {
         "new Response(JSON.stringify(data), extraArgument)",
         "new Response( (( JSON.stringify( (( 0, data )), ) )), )",
         "function foo() {
-				return new // comment
-					Response(JSON.stringify(data))
-			}",
+                return new // comment
+                    Response(JSON.stringify(data))
+            }",
         "new Response(JSON.stringify(data), {status: 200})",
         "foo
-			new (( Response ))(JSON.stringify(data))",
+            new (( Response ))(JSON.stringify(data))",
         "foo;
-			new (( Response ))(JSON.stringify(data))",
+            new (( Response ))(JSON.stringify(data))",
         "foo;
-			(( new (( Response ))(JSON.stringify(data)) ))",
+            (( new (( Response ))(JSON.stringify(data)) ))",
         "foo
-			(( new (( Response ))(JSON.stringify(data)) ))",
+            (( new (( Response ))(JSON.stringify(data)) ))",
     ];
 
     let fix = vec![
@@ -195,38 +195,38 @@ fn test() {
         ),
         (
             "function foo() {
-				return new // comment
-					Response(JSON.stringify(data))
-			}",
+                return new // comment
+                    Response(JSON.stringify(data))
+            }",
             "function foo() {
-				return ( // comment
-					Response.json(data))
-			}",
+                return ( // comment
+                    Response.json(data))
+            }",
         ),
         ("new Response(JSON.stringify(data), {status: 200})", "Response.json(data, {status: 200})"),
         (
             "foo
-			new (( Response ))(JSON.stringify(data))",
+            new (( Response ))(JSON.stringify(data))",
             "foo
-			;(( Response.json ))(data)",
+            ;(( Response.json ))(data)",
         ),
         (
             "foo;
-			new (( Response ))(JSON.stringify(data))",
+            new (( Response ))(JSON.stringify(data))",
             "foo;
-			(( Response.json ))(data)",
+            (( Response.json ))(data)",
         ),
         (
             "foo;
-			(( new (( Response ))(JSON.stringify(data)) ))",
+            (( new (( Response ))(JSON.stringify(data)) ))",
             "foo;
-			(( (( Response.json ))(data) ))",
+            (( (( Response.json ))(data) ))",
         ),
         (
             "foo
-			(( new (( Response ))(JSON.stringify(data)) ))",
+            (( new (( Response ))(JSON.stringify(data)) ))",
             "foo
-			(( (( Response.json ))(data) ))",
+            (( (( Response.json ))(data) ))",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -290,10 +290,10 @@ fn test() {
 
     let pass = vec![
         "
-        	const foo = new Set([1, 2, 3]);
-        	function unicorn() {
-        		return foo.has(1);
-        	}
+            const foo = new Set([1, 2, 3]);
+            function unicorn() {
+                return foo.has(1);
+            }
         ",
         "
             const foo = [1, 2, 3];
@@ -301,8 +301,8 @@ fn test() {
         ",
         "
             while (a) {
-            	const foo = [1, 2, 3];
-            	const isExists = foo.includes(1);
+                const foo = [1, 2, 3];
+                const isExists = foo.includes(1);
             }
         ",
         "
@@ -312,7 +312,7 @@ fn test() {
         "
             foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
@@ -327,284 +327,284 @@ fn test() {
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes;
+                return foo.includes;
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return includes(foo);
+                return includes(foo);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return bar.includes(foo);
+                return bar.includes(foo);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo[includes](1);
+                return foo[includes](1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.indexOf(1) !== -1;
+                return foo.indexOf(1) !== -1;
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	foo.includes(1);
-            	foo.length = 1;
+                foo.includes(1);
+                foo.length = 1;
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	if (foo.includes(1)) {}
-            	return foo;
-            				}
+                if (foo.includes(1)) {}
+                return foo;
+                            }
         ",
         "
             var foo = [1, 2, 3];
             var foo = [4, 5, 6];
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = bar;
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes();
+                return foo.includes();
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1, 1);
+                return foo.includes(1, 1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1, 0);
+                return foo.includes(1, 0);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1, undefined);
+                return foo.includes(1, undefined);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(...[1]);
+                return foo.includes(...[1]);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo?.includes(1);
+                return foo?.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes?.(1);
+                return foo.includes?.(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo?.includes?.(1);
+                return foo?.includes?.(1);
             }
         ",
         "
             function unicorn() {
-            	const foo = [1, 2, 3];
+                const foo = [1, 2, 3];
             }
             function unicorn2() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             export const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             module.exports = [1, 2, 3];
             function unicorn() {
-            	return module.exports.includes(1);
+                return module.exports.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             export {foo};
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             export default foo;
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             export {foo as bar};
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             module.exports = foo;
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             exports = foo;
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             module.exports.foo = foo;
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = NotArray(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = new NotArray(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = NotArray.from({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = NotArray.of(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array.notListed();
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array[from]({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array[of](1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = 'Array'.from({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = 'Array'.of(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array['from']({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array['of'](1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = of(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = from({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = bar.notListed();
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = _.map([1, 2, 3], value => value);
             function unicorn() {
-            	return _.includes(foo, 1);
+                return _.includes(foo, 1);
             }
         ",
         "
             @connect(
-            	state => {
-            		const availableComponents = ['is']
-            		if (nsConfig.enabled) availableComponents.push('ns')
-            		if (jsConfig.enabled) availableComponents.push('js')
-            		if (asConfig.enabled) availableComponents.push('as')
-            		return {
-            			availableComponents,
-            		}
-            	},
+                state => {
+                    const availableComponents = ['is']
+                    if (nsConfig.enabled) availableComponents.push('ns')
+                    if (jsConfig.enabled) availableComponents.push('js')
+                    if (asConfig.enabled) availableComponents.push('as')
+                    return {
+                        availableComponents,
+                    }
+                },
             )
             export default class A {}
         ",
         "
             @connect(
-            	state => {
-            		const availableComponents = ['is']
-            		if (nsConfig.enabled) availableComponents.push('ns')
-            		if (jsConfig.enabled) availableComponents.push('js')
-            		return {
-            			availableComponents,
-            		}
-            	},
+                state => {
+                    const availableComponents = ['is']
+                    if (nsConfig.enabled) availableComponents.push('ns')
+                    if (jsConfig.enabled) availableComponents.push('js')
+                    return {
+                        availableComponents,
+                    }
+                },
             )
             export default class A {}
         ",
@@ -612,11 +612,11 @@ fn test() {
 
     let fail = vec![
         "
-			const foo = [1, 2, 3];
-			function unicorn() {
-				return foo.includes(1);
-			}
-		",
+            const foo = [1, 2, 3];
+            function unicorn() {
+                return foo.includes(1);
+            }
+        ",
         "
             const foo = [1, 2, 3];
             const isExists = foo.includes(1);
@@ -625,75 +625,75 @@ fn test() {
         "
             const foo = [1, 2, 3];
             for (const a of b) {
-            	foo.includes(1);
+                foo.includes(1);
             }
         ",
         "
             async function unicorn() {
-            	const foo = [1, 2, 3];
-            	for await (const a of b) {
-            		foo.includes(1);
-            	}
+                const foo = [1, 2, 3];
+                for await (const a of b) {
+                    foo.includes(1);
+                }
             }
         ",
         "
             const foo = [1, 2, 3];
             for (let i = 0; i < n; i++) {
-            	foo.includes(1);
+                foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             for (let a in b) {
-            	foo.includes(1);
+                foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             while (a)  {
-            	foo.includes(1);
+                foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             do {
-            	foo.includes(1);
+                foo.includes(1);
             } while (a)
         ",
         "
             const foo = [1, 2, 3];
             do {
-            	// …
+                // …
             } while (foo.includes(1))
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function * unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             async function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             async function * unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             const unicorn = function () {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
@@ -703,104 +703,104 @@ fn test() {
         "
             const foo = [1, 2, 3];
             const a = {
-            	b() {
-            		return foo.includes(1);
-            	}
+                b() {
+                    return foo.includes(1);
+                }
             };
         ",
         "
             const foo = [1, 2, 3];
             class A {
-            	b() {
-            		return foo.includes(1);
-            	}
+                b() {
+                    return foo.includes(1);
+                }
             }
         ",
         "
             const foo = [...bar];
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
             bar.pop();
         ",
         "
             const foo = [1, 2, 3];
             function unicorn() {
-            	const exists = foo.includes(1);
-            	function isExists(find) {
-            		return foo.includes(find);
-            	}
+                const exists = foo.includes(1);
+                function isExists(find) {
+                    return foo.includes(find);
+                }
             }
         ",
         "
             function wrap() {
-            	const foo = [1, 2, 3];
-            	function unicorn() {
-            		return foo.includes(1);
-            	}
+                const foo = [1, 2, 3];
+                function unicorn() {
+                    return foo.includes(1);
+                }
             }
             const bar = [4, 5, 6];
             function unicorn() {
-            	return bar.includes(1);
+                return bar.includes(1);
             }
         ",
         "
             const foo = [1, 2, 3];
             function wrap() {
-            	const exists = foo.includes(1);
-            	const bar = [1, 2, 3];
-            	function outer(find) {
-            		const foo = [1, 2, 3];
-            		while (a) {
-            			foo.includes(1);
-            		}
-            		function inner(find) {
-            			const bar = [1, 2, 3];
-            			while (a) {
-            				const exists = bar.includes(1);
-            			}
-            		}
-            	}
+                const exists = foo.includes(1);
+                const bar = [1, 2, 3];
+                function outer(find) {
+                    const foo = [1, 2, 3];
+                    while (a) {
+                        foo.includes(1);
+                    }
+                    function inner(find) {
+                        const bar = [1, 2, 3];
+                        while (a) {
+                            const exists = bar.includes(1);
+                        }
+                    }
+                }
             }
         ",
         "
             const foo = Array(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = new Array(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array.from({length: 1}, (_, index) => index);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = Array.of(1, 2);
             function unicorn() {
-            	return foo.includes(1);
+                return foo.includes(1);
             }
         ",
         "
             const foo = _([1,2,3]);
             const bar = foo.map(value => value);
             function unicorn() {
-            	return bar.includes(1);
+                return bar.includes(1);
             }
         ",
         "
             const a: Array<'foo' | 'bar'> = ['foo', 'bar']
 
             for (let i = 0; i < 3; i++) {
-            	if (a.includes(someString)) {
-            		console.log(123)
-            	}
+                if (a.includes(someString)) {
+                    console.log(123)
+                }
             }
         ",
     ];
@@ -824,14 +824,14 @@ fn test() {
             "
                 const foo = [...bar];
                 function unicorn() {
-                	return foo.includes(1);
+                    return foo.includes(1);
                 }
                 bar.pop();
             ",
             "
                 const foo = new Set([...bar]);
                 function unicorn() {
-                	return foo.has(1);
+                    return foo.has(1);
                 }
                 bar.pop();
             ",
@@ -840,13 +840,13 @@ fn test() {
             "
                 const foo = Array(1, 2);
                 function unicorn() {
-                	return foo.includes(1);
+                    return foo.includes(1);
                 }
             ",
             "
                 const foo = new Set([1, 2]);
                 function unicorn() {
-                	return foo.has(1);
+                    return foo.has(1);
                 }
             ",
         ),
@@ -854,13 +854,13 @@ fn test() {
             "
                 const foo = new Array(1, 2);
                 function unicorn() {
-                	return foo.includes(1);
+                    return foo.includes(1);
                 }
             ",
             "
                 const foo = new Set([1, 2]);
                 function unicorn() {
-                	return foo.has(1);
+                    return foo.has(1);
                 }
             ",
         ),
@@ -869,14 +869,14 @@ fn test() {
                 const foo = _([1,2,3]);
                 const bar = foo.map(value => value);
                 function unicorn() {
-                	return bar.includes(1);
+                    return bar.includes(1);
                 }
             ",
             "
                 const foo = _([1,2,3]);
                 const bar = new Set(foo.map(value => value));
                 function unicorn() {
-                	return bar.has(1);
+                    return bar.has(1);
                 }
             ",
         ),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -308,7 +308,7 @@ fn test() {
         r#""foo".concat("bar")"#,
         r#"`${foo}`.concat("bar")"#,
         r#"const string = 'foo';
-			foo = string.concat("bar");"#,
+            foo = string.concat("bar");"#,
         "const bufA = Buffer.concat([buf1, buf2, buf3], totalLength);",
         "Foo.concat(1)",
         "FooBar.concat(1)",
@@ -386,42 +386,42 @@ fn test() {
         "Array.from(new Set([1, 2])).map(() => {});",
         r#"Array.from(document.querySelectorAll("*")).map(() => {});"#,
         "const foo = []
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         r#"const foo = "1"
-			Array.from(arrayLike).forEach(doSomething)"#,
+            Array.from(arrayLike).forEach(doSomething)"#,
         "const foo = null
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = true
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = 1
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = /./
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = /./g
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = bar
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = bar.baz
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "function* foo() {
-				yield Array.from(arrayLike).forEach(doSomething)
-			}",
+                yield Array.from(arrayLike).forEach(doSomething)
+            }",
         "const foo = \\`bar\\`
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = [];
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "for (const key of Array.from(arrayLike)) {
-			}",
+            }",
         "for (const key in Array.from(arrayLike)) {
-			}",
+            }",
         "const foo = `${Array.from(arrayLike)}`",
         "async function foo(){
-				return await Array.from(arrayLike)
-			}",
+                return await Array.from(arrayLike)
+            }",
         "foo()
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "const foo = {}
-			Array.from(arrayLike).forEach(doSomething)",
+            Array.from(arrayLike).forEach(doSomething)",
         "(Array).from(foo)",
         "(Array.from)(foo)",
         "((Array).from)(foo)",
@@ -451,13 +451,13 @@ fn test() {
         "(( (( ((foo)).concat ))( (([2, 3])) ,) ))",
         "(( (( ((foo)).concat ))( (([2, 3])) , bar ) ))",
         "bar()
-			foo.concat(2)",
+            foo.concat(2)",
         "const foo = foo.concat(2)",
         "const foo = () => foo.concat(2)",
         "const five = 2 + 3;
-			foo.concat(five);",
+            foo.concat(five);",
         "const array = [2 + 3];
-			foo.concat(array);",
+            foo.concat(array);",
         "foo.concat([bar])",
         "foo.concat(bar)",
         "Array.from(set).concat([2, 3])",
@@ -485,17 +485,17 @@ fn test() {
         "[1,].concat([2,,], [3,,])",
         "[].concat([], [])",
         r#"const EMPTY_STRING = ""
-			const EMPTY_STRING_IN_ARRAY = ""
-			const EMPTY_STRING_IN_ARRAY_OF_ARRAY = ""
-			const array = [].concat(
-				undefined,
-				null,
-				EMPTY_STRING,
-				false,
-				0,
-				[EMPTY_STRING_IN_ARRAY],
-				[[EMPTY_STRING_IN_ARRAY_OF_ARRAY]]
-			)"#,
+            const EMPTY_STRING_IN_ARRAY = ""
+            const EMPTY_STRING_IN_ARRAY_OF_ARRAY = ""
+            const array = [].concat(
+                undefined,
+                null,
+                EMPTY_STRING,
+                false,
+                0,
+                [EMPTY_STRING_IN_ARRAY],
+                [[EMPTY_STRING_IN_ARRAY_OF_ARRAY]]
+            )"#,
         "[].concat((a.b.c), 2)",
         "[].concat(a.b(), 2)",
         "foo.concat(bar, 2, [3, 4], baz, 5, [6, 7])",
@@ -516,7 +516,7 @@ fn test() {
         "do foo.concat(1); while (test)",
         "with (foo) foo.concat(1)", // {"parserOptions": {"ecmaVersion": 6, "sourceType": "script"}},
         "const baz = [2];
-			call(foo, ...[bar].concat(baz));",
+            call(foo, ...[bar].concat(baz));",
         r#"foo.join(foo, bar).concat("...")"#,
         "array.slice()",
         "array.slice().slice()",
@@ -526,7 +526,7 @@ fn test() {
         "(( (( (( array )).slice ))() ))",
         "(scopeManager?.scopes).slice()",
         "bar()
-			foo.slice()",
+            foo.slice()",
         r#""".slice()"#,
         "new Uint8Array([10, 20, 30, 40, 50]).slice()",
         "array.slice(0)",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_top_level_await.rs
@@ -192,10 +192,10 @@ fn test() {
         ("(async function *() {})()", None, None, None),
         (
             "function foo() {
-				if (foo) {
-					(async () => {})()
-				}
-			}",
+                if (foo) {
+                    (async () => {})()
+                }
+            }",
             None,
             None,
             None,
@@ -209,36 +209,36 @@ fn test() {
         ("await foo.then(bar)?.catch?.(bar)", None, None, None),
         (
             "class Example {
-				property = promise.then(bar)
-			}",
+                property = promise.then(bar)
+            }",
             None,
             None,
             None,
         ),
         (
             "const Example = class Example {
-				property = promise.then(bar)
-			}",
+                property = promise.then(bar)
+            }",
             None,
             None,
             None,
         ),
         (
             "class Example {
-				static {
-					promise.then(bar)
-				}
-			}",
+                static {
+                    promise.then(bar)
+                }
+            }",
             None,
             None,
             None,
         ),
         (
             "const Example = class Example {
-				static {
-					promise.then(bar)
-				}
-			}",
+                static {
+                    promise.then(bar)
+                }
+            }",
             None,
             None,
             None,
@@ -248,81 +248,81 @@ fn test() {
         ("foo.bar()", None, None, None),
         (
             "function foo() {
-				return async () => {};
-			}
-			foo()();",
+                return async () => {};
+            }
+            foo()();",
             None,
             None,
             None,
         ),
         (
             "const [foo] = [async () => {}];
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "function foo() {}
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "async function * foo() {}
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "var foo = async () => {};
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "let foo = async () => {};
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "const foo = 1, bar = async () => {};
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "async function foo() {}
-			const bar = foo;
-			bar();",
+            const bar = foo;
+            bar();",
             None,
             None,
             None,
         ),
         (
             "const program = {async run () {}};
-			program.run()",
+            program.run()",
             None,
             None,
             None,
         ),
         (
             "const program = {async run () {}};
-			const {run} = program;
-			run()",
+            const {run} = program;
+            run()",
             None,
             None,
             None,
         ),
         (
             "const foo = async () => {};
-			await foo();",
+            await foo();",
             None,
             None,
             None,
@@ -330,29 +330,29 @@ fn test() {
         ("for (const statement of statements) { statement() };", None, None, None),
         (
             "const foo = async () => {};
-			await Promise.all([
-				(async () => {})(),
-				/* hole */,
-				foo(),
-				foo.then(bar),
-				foo.catch(bar),
-			]);
-			await Promise.allSettled([foo()]);
-			await Promise?.any([foo()]);
-			await Promise.race?.([foo()]);",
+            await Promise.all([
+                (async () => {})(),
+                /* hole */,
+                foo(),
+                foo.then(bar),
+                foo.catch(bar),
+            ]);
+            await Promise.allSettled([foo()]);
+            await Promise?.any([foo()]);
+            await Promise.race?.([foo()]);",
             None,
             None,
             None,
         ),
         (
             "const foo = async () => {};
-			const promise = Promise.all([
-				(async () => {})(),
-				foo(),
-				foo.then(bar),
-				foo.catch(bar),
-			]);
-			await promise;",
+            const promise = Promise.all([
+                (async () => {})(),
+                foo(),
+                foo.then(bar),
+                foo.catch(bar),
+            ]);
+            await promise;",
             None,
             None,
             None,
@@ -361,10 +361,10 @@ fn test() {
         ("await foo()", None, None, None),
         (
             "try {
-				await run()
-			} catch {
-				process.exit(1)
-			}",
+                await run()
+            } catch {
+                process.exit(1)
+            }",
             None,
             None,
             None,
@@ -381,8 +381,8 @@ fn test() {
         ("if (foo) (async () => {})()", None, None, None),
         (
             "{
-				(async () => {})();
-			}",
+                (async () => {})();
+            }",
             None,
             None,
             None,
@@ -410,46 +410,46 @@ fn test() {
         ("foo.then(bar).catch(bar).finally(bar)", None, None, None),
         (
             "const foo = async () => {};
-			foo();",
+            foo();",
             None,
             None,
             None,
         ),
         (
             "const foo = async () => {};
-			foo?.();",
+            foo?.();",
             None,
             None,
             None,
         ),
         (
             "const foo = async () => {};
-			foo().then(foo);",
+            foo().then(foo);",
             None,
             None,
             None,
         ),
         (
             "const foo = async function () {}, bar = 1;
-			foo(bar);",
+            foo(bar);",
             None,
             None,
             None,
         ),
         (
             "foo();
-			async function foo() {}",
+            async function foo() {}",
             None,
             None,
             None,
         ),
         (
             "const foo = async () => {};
-			if (true) {
-				alert();
-			} else {
-				foo();
-			}",
+            if (true) {
+                alert();
+            } else {
+                foo();
+            }",
             None,
             None,
             None,

--- a/crates/oxc_linter/src/snapshots/unicorn_consistent_existence_index_check.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_consistent_existence_index_check.snap
@@ -87,7 +87,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace index check with strict equality check
 
   ⚠ eslint-plugin-unicorn(consistent-existence-index-check): Prefer `=== -1` over `< 0` to check non-existence.
-   ╭─[consistent_existence_index_check.tsx:5:15]
+   ╭─[consistent_existence_index_check.tsx:5:21]
  4 │             function foo () {
  5 │                 if (index < 0) {}
    ·                     ─────────
@@ -96,7 +96,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace index check with strict equality check
 
   ⚠ eslint-plugin-unicorn(consistent-existence-index-check): Prefer `=== -1` over `< 0` to check non-existence.
-   ╭─[consistent_existence_index_check.tsx:4:10]
+   ╭─[consistent_existence_index_check.tsx:4:13]
  3 │                 index2 = foo.indexOf('2');
  4 │             index1 < 0;
    ·             ──────────
@@ -105,7 +105,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace index check with strict equality check
 
   ⚠ eslint-plugin-unicorn(consistent-existence-index-check): Prefer `!== -1` over `>= 0` to check non-existence.
-   ╭─[consistent_existence_index_check.tsx:5:10]
+   ╭─[consistent_existence_index_check.tsx:5:13]
  4 │             index1 < 0;
  5 │             index2 >= 0;
    ·             ───────────
@@ -114,27 +114,27 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace index check with strict equality check
 
   ⚠ eslint-plugin-unicorn(consistent-existence-index-check): Prefer `=== -1` over `< 0` to check non-existence.
-    ╭─[consistent_existence_index_check.tsx:5:17]
-  4 │                         /* comment 1 */
-  5 │ ╭─▶                     ((
-  6 │ │                           /* comment 2 */
-  7 │ │                           index
-  8 │ │                           /* comment 3 */
-  9 │ │                       ))
- 10 │ │                       /* comment 4 */
- 11 │ │                       <
- 12 │ │                       /* comment 5 */
- 13 │ │                       ((
- 14 │ │                           /* comment 6 */
- 15 │ │                           0
- 16 │ │                           /* comment 7 */
- 17 │ ╰─▶                     ))
- 18 │                         /* comment 8 */
+    ╭─[consistent_existence_index_check.tsx:5:23]
+  4 │                           /* comment 1 */
+  5 │ ╭─▶                       ((
+  6 │ │                             /* comment 2 */
+  7 │ │                             index
+  8 │ │                             /* comment 3 */
+  9 │ │                         ))
+ 10 │ │                         /* comment 4 */
+ 11 │ │                         <
+ 12 │ │                         /* comment 5 */
+ 13 │ │                         ((
+ 14 │ │                             /* comment 6 */
+ 15 │ │                             0
+ 16 │ │                             /* comment 7 */
+ 17 │ ╰─▶                       ))
+ 18 │                           /* comment 8 */
     ╰────
   help: Replace index check with strict equality check
 
   ⚠ eslint-plugin-unicorn(consistent-existence-index-check): Prefer `!== -1` over `> -1` to check non-existence.
-    ╭─[consistent_existence_index_check.tsx:5:11]
+    ╭─[consistent_existence_index_check.tsx:5:17]
   4 │                     /* comment 1 */
   5 │ ╭─▶                 ((
   6 │ │                       /* comment 2 */

--- a/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
@@ -273,7 +273,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Array()` instead of `Array()`
-    ╭─[new_for_builtins.tsx:13:12]
+    ╭─[new_for_builtins.tsx:13:24]
  12 │                 }
  13 │                 return Array()
     ·                        ───────
@@ -281,7 +281,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Map()` instead of `Map()`
-    ╭─[new_for_builtins.tsx:19:12]
+    ╭─[new_for_builtins.tsx:19:24]
  18 │                 }
  19 │                 return Map()
     ·                        ─────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_accessor_recursion.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_accessor_recursion.snap
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove this property access, or remove `get` from the method
 
   ⚠ eslint-plugin-unicorn(no-accessor-recursion): Disallow recursive access to `this` within getters.
-   ╭─[no_accessor_recursion.tsx:4:19]
+   ╭─[no_accessor_recursion.tsx:4:28]
  3 │                 get bar() {
  4 │                     return this.bar;
    ·                            ────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove this property access, or remove `get` from the method
 
   ⚠ eslint-plugin-unicorn(no-accessor-recursion): Disallow recursive access to `this` within getters.
-   ╭─[no_accessor_recursion.tsx:4:19]
+   ╭─[no_accessor_recursion.tsx:4:28]
  3 │                 get bar() {
  4 │                     return this.bar.baz;
    ·                            ────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_anonymous_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_anonymous_default_export.snap
@@ -69,14 +69,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:19]
+   ╭─[no_anonymous_default_export.tsx:2:28]
  1 │ let Foo, Foo_, foo, foo_
  2 │             export default class {}
    ·                            ────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:20]
+   ╭─[no_anonymous_default_export.tsx:2:29]
  1 │ let Foo, Foo_, foo, foo_
  2 │             export default (class{})
    ·                             ───────
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This class default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:14]
+   ╭─[no_anonymous_default_export.tsx:2:23]
  1 │ let Exports, Exports_, exports, exports_
  2 │             exports = class {}
    ·                       ────────
@@ -150,21 +150,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:19]
+   ╭─[no_anonymous_default_export.tsx:2:28]
  1 │ let Foo, Foo_, foo, foo_
  2 │             export default async function * () {}
    ·                            ──────────────────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:20]
+   ╭─[no_anonymous_default_export.tsx:2:29]
  1 │ let Foo, Foo_, foo, foo_
  2 │             export default (async function * () {})
    ·                             ──────────────────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:14]
+   ╭─[no_anonymous_default_export.tsx:2:23]
  1 │ let Exports, Exports_, exports, exports_
  2 │             exports = function() {}
    ·                       ─────────────
@@ -219,28 +219,28 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:6:4]
+   ╭─[no_anonymous_default_export.tsx:6:13]
  5 │             // comment 3
  6 │             () => {}
    ·             ────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:19]
+   ╭─[no_anonymous_default_export.tsx:2:28]
  1 │ let Foo, Foo_, foo, foo_
  2 │             export default async () => {}
    ·                            ──────────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:2:17]
+   ╭─[no_anonymous_default_export.tsx:2:26]
  1 │ let Exports, Exports_, exports, exports_
  2 │             exports = (( () => {} ))
    ·                          ────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(no-anonymous-default-export): This function default export is missing a name
-   ╭─[no_anonymous_default_export.tsx:8:4]
+   ╭─[no_anonymous_default_export.tsx:8:13]
  7 │             // comment 4
  8 │             () => {};
    ·             ────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_array_callback_reference.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_array_callback_reference.snap
@@ -31,7 +31,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:2:5]
+   ╭─[no_array_callback_reference.tsx:2:17]
  1 │     foo.map(
  2 │ ╭─▶                 _
  3 │ │                       ? String // This one should be ignored
@@ -41,7 +41,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:2:5]
+   ╭─[no_array_callback_reference.tsx:2:17]
  1 │     foo.forEach(
  2 │ ╭─▶                 _
  3 │ │                       ? callbackA
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:3:13]
+   ╭─[no_array_callback_reference.tsx:3:25]
  2 │                 foo.map((0, bar));
  3 │                 foo.map(yield bar);
    ·                         ─────────
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:4:13]
+   ╭─[no_array_callback_reference.tsx:4:25]
  3 │                 foo.map(yield bar);
  4 │                 foo.map(yield* bar);
    ·                         ──────────
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:6:13]
+   ╭─[no_array_callback_reference.tsx:6:25]
  5 │                 foo.map(() => bar);
  6 │                 foo.map(bar &&= baz);
    ·                         ───────────
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:7:13]
+   ╭─[no_array_callback_reference.tsx:7:25]
  6 │                 foo.map(bar &&= baz);
  7 │                 foo.map(bar || baz);
    ·                         ──────────
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-   ╭─[no_array_callback_reference.tsx:8:13]
+   ╭─[no_array_callback_reference.tsx:8:25]
  7 │                 foo.map(bar || baz);
  8 │                 foo.map(bar + bar);
    ·                         ─────────
@@ -98,7 +98,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-    ╭─[no_array_callback_reference.tsx:9:13]
+    ╭─[no_array_callback_reference.tsx:9:25]
   8 │                 foo.map(bar + bar);
   9 │                 foo.map(+ bar);
     ·                         ─────
@@ -107,7 +107,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-    ╭─[no_array_callback_reference.tsx:10:13]
+    ╭─[no_array_callback_reference.tsx:10:25]
   9 │                 foo.map(+ bar);
  10 │                 foo.map(++ bar);
     ·                         ──────
@@ -116,7 +116,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrap the function in an arrow function to explicitly pass only the element argument
 
   ⚠ eslint-plugin-unicorn(no-array-callback-reference): Avoid passing a function reference directly to iterator methods
-    ╭─[no_array_callback_reference.tsx:11:13]
+    ╭─[no_array_callback_reference.tsx:11:25]
  10 │                 foo.map(++ bar);
  11 │                 foo.map(new Function(''));
     ·                         ────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_array_reduce.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_array_reduce.snap
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:10]
+   ╭─[no_array_reduce.tsx:2:19]
  1 │ 
  2 │             array.reduce((obj, item) => {
    ·                   ──────
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:3:20]
+   ╭─[no_array_reduce.tsx:3:29]
  2 │             const hyphenate = (str, char) => `${str}-${char}`;
  3 │             ["a", "b", "c"].reduce(hyphenate);
    ·                             ──────
@@ -98,7 +98,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:10]
+   ╭─[no_array_reduce.tsx:2:19]
  1 │ 
  2 │             array.reduce((total, item) => {
    ·                   ──────
@@ -149,7 +149,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:11]
+   ╭─[no_array_reduce.tsx:2:23]
  1 │ 
  2 │                 array.reduce((total, item) => {
    ·                       ──────
@@ -165,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:10]
+   ╭─[no_array_reduce.tsx:2:19]
  1 │ 
  2 │             array.reduceRight((obj, item) => {
    ·                   ───────────
@@ -181,7 +181,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:3:20]
+   ╭─[no_array_reduce.tsx:3:29]
  2 │             const hyphenate = (str, char) => `${str}-${char}`;
  3 │             ["a", "b", "c"].reduceRight(hyphenate);
    ·                             ───────────
@@ -253,7 +253,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:10]
+   ╭─[no_array_reduce.tsx:2:19]
  1 │ 
  2 │             array.reduceRight((total, item) => {
    ·                   ───────────
@@ -304,7 +304,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor your code to use `for` loops instead.
 
   ⚠ eslint-plugin-unicorn(no-array-reduce): Don't use `Array#reduce()` and `Array#reduceRight()`, use `for` loops instead.
-   ╭─[no_array_reduce.tsx:2:11]
+   ╭─[no_array_reduce.tsx:2:23]
  1 │ 
  2 │                 array.reduceRight((total, item) => {
    ·                       ───────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_immediate_mutation.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_immediate_mutation.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push(3, 4);
    ·             ────────────────
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             array = [1, 2];
  3 │             array.push(3, 4);
    ·             ────────────────
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [3, 4];
  2 │             array.unshift(1, 2);
    ·             ───────────────────
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [];
  2 │             array.push(3, 4,);
    ·             ─────────────────
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [];
  2 │             array.unshift(1, 2,);
    ·             ────────────────────
@@ -43,7 +43,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2,];
  2 │             array.push(3, 4);
    ·             ────────────────
@@ -51,7 +51,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [3, 4,];
  2 │             array.unshift(1, 2);
    ·             ───────────────────
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │                 array = [1, 2,];
  3 │             array.push(3, 4);
    ·             ────────────────
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push( (( 0, 3 )), (( 0, 4 )) );
    ·             ────────────────────────────────────
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push(3, 4); // comment
    ·             ────────────────
@@ -97,7 +97,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push(3, 4);
    ·             ────────────────
@@ -106,7 +106,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push(...bar);
    ·             ──────────────────
@@ -114,7 +114,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.unshift(...bar);
    ·             ─────────────────────
@@ -122,7 +122,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.unshift(foo());
    ·             ────────────────────
@@ -130,7 +130,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.unshift(...foo());
    ·             ───────────────────────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `unshift()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.unshift([foo()]);
    ·             ──────────────────────
@@ -146,7 +146,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `unshift()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │     const array = [1, 2];
  2 │ ╭─▶             array.push(
  3 │ │                   3,
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1, 2];
  2 │             array.push(((array) => foo(array.length))());
    ·             ────────────────────────────────────────────
@@ -164,7 +164,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ let array= [1, 2];
  2 │             array.push(3, 4);
    ·             ────────────────
@@ -172,7 +172,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ var array = [1, 2];
  2 │             array.push(3, 4);
    ·             ────────────────
@@ -180,7 +180,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1]
  2 │             array.push(2);
    ·             ─────────────
@@ -189,7 +189,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:8]
+   ╭─[no_immediate_mutation.tsx:2:17]
  1 │ const array = [1]
  2 │             ;(( array.push(2) ))
    ·                 ─────────────
@@ -198,7 +198,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1]
  2 │             array.push(2);
    ·             ─────────────
@@ -207,7 +207,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1]
  2 │             array.push(2);
    ·             ─────────────
@@ -216,7 +216,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const array = [1]
  2 │             array.push(2);
    ·             ─────────────
@@ -225,7 +225,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:3:5]
+   ╭─[no_immediate_mutation.tsx:3:17]
  2 │                 const array = [1]
  3 │                 array.push(2);
    ·                 ─────────────
@@ -234,7 +234,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `push()` immediately after initializing an array.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             array = [1, 2]
  3 │             array.push(3, 4)
    ·             ────────────────
@@ -243,7 +243,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the elements from `push()` into the array initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.bar = 2;
    ·             ──────────────
@@ -251,7 +251,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             object = {foo: 1};
  3 │             object.bar = 2;
    ·             ──────────────
@@ -259,7 +259,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object[bar] = 2;
    ·             ───────────────
@@ -267,7 +267,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object[(( 0, bar ))] = (( baz ));
    ·             ────────────────────────────────
@@ -275,7 +275,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {};
  2 │             object.bar = 2;
    ·             ──────────────
@@ -283,7 +283,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1,};
  2 │             object.bar = 2;
    ·             ──────────────
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │                 object = {foo: 1};
  3 │             object.bar = 2;
    ·             ──────────────
@@ -313,7 +313,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.bar = 2; // comment
    ·             ──────────────
@@ -321,7 +321,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.bar = 2;
    ·             ──────────────
@@ -330,7 +330,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.bar = anotherObject.baz = 2;
    ·             ──────────────────────────────────
@@ -338,7 +338,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.bar = (object) => object.foo;
    ·             ───────────────────────────────────
@@ -346,7 +346,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             object.object = 2;
    ·             ─────────────────
@@ -354,7 +354,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1}
  2 │             object.bar = 2
    ·             ──────────────
@@ -363,7 +363,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1}
  2 │             object.bar = 2
    ·             ──────────────
@@ -372,7 +372,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not assign a property immediately after initializing an object literal.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             object = {foo: 1}
  3 │             object.bar = 2
    ·             ──────────────
@@ -381,7 +381,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar);
    ·             ──────────────────────────
@@ -389,7 +389,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             object = {foo: 1};
  3 │             Object.assign(object, bar);
    ·             ──────────────────────────
@@ -397,7 +397,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, {bar: 2});
    ·             ───────────────────────────────
@@ -405,7 +405,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, {bar, baz,});
    ·             ──────────────────────────────────
@@ -413,7 +413,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1,};
  2 │             Object.assign(object, {bar, baz,});
    ·             ──────────────────────────────────
@@ -421,7 +421,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {};
  2 │             Object.assign(object, {bar, baz,});
    ·             ──────────────────────────────────
@@ -429,7 +429,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {};
  2 │             Object.assign(object, {});
    ·             ─────────────────────────
@@ -437,7 +437,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {};
  2 │             Object.assign((( object )), (( 0, bar)));
    ·             ────────────────────────────────────────
@@ -445,7 +445,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {};
  2 │             Object.assign((( object )), (( {bar: 2} )));
    ·             ───────────────────────────────────────────
@@ -453,7 +453,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │                 object = {foo: 1};
  3 │             Object.assign(object, bar);
    ·             ──────────────────────────
@@ -475,7 +475,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the property into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar) // comment
    ·             ──────────────────────────
@@ -483,7 +483,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar)
    ·             ──────────────────────────
@@ -492,7 +492,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, {baz(object){return object}})
    ·             ───────────────────────────────────────────────────
@@ -500,7 +500,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar());
    ·             ────────────────────────────
@@ -508,7 +508,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ let object = {foo: 1};
  2 │             Object.assign(object, bar);
    ·             ──────────────────────────
@@ -516,7 +516,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ var object = {foo: 1};
  2 │             Object.assign(object, bar);
    ·             ──────────────────────────
@@ -524,7 +524,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar, baz);
    ·             ───────────────────────────────
@@ -532,7 +532,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, {}, baz);
    ·             ──────────────────────────────
@@ -540,7 +540,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1};
  2 │             Object.assign(object, bar, ...baz, {bar: 2});
    ·             ────────────────────────────────────────────
@@ -548,7 +548,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1}
  2 │             Object.assign(object, bar)
    ·             ──────────────────────────
@@ -557,7 +557,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const object = {foo: 1}
  2 │             Object.assign(object, bar)
    ·             ──────────────────────────
@@ -566,7 +566,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `Object.assign()` immediately after initializing an object.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             object = {foo: 1}
  3 │             Object.assign(object, bar)
    ·             ──────────────────────────
@@ -575,7 +575,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the properties from `Object.assign()` into the object initializer.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2]);
  2 │             set.add(3);
    ·             ──────────
@@ -583,7 +583,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             set = new Set([1, 2]);
  3 │             set.add(3);
    ·             ──────────
@@ -591,7 +591,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const weakSet = new WeakSet([a, b]);
  2 │             weakSet.add(c);
    ·             ──────────────
@@ -599,7 +599,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([]);
  2 │             set.add(3);
    ·             ──────────
@@ -607,7 +607,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set();
  2 │             set.add(3);
    ·             ──────────
@@ -615,7 +615,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set;
  2 │             set.add(3);
    ·             ──────────
@@ -623,7 +623,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = (( new Set ));
  2 │             set.add(3);
    ·             ──────────
@@ -631,7 +631,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new (( Set ));
  2 │             set.add(3);
    ·             ──────────
@@ -639,7 +639,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │                 set = new Set;
  3 │             set.add(3);
    ·             ──────────
@@ -647,7 +647,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2]);
  2 │             set.add( ((0, 3)), );
    ·             ────────────────────
@@ -669,7 +669,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2]);
  2 │             set.add(3); // comment
    ·             ──────────
@@ -677,7 +677,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2]);
  2 │             set.add(foo());
    ·             ──────────────
@@ -685,7 +685,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │     const set = new Set([1, 2]);
  2 │ ╭─▶             set
  3 │ │                   .add(
@@ -695,7 +695,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ let set = new Set([1, 2]);
  2 │             set.add(3);
    ·             ──────────
@@ -703,7 +703,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ var set = new Set([1, 2]);
  2 │             set.add(3);
    ·             ──────────
@@ -711,7 +711,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2])
  2 │             set.add(3);
    ·             ──────────
@@ -720,7 +720,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set([1, 2])
  2 │             set.add(3);
    ·             ──────────
@@ -729,7 +729,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set
  2 │             set.add(3);
    ·             ──────────
@@ -738,7 +738,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const set = new Set
  2 │             set.add(3);
    ·             ──────────
@@ -747,7 +747,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.add()` immediately after initializing a Set.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             set = new Set([1, 2])
  3 │             set.add(3)
    ·             ──────────
@@ -756,7 +756,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the element to the Set initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]]);
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -764,7 +764,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             map = new Map([["foo", 1]]);
  3 │             map.set("bar", 2);
    ·             ─────────────────
@@ -772,7 +772,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const weakMap = new WeakMap([[foo, 1]]);
  2 │             weakMap.set(bar, 2);
    ·             ───────────────────
@@ -780,7 +780,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([]);
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -788,7 +788,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map();
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -796,7 +796,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map;
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -804,7 +804,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = (( new Map ));
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -812,7 +812,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new (( Map ));
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -820,7 +820,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │                 map = new Map;
  3 │             map.set("bar", 2);
    ·             ─────────────────
@@ -828,7 +828,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo",1]]);
  2 │             map.set( ((0, "bar")), ((0, 2)), );
    ·             ──────────────────────────────────
@@ -850,7 +850,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]]);
  2 │             map.set("bar", 2); // comment
    ·             ─────────────────
@@ -858,7 +858,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]]);
  2 │             map.set("bar", foo());
    ·             ─────────────────────
@@ -866,7 +866,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]]);
  2 │             map.set(bar(), 2);
    ·             ─────────────────
@@ -874,7 +874,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │     const map = new Map([["foo", 1]]);
  2 │ ╭─▶             map
  3 │ │                   .set(
@@ -885,7 +885,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ let map = new Map([["foo", 1]]);
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -893,7 +893,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ var map = new Map([["foo", 1]]);
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -901,7 +901,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]])
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -910,7 +910,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map([["foo", 1]])
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -919,7 +919,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -928,7 +928,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const map = new Map
  2 │             map.set("bar", 2);
    ·             ─────────────────
@@ -937,7 +937,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:3:4]
+   ╭─[no_immediate_mutation.tsx:3:13]
  2 │             map = new Map([["foo", 1]])
  3 │             map.set("bar", 2)
    ·             ─────────────────
@@ -946,7 +946,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>();
  2 │             cellOutputMappers.set('display_data', translateDisplayDataOutput);
    ·             ─────────────────────────────────────────────────────────────────
@@ -954,7 +954,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>([]);
  2 │             cellOutputMappers.set('display_data', translateDisplayDataOutput);
    ·             ─────────────────────────────────────────────────────────────────
@@ -962,7 +962,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add the entry to the Map initializer array.
 
   ⚠ eslint-plugin-unicorn(no-immediate-mutation): Do not call `.set()` immediately after initializing a Map.
-   ╭─[no_immediate_mutation.tsx:2:4]
+   ╭─[no_immediate_mutation.tsx:2:13]
  1 │ const cellOutputMappers = new Map<OutputType, (output: any) => NotebookCellOutput>;
  2 │             cellOutputMappers.set('display_data', translateDisplayDataOutput);
    ·             ─────────────────────────────────────────────────────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_negation_in_equality_check.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_negation_in_equality_check.snap
@@ -31,7 +31,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '==' instead of '!='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:14]
+   ╭─[no_negation_in_equality_check.tsx:3:35]
  2 │                         function x() {
  3 │                             return!foo === bar;
    ·                                   ────
@@ -40,7 +40,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:14]
+   ╭─[no_negation_in_equality_check.tsx:3:35]
  2 │                             function x() {
  3 │ ╭─▶                             return!
  4 │ ╰─▶                                 foo === bar;
@@ -49,7 +49,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:5:13]
+   ╭─[no_negation_in_equality_check.tsx:5:34]
  4 │                                     foo === bar;
  5 │ ╭─▶                             throw!
  6 │ ╰─▶                                 foo === bar;
@@ -58,7 +58,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:7]
+   ╭─[no_negation_in_equality_check.tsx:3:25]
  2 │                         foo
  3 │                         !(a) === b
    ·                         ────
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:7]
+   ╭─[no_negation_in_equality_check.tsx:3:25]
  2 │                         foo
  3 │                         ![a, b].join('') === c
    ·                         ────────────────
@@ -76,7 +76,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:7]
+   ╭─[no_negation_in_equality_check.tsx:3:25]
  2 │                         foo
  3 │                         ! [a, b].join('') === c
    ·                         ─────────────────
@@ -85,7 +85,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and use '!==' instead of '==='.
 
   ⚠ eslint-plugin-unicorn(no-negation-in-equality-check): Negated expression is not allowed in equality check.
-   ╭─[no_negation_in_equality_check.tsx:3:7]
+   ╭─[no_negation_in_equality_check.tsx:3:25]
  2 │                         foo
  3 │                         !/* comment */[a, b].join('') === c
    ·                         ─────────────────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_new_array.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_new_array.snap
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
   help: It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.
 
   ⚠ eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.
-   ╭─[no_new_array.tsx:2:18]
+   ╭─[no_new_array.tsx:2:27]
  1 │ const zero = 0;
  2 │             const array = new Array(zero);
    ·                           ───────────────
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
   help: It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.
 
   ⚠ eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.
-   ╭─[no_new_array.tsx:2:18]
+   ╭─[no_new_array.tsx:2:27]
  1 │ const length = 1;
  2 │             const array = new Array(length);
    ·                           ─────────────────
@@ -68,7 +68,7 @@ source: crates/oxc_linter/src/tester.rs
   help: It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.
 
   ⚠ eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.
-   ╭─[no_new_array.tsx:2:4]
+   ╭─[no_new_array.tsx:2:13]
  1 │ const foo = []
  2 │             new Array("bar").forEach(baz)
    ·             ────────────────
@@ -419,7 +419,7 @@ source: crates/oxc_linter/src/tester.rs
   help: It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.
 
   ⚠ eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.
-   ╭─[no_new_array.tsx:2:4]
+   ╭─[no_new_array.tsx:2:13]
  1 │ const foo = []
  2 │             new Array(bar).forEach(baz)
    ·             ──────────────
@@ -427,7 +427,7 @@ source: crates/oxc_linter/src/tester.rs
   help: It's not clear whether the argument is meant to be the length of the array or the only element. If the argument is the array's length, consider using `Array.from({ length: n })`. If the argument is the only element, use `[element]`.
 
   ⚠ eslint-plugin-unicorn(no-new-array): Do not use `new Array(singleArgument)`.
-   ╭─[no_new_array.tsx:2:4]
+   ╭─[no_new_array.tsx:2:13]
  1 │ const foo = []
  2 │             new Array(...bar).forEach(baz)
    ·             ─────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
@@ -250,7 +250,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:3:11]
+   ╭─[no_single_promise_in_promise_methods.mts:3:17]
  2 │         foo
  3 │         Promise.all([(0, promise),],)
    ·                 ───

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_error_capture_stack_trace.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_error_capture_stack_trace.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:4:7]
+   ╭─[no_useless_error_capture_stack_trace.tsx:4:25]
  3 │                     const foo = () => {
  4 │                         Error.captureStackTrace(this, MyError)
    ·                         ──────────────────────────────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The Error constructor already calls `captureStackTrace` internally, so calling it again is unnecessary.
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:3:13]
+   ╭─[no_useless_error_capture_stack_trace.tsx:3:28]
  2 │                 constructor() {
  3 │                     if (a) Error.captureStackTrace(this, MyError)
    ·                            ──────────────────────────────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The Error constructor already calls `captureStackTrace` internally, so calling it again is unnecessary.
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:3:22]
+   ╭─[no_useless_error_capture_stack_trace.tsx:3:37]
  2 │                 constructor() {
  3 │                     const x = () => Error.captureStackTrace(this, MyError)
    ·                                     ──────────────────────────────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The Error constructor already calls `captureStackTrace` internally, so calling it again is unnecessary.
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:3:11]
+   ╭─[no_useless_error_capture_stack_trace.tsx:3:26]
  2 │                 constructor() {
  3 │                     void Error.captureStackTrace(this, MyError)
    ·                          ──────────────────────────────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The Error constructor already calls `captureStackTrace` internally, so calling it again is unnecessary.
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:3:6]
+   ╭─[no_useless_error_capture_stack_trace.tsx:3:21]
  2 │                 constructor() {
  3 │                     Error.captureStackTrace(this, new.target)
    ·                     ─────────────────────────────────────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The Error constructor already calls `captureStackTrace` internally, so calling it again is unnecessary.
 
   ⚠ eslint-plugin-unicorn(no-useless-error-capture-stack-trace): Do not use `Error.captureStackTrace(…)` in the constructor of an Error subclass
-   ╭─[no_useless_error_capture_stack_trace.tsx:4:7]
+   ╭─[no_useless_error_capture_stack_trace.tsx:4:25]
  3 │                     constructor() {
  4 │                         Error.captureStackTrace(this, new.target)
    ·                         ─────────────────────────────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_promise_resolve_reject.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_promise_resolve_reject.snap
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `return value` over `return Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             (async function() {
  3 │                 return Promise.resolve(bar);
    ·                        ────────────────────
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `return value` over `return Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             async function * foo() {
  3 │                 return Promise.resolve(bar);
    ·                        ────────────────────
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `return value` over `return Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:15]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             (async function*() {
  3 │                 return Promise.resolve(bar);
    ·                        ────────────────────
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             async () => {
  3 │                 return Promise.reject(bar);
    ·                        ───────────────────
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             async function foo() {
  3 │                 return Promise.reject(bar);
    ·                        ───────────────────
@@ -98,7 +98,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             (async function() {
  3 │                 return Promise.reject(bar);
    ·                        ───────────────────
@@ -107,7 +107,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             async function * foo() {
  3 │                 return Promise.reject(bar);
    ·                        ───────────────────
@@ -116,7 +116,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:24]
  2 │             (async function*() {
  3 │                 return Promise.reject(bar);
    ·                        ───────────────────
@@ -125,7 +125,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `yield value` over `yield Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 async function * foo() {
  3 │                     yield Promise.resolve(bar);
    ·                           ────────────────────
@@ -134,7 +134,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `yield value` over `yield Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 (async function * () {
  3 │                     yield Promise.resolve(bar);
    ·                           ────────────────────
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `yield Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 async function * foo() {
  3 │                     yield Promise.reject(bar);
    ·                           ───────────────────
@@ -152,7 +152,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `yield Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 (async function * () {
  3 │                     yield Promise.reject(bar);
    ·                           ───────────────────
@@ -168,7 +168,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `return value` over `return Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:13]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:28]
  2 │                 async function foo() {
  3 │                     return Promise.resolve();
    ·                            ─────────────────
@@ -184,7 +184,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:13]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:28]
  2 │                 async function foo() {
  3 │                     return Promise.reject();
    ·                            ────────────────
@@ -193,7 +193,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `yield value` over `yield Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 async function * foo() {
  3 │                     yield Promise.resolve();
    ·                           ─────────────────
@@ -216,7 +216,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `yield value` over `yield Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:12]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:27]
  2 │                 async function * foo() {
  3 │                     yield Promise.resolve((bar, baz));
    ·                           ───────────────────────────
@@ -239,7 +239,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `return value` over `return Promise.resolve(value)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:4:14]
+   ╭─[no_useless_promise_resolve_reject.tsx:4:32]
  3 │                     try {
  4 │                         return Promise.resolve(1);
    ·                                ──────────────────
@@ -248,7 +248,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the return value in `Promise.resolve` is needlessly verbose. All return values in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `return Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:4:14]
+   ╭─[no_useless_promise_resolve_reject.tsx:4:32]
  3 │                     try {
  4 │                         return Promise.reject(1);
    ·                                ─────────────────
@@ -310,20 +310,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `yield Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:16]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:25]
  2 │             async function * foo() {
- 3 │                 (yield Promise.reject(bar));
-   ·                        ───────────────────
- 4 │             }
+ 3 │                  (yield Promise.reject(bar));
+   ·                         ───────────────────
+ 4 │              }
    ╰────
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 
   ⚠ eslint-plugin-unicorn(no-useless-promise-resolve-reject): Prefer `throw error` over `yield Promise.reject(error)`.
-   ╭─[no_useless_promise_resolve_reject.tsx:3:17]
+   ╭─[no_useless_promise_resolve_reject.tsx:3:26]
  2 │             async function * foo() {
- 3 │                 ((yield Promise.reject(bar)));
-   ·                         ───────────────────
- 4 │             }
+ 3 │                  ((yield Promise.reject(bar)));
+   ·                          ───────────────────
+ 4 │              }
    ╰────
   help: Wrapping the error in `Promise.reject` is needlessly verbose. All errors thrown in async functions are already wrapped in a `Promise`.
 

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_undefined.snap
@@ -25,7 +25,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing `undefined` or using `null` instead.
 
   ⚠ eslint-plugin-unicorn(no-useless-undefined): Do not use useless `undefined`.
-   ╭─[no_useless_undefined.tsx:5:5]
+   ╭─[no_useless_undefined.tsx:5:17]
  4 │                 bar,
  5 │                 undefined,
    ·                 ─────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:6]
+   ╭─[prefer_array_find.tsx:3:18]
  2 │                 // comment 1
  3 │                 .filter(
    ·                  ──────
@@ -159,7 +159,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:8:6]
+   ╭─[prefer_array_find.tsx:8:18]
  7 │                 // comment 3
  8 │                 .filter(
    ·                  ──────
@@ -266,7 +266,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:19]
+   ╭─[prefer_array_find.tsx:3:28]
  2 │             const bar = []
  3 │             ;[foo] = array.filter(bar)
    ·                            ──────
@@ -366,7 +366,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:25]
+   ╭─[prefer_array_find.tsx:3:37]
  2 │             function f() {
  3 │                 const items = array.filter(bar);
    ·                                     ──────
@@ -399,7 +399,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:25]
+   ╭─[prefer_array_find.tsx:2:37]
  1 │ function f() {
  2 │                 const items = array.filter(bar);
    ·                                     ──────
@@ -445,7 +445,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:22]
+   ╭─[prefer_array_find.tsx:2:31]
  1 │ let baz;
  2 │             const foo = array.filter(bar);
    ·                               ──────
@@ -462,7 +462,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:24]
+   ╭─[prefer_array_find.tsx:2:33]
  1 │ const quz = array.filter(fn);
  2 │             const [foo] = array.filter(quz[0]);
    ·                                 ──────
@@ -471,7 +471,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:5:6]
+   ╭─[prefer_array_find.tsx:5:15]
  4 │                 array.filter(fn)[0]
  5 │             ].filter(
    ·               ──────
@@ -480,7 +480,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:4:11]
+   ╭─[prefer_array_find.tsx:4:23]
  3 │             [{bar: baz}] = foo[
  4 │                 array.filter(fn)[0]
    ·                       ──────
@@ -489,7 +489,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:6:11]
+   ╭─[prefer_array_find.tsx:6:23]
  5 │             ].filter(
  6 │                 array.filter(fn).shift()
    ·                       ──────
@@ -498,7 +498,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:24]
+   ╭─[prefer_array_find.tsx:2:33]
  1 │ const quz = array.find(fn);
  2 │             const [foo] = array.filter(quz);
    ·                                 ──────
@@ -507,7 +507,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:4:11]
+   ╭─[prefer_array_find.tsx:4:23]
  3 │             ({bar: baz} = foo[
  4 │                 array.filter(fn)[0]
    ·                       ──────
@@ -516,7 +516,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:6:11]
+   ╭─[prefer_array_find.tsx:6:23]
  5 │             ].find(
  6 │                 array.filter(fn).shift()
    ·                       ──────
@@ -539,7 +539,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:6]
+   ╭─[prefer_array_find.tsx:3:18]
  2 │                 // comment 1
  3 │                 .filter(
    ·                  ──────
@@ -562,7 +562,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:6]
+   ╭─[prefer_array_find.tsx:3:18]
  2 │                 // comment 1
  3 │                 .filter(
    ·                  ──────
@@ -599,7 +599,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ eslint-plugin-unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:3:6]
+   ╭─[prefer_array_find.tsx:3:18]
  2 │                 // comment 1
  3 │                 .filter(
    ·                  ──────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
@@ -402,7 +402,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], [array].concat(array))
    ·             ───────────────────────────────────────────────────────
@@ -410,7 +410,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], +1)
    ·             ────────────────────────────────────
@@ -418,7 +418,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.call([], +1)
    ·             ───────────────────────────────────
@@ -447,7 +447,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], 1)
    ·             ───────────────────────────────────
@@ -455,7 +455,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.call([], 1)
    ·             ──────────────────────────────────
@@ -463,7 +463,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], 1.)
    ·             ────────────────────────────────────
@@ -471,7 +471,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.call([], 1.)
    ·             ───────────────────────────────────
@@ -479,7 +479,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], .1)
    ·             ────────────────────────────────────
@@ -487,7 +487,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.call([], .1)
    ·             ───────────────────────────────────
@@ -495,7 +495,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.apply([], 1.0)
    ·             ─────────────────────────────────────
@@ -503,7 +503,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Call `.flat()` on the array instead.
 
   ⚠ eslint-plugin-unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
-   ╭─[prefer_array_flat.tsx:2:4]
+   ╭─[prefer_array_flat.tsx:2:13]
  1 │ before()
  2 │             Array.prototype.concat.call([], 1.0)
    ·             ────────────────────────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_class_fields.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_class_fields.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:6]
+   ╭─[prefer_class_fields.tsx:3:21]
  2 │                 constructor() {
  3 │                     this.bar = 1;
    ·                     ────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                     ;
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:6]
+   ╭─[prefer_class_fields.tsx:3:21]
  2 │                 constructor() {
  3 │                     this.bar = 1;
    ·                     ────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:6]
+   ╭─[prefer_class_fields.tsx:3:21]
  2 │                 constructor() {
  3 │                     this.bar = 1;
    ·                     ────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.#bar = 1;
    ·                     ─────────────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Encountered same-named class field declaration and `this` assignment in constructor.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the class field declaration with the value from `this` assignment.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Encountered same-named class field declaration and `this` assignment in constructor.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.#bar = 1;
    ·                     ─────────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the class field declaration with the value from `this` assignment.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor() {
  4 │                     this.bar = 1;
    ·                     ────────────
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:5]
+   ╭─[prefer_class_fields.tsx:3:17]
  2 │             constructor() {
  3 │                 this.bar = 1;
    ·                 ────────────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:5]
+   ╭─[prefer_class_fields.tsx:3:17]
  2 │             constructor() {
  3 │                 this.bar = 1;
    ·                 ────────────
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:5]
+   ╭─[prefer_class_fields.tsx:3:17]
  2 │             constructor() {
  3 │                 this.bar = 1;
    ·                 ────────────
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:3:6]
+   ╭─[prefer_class_fields.tsx:3:21]
  2 │                 constructor(message: string) {
  3 │                     this.name = "MyError";
    ·                     ─────────────────────
@@ -165,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Declare static values as class fields instead of assigning them to `this` in the constructor.
 
   ⚠ eslint-plugin-unicorn(prefer-class-fields): Prefer class field declaration over `this` assignment in constructor for static values.
-   ╭─[prefer_class_fields.tsx:4:6]
+   ╭─[prefer_class_fields.tsx:4:21]
  3 │                 constructor(message: string) {
  4 │                     this.name = "MyError";
    ·                     ─────────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_classlist_toggle.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_classlist_toggle.snap
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:4]
+   ╭─[prefer_classlist_toggle.tsx:2:13]
  1 │     foo
  2 │ ╭─▶             if (condition) {
  3 │ │                   (( element )).classList.add('className')
@@ -278,7 +278,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:18]
+   ╭─[prefer_classlist_toggle.tsx:2:30]
  1 │ function foo() {
  2 │                 return!foo ? element.classList.add(className) : element.classList.remove(className)
    ·                              ──────────────────────────────────────────────────────────────────────
@@ -287,7 +287,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:16]
+   ╭─[prefer_classlist_toggle.tsx:2:25]
  1 │ foo
  2 │             condition ? (( element )).classList.add(className) : element.classList.remove(className);
    ·                         ────────────────────────────────────────────────────────────────────────────
@@ -295,7 +295,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList.contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -303,7 +303,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element?.classList.contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -311,7 +311,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList.contains?.('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -319,7 +319,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList?.contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -327,7 +327,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList.notContains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -335,7 +335,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList.contains('not-same-class-name')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -343,7 +343,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.notClassList.contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -351,7 +351,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -359,7 +359,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     notSameElement.classList.contains('className')
  2 │ ╭─▶                 ? element.classList.remove('className')
  3 │ ╰─▶                 : element.classList.add('className')
@@ -367,7 +367,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     element.classList.contains('className')
  2 │ ╭─▶                 ? element.classList.add('className')
  3 │ ╰─▶                 : element.classList.remove('className')
@@ -375,7 +375,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `classList.toggle()` instead
 
   ⚠ eslint-plugin-unicorn(prefer-classlist-toggle): Prefer `classList.toggle()` over `classList.add()` and `classList.remove()`
-   ╭─[prefer_classlist_toggle.tsx:2:7]
+   ╭─[prefer_classlist_toggle.tsx:2:19]
  1 │     !element.classList.contains('className')
  2 │ ╭─▶                 ? element.classList.add('className')
  3 │ ╰─▶                 : element.classList.remove('className')

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_default_parameters.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_default_parameters.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || 123;
    ·     ────────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || true;
    ·     ─────────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || 123;
    ·     ────────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     const bar = foo || 'bar';
    ·     ─────────────────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     let bar = foo || 'bar';
    ·     ───────────────────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ const abc = function(foo) {
  2 │     foo = foo || 123;
    ·     ────────────────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ const abc = (foo) => {
  2 │     foo = foo || 'bar';
    ·     ──────────────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ const abc = foo => {
  2 │     foo = foo || 'bar';
    ·     ──────────────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ const abc = (foo) => {
  2 │     const bar = foo || 'bar';
    ·     ─────────────────────────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || 'bar';
    ·     ──────────────────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo ?? 123;
    ·     ────────────────
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     const bar = foo || 'bar';
    ·     ─────────────────────────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ const abc = function(foo) {
  2 │     const bar = foo || 'bar';
    ·     ─────────────────────────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -177,7 +177,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || 'bar'; bar(); baz();
    ·     ──────────────────
@@ -186,7 +186,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:2:2]
+   ╭─[prefer_default_parameters.tsx:2:5]
  1 │ function abc(foo) {
  2 │     foo = foo || 'bar';
    ·     ──────────────────
@@ -195,7 +195,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'bar'.
-   ╭─[prefer_default_parameters.tsx:4:3]
+   ╭─[prefer_default_parameters.tsx:4:9]
  3 │     function def(bar) {
  4 │         bar = bar || 'foo';
    ·         ──────────────────
@@ -204,7 +204,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'bar'.
-   ╭─[prefer_default_parameters.tsx:4:3]
+   ╭─[prefer_default_parameters.tsx:4:9]
  3 │     function def(bar) {
  4 │         bar = bar || 'foo';
    ·         ──────────────────
@@ -213,7 +213,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'baz'.
-   ╭─[prefer_default_parameters.tsx:7:3]
+   ╭─[prefer_default_parameters.tsx:7:9]
  6 │     function ghi(baz) {
  7 │         const bay = baz || 'bar';
    ·         ─────────────────────────
@@ -222,7 +222,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -231,7 +231,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:6:3]
+   ╭─[prefer_default_parameters.tsx:6:9]
  5 │     def(foo) {
  6 │         foo = foo || 123;
    ·         ────────────────
@@ -240,7 +240,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:3]
+   ╭─[prefer_default_parameters.tsx:3:9]
  2 │     abc(foo) {
  3 │         foo = foo || 123;
    ·         ────────────────
@@ -249,7 +249,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:6:3]
+   ╭─[prefer_default_parameters.tsx:6:9]
  5 │     def(foo) {
  6 │         foo = foo || 123;
    ·         ────────────────
@@ -258,7 +258,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:2]
+   ╭─[prefer_default_parameters.tsx:3:5]
  2 │     const noSideEffects = 123;
  3 │     foo = foo || 123;
    ·     ────────────────
@@ -267,7 +267,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:5:2]
+   ╭─[prefer_default_parameters.tsx:5:5]
  4 │ 
  5 │     foo = foo || 123;
    ·     ────────────────
@@ -276,7 +276,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the reassignment with a default parameter.
 
   ⚠ eslint-plugin-unicorn(prefer-default-parameters): Prefer default parameters over reassignment for 'foo'.
-   ╭─[prefer_default_parameters.tsx:3:2]
+   ╭─[prefer_default_parameters.tsx:3:5]
  2 │     const bar = function() {};
  3 │     foo = foo || 123;
    ·     ────────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_global_this.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_global_this.snap
@@ -87,7 +87,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:12]
+   ╭─[prefer_global_this.tsx:2:21]
  1 │ function* gen() {
  2 │               yield window
    ·                     ──────
@@ -96,7 +96,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:12]
+   ╭─[prefer_global_this.tsx:2:21]
  1 │ async function gen() {
  2 │               await window
    ·                     ──────
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:13]
+   ╭─[prefer_global_this.tsx:2:22]
  1 │ function foo() {
  2 │               return window
    ·                      ──────
@@ -142,7 +142,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:10]
+   ╭─[prefer_global_this.tsx:2:22]
  1 │ const obj = {
  2 │                 foo: window.foo,
    ·                      ──────
@@ -151,7 +151,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:3:10]
+   ╭─[prefer_global_this.tsx:3:22]
  2 │                 foo: window.foo,
  3 │                 bar: window.bar,
    ·                      ──────
@@ -160,7 +160,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:4:13]
+   ╭─[prefer_global_this.tsx:4:25]
  3 │                 bar: window.bar,
  4 │                 window: window
    ·                         ──────
@@ -169,7 +169,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:3:25]
+   ╭─[prefer_global_this.tsx:3:37]
  2 │                 let x, y;
  3 │                 x = (y = 10, y + 5, window);
    ·                                     ──────
@@ -267,7 +267,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:10]
+   ╭─[prefer_global_this.tsx:2:22]
  1 │ switch (true) {
  2 │                 case window:
    ·                      ──────
@@ -276,7 +276,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the alias with `globalThis`.
 
   ⚠ eslint-plugin-unicorn(prefer-global-this): Prefer `globalThis` over environment-specific global aliases like `window`, `self`, and `global`.
-   ╭─[prefer_global_this.tsx:2:10]
+   ╭─[prefer_global_this.tsx:2:22]
  1 │ switch (true) {
  2 │                 case window.foo:
    ·                      ──────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:19]
+   ╭─[prefer_keyboard_event_key.tsx:2:31]
  1 │ window.addEventListener('click', e => {
  2 │                 console.log(e.keyCode);
    ·                               ───────
@@ -36,7 +36,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 27) {
    ·                           ───────
@@ -45,7 +45,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', event => {
  2 │                 if (event.keyCode === 65) {}
    ·                           ───────
@@ -54,7 +54,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', event => {
  2 │                 if (event.keyCode === 10) {}
    ·                           ───────
@@ -63,7 +63,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:16]
+   ╭─[prefer_keyboard_event_key.tsx:2:28]
  1 │ foo.addEventListener('click', event => {
  2 │                 if (!event.keyCode) {}
    ·                            ───────
@@ -72,7 +72,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', a => {
  2 │                 if (a.keyCode === 27) {
    ·                       ───────
@@ -81,7 +81,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', (a, b, c) => {
  2 │                 if (a.keyCode === 27) {
    ·                       ───────
@@ -90,7 +90,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(a, b, c) {
  2 │                 if (a.keyCode === 27) {
    ·                       ───────
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(b) {
  2 │                 if (b.keyCode === 27) {
    ·                       ───────
@@ -108,7 +108,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:12]
+   ╭─[prefer_keyboard_event_key.tsx:2:24]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {keyCode, a, b} = e;
    ·                        ───────
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {a: keyCode, a, b} = e;
    ·                           ───────
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:3:13]
+   ╭─[prefer_keyboard_event_key.tsx:3:28]
  2 │                 f.addEventList('some', e => {
  3 │                     const {keyCode} = event;
    ·                            ───────
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:19]
+   ╭─[prefer_keyboard_event_key.tsx:2:31]
  1 │ window.addEventListener('click', e => {
  2 │                 console.log(e.charCode);
    ·                               ────────
@@ -144,7 +144,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo11111111.addEventListener('click', event => {
  2 │                 if (event.charCode === 27) {
    ·                           ────────
@@ -153,7 +153,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', a => {
  2 │                 if (a.charCode === 27) {
    ·                       ────────
@@ -162,7 +162,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', (a, b, c) => {
  2 │                 if (a.charCode === 27) {
    ·                       ────────
@@ -171,7 +171,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(a, b, c) {
  2 │                 if (a.charCode === 27) {
    ·                       ────────
@@ -180,7 +180,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(b) {
  2 │                 if (b.charCode === 27) {
    ·                       ────────
@@ -189,7 +189,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:12]
+   ╭─[prefer_keyboard_event_key.tsx:2:24]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {charCode, a, b} = e;
    ·                        ────────
@@ -198,7 +198,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {a: charCode, a, b} = e;
    ·                           ────────
@@ -207,7 +207,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:19]
+   ╭─[prefer_keyboard_event_key.tsx:2:31]
  1 │ window.addEventListener('click', e => {
  2 │                 console.log(e.which);
    ·                               ─────
@@ -216,7 +216,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', event => {
  2 │                 if (event.which === 27) {
    ·                           ─────
@@ -225,7 +225,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', a => {
  2 │                 if (a.which === 27) {
    ·                       ─────
@@ -234,7 +234,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', (a, b, c) => {
  2 │                 if (a.which === 27) {
    ·                       ─────
@@ -243,7 +243,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(a, b, c) {
  2 │                 if (a.which === 27) {
    ·                       ─────
@@ -252,7 +252,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(b) {
  2 │                 if (b.which === 27) {
    ·                       ─────
@@ -261,7 +261,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:12]
+   ╭─[prefer_keyboard_event_key.tsx:2:24]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {which, a, b} = e;
    ·                        ─────
@@ -270,7 +270,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo.addEventListener('click', e => {
  2 │                 const {a: which, a, b} = e;
    ·                           ─────
@@ -279,7 +279,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(b) {
  2 │                 if (b.which === 27) {
    ·                       ─────
@@ -288,7 +288,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:4:12]
+   ╭─[prefer_keyboard_event_key.tsx:4:24]
  3 │                 }
  4 │                 const {keyCode} = b;
    ·                        ───────
@@ -297,7 +297,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.which`
-   ╭─[prefer_keyboard_event_key.tsx:2:11]
+   ╭─[prefer_keyboard_event_key.tsx:2:23]
  1 │ foo.addEventListener('click', function(b) {
  2 │                 if (b.which > 27) {
    ·                       ─────
@@ -306,7 +306,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:4:12]
+   ╭─[prefer_keyboard_event_key.tsx:4:24]
  3 │                 }
  4 │                 const {keyCode} = b;
    ·                        ───────
@@ -315,7 +315,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:7:17]
+   ╭─[prefer_keyboard_event_key.tsx:7:41]
  6 │                             {
  7 │                                 const { charCode } = e;
    ·                                         ────────
@@ -324,7 +324,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `charCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:8:23]
+   ╭─[prefer_keyboard_event_key.tsx:8:47]
  7 │                                 const { charCode } = e;
  8 │                                 console.log(e.keyCode, charCode);
    ·                                               ───────
@@ -333,7 +333,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 13) {
    ·                           ───────
@@ -342,7 +342,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 38) {
    ·                           ───────
@@ -351,7 +351,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 40) {
    ·                           ───────
@@ -360,7 +360,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 37) {
    ·                           ───────
@@ -369,7 +369,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 39) {
    ·                           ───────
@@ -378,7 +378,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 221) {
    ·                           ───────
@@ -387,7 +387,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 186) {
    ·                           ───────
@@ -396,7 +396,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 187) {
    ·                           ───────
@@ -405,7 +405,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 188) {
    ·                           ───────
@@ -414,7 +414,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 189) {
    ·                           ───────
@@ -423,7 +423,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 190) {
    ·                           ───────
@@ -432,7 +432,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 191) {
    ·                           ───────
@@ -441,7 +441,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 219) {
    ·                           ───────
@@ -450,7 +450,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 222) {
    ·                           ───────
@@ -467,7 +467,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The `which` property is deprecated.
 
   ⚠ eslint-plugin-unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
-   ╭─[prefer_keyboard_event_key.tsx:2:15]
+   ╭─[prefer_keyboard_event_key.tsx:2:27]
  1 │ foo123.addEventListener('click', event => {
  2 │                 if (event.keyCode === 27) {
    ·                           ───────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_modern_math_apis.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_modern_math_apis.snap
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-modern-math-apis): Prefer `Math.log10(x)` over `Math.log(x) / Math.LN10`
-   ╭─[prefer_modern_math_apis.tsx:4:6]
+   ╭─[prefer_modern_math_apis.tsx:4:21]
  3 │                     return (
  4 │ ╭─▶                     Math.log(x)
  5 │ ╰─▶                         / Math.LN10
@@ -161,7 +161,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-modern-math-apis): Prefer `Math.log2(x)` over `Math.log(x) / Math.LN2`
-   ╭─[prefer_modern_math_apis.tsx:4:6]
+   ╭─[prefer_modern_math_apis.tsx:4:21]
  3 │                     return (
  4 │ ╭─▶                     Math.log(x)
  5 │ ╰─▶                         / Math.LN2

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `Object.fromEntries(pairs)` instead of manually building objects with `reduce` or `forEach`.
 
   ⚠ eslint-plugin-unicorn(prefer-object-from-entries): Prefer `Object.fromEntries` over manual object construction from entries.
-   ╭─[prefer_object_from_entries.tsx:8:11]
+   ╭─[prefer_object_from_entries.tsx:8:32]
  7 │                                 Object
  8 │                             )).assign(
    ·                                ──────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_response_static_json.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_response_static_json.snap
@@ -24,7 +24,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `new Response(JSON.stringify(...))` with `Response.json(...)`
 
   ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
-   ╭─[prefer_response_static_json.tsx:3:15]
+   ╭─[prefer_response_static_json.tsx:3:30]
  2 │                 return new // comment
  3 │                     Response(JSON.stringify(data))
    ·                              ──────────────
@@ -40,7 +40,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `new Response(JSON.stringify(...))` with `Response.json(...)`
 
   ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
-   ╭─[prefer_response_static_json.tsx:2:23]
+   ╭─[prefer_response_static_json.tsx:2:32]
  1 │ foo
  2 │             new (( Response ))(JSON.stringify(data))
    ·                                ──────────────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `new Response(JSON.stringify(...))` with `Response.json(...)`
 
   ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
-   ╭─[prefer_response_static_json.tsx:2:23]
+   ╭─[prefer_response_static_json.tsx:2:32]
  1 │ foo;
  2 │             new (( Response ))(JSON.stringify(data))
    ·                                ──────────────
@@ -56,7 +56,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `new Response(JSON.stringify(...))` with `Response.json(...)`
 
   ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
-   ╭─[prefer_response_static_json.tsx:2:26]
+   ╭─[prefer_response_static_json.tsx:2:35]
  1 │ foo;
  2 │             (( new (( Response ))(JSON.stringify(data)) ))
    ·                                   ──────────────
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `new Response(JSON.stringify(...))` with `Response.json(...)`
 
   ⚠ eslint-plugin-unicorn(prefer-response-static-json): Prefer using `Response.json(…)` over `JSON.stringify()`.
-   ╭─[prefer_response_static_json.tsx:2:26]
+   ╭─[prefer_response_static_json.tsx:2:35]
  1 │ foo
  2 │             (( new (( Response ))(JSON.stringify(data)) ))
    ·                                   ──────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_set_has.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_set_has.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-unicorn(prefer-set-has): should be a `Set`, and use `.has()` to check existence or non-existence.
-   ╭─[prefer_set_has.tsx:2:10]
+   ╭─[prefer_set_has.tsx:2:19]
  1 │ 
  2 │             const foo = [1, 2, 3];
    ·                   ───────────────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Switch to `Set`
 
   ⚠ eslint-plugin-unicorn(prefer-set-has): should be a `Set`, and use `.has()` to check existence or non-existence.
-   ╭─[prefer_set_has.tsx:3:20]
+   ╭─[prefer_set_has.tsx:3:23]
  2 │             async function unicorn() {
  3 │                 const foo = [1, 2, 3];
    ·                       ───────────────
@@ -174,7 +174,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Switch to `Set`
 
   ⚠ eslint-plugin-unicorn(prefer-set-has): should be a `Set`, and use `.has()` to check existence or non-existence.
-   ╭─[prefer_set_has.tsx:3:20]
+   ╭─[prefer_set_has.tsx:3:23]
  2 │             function wrap() {
  3 │                 const foo = [1, 2, 3];
    ·                       ───────────────
@@ -201,7 +201,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Switch to `Set`
 
   ⚠ eslint-plugin-unicorn(prefer-set-has): should be a `Set`, and use `.has()` to check existence or non-existence.
-   ╭─[prefer_set_has.tsx:7:21]
+   ╭─[prefer_set_has.tsx:7:27]
  6 │                 function outer(find) {
  7 │                     const foo = [1, 2, 3];
    ·                           ───────────────
@@ -210,7 +210,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Switch to `Set`
 
   ⚠ eslint-plugin-unicorn(prefer-set-has): should be a `Set`, and use `.has()` to check existence or non-existence.
-    ╭─[prefer_set_has.tsx:12:22]
+    ╭─[prefer_set_has.tsx:12:31]
  11 │                     function inner(find) {
  12 │                         const bar = [1, 2, 3];
     ·                               ───────────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_spread.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_spread.snap
@@ -31,7 +31,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = []
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = "1"
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -47,7 +47,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = null
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = true
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -63,7 +63,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = 1
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -71,7 +71,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = /./
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -79,7 +79,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = /./g
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -87,7 +87,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = bar
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -95,7 +95,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = bar.baz
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -103,7 +103,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:11]
+   ╭─[prefer_spread.tsx:2:23]
  1 │ function* foo() {
  2 │                 yield Array.from(arrayLike).forEach(doSomething)
    ·                       ─────────────────────
@@ -126,7 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = [];
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -157,7 +157,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:18]
+   ╭─[prefer_spread.tsx:2:30]
  1 │ async function foo(){
  2 │                 return await Array.from(arrayLike)
    ·                              ─────────────────────
@@ -166,7 +166,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ foo()
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -174,7 +174,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over Array.from()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const foo = {}
  2 │             Array.from(arrayLike).forEach(doSomething)
    ·             ─────────────────────
@@ -378,7 +378,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.concat()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ bar()
  2 │             foo.concat(2)
    ·             ─────────────
@@ -400,7 +400,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.concat()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const five = 2 + 3;
  2 │             foo.concat(five);
    ·             ────────────────
@@ -408,7 +408,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.concat()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ const array = [2 + 3];
  2 │             foo.concat(array);
    ·             ─────────────────
@@ -612,7 +612,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.concat()
-    ╭─[prefer_spread.tsx:4:18]
+    ╭─[prefer_spread.tsx:4:27]
   3 │                 const EMPTY_STRING_IN_ARRAY_OF_ARRAY = ""
   4 │ ╭─▶             const array = [].concat(
   5 │ │                   undefined,
@@ -760,7 +760,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.concat()
-   ╭─[prefer_spread.tsx:2:17]
+   ╭─[prefer_spread.tsx:2:26]
  1 │ const baz = [2];
  2 │             call(foo, ...[bar].concat(baz));
    ·                          ─────────────────
@@ -831,7 +831,7 @@ source: crates/oxc_linter/src/tester.rs
   help: The spread operator (`...`) is more concise and readable.
 
   ⚠ eslint-plugin-unicorn(prefer-spread): Prefer the spread operator (`...`) over array.slice()
-   ╭─[prefer_spread.tsx:2:4]
+   ╭─[prefer_spread.tsx:2:13]
  1 │ bar()
  2 │             foo.slice()
    ·             ───────────

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_top_level_await.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_top_level_await.snap
@@ -45,7 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over using an async IIFE.
-   ╭─[prefer_top_level_await.mjs:2:5]
+   ╭─[prefer_top_level_await.mjs:2:17]
  1 │ {
  2 │                 (async () => {})();
    ·                 ──────────────────
@@ -191,7 +191,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over an async function call.
-   ╭─[prefer_top_level_await.mjs:2:4]
+   ╭─[prefer_top_level_await.mjs:2:13]
  1 │ const foo = async () => {};
  2 │             foo();
    ·             ─────
@@ -199,7 +199,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add `await` before the function call.
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over an async function call.
-   ╭─[prefer_top_level_await.mjs:2:4]
+   ╭─[prefer_top_level_await.mjs:2:13]
  1 │ const foo = async () => {};
  2 │             foo?.();
    ·             ───────
@@ -207,14 +207,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Add `await` before the function call.
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over using a promise chain.
-   ╭─[prefer_top_level_await.mjs:2:4]
+   ╭─[prefer_top_level_await.mjs:2:13]
  1 │ const foo = async () => {};
  2 │             foo().then(foo);
    ·             ───────────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over an async function call.
-   ╭─[prefer_top_level_await.mjs:2:4]
+   ╭─[prefer_top_level_await.mjs:2:13]
  1 │ const foo = async function () {}, bar = 1;
  2 │             foo(bar);
    ·             ────────
@@ -230,7 +230,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add `await` before the function call.
 
   ⚠ eslint-plugin-unicorn(prefer-top-level-await): Prefer top-level await over an async function call.
-   ╭─[prefer_top_level_await.mjs:5:5]
+   ╭─[prefer_top_level_await.mjs:5:17]
  4 │             } else {
  5 │                 foo();
    ·                 ─────


### PR DESCRIPTION
Use spaces instead of tabs so we have consistency with the results we expect to get out of generating the unicorn rules. Also update the example code in the docs for a few of the rules, but mainly just the tests.

This helps make it easier to figure out what changes are legitimate when regenerating the tests for the unicorn rules, so we can easily spot and code review updates to the tests here.