### PR TITLE
refactor(linter/plugins): lock `ajv` dependency version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate", "helpers:pinGitHubActionDigestsToSemver"],
   "ignorePaths": ["apps/oxfmt/test/**/fixtures/**", "crates/oxc_linter/fixtures/**", "tasks/e2e"],
-  "ignoreDeps": ["@types/vscode", "allocator-api2"],
+  "ignoreDeps": ["@types/vscode", "allocator-api2", "ajv"],
   "packageRules": [
     {
       "groupName": "oxlint",

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -47,7 +47,7 @@
     "@types/node": "catalog:",
     "@typescript-eslint/parser": "^8.54.0",
     "@typescript-eslint/scope-manager": "^8.54.0",
-    "ajv": "^6.12.6",
+    "ajv": "6.12.6",
     "cross-env": "catalog:",
     "eslint": "catalog:",
     "eslint-vitest-rule-tester": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: ^8.54.0
         version: 8.54.0
       ajv:
-        specifier: ^6.12.6
+        specifier: 6.12.6
         version: 6.12.6
       cross-env:
         specifier: 'catalog:'


### PR DESCRIPTION
As discussed in #19405, we need to keep `ajv` dependency (used in Oxlint JS plugins) on v6 as later versions remove some features that we use. This matches ESLint.

Lock the version to exactly 6.12.6. Initially I had `^6.12.6`, in case a new version appeared on v6 line. But that seems unlikely- it's not been updated for 5 years!

Also add `ajv` to Renovate's ignore list, so it stops trying to update it.