### PR TITLE
feat(formatter/sort_imports)!: Change default `groups` order

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/options.rs
@@ -141,15 +141,16 @@ pub fn default_internal_patterns() -> Vec<String> {
 
 /// Returns default groups configuration for organizing imports.
 pub fn default_groups() -> Vec<Vec<GroupEntry>> {
-    // Helper to parse a predefined group name, panicking on invalid names.
+    // Helper to parse a predefined group name
     let p = |s: &str| GroupEntry::Predefined(GroupName::parse(s).unwrap());
+    // Our policy: far to near, built-in to local.
+    // Do not include side effects by default, it may break some code if moved around.
     vec![
-        vec![p("type-import")],
-        vec![p("value-builtin"), p("value-external")],
-        vec![p("type-internal")],
-        vec![p("value-internal")],
-        vec![p("type-parent"), p("type-sibling"), p("type-index")],
-        vec![p("value-parent"), p("value-sibling"), p("value-index")],
+        vec![p("builtin")],
+        vec![p("external")],
+        vec![p("internal"), p("subpath")],
+        vec![p("parent"), p("sibling"), p("index")],
+        vec![p("style")],
         vec![GroupEntry::Unknown],
     ]
 }

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -1051,11 +1051,9 @@ import { d } from "../d";
         r##"{ "experimentalSortImports": { "internalPattern": ["#"] } }"##,
         r##"
 import type { T } from "a";
-
 import { a } from "a";
 
 import type { S } from "#b";
-
 import { b1, b2 } from "#b";
 import c from "#c";
 
@@ -1078,12 +1076,11 @@ import type { Hello } from "pkg"
 "#,
         r#"{ "experimentalSortImports": {} }"#,
         r#"
-import type { Hello } from "pkg";
-
 /*
  * hi
  */
 import cn from "classnames";
+import type { Hello } from "pkg";
 "#,
     );
     assert_format(
@@ -1211,8 +1208,8 @@ import { b1, b2 } from "~/b";
 "#,
         r#"{ "experimentalSortImports": { "newlinesBetween": false } }"#,
         r#"
-import type { T } from "t";
 import { a1, a2, a3 } from "a";
+import type { T } from "t";
 import { b1, b2 } from "~/b";
 import { c1, c2, c3 } from "~/c";
 import d from ".";
@@ -1234,9 +1231,8 @@ import { b1, b2 } from "~/b";
 "#,
         r#"{ "experimentalSortImports": { "newlinesBetween": true } }"#,
         r#"
-import type { T } from "t";
-
 import { a1, a2, a3 } from "a";
+import type { T } from "t";
 
 import { b1, b2 } from "~/b";
 import { c1, c2, c3 } from "~/c";

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
@@ -23,92 +23,89 @@ import type { H } from "./index.d.ts";
 
 import a from ".";
 import type { T } from "t";
-import "./style.css";
 import { j } from "../j";
 import { K, L, M } from "../k";
+import "./style.css";
 "#,
         r#"{ "experimentalSortImports": {} }"#,
         r#"
-import type { T } from "t";
+import fs from "fs";
+import path from "path";
 
 import { c1, c2, c3, c4 } from "c";
 import { e1 } from "e/a";
 import { e2 } from "e/b";
-import fs from "fs";
-import path from "path";
-
-import type { I } from "~/i";
+import type { T } from "t";
 
 import { b1, b2 } from "~/b";
 import { c1 } from "~/c";
+import type { I } from "~/i";
 import { i1, i2, i3 } from "~/i";
 
 import type { A } from ".";
+import a from ".";
+import h from "../../h";
 import type { F } from "../f";
+import { j } from "../j";
+import { K, L, M } from "../k";
 import type { D } from "./d";
 import type { H } from "./index.d.ts";
 
-import a from ".";
-import h from "../../h";
 import "./style.css";
-import { j } from "../j";
-import { K, L, M } from "../k";
 "#,
     );
     // Input is already in the correct order, should remain unchanged
     assert_format(
         r#"
-import type { T } from "t";
+import fs from "fs";
+import path from "path";
 
 import { c1, c2, c3, c4 } from "c";
 import { e1 } from "e/a";
 import { e2 } from "e/b";
-import fs from "fs";
-import path from "path";
-
-import type { I } from "~/i";
+import type { T } from "t";
 
 import { b1, b2 } from "~/b";
 import { c1 } from "~/c";
+import type { I } from "~/i";
 import { i1, i2, i3 } from "~/i";
 
 import type { A } from ".";
+import a from ".";
+import h from "../../h";
 import type { F } from "../f";
+import { j } from "../j";
+import { K, L, M } from "../k";
 import type { D } from "./d";
 import type { H } from "./index.d.ts";
 
-import a from ".";
-import h from "../../h";
 import "./style.css";
-import { j } from "../j";
-import { K, L, M } from "../k";
 "#,
         r#"{ "experimentalSortImports": {} }"#,
         r#"
-import type { T } from "t";
+import fs from "fs";
+import path from "path";
 
 import { c1, c2, c3, c4 } from "c";
 import { e1 } from "e/a";
 import { e2 } from "e/b";
-import fs from "fs";
-import path from "path";
-
-import type { I } from "~/i";
+import type { T } from "t";
 
 import { b1, b2 } from "~/b";
 import { c1 } from "~/c";
+import type { I } from "~/i";
 import { i1, i2, i3 } from "~/i";
 
 import type { A } from ".";
+import a from ".";
+import h from "../../h";
 import type { F } from "../f";
+import { j } from "../j";
+import { K, L, M } from "../k";
 import type { D } from "./d";
 import type { H } from "./index.d.ts";
 
-import a from ".";
-import h from "../../h";
 import "./style.css";
-import { j } from "../j";
-import { K, L, M } from "../k";
 "#,
     );
     // Ignore comments
@@ -122,7 +119,6 @@ import { t } from "t";
         r#"{ "experimentalSortImports": {} }"#,
         r#"
 import type { T } from "t";
-
 // @ts-expect-error missing types
 import { t } from "t";
 "#,


### PR DESCRIPTION
Thank you for your feedback in https://github.com/oxc-project/oxc/discussions/18688 .

With the current highest number of 🆙 and 👍, we plan to make this setting the new default.

```
[
  "builtin",
  ["external", "subpath"],
  "internal",
  ["parent", "sibling", "index"],
  "style",
  "side-effect",
  "side-effect-style",
  "unknown"
]
```

However, there are two modifications:

- Change `subpath` from `external` equivalent to `internal` equivalent
  - (This received the most upvotes!, and) I believe most use cases are for `internal` aliases
- Do not include `side_effect`
  - Including `side_effect` in `groups` causes its position to shift, regardless of the `sortSideEffects` option (whether to sort by side_effect A vs side_effect B)
  - While I expect few cases where this would cause problems, I will err on the side of caution

This is the final form.

```
[
  "builtin",
  "external",
  ["internal", "subpath"],
  ["parent", "sibling", "index"],
  "style",
  "unknown"
]
```
