### PR TITLE
chore(linter): update the indentation of rule tests to use spaces.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -248,25 +248,25 @@ fn test() {
         (
             "
               class Foo {
-            	constructor(a) {}
+                constructor(a) {}
               }
-            	  ",
+                  ",
             None,
         ),
         (
             "
               class Foo {
-            	method(this: void, a, b, c) {}
+                method(this: void, a, b, c) {}
               }
-            	  ",
+                  ",
             None,
         ),
         (
             "
               class Foo {
-            	method(this: Foo, a, b) {}
+                method(this: Foo, a, b) {}
               }
-            	  ",
+                  ",
             None,
         ),
         ("function foo(a, b, c, d) {}", Some(serde_json::json!([{ "max": 4 }]))),
@@ -274,25 +274,25 @@ fn test() {
         (
             "
               class Foo {
-            	method(this: void) {}
+                method(this: void) {}
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 0 }])),
         ),
         (
             "
               class Foo {
-            	method(this: void, a) {}
+                method(this: void, a) {}
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 1 }])),
         ),
         (
             "
               class Foo {
-            	method(this: void, a) {}
+                method(this: void, a) {}
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "countVoidThis": true, "max": 2 }])),
         ),
         ("function testD(this: void, a) {}", Some(serde_json::json!([{ "max": 1 }]))),
@@ -308,13 +308,13 @@ fn test() {
         (
             "
               declare function makeDate(m: number, d: number, y: number): Date;
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 3 }])),
         ),
         (
             "
               type sum = (a: number, b: number) => number;
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 2 }])),
         ),
         (
@@ -350,25 +350,25 @@ fn test() {
         (
             "
               class Foo {
-            	method(this: void, a, b, c, d) {}
+                method(this: void, a, b, c, d) {}
               }
-            		",
+                    ",
             None,
         ),
         (
             "
               class Foo {
-            	method(this: void, a) {}
+                method(this: void, a) {}
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "countVoidThis": true, "max": 1 }])),
         ),
         (
             "
               class Foo {
-            	method(this: void, a) {}
+                method(this: void, a) {}
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "countThis": "always", "max": 1 }])),
         ),
         (
@@ -398,21 +398,21 @@ fn test() {
         (
             "
               class Foo {
-            	method(this: Foo, a, b, c) {}
+                method(this: Foo, a, b, c) {}
               }
-            		",
+                    ",
             None,
         ),
         (
             "
               declare function makeDate(m: number, d: number, y: number): Date;
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 1 }])),
         ),
         (
             "
               type sum = (a: number, b: number) => number;
-            		",
+                    ",
             Some(serde_json::json!([{ "max": 1 }])),
         ),
         (

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -159,19 +159,19 @@ fn test() {
         "window['prompt'](foo)",
         "function alert() {} window.alert(foo)",
         "var alert = function() {};
-        	window.alert(foo)",
+            window.alert(foo)",
         "function foo(alert) { window.alert(); }",
         "function foo() { alert(); }",
         "function foo() { var alert = function() {}; }
-        	alert();",
+            alert();",
         "this.alert(foo)",
         "this['alert'](foo)",
         "function foo() { var window = bar; window.alert(); }
-        	window.alert();",
+            window.alert();",
         "globalThis['alert'](foo)", // { "ecmaVersion": 2020 },
         "globalThis.alert();",      // { "ecmaVersion": 2020 },
         "function foo() { var globalThis = bar; globalThis.alert(); }
-        	globalThis.alert();", // { "ecmaVersion": 2020 },
+            globalThis.alert();", // { "ecmaVersion": 2020 },
         "window?.alert(foo)",       // { "ecmaVersion": 2020 },
         "(window?.alert)(foo)",     // { "ecmaVersion": 2020 }
     ];

--- a/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
@@ -466,10 +466,10 @@ fn test_eslint() {
         (
             "
               function foo<T extends (id: string, ...args: any[]) => any>(
-            	fn: T,
-            	...args: any[]
+                fn: T,
+                ...args: any[]
               ) {}
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -478,7 +478,7 @@ fn test_eslint() {
             "
               type Args = 1;
               function foo<T extends (Args: any) => void>(arg: T) {}
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -486,11 +486,11 @@ fn test_eslint() {
         (
             "
               export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any
-            	? T[]
-            	: Func extends (...args: infer T) => any
-            	  ? T
-            	  : never;
-            	  ",
+                ? T[]
+                : Func extends (...args: infer T) => any
+                  ? T
+                  : never;
+                  ",
             None,
             None,
             None,
@@ -498,9 +498,9 @@ fn test_eslint() {
         (
             "
               function foo() {
-            	var Object = 0;
+                var Object = 0;
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -508,9 +508,9 @@ fn test_eslint() {
         (
             "
               function test(this: Foo) {
-            	function test2(this: Bar) {}
+                function test2(this: Bar) {}
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -518,12 +518,12 @@ fn test_eslint() {
         (
             "
               class Foo {
-            	prop = 1;
+                prop = 1;
               }
               namespace Foo {
-            	export const v = 2;
+                export const v = 2;
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -532,9 +532,9 @@ fn test_eslint() {
             "
               function Foo() {}
               namespace Foo {
-            	export const v = 2;
+                export const v = 2;
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -542,12 +542,12 @@ fn test_eslint() {
         (
             "
               class Foo {
-            	prop = 1;
+                prop = 1;
               }
               interface Foo {
-            	prop2: string;
+                prop2: string;
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -557,11 +557,11 @@ fn test_eslint() {
               import type { Foo } from 'bar';
 
               declare module 'bar' {
-            	export interface Foo {
-            	  x: string;
-            	}
+                export interface Foo {
+                  x: string;
+                }
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -570,7 +570,7 @@ fn test_eslint() {
             "
               const x = 1;
               type x = string;
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -579,9 +579,9 @@ fn test_eslint() {
             "
               const x = 1;
               {
-            	type x = string;
+                type x = string;
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -589,7 +589,7 @@ fn test_eslint() {
         (
             "
               type Foo = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": true }])),
             None,
             None,
@@ -597,7 +597,7 @@ fn test_eslint() {
         (
             "
               type Foo = 1;
-            		",
+                    ",
             Some(
                 serde_json::json!([ { "builtinGlobals": false, "ignoreTypeValueShadow": false, }, ]),
             ),
@@ -607,10 +607,10 @@ fn test_eslint() {
         (
             "
               enum Direction {
-            	left = 'left',
-            	right = 'right',
+                left = 'left',
+                right = 'right',
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -619,7 +619,7 @@ fn test_eslint() {
             "
               const test = 1;
               type Fn = (test: string) => typeof test;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -627,7 +627,7 @@ fn test_eslint() {
         (
             "
               type Fn = (Foo: string) => typeof Foo;
-            		",
+                    ",
             Some(
                 serde_json::json!([ { "builtinGlobals": false, "ignoreFunctionTypeParameterNameValueShadow": true, }, ]),
             ),
@@ -639,9 +639,9 @@ fn test_eslint() {
               const arg = 0;
 
               interface Test {
-            	(arg: string): typeof arg;
+                (arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -651,9 +651,9 @@ fn test_eslint() {
               const arg = 0;
 
               interface Test {
-            	p1(arg: string): typeof arg;
+                p1(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -663,7 +663,7 @@ fn test_eslint() {
               const arg = 0;
 
               declare function test(arg: string): typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -673,7 +673,7 @@ fn test_eslint() {
               const arg = 0;
 
               declare const test: (arg: string) => typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -683,9 +683,9 @@ fn test_eslint() {
               const arg = 0;
 
               declare class Test {
-            	p1(arg: string): typeof arg;
+                p1(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -695,9 +695,9 @@ fn test_eslint() {
               const arg = 0;
 
               declare const Test: {
-            	new (arg: string): typeof arg;
+                new (arg: string): typeof arg;
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -707,7 +707,7 @@ fn test_eslint() {
               const arg = 0;
 
               type Bar = new (arg: number) => typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
@@ -717,62 +717,62 @@ fn test_eslint() {
               const arg = 0;
 
               declare namespace Lib {
-            	function test(arg: string): typeof arg;
+                function test(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": true }])),
             None,
             None,
         ),
         (
             "
-            		  declare global {
-            			interface ArrayConstructor {}
-            		  }
-            		  export {};
-            		",
+                      declare global {
+                        interface ArrayConstructor {}
+                      }
+                      export {};
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             None,
         ),
         (
             "
-            		declare global {
-            		  const a: string;
+                    declare global {
+                      const a: string;
 
-            		  namespace Foo {
-            			const a: number;
-            		  }
-            		}
-            		export {};
-            	  ",
+                      namespace Foo {
+                        const a: number;
+                      }
+                    }
+                    export {};
+                  ",
             None,
             None,
             None,
         ),
         (
             "
-            		  declare global {
-            			type A = 'foo';
+                      declare global {
+                        type A = 'foo';
 
-            			namespace Foo {
-            			  type A = 'bar';
-            			}
-            		  }
-            		  export {};
-            		",
+                        namespace Foo {
+                          type A = 'bar';
+                        }
+                      }
+                      export {};
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": false }])),
             None,
             None,
         ),
         (
             "
-            		  declare global {
-            			const foo: string;
-            			type Fn = (foo: number) => void;
-            		  }
-            		  export {};
-            		",
+                      declare global {
+                        const foo: string;
+                        type Fn = (foo: number) => void;
+                      }
+                      export {};
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -780,17 +780,17 @@ fn test_eslint() {
         (
             "
               export class Wrapper<Wrapped> {
-            	private constructor(private readonly wrapped: Wrapped) {}
+                private constructor(private readonly wrapped: Wrapped) {}
 
-            	unwrap(): Wrapped {
-            	  return this.wrapped;
-            	}
+                unwrap(): Wrapped {
+                  return this.wrapped;
+                }
 
-            	static create<Wrapped>(wrapped: Wrapped) {
-            	  return new Wrapper<Wrapped>(wrapped);
-            	}
+                static create<Wrapped>(wrapped: Wrapped) {
+                  return new Wrapper<Wrapped>(wrapped);
+                }
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -798,15 +798,15 @@ fn test_eslint() {
         (
             "
               function makeA() {
-            	return class A<T> {
-            	  constructor(public value: T) {}
+                return class A<T> {
+                  constructor(public value: T) {}
 
-            	  static make<T>(value: T) {
-            		return new A<T>(value);
-            	  }
-            	};
+                  static make<T>(value: T) {
+                    return new A<T>(value);
+                  }
+                };
               }
-            	  ",
+                  ",
             None,
             None,
             None,
@@ -819,7 +819,7 @@ fn test_eslint() {
               // 'foo' is already declared in the upper scope
               // 'bar' is fine
               function doThing(foo: number, bar: number) {}
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": true }])),
             None,
             None,
@@ -830,7 +830,7 @@ fn test_eslint() {
 
               // 'foo' is already declared in the upper scope
               function doThing(foo: number) {}
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": true }])),
             None,
             None,
@@ -844,9 +844,9 @@ fn test_eslint() {
         (
             "
               const a = [].find(function (a) {
-            	return a;
+                return a;
               });
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -873,7 +873,7 @@ fn test_eslint() {
             "
               for (const a in [].find(a => true)) {
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -882,7 +882,7 @@ fn test_eslint() {
             "
               for (const a of [].find(a => true)) {
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -896,10 +896,10 @@ fn test_eslint() {
         (
             "
               const a = []
-            	.map(a => true)
-            	.filter(a => a === 'b')
-            	.find(a => a === 'c');
-            		",
+                .map(a => true)
+                .filter(a => a === 'b')
+                .find(a => a === 'c');
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -913,10 +913,10 @@ fn test_eslint() {
         (
             "
               const person = people.find(item => {
-            	const person = item.name;
-            	return person === 'foo';
+                const person = item.name;
+                return person === 'foo';
               });
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -948,10 +948,10 @@ fn test_eslint() {
         (
             "
               var match = function (person) {
-            	return person.name === 'foo';
+                return person.name === 'foo';
               };
               const person = [].find(match);
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -977,11 +977,11 @@ fn test_eslint() {
         (
             "
               const person = {
-            	firstName: people
-            	  .filter(person => person.firstName.startsWith('s'))
-            	  .map(person => person.firstName)[0],
+                firstName: people
+                  .filter(person => person.firstName.startsWith('s'))
+                  .map(person => person.firstName)[0],
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -989,9 +989,9 @@ fn test_eslint() {
         (
             "
               () => {
-            	const y = foo(y => y);
+                const y = foo(y => y);
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -1029,9 +1029,9 @@ fn test_eslint() {
         (
             "
               () => {
-            	const y = (y => y)();
+                const y = (y => y)();
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreOnInitialization": true }])),
             None,
             None,
@@ -1041,7 +1041,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1050,7 +1050,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1059,7 +1059,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1068,7 +1068,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1076,10 +1076,10 @@ fn test_eslint() {
         (
             "
               {
-            	type A = 1;
+                type A = 1;
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1087,10 +1087,10 @@ fn test_eslint() {
         (
             "
               {
-            	interface Foo<A> {}
+                interface Foo<A> {}
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "never" }])),
             None,
             None,
@@ -1099,7 +1099,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1108,7 +1108,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1117,7 +1117,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1126,7 +1126,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1134,10 +1134,10 @@ fn test_eslint() {
         (
             "
               {
-            	type A = 1;
+                type A = 1;
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1145,10 +1145,10 @@ fn test_eslint() {
         (
             "
               {
-            	interface Foo<A> {}
+                interface Foo<A> {}
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -1158,9 +1158,9 @@ fn test_eslint() {
               import type { Foo } from 'bar';
 
               declare module 'bar' {
-            	export type Foo = string;
+                export type Foo = string;
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1170,11 +1170,11 @@ fn test_eslint() {
               import type { Foo } from 'bar';
 
               declare module 'bar' {
-            	interface Foo {
-            	  x: string;
-            	}
+                interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1184,9 +1184,9 @@ fn test_eslint() {
               import { type Foo } from 'bar';
 
               declare module 'bar' {
-            	export type Foo = string;
+                export type Foo = string;
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1196,11 +1196,11 @@ fn test_eslint() {
               import { type Foo } from 'bar';
 
               declare module 'bar' {
-            	export interface Foo {
-            	  x: string;
-            	}
+                export interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1210,9 +1210,9 @@ fn test_eslint() {
               import { type Foo } from 'bar';
 
               declare module 'bar' {
-            	type Foo = string;
+                type Foo = string;
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1222,11 +1222,11 @@ fn test_eslint() {
               import { type Foo } from 'bar';
 
               declare module 'bar' {
-            	interface Foo {
-            	  x: string;
-            	}
+                interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1234,7 +1234,7 @@ fn test_eslint() {
         (
             "
               declare const foo1: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1242,7 +1242,7 @@ fn test_eslint() {
         (
             "
               declare let foo2: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1250,7 +1250,7 @@ fn test_eslint() {
         (
             "
               declare var foo3: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1258,7 +1258,7 @@ fn test_eslint() {
         (
             "
               function foo4(name: string): void;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1266,9 +1266,9 @@ fn test_eslint() {
         (
             "
               declare class Foopy1 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1276,9 +1276,9 @@ fn test_eslint() {
         (
             "
               declare interface Foopy2 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1286,9 +1286,9 @@ fn test_eslint() {
         (
             "
               declare type Foopy3 = {
-            	x: number;
+                x: number;
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1296,9 +1296,9 @@ fn test_eslint() {
         (
             "
               declare enum Foopy4 {
-            	x,
+                x,
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1306,7 +1306,7 @@ fn test_eslint() {
         (
             "
               declare namespace Foopy5 {}
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1315,7 +1315,7 @@ fn test_eslint() {
             "
               declare;
               foo5: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.ts")),
@@ -1323,7 +1323,7 @@ fn test_eslint() {
         (
             "
               declare const foo1: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1331,7 +1331,7 @@ fn test_eslint() {
         (
             "
               declare let foo2: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1339,7 +1339,7 @@ fn test_eslint() {
         (
             "
               declare var foo3: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1347,7 +1347,7 @@ fn test_eslint() {
         (
             "
               function foo4(name: string): void;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1355,9 +1355,9 @@ fn test_eslint() {
         (
             "
               declare class Foopy1 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1365,9 +1365,9 @@ fn test_eslint() {
         (
             "
               declare interface Foopy2 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1375,9 +1375,9 @@ fn test_eslint() {
         (
             "
               declare type Foopy3 = {
-            	x: number;
+                x: number;
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1385,9 +1385,9 @@ fn test_eslint() {
         (
             "
               declare enum Foopy4 {
-            	x,
+                x,
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1395,7 +1395,7 @@ fn test_eslint() {
         (
             "
               declare namespace Foopy5 {}
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1404,7 +1404,7 @@ fn test_eslint() {
             "
               declare;
               foo5: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.cts")),
@@ -1412,7 +1412,7 @@ fn test_eslint() {
         (
             "
               declare const foo1: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1420,7 +1420,7 @@ fn test_eslint() {
         (
             "
               declare let foo2: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1428,7 +1428,7 @@ fn test_eslint() {
         (
             "
               declare var foo3: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1436,7 +1436,7 @@ fn test_eslint() {
         (
             "
               function foo4(name: string): void;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1444,9 +1444,9 @@ fn test_eslint() {
         (
             "
               declare class Foopy1 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1454,9 +1454,9 @@ fn test_eslint() {
         (
             "
               declare interface Foopy2 {
-            	name: string;
+                name: string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1464,9 +1464,9 @@ fn test_eslint() {
         (
             "
               declare type Foopy3 = {
-            	x: number;
+                x: number;
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1474,9 +1474,9 @@ fn test_eslint() {
         (
             "
               declare enum Foopy4 {
-            	x,
+                x,
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1484,7 +1484,7 @@ fn test_eslint() {
         (
             "
               declare namespace Foopy5 {}
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1493,7 +1493,7 @@ fn test_eslint() {
             "
               declare;
               foo5: boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("baz.d.mts")),
@@ -1753,9 +1753,9 @@ fn test_eslint() {
             "
               type T = 1;
               {
-            	type T = 2;
+                type T = 2;
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1764,7 +1764,7 @@ fn test_eslint() {
             "
               type T = 1;
               function foo<T>(arg: T) {}
-            		",
+                    ",
             None,
             None,
             None,
@@ -1772,9 +1772,9 @@ fn test_eslint() {
         (
             "
               function foo<T>() {
-            	return function <T>() {};
+                return function <T>() {};
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1783,7 +1783,7 @@ fn test_eslint() {
             "
               type T = string;
               function foo<T extends (arg: any) => void>(arg: T) {}
-            		",
+                    ",
             None,
             None,
             None,
@@ -1792,9 +1792,9 @@ fn test_eslint() {
             "
               const x = 1;
               {
-            	type x = string;
+                type x = string;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": false }])),
             None,
             None,
@@ -1802,7 +1802,7 @@ fn test_eslint() {
         (
             "
               type Foo = 1;
-            		",
+                    ",
             Some(
                 serde_json::json!([ { "builtinGlobals": true, "ignoreTypeValueShadow": false, }, ]),
             ),
@@ -1813,7 +1813,7 @@ fn test_eslint() {
             "
               const test = 1;
               type Fn = (test: string) => typeof test;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1821,7 +1821,7 @@ fn test_eslint() {
         (
             "
               type Fn = (Foo: string) => typeof Foo;
-            		",
+                    ",
             Some(
                 serde_json::json!([ { "builtinGlobals": true, "ignoreFunctionTypeParameterNameValueShadow": false, }, ]),
             ),
@@ -1833,9 +1833,9 @@ fn test_eslint() {
               const arg = 0;
 
               interface Test {
-            	(arg: string): typeof arg;
+                (arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1845,9 +1845,9 @@ fn test_eslint() {
               const arg = 0;
 
               interface Test {
-            	p1(arg: string): typeof arg;
+                p1(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1857,7 +1857,7 @@ fn test_eslint() {
               const arg = 0;
 
               declare function test(arg: string): typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1867,7 +1867,7 @@ fn test_eslint() {
               const arg = 0;
 
               declare const test: (arg: string) => typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1877,9 +1877,9 @@ fn test_eslint() {
               const arg = 0;
 
               declare class Test {
-            	p1(arg: string): typeof arg;
+                p1(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1889,9 +1889,9 @@ fn test_eslint() {
               const arg = 0;
 
               declare const Test: {
-            	new (arg: string): typeof arg;
+                new (arg: string): typeof arg;
               };
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1901,7 +1901,7 @@ fn test_eslint() {
               const arg = 0;
 
               type Bar = new (arg: number) => typeof arg;
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1911,9 +1911,9 @@ fn test_eslint() {
               const arg = 0;
 
               declare namespace Lib {
-            	function test(arg: string): typeof arg;
+                function test(arg: string): typeof arg;
               }
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreFunctionTypeParameterNameValueShadow": false }])),
             None,
             None,
@@ -1922,7 +1922,7 @@ fn test_eslint() {
             "
               import type { foo } from './foo';
               function doThing(foo: number) {}
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": false }])),
             None,
             None,
@@ -1931,7 +1931,7 @@ fn test_eslint() {
             "
               import { type foo } from './foo';
               function doThing(foo: number) {}
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": false }])),
             None,
             None,
@@ -1940,7 +1940,7 @@ fn test_eslint() {
             "
               import { foo } from './foo';
               function doThing(foo: number, bar: number) {}
-            		",
+                    ",
             Some(serde_json::json!([{ "ignoreTypeValueShadow": true }])),
             None,
             None,
@@ -1950,11 +1950,11 @@ fn test_eslint() {
               interface Foo {}
 
               declare module 'bar' {
-            	export interface Foo {
-            	  x: string;
-            	}
+                export interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1964,11 +1964,11 @@ fn test_eslint() {
               import type { Foo } from 'bar';
 
               declare module 'baz' {
-            	export interface Foo {
-            	  x: string;
-            	}
+                export interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1978,11 +1978,11 @@ fn test_eslint() {
               import { type Foo } from 'bar';
 
               declare module 'baz' {
-            	export interface Foo {
-            	  x: string;
-            	}
+                export interface Foo {
+                  x: string;
+                }
               }
-            		",
+                    ",
             None,
             None,
             None,
@@ -1991,7 +1991,7 @@ fn test_eslint() {
             "
               let x = foo((x, y) => {});
               let y;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2000,7 +2000,7 @@ fn test_eslint() {
             "
               let x = foo((x, y) => {});
               let y;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions" }])),
             None,
             None,
@@ -2009,7 +2009,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2018,7 +2018,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2027,7 +2027,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2036,7 +2036,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2044,10 +2044,10 @@ fn test_eslint() {
         (
             "
               {
-            	type A = 1;
+                type A = 1;
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2055,10 +2055,10 @@ fn test_eslint() {
         (
             "
               {
-            	interface A {}
+                interface A {}
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2067,7 +2067,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2076,7 +2076,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2085,7 +2085,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2094,7 +2094,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2102,10 +2102,10 @@ fn test_eslint() {
         (
             "
               {
-            	type A = 1;
+                type A = 1;
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2113,10 +2113,10 @@ fn test_eslint() {
         (
             "
               {
-            	interface A {}
+                interface A {}
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "all" }])),
             None,
             None,
@@ -2125,53 +2125,53 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
         ),
         (
             "
-            	if (true) {
-            		const foo = 6;
-            	}
+                if (true) {
+                    const foo = 6;
+                }
 
-            	function foo() { }
-            		",
+                function foo() { }
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
         ),
         (
             "
-            	// types
-            	type Bar<Foo> = 1;
-            	type Foo = 1;
+                // types
+                type Bar<Foo> = 1;
+                type Foo = 1;
 
-            	// functions
-            	if (true) {
-            		const b = 6;
-            	}
+                // functions
+                if (true) {
+                    const b = 6;
+                }
 
-            	function b() { }
-            		",
+                function b() { }
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
         ),
         (
             "
-            	// types
-            	type Bar<Foo> = 1;
-            	type Foo = 1;
+                // types
+                type Bar<Foo> = 1;
+                type Foo = 1;
 
-            	// functions
-            	if (true) {
-            		const b = 6;
-            	}
+                // functions
+                if (true) {
+                    const b = 6;
+                }
 
-            	function b() { }
-            		",
+                function b() { }
+                    ",
             Some(serde_json::json!([{ "hoist": "types" }])),
             None,
             None,
@@ -2180,7 +2180,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
@@ -2189,7 +2189,7 @@ fn test_eslint() {
             "
               interface Foo<A> {}
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
@@ -2198,7 +2198,7 @@ fn test_eslint() {
             "
               type Foo<A> = 1;
               interface A {}
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
@@ -2206,10 +2206,10 @@ fn test_eslint() {
         (
             "
               {
-            	type A = 1;
+                type A = 1;
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
@@ -2217,10 +2217,10 @@ fn test_eslint() {
         (
             "
               {
-            	interface A {}
+                interface A {}
               }
               type A = 1;
-            		",
+                    ",
             Some(serde_json::json!([{ "hoist": "functions-and-types" }])),
             None,
             None,
@@ -2228,7 +2228,7 @@ fn test_eslint() {
         (
             "
               function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
-            		",
+                    ",
             Some(
                 serde_json::json!([ { "builtinGlobals": true, "ignoreTypeValueShadow": false, }, ]),
             ),
@@ -2238,7 +2238,7 @@ fn test_eslint() {
         (
             "
               declare const has = (environment: 'dev' | 'prod' | 'test') => boolean;
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             Some(serde_json::json!({ "globals": { "has": false } })),
             None,
@@ -2247,19 +2247,19 @@ fn test_eslint() {
             "
               declare const has: (environment: 'dev' | 'prod' | 'test') => boolean;
               const fn = (has: string) => {};
-            		",
+                    ",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
             None,
             Some(PathBuf::from("foo.d.ts")),
         ), // { "globals": { "has": false, }, },
         (
             "
-            			const A = 2;
-            			enum Test {
-            				A = 1,
-            				B = A,
-            			}
-            		",
+                        const A = 2;
+                        enum Test {
+                            A = 1,
+                            B = A,
+                        }
+                    ",
             None,
             None,
             None,

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -117,20 +117,20 @@ fn test() {
         "let z: number | undefined = undefined; log(z);",
         "declare let c: string | undefined; log(c);",
         "
-        				const foo = (two: string): void => {
-        					let one: string | undefined;
-        					if (one !== two) {
-        						one = two;
-        					}
-        				}
-        			",
+                        const foo = (two: string): void => {
+                            let one: string | undefined;
+                            if (one !== two) {
+                                one = two;
+                            }
+                        }
+                    ",
         "
-        				declare module 'module' {
-        					import type { T } from 'module';
-        					let x: T;
-        					export = x;
-        				}
-        			",
+                        declare module 'module' {
+                            import type { T } from 'module';
+                            let x: T;
+                            export = x;
+                        }
+                    ",
         "for (let p of pathToRemove) { p.remove() }",
     ];
 
@@ -146,12 +146,12 @@ fn test() {
         "let x: number | undefined; log(x);",
         "const foo = (two: string): void => { let one: string | undefined; if (one === two) {} }",
         "
-							declare module 'module' {
-								let x: string;
-							}
-							let y: string;
-							console.log(y);
-						",
+                            declare module 'module' {
+                                let x: string;
+                            }
+                            let y: string;
+                            console.log(y);
+                        ",
     ];
 
     Tester::new(NoUnassignedVars::NAME, NoUnassignedVars::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -310,89 +310,89 @@ fn test() {
         ",
         r"class Foo {}",
         r"class Foo {
-        	    publicMember = 42;
-        	}",
+                publicMember = 42;
+            }",
         r"class Foo {
-        	    #usedMember = 42;
-        	    method() {
-        	        return this.#usedMember;
-        	    }
-        	}",
+                #usedMember = 42;
+                method() {
+                    return this.#usedMember;
+                }
+            }",
         r"class Foo {
-        	    #usedMember = 42;
-        	    anotherMember = this.#usedMember;
-        	}",
+                #usedMember = 42;
+                anotherMember = this.#usedMember;
+            }",
         r"class Foo {
-        	    #usedMember = 42;
-        	    foo() {
-        	        anotherMember = this.#usedMember;
-        	    }
-        	}",
+                #usedMember = 42;
+                foo() {
+                    anotherMember = this.#usedMember;
+                }
+            }",
         r"class C {
-			    #usedMember;
+                #usedMember;
 
-			    foo() {
-			        bar(this.#usedMember += 1);
-			    }
-			}",
+                foo() {
+                    bar(this.#usedMember += 1);
+                }
+            }",
         r"class Foo {
-			    #usedMember = 42;
-			    method() {
-			        return someGlobalMethod(this.#usedMember);
-			    }
-			}",
+                #usedMember = 42;
+                method() {
+                    return someGlobalMethod(this.#usedMember);
+                }
+            }",
         r"class C {
-			    #usedInOuterClass;
+                #usedInOuterClass;
 
-			    foo() {
-			        return class {};
-			    }
+                foo() {
+                    return class {};
+                }
 
-			    bar() {
-			        return this.#usedInOuterClass;
-			    }
-			}",
+                bar() {
+                    return this.#usedInOuterClass;
+                }
+            }",
         r"class Foo {
-			    #usedInForInLoop;
-			    method() {
-			        for (const bar in this.#usedInForInLoop) {
+                #usedInForInLoop;
+                method() {
+                    for (const bar in this.#usedInForInLoop) {
 
-			        }
-			    }
-			}",
+                    }
+                }
+            }",
         r"class Foo {
-			    #usedInForOfLoop;
-			    method() {
-			        for (const bar of this.#usedInForOfLoop) {
+                #usedInForOfLoop;
+                method() {
+                    for (const bar of this.#usedInForOfLoop) {
 
-			        }
-			    }
-			}",
+                    }
+                }
+            }",
         r"class Foo {
-			    #usedInAssignmentPattern;
-			    method() {
-			        [bar = 1] = this.#usedInAssignmentPattern;
-			    }
-			}",
+                #usedInAssignmentPattern;
+                method() {
+                    [bar = 1] = this.#usedInAssignmentPattern;
+                }
+            }",
         r"class Foo {
-			    #usedInArrayPattern;
-			    method() {
-			        [bar] = this.#usedInArrayPattern;
-			    }
-			}",
+                #usedInArrayPattern;
+                method() {
+                    [bar] = this.#usedInArrayPattern;
+                }
+            }",
         r"class Foo {
-			    #usedInAssignmentPattern;
-			    method() {
-			        [bar] = this.#usedInAssignmentPattern;
-			    }
-			}",
+                #usedInAssignmentPattern;
+                method() {
+                    [bar] = this.#usedInAssignmentPattern;
+                }
+            }",
         r"class C {
-			    #usedInObjectAssignment;
+                #usedInObjectAssignment;
 
-			    method() {
-			        ({ [this.#usedInObjectAssignment]: a } = foo);
-			    }
-			}",
+                method() {
+                    ({ [this.#usedInObjectAssignment]: a } = foo);
+                }
+            }",
         r"class C {
             set #accessorWithSetterFirst(value) {
                 doSomething(value);
@@ -433,13 +433,13 @@ fn test() {
         //     }
         // }",
         r"class Foo {
-			    #usedMethod() {
-			        return 42;
-			    }
-			    anotherMethod() {
-			        return this.#usedMethod();
-			    }
-			}",
+                #usedMethod() {
+                    return 42;
+                }
+                anotherMethod() {
+                    return this.#usedMethod();
+                }
+            }",
         r"class C {
             set #x(value) {
                 doSomething(value);
@@ -504,147 +504,147 @@ fn test() {
 
     let fail = vec![
         r"class Foo {
-			    #unusedMember = 5;
-			}",
+                #unusedMember = 5;
+            }",
         r"class First {}
-			class Second {
-			    #unusedMemberInSecondClass = 5;
-			}",
+            class Second {
+                #unusedMemberInSecondClass = 5;
+            }",
         r"class First {
-			    #unusedMemberInFirstClass = 5;
-			}
-			class Second {}",
+                #unusedMemberInFirstClass = 5;
+            }
+            class Second {}",
         r"class First {
-			    #firstUnusedMemberInSameClass = 5;
-			    #secondUnusedMemberInSameClass = 5;
-			}",
+                #firstUnusedMemberInSameClass = 5;
+                #secondUnusedMemberInSameClass = 5;
+            }",
         r"class Foo {
-			    #usedOnlyInWrite = 5;
-			    method() {
-			        this.#usedOnlyInWrite = 42;
-			    }
-			}",
+                #usedOnlyInWrite = 5;
+                method() {
+                    this.#usedOnlyInWrite = 42;
+                }
+            }",
         r"class Foo {
-			    #usedOnlyInWriteStatement = 5;
-			    method() {
-			        this.#usedOnlyInWriteStatement += 42;
-			    }
-			}",
+                #usedOnlyInWriteStatement = 5;
+                method() {
+                    this.#usedOnlyInWriteStatement += 42;
+                }
+            }",
         r"class C {
-			    #usedOnlyInIncrement;
+                #usedOnlyInIncrement;
 
-			    foo() {
-			        this.#usedOnlyInIncrement++;
-			    }
-			}",
+                foo() {
+                    this.#usedOnlyInIncrement++;
+                }
+            }",
         r"class C {
-			    #unusedInOuterClass;
+                #unusedInOuterClass;
 
-			    foo() {
-			        return class {
-			            #unusedInOuterClass;
+                foo() {
+                    return class {
+                        #unusedInOuterClass;
 
-			            bar() {
-			                return this.#unusedInOuterClass;
-			            }
-			        };
-			    }
-			}",
+                        bar() {
+                            return this.#unusedInOuterClass;
+                        }
+                    };
+                }
+            }",
         r"class C {
-			    #unusedOnlyInSecondNestedClass;
+                #unusedOnlyInSecondNestedClass;
 
-			    foo() {
-			        return class {
-			            #unusedOnlyInSecondNestedClass;
+                foo() {
+                    return class {
+                        #unusedOnlyInSecondNestedClass;
 
-			            bar() {
-			                return this.#unusedOnlyInSecondNestedClass;
-			            }
-			        };
-			    }
+                        bar() {
+                            return this.#unusedOnlyInSecondNestedClass;
+                        }
+                    };
+                }
 
-			    baz() {
-			        return this.#unusedOnlyInSecondNestedClass;
-			    }
+                baz() {
+                    return this.#unusedOnlyInSecondNestedClass;
+                }
 
-			    bar() {
-			        return class {
-			            #unusedOnlyInSecondNestedClass;
-			        }
-			    }
-			}",
+                bar() {
+                    return class {
+                        #unusedOnlyInSecondNestedClass;
+                    }
+                }
+            }",
         r"class Foo {
-			    #unusedMethod() {}
-			}",
+                #unusedMethod() {}
+            }",
         r"class Foo {
-			    #unusedMethod() {}
-			    #usedMethod() {
-			        return 42;
-			    }
-			    publicMethod() {
-			        return this.#usedMethod();
-			    }
-			}",
+                #unusedMethod() {}
+                #usedMethod() {
+                    return 42;
+                }
+                publicMethod() {
+                    return this.#usedMethod();
+                }
+            }",
         r"class Foo {
-			    set #unusedSetter(value) {}
-			}",
+                set #unusedSetter(value) {}
+            }",
         r"class Foo {
-			    #unusedForInLoop;
-			    method() {
-			        for (this.#unusedForInLoop in bar) {
+                #unusedForInLoop;
+                method() {
+                    for (this.#unusedForInLoop in bar) {
 
-			        }
-			    }
-			}",
+                    }
+                }
+            }",
         r"class Foo {
-			    #unusedForOfLoop;
-			    method() {
-			        for (this.#unusedForOfLoop of bar) {
+                #unusedForOfLoop;
+                method() {
+                    for (this.#unusedForOfLoop of bar) {
 
-			        }
-			    }
-			}",
+                    }
+                }
+            }",
         r"class Foo {
-			    #unusedInDestructuring;
-			    method() {
-			        ({ x: this.#unusedInDestructuring } = bar);
-			    }
-			}",
+                #unusedInDestructuring;
+                method() {
+                    ({ x: this.#unusedInDestructuring } = bar);
+                }
+            }",
         r"class Foo {
-			    #unusedInRestPattern;
-			    method() {
-			        [...this.#unusedInRestPattern] = bar;
-			    }
-			}",
+                #unusedInRestPattern;
+                method() {
+                    [...this.#unusedInRestPattern] = bar;
+                }
+            }",
         r"class Foo {
-			    #unusedInAssignmentPattern;
-			    method() {
-			        [this.#unusedInAssignmentPattern = 1] = bar;
-			    }
-			}",
+                #unusedInAssignmentPattern;
+                method() {
+                    [this.#unusedInAssignmentPattern = 1] = bar;
+                }
+            }",
         r"class Foo {
-			    #unusedInAssignmentPattern;
-			    method() {
-			        [this.#unusedInAssignmentPattern] = bar;
-			    }
-			}",
+                #unusedInAssignmentPattern;
+                method() {
+                    [this.#unusedInAssignmentPattern] = bar;
+                }
+            }",
         r"class C {
-			    #usedOnlyInTheSecondInnerClass;
+                #usedOnlyInTheSecondInnerClass;
 
-			    method(a) {
-			        return class {
-			            #usedOnlyInTheSecondInnerClass;
+                method(a) {
+                    return class {
+                        #usedOnlyInTheSecondInnerClass;
 
-			            method2(b) {
-			                foo = b.#usedOnlyInTheSecondInnerClass;
-			            }
+                        method2(b) {
+                            foo = b.#usedOnlyInTheSecondInnerClass;
+                        }
 
-			            method3(b) {
-			                foo = b.#usedOnlyInTheSecondInnerClass;
-			            }
-			        }
-			    }
-			}",
+                        method3(b) {
+                            foo = b.#usedOnlyInTheSecondInnerClass;
+                        }
+                    }
+                }
+            }",
         r"class Foo { #awaitedMember; async method() { await this.#awaitedMember; } }",
         r"class Foo { #unused; method() { Math.random() > 0.5 ? this.#unused : []; } }",
         r"class Foo { #x; #y; method(a, b, c) { a ? (b ? this.#x : c) : this.#y; } }",

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/eslint.rs
@@ -17,7 +17,7 @@ fn fixme() {
         ("function foo(cb) { cb = (0, function(a) { cb(1 + a); }); } foo();", None),
         (
             "let x = [];
-        	x = x.concat(x);",
+             x = x.concat(x);",
             None,
         ), // { "ecmaVersion": 2015 },
     ];
@@ -913,7 +913,7 @@ fn test() {
         // TODO
         (
             "const [ a, _b ] = items;
-        	console.log(a+_b);",
+             console.log(a+_b);",
             Some(
                 serde_json::json!([{ "destructuredArrayIgnorePattern": "^_", "reportUsedIgnorePattern": true }]),
             ),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/react.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/react.rs
@@ -11,119 +11,119 @@ use crate::{RuleMeta as _, tester::Tester};
 fn test() {
     let pass = vec![
         "
-			var App;
-			React.render(<App/>);
+            var App;
+            React.render(<App/>);
         ",
         "
-			function foo() {
-				var App;
-				var bar = React.render(<App/>);
-				return bar;
-			};
-			foo()
+            function foo() {
+                var App;
+                var bar = React.render(<App/>);
+                return bar;
+            };
+            foo()
         ",
         "
-			var a = 1;
-			React.render(<img src={a} />);
+            var a = 1;
+            React.render(<img src={a} />);
         ",
         "
-			var App;
-			function f() {
-				return <App />;
-			}
-			f();
+            var App;
+            function f() {
+                return <App />;
+            }
+            f();
         ",
         "
-			var App;
-			<App.Hello />
+            var App;
+            <App.Hello />
         ",
         "
-			class HelloMessage {};
-			<HelloMessage />
+            class HelloMessage {};
+            <HelloMessage />
         ",
         "
-			class HelloMessage {
-				render() {
-				var HelloMessage = <div>Hello</div>;
-				return HelloMessage;
-				}
-			};
-			<HelloMessage />
+            class HelloMessage {
+                render() {
+                var HelloMessage = <div>Hello</div>;
+                return HelloMessage;
+                }
+            };
+            <HelloMessage />
         ",
         "
-			function foo() {
-				var App = { Foo: { Bar: {} } };
-				var bar = React.render(<App.Foo.Bar/>);
-				return bar;
-			};
-			foo()
+            function foo() {
+                var App = { Foo: { Bar: {} } };
+                var bar = React.render(<App.Foo.Bar/>);
+                return bar;
+            };
+            foo()
         ",
         "
-			function foo() {
-				var App = { Foo: { Bar: { Baz: {} } } };
-				var bar = React.render(<App.Foo.Bar.Baz/>);
-				return bar;
-			};
-			foo()
+            function foo() {
+                var App = { Foo: { Bar: { Baz: {} } } };
+                var bar = React.render(<App.Foo.Bar.Baz/>);
+                return bar;
+            };
+            foo()
         ",
         "
-			var object;
-			React.render(<object.Tag />);
-		",
+            var object;
+            React.render(<object.Tag />);
+        ",
         "
-			var object;
-			React.render(<object.tag />);
-		",
+            var object;
+            React.render(<object.tag />);
+        ",
     ];
 
     let fail = vec![
         "
-			var App;
-		",
+            var App;
+        ",
         r#"
-			var App;
-          	var unused;
-          	React.render(<App unused=""/>);
-		"#,
+            var App;
+              var unused;
+              React.render(<App unused=""/>);
+        "#,
         "
-			var App;
-          	var Hello;
-          	React.render(<App:Hello/>);
-		",
+            var App;
+              var Hello;
+              React.render(<App:Hello/>);
+        ",
         r#"
-			var Button;
-			var Input;
-			React.render(<Button.Input unused=""/>);
-		"#,
+            var Button;
+            var Input;
+            React.render(<Button.Input unused=""/>);
+        "#,
         "
-			class unused {}
-		",
+            class unused {}
+        ",
         "
-			class HelloMessage {
-				render() {
-					var HelloMessage = <div>Hello</div>;
-					return HelloMessage;
-				}
-			}
-		",
+            class HelloMessage {
+                render() {
+                    var HelloMessage = <div>Hello</div>;
+                    return HelloMessage;
+                }
+            }
+        ",
         "
-			import {Hello} from 'Hello';
-			function Greetings() {
-				const Hello = require('Hello').default;
-				return <Hello />;
-			}
-			Greetings();
-		",
+            import {Hello} from 'Hello';
+            function Greetings() {
+                const Hello = require('Hello').default;
+                return <Hello />;
+            }
+            Greetings();
+        ",
         "
-			var lowercase;
-          	React.render(<lowercase />);
-		",
+            var lowercase;
+              React.render(<lowercase />);
+        ",
         "
-			function Greetings(div) {
-				return <div />;
-			}
-			Greetings();
-		",
+            function Greetings(div) {
+                return <div />;
+            }
+            Greetings();
+        ",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -629,13 +629,13 @@ fn test() {
         ("var foo /* comment */ = object.foo, a;", None),
         (
             "var foo // comment
-			 = object.foo;",
+             = object.foo;",
             None,
         ),
         ("var foo = /* comment */ object.foo;", None),
         (
             "var foo = // comment
-			 object.foo;",
+             object.foo;",
             None,
         ),
         ("var foo = (/* comment */ object).foo;", None),
@@ -644,18 +644,18 @@ fn test() {
         ("var foo = bar/* comment */.baz.foo;", None),
         (
             "var foo = bar[// comment
-			baz].foo;",
+            baz].foo;",
             None,
         ),
         (
             "var foo // comment
-			 = bar(/* comment */).foo;",
+             = bar(/* comment */).foo;",
             None,
         ),
         ("var foo = bar/* comment */.baz/* comment */.foo;", None),
         (
             "var foo = object// comment
-			.foo;",
+            .foo;",
             None,
         ),
         ("var foo = object./* comment */foo;", None),
@@ -666,7 +666,7 @@ fn test() {
         ("var foo = object.foo/* comment */, a;", None),
         (
             "var foo = object.foo// comment
-			, a;",
+            , a;",
             None,
         ),
         ("var foo = object.foo, /* comment */ a;", None),
@@ -691,9 +691,9 @@ fn test() {
         ("var foo = bar/* comment */.baz.foo;", "var {foo} = bar/* comment */.baz;", None),
         (
             "var foo = bar[// comment
-        		baz].foo;",
+                baz].foo;",
             "var {foo} = bar[// comment
-        		baz];",
+                baz];",
             None,
         ),
         ("var foo = (bar[baz]).foo;", "var {foo} = bar[baz];", None),
@@ -702,9 +702,9 @@ fn test() {
         ("var foo = object.foo/* comment */, a;", "var {foo} = object/* comment */, a;", None),
         (
             "var foo = object.foo// comment
-        		, a;",
+                , a;",
             "var {foo} = object// comment
-        		, a;",
+                , a;",
             None,
         ),
         ("var foo = object.foo, /* comment */ a;", "var {foo} = object, /* comment */ a;", None),

--- a/crates/oxc_linter/src/rules/eslint/require_await.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_await.rs
@@ -235,24 +235,24 @@ fn test() {
         "async function foo() { for await (x of xs); }",
         "await foo()",
         "
-        	                for await (let num of asyncIterable) {
-        	                    console.log(num);
-        	                }
-        	            ",
+                            for await (let num of asyncIterable) {
+                                console.log(num);
+                            }
+                        ",
         "async function* run() { yield * anotherAsyncGenerator() }",
         "async function* run() {
-        	                await new Promise(resolve => setTimeout(resolve, 100));
-        	                yield 'Hello';
-        	                console.log('World');
-        	            }
-        	            ",
+                            await new Promise(resolve => setTimeout(resolve, 100));
+                            yield 'Hello';
+                            console.log('World');
+                        }
+                        ",
         "
         async function foo() {
             {
                 await doSomething()
             }
         }
-        	            ",
+                        ",
         "async function* run() { }",
         "const foo = async function *(){}",
         r#"const foo = async function *(){ console.log("bar") }"#,

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -645,185 +645,185 @@ fn test() {
         ),
         (
             "
-        	                var obj = {
-        	                    e: 1,
-        	                    f: 2,
-        	                    g: 3,
+                            var obj = {
+                                e: 1,
+                                f: 2,
+                                g: 3,
 
-        	                    a: 4,
-        	                    b: 5,
-        	                    c: 6
-        	                }
-        	            ",
+                                a: 4,
+                                b: 5,
+                                c: 6
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ),
         (
             "
-        	                var obj = {
-        	                    b: 1,
+                            var obj = {
+                                b: 1,
 
-        	                    // comment
-        	                    a: 2,
-        	                    c: 3
-        	                }
-        	            ",
+                                // comment
+                                a: 2,
+                                c: 3
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ),
         (
             "
-        	                var obj = {
-        	                    b: 1
+                            var obj = {
+                                b: 1
 
-        	                    ,
+                                ,
 
-        	                    // comment
-        	                    a: 2,
-        	                    c: 3
-        	                }
-        	            ",
+                                // comment
+                                a: 2,
+                                c: 3
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ),
         (
             "
-        	                var obj = {
-        	                    c: 1,
-        	                    d: 2,
+                            var obj = {
+                                c: 1,
+                                d: 2,
 
-        	                    b() {
-        	                    },
-        	                    e: 4
-        	                }
-        	            ",
+                                b() {
+                                },
+                                e: 4
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                    c: 1,
-        	                    d: 2,
-        	                    // comment
+                            var obj = {
+                                c: 1,
+                                d: 2,
+                                // comment
 
-        	                    // comment
-        	                    b() {
-        	                    },
-        	                    e: 4
-        	                }
-        	            ",
+                                // comment
+                                b() {
+                                },
+                                e: 4
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                  b,
+                            var obj = {
+                              b,
 
-        	                  [a+b]: 1,
-        	                  a
-        	                }
-        	            ",
+                              [a+b]: 1,
+                              a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                    c: 1,
-        	                    d: 2,
+                            var obj = {
+                                c: 1,
+                                d: 2,
 
-        	                    a() {
+                                a() {
 
-        	                    },
+                                },
 
-        	                    // abce
-        	                    f: 3,
+                                // abce
+                                f: 3,
 
-        	                    /*
+                                /*
 
-        	                    */
-        	                    [a+b]: 1,
-        	                    cc: 1,
-        	                    e: 2
-        	                }
-        	            ",
+                                */
+                                [a+b]: 1,
+                                cc: 1,
+                                e: 2
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             r#"
-        	                var obj = {
-        	                    b: "/*",
+                            var obj = {
+                                b: "/*",
 
-        	                    a: "*/",
-        	                }
-        	            "#,
+                                a: "*/",
+                            }
+                        "#,
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ),
         (
             "
-        	                var obj = {
-        	                    b,
-        	                    /*
-        	                    */ //
+                            var obj = {
+                                b,
+                                /*
+                                */ //
 
-        	                    a
-        	                }
-        	            ",
+                                a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                    b,
+                            var obj = {
+                                b,
 
-        	                    /*
-        	                    */ //
-        	                    a
-        	                }
-        	            ",
+                                /*
+                                */ //
+                                a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                    b: 1
+                            var obj = {
+                                b: 1
 
-        	                    ,a: 2
-        	                };
-        	            ",
+                                ,a: 2
+                            };
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                    b: 1
-        	                // comment before comma
+                            var obj = {
+                                b: 1
+                            // comment before comma
 
-        	                ,
-        	                a: 2
-        	                };
-        	            ",
+                            ,
+                            a: 2
+                            };
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                var obj = {
-        	                  b,
+                            var obj = {
+                              b,
 
-        	                  a,
-        	                  ...z,
-        	                  c
-        	                }
-        	            ",
+                              a,
+                              ...z,
+                              c
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 2018 },
         (
             "
-        	                var obj = {
-        	                  b,
+                            var obj = {
+                              b,
 
-        	                  [foo()]: [
+                              [foo()]: [
 
-        	                  ],
-        	                  a
-        	                }
-        	            ",
+                              ],
+                              a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 2018 }
     ];
@@ -1033,137 +1033,137 @@ fn test() {
         ),
         (
             "
-        	                var obj = {
-        	                    b: 1,
-        	                    c: 2,
-        	                    a: 3
-        	                }
-        	            ",
+                            var obj = {
+                                b: 1,
+                                c: 2,
+                                a: 3
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": false }])),
         ),
         (
             "
-        	                let obj = {
-        	                    b
+                            let obj = {
+                                b
 
-        	                    ,a
-        	                }
-        	            ",
+                                ,a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": false }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                 var obj = {
-        	                    b: 1,
-        	                    c () {
+                             var obj = {
+                                b: 1,
+                                c () {
 
-        	                    },
-        	                    a: 3
-        	                  }
-        	             ",
+                                },
+                                a: 3
+                              }
+                         ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-        	                 var obj = {
-        	                    a: 1,
-        	                    b: 2,
+                             var obj = {
+                                a: 1,
+                                b: 2,
 
-        	                    z () {
+                                z () {
 
-        	                    },
-        	                    y: 3
-        	                  }
-        	             ",
+                                },
+                                y: 3
+                              }
+                         ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			                 var obj = {
-			                    b: 1,
-			                    c () {
-			                    },
-			                    // comment
-			                    a: 3
-			                  }
-			             ",
+                             var obj = {
+                                b: 1,
+                                c () {
+                                },
+                                // comment
+                                a: 3
+                              }
+                         ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			                var obj = {
-			                  b,
-			                  [a+b]: 1,
-			                  a // sort-keys: 'a' should be before 'b'
-			                }
-			            ",
+                            var obj = {
+                              b,
+                              [a+b]: 1,
+                              a // sort-keys: 'a' should be before 'b'
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			                var obj = {
-			                    c: 1,
-			                    d: 2,
-			                    // comment
-			                    // comment
-			                    b() {
-			                    },
-			                    e: 4
-			                }
-			            ",
+                            var obj = {
+                                c: 1,
+                                d: 2,
+                                // comment
+                                // comment
+                                b() {
+                                },
+                                e: 4
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			                var obj = {
-			                    c: 1,
-			                    d: 2,
+                            var obj = {
+                                c: 1,
+                                d: 2,
 
-			                    z() {
+                                z() {
 
-			                    },
-			                    f: 3,
-			                    /*
+                                },
+                                f: 3,
+                                /*
 
 
-			                    */
-			                    [a+b]: 1,
-			                    b: 1,
-			                    e: 2
-			                }
-			            ",
+                                */
+                                [a+b]: 1,
+                                b: 1,
+                                e: 2
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             r#"
-			                var obj = {
-			                    b: "/*",
-			                    a: "*/",
-			                }
-			            "#,
+                            var obj = {
+                                b: "/*",
+                                a: "*/",
+                            }
+                        "#,
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ),
         (
             "
-			                var obj = {
-			                    b: 1
-			                    // comment before comma
-			                    , a: 2
-			                };
-			            ",
+                            var obj = {
+                                b: 1
+                                // comment before comma
+                                , a: 2
+                            };
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 6 },
         (
             "
-			                let obj = {
-			                  b,
-			                  [foo()]: [
-			                  // ↓ this blank is inside a property and therefore should not count
+                            let obj = {
+                              b,
+                              [foo()]: [
+                              // ↓ this blank is inside a property and therefore should not count
 
-			                  ],
-			                  a
-			                }
-			            ",
+                              ],
+                              a
+                            }
+                        ",
             Some(serde_json::json!(["asc", { "allowLineSeparatedGroups": true }])),
         ), // { "ecmaVersion": 2018 }
     ];

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -368,28 +368,28 @@ fn test() {
         ("test('verifies expect method call', () => new Foo().expect(123));", Some(serde_json::json!([{ "assertFunctionNames": ["Foo.expect"] }]))),
         (
             "
-        	test('verifies deep expect method call', () => {
-        	tester.foo().expect(123);
-        	});
+            test('verifies deep expect method call', () => {
+            tester.foo().expect(123);
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.expect"] }])),
         ),
         (
             "
-        	test('verifies chained expect method call', () => {
-        	tester
-        		.foo()
-        		.bar()
-        		.expect(456);
-        	});
+            test('verifies chained expect method call', () => {
+            tester
+                .foo()
+                .bar()
+                .expect(456);
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.bar.expect"] }])),
         ),
         (
             "
-        	test('verifies the function call', () => {
-        	td.verify(someFunctionCall())
-        	})
+            test('verifies the function call', () => {
+            td.verify(someFunctionCall())
+            })
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["td.verify"] }])),
         ),
@@ -423,36 +423,36 @@ fn test() {
         ("test('should pass', () => request.get().foo().expect(456));", Some(serde_json::json!([{ "assertFunctionNames": ["request.**.e*e*t"] }]))),
         (
             "
-        	import { test } from '@jest/globals';
+            import { test } from '@jest/globals';
 
-        	test('should pass', () => {
-        	expect(true).toBeDefined();
-        	foo(true).toBe(true);
-        	});
+            test('should pass', () => {
+            expect(true).toBeDefined();
+            foo(true).toBe(true);
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
         ),
         (
             "
-        	import { test as checkThat } from '@jest/globals';
+            import { test as checkThat } from '@jest/globals';
 
-        	checkThat('this passes', () => {
-        	expect(true).toBeDefined();
-        	foo(true).toBe(true);
-        	});
+            checkThat('this passes', () => {
+            expect(true).toBeDefined();
+            foo(true).toBe(true);
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
         ),
         (
             "
-        	const { test } = require('@jest/globals');
+            const { test } = require('@jest/globals');
 
-        	test('verifies chained expect method call', () => {
-        	tester
-        		.foo()
-        		.bar()
-        		.expect(456);
-        	});
+            test('verifies chained expect method call', () => {
+            tester
+                .foo()
+                .bar()
+                .expect(456);
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["tester.foo.bar.expect"] }])),
         ),
@@ -557,21 +557,21 @@ fn test() {
         ),
         (
             "
-        	import { test as checkThat } from '@jest/globals';
+            import { test as checkThat } from '@jest/globals';
 
-        	checkThat('this passes', () => {
-        	// ...
-        	});
+            checkThat('this passes', () => {
+            // ...
+            });
         ",
             Some(serde_json::json!([{ "assertFunctionNames": ["expect", "foo"] }])),
         ),
         (
             "
-        	import { test as checkThat } from '@jest/globals';
+            import { test as checkThat } from '@jest/globals';
 
-        	checkThat.skip('this passes', () => {
-        	// ...
-        	});
+            checkThat.skip('this passes', () => {
+            // ...
+            });
         ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -108,37 +108,37 @@ fn test() {
     let pass = vec![
         (
             r"
-			          /**
-			           *
-			           */
-			          function quux (foo) {
+                      /**
+                       *
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @access public
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access public
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @accessLevel package
-			           */
-			          function quux (foo) {
+                      /**
+                       * @accessLevel package
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -150,37 +150,37 @@ fn test() {
         ),
         (
             r"
-			      class MyClass {
-			        /**
-			         * @access private
-			         */
-			        myClassField = 1
-			      }
-			      ",
+                  class MyClass {
+                    /**
+                     * @access private
+                     */
+                    myClassField = 1
+                  }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @public
-			           */
-			          function quux (foo) {
+                      /**
+                       * @public
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @private
-			           */
-			          function quux (foo) {
+                      /**
+                       * @private
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -190,10 +190,10 @@ fn test() {
         ),
         (
             r"
-			      (function(exports, require, module, __filename, __dirname) {
-			      // Module code actually lives in here
-			      });
-			      ",
+                  (function(exports, require, module, __filename, __dirname) {
+                  // Module code actually lives in here
+                  });
+                  ",
             None,
             None,
         ),
@@ -202,25 +202,25 @@ fn test() {
     let fail = vec![
         (
             r"
-			          /**
-			           * @access foo
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access foo
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @access foo
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access foo
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -230,13 +230,13 @@ fn test() {
         ),
         (
             r"
-        			          /**
-        			           * @accessLevel foo
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @accessLevel foo
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -248,13 +248,13 @@ fn test() {
         ),
         (
             r"
-			          /**
-			           * @access
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -266,52 +266,52 @@ fn test() {
         ),
         (
             r"
-			      class MyClass {
-			        /**
-			         * @access
-			         */
-			        myClassField = 1
-			      }
-			      ",
+                  class MyClass {
+                    /**
+                     * @access
+                     */
+                    myClassField = 1
+                  }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @access public
-			           * @public
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access public
+                       * @public
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @access public
-			           * @access private
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access public
+                       * @access private
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @access public
-			           * @access private
-			           */
-			          function quux (foo) {
+                      /**
+                       * @access public
+                       * @access private
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -321,27 +321,27 @@ fn test() {
         ),
         (
             r"
-			          /**
-			           * @public
-			           * @private
-			           */
-			          function quux (foo) {
+                      /**
+                       * @public
+                       * @private
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             r"
-			          /**
-			           * @public
-			           * @private
-			           */
-			          function quux (foo) {
+                      /**
+                       * @public
+                       * @private
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -351,14 +351,14 @@ fn test() {
         ),
         (
             r"
-			          /**
-			           * @public
-			           * @public
-			           */
-			          function quux (foo) {
+                      /**
+                       * @public
+                       * @public
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -321,37 +321,37 @@ fn test() {
     let pass = vec![
         (
             "
-			          /**
-			           * @param foo (pass: valid name)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @param foo (pass: valid name)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             "
-			          /**
-			           * @memberof! foo (pass: valid name)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @memberof! foo (pass: valid name)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             "
-			          /**
-			           * @bar foo (pass: invalid name but defined)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @bar foo (pass: invalid name but defined)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             Some(serde_json::json!([
               {
                 "definedTags": [
@@ -363,13 +363,13 @@ fn test() {
         ),
         (
             "
-			          /**
-			           * @baz @bar foo (pass: invalid names but defined)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @baz @bar foo (pass: invalid names but defined)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             Some(serde_json::json!([
               {
                 "definedTags": [
@@ -381,13 +381,13 @@ fn test() {
         ),
         (
             "
-			          /**
-			           * @baz @bar foo (pass: invalid names but user preferred)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @baz @bar foo (pass: invalid names but user preferred)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings": { "jsdoc": {
@@ -404,13 +404,13 @@ fn test() {
         ),
         (
             "
-			          /**
-			           * @arg foo (pass: invalid name but user preferred)
-			           */
-			          function quux (foo) {
+                      /**
+                       * @arg foo (pass: invalid name but user preferred)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -422,48 +422,48 @@ fn test() {
         ),
         (
             "
-			      /**
-			       * @returns (pass: valid name)
-			       */
-			      function quux (foo) {}
-			      ",
+                  /**
+                   * @returns (pass: valid name)
+                   */
+                  function quux (foo) {}
+                  ",
             None,
             None,
         ),
         ("", None, None),
         (
             "
-			          /**
-			           * (pass: no tag)
-			           */
-			          function quux (foo) {
+                      /**
+                       * (pass: no tag)
+                       */
+                      function quux (foo) {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             "
-			          /**
-			           * @todo (pass: valid name)
-			           */
-			          function quux () {
+                      /**
+                       * @todo (pass: valid name)
+                       */
+                      function quux () {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             None,
         ),
         (
             "
-			          /**
-			           * @extends Foo (pass: invalid name but user preferred)
-			           */
-			          function quux () {
+                      /**
+                       * @extends Foo (pass: invalid name but user preferred)
+                       */
+                      function quux () {
 
-			          }
-			      ",
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -478,15 +478,15 @@ fn test() {
         ),
         (
             "
-			          /**
-			           * (Set tag name preference to itself to get aliases to
-			           *   work along with main tag name.)
-			           * @augments Bar
-			           * @extends Foo (pass: invalid name but user preferred)
-			           */
-			          function quux () {
-			          }
-			      ",
+                      /**
+                       * (Set tag name preference to itself to get aliases to
+                       *   work along with main tag name.)
+                       * @augments Bar
+                       * @extends Foo (pass: invalid name but user preferred)
+                       */
+                      function quux () {
+                      }
+                  ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -498,31 +498,31 @@ fn test() {
         ),
         (
             "
-			      /**
-			       * Registers the `target` class as a transient dependency; each time the dependency is resolved a new instance will be created.
-			       *
-			       * @param target - The class / constructor function to register as transient.
-			       *
-			       * @example ```ts
-			      @transient()
-			      class Foo { }
-			      ```
-			       * @param Time for a new tag (pass: valid names)
-			       */
-			      export function transient<T>(target?: T): T {
-			        // ...
-			      }
-			",
+                  /**
+                   * Registers the `target` class as a transient dependency; each time the dependency is resolved a new instance will be created.
+                   *
+                   * @param target - The class / constructor function to register as transient.
+                   *
+                   * @example ```ts
+                  @transient()
+                  class Foo { }
+                  ```
+                   * @param Time for a new tag (pass: valid names)
+                   */
+                  export function transient<T>(target?: T): T {
+                    // ...
+                  }
+            ",
             None,
             None,
         ),
         (
             "
-			        /** @jsx h */
-			        /** @jsxFrag Fragment */
-			        /** @jsxImportSource preact */
-			        /** @jsxRuntime automatic (pass: valid jsx names)*/
-			      ",
+                    /** @jsx h */
+                    /** @jsxFrag Fragment */
+                    /** @jsxImportSource preact */
+                    /** @jsxRuntime automatic (pass: valid jsx names)*/
+                  ",
             Some(serde_json::json!([
               {
                 "jsxTags": true,
@@ -532,10 +532,10 @@ fn test() {
         ),
         (
             "
-			      /**
-			       * @internal (pass: valid name)
-			       */
-			      ",
+                  /**
+                   * @internal (pass: valid name)
+                   */
+                  ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": { }},
@@ -543,11 +543,11 @@ fn test() {
         ),
         (
             "
-			        /**
-			         * @overload
-			         * @satisfies (pass: valid names)
-			         */
-			      ",
+                    /**
+                     * @overload
+                     * @satisfies (pass: valid names)
+                     */
+                  ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": { }},
@@ -555,20 +555,20 @@ fn test() {
         ),
         (
             "
-			        /**
-			         * @module
-			         * A comment related to the module
-			         */
-			      ",
+                    /**
+                     * @module
+                     * A comment related to the module
+                     */
+                  ",
             None,
             None,
         ),
         // Typed
         (
             "
-      			        /** @default 0 */
-      			        let a;
-      			      ",
+                          /** @default 0 */
+                          let a;
+                        ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -578,9 +578,9 @@ fn test() {
         ),
         (
             "
-			        /** @template name */
-			        let a;
-			      ",
+                    /** @template name */
+                    let a;
+                  ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -590,9 +590,9 @@ fn test() {
         ),
         (
             "
-			        /** @param param - takes information */
-			        function takesOne(param) {}
-			      ",
+                    /** @param param - takes information */
+                    function takesOne(param) {}
+                  ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -658,57 +658,57 @@ fn test() {
     let fail = vec![
         (
             "
-        			        /** @typoo {string} (fail: invalid name) */
-        			        let a;
-        			      ",
+                            /** @typoo {string} (fail: invalid name) */
+                            let a;
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @Param (fail: invalid name)
-        			           */
-        			          function quux () {
+                              /**
+                               * @Param (fail: invalid name)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @foo (fail: invalid name)
-        			           */
-        			          function quux () {
+                              /**
+                               * @foo (fail: invalid name)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @arg foo (fail: invalid name, default aliased)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @arg foo (fail: invalid name, default aliased)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @param foo (fail: valid name but user preferred)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @param foo (fail: valid name but user preferred)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -720,13 +720,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @constructor foo (fail: invalid name and user preferred)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @constructor foo (fail: invalid name and user preferred)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -738,13 +738,13 @@ fn test() {
         ),
         (
             "
-        			          /**
+                              /**
                                * @arg foo (fail: invalid name and user preferred)
-        			           */
-        			          function quux (foo) {
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -756,13 +756,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @param foo (fail: valid name but user preferred)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @param foo (fail: valid name but user preferred)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -774,25 +774,25 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @bar foo (fail: invalid name)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @bar foo (fail: invalid name)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @baz @bar foo (fail: invalid name)
-        			           */
-        			          function quux (foo) {
+                              /**
+                               * @baz @bar foo (fail: invalid name)
+                               */
+                              function quux (foo) {
 
-        			          }
-        			      ",
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "definedTags": [
@@ -804,14 +804,14 @@ fn test() {
         ),
         (
             "
-        			            /**
-        			             * @bar
-        			             * @baz (fail: invalid name)
-        			             */
-        			            function quux (foo) {
+                                /**
+                                 * @bar
+                                 * @baz (fail: invalid name)
+                                 */
+                                function quux (foo) {
 
-        			            }
-        			        ",
+                                }
+                            ",
             Some(serde_json::json!([
               {
                 "definedTags": [
@@ -823,13 +823,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @todo (fail: valid name but blocked)
-        			           */
-        			          function quux () {
+                              /**
+                               * @todo (fail: valid name but blocked)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -841,13 +841,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @todo (fail: valid name but blocked)
-        			           */
-        			          function quux () {
+                              /**
+                               * @todo (fail: valid name but blocked)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -861,13 +861,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @todo (fail: valid name but blocked)
-        			           */
-        			          function quux () {
+                              /**
+                               * @todo (fail: valid name but blocked)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -882,27 +882,27 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @property {object} a
-        			           * @prop {boolean} b (fail: invalid name, default aliased)
-        			           */
-        			          function quux () {
+                              /**
+                               * @property {object} a
+                               * @prop {boolean} b (fail: invalid name, default aliased)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @abc foo (fail: invalid name and user preferred)
-        			           * @abcd bar
-        			           */
-        			          function quux () {
+                              /**
+                               * @abc foo (fail: invalid name and user preferred)
+                               * @abcd bar
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "definedTags": [
@@ -920,14 +920,14 @@ fn test() {
         ),
         (
             "
-        			          /**
+                              /**
                                * @abc (fail: invalid name and user preferred)
-        			           * @abcd
-        			           */
-        			          function quux () {
+                               * @abcd
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -939,23 +939,23 @@ fn test() {
         ),
         (
             "
-        			        /** @jsx h */
-        			        /** @jsxFrag Fragment */
-        			        /** @jsxImportSource preact */
-        			        /** @jsxRuntime automatic */
-        			      ",
+                            /** @jsx h */
+                            /** @jsxFrag Fragment */
+                            /** @jsxImportSource preact */
+                            /** @jsxRuntime automatic */
+                          ",
             None,
             None,
         ),
         (
             "
-        			      /**
-        			       * @constructor (fail: invalid name)
-        			       */
-        			      function Test() {
-        			        this.works = false;
-        			      }
-        			      ",
+                          /**
+                           * @constructor (fail: invalid name)
+                           */
+                          function Test() {
+                            this.works = false;
+                          }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -967,13 +967,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @todo (fail: valid name but blocked)
-        			           */
-        			          function quux () {
+                              /**
+                               * @todo (fail: valid name but blocked)
+                               */
+                              function quux () {
 
-        			          }
-        			      ",
+                              }
+                          ",
             None,
             Some(serde_json::json!({
               "settings" : { "jsdoc": {
@@ -988,11 +988,11 @@ fn test() {
         // Typed
         (
             "
-			        /**
-			         * @module
-			         * A comment related to the module
-			         */
-			      ",
+                    /**
+                     * @module
+                     * A comment related to the module
+                     */
+                  ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1002,7 +1002,7 @@ fn test() {
         ),
         (
             "/** @type {string} */let a;
-        			      ",
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1012,12 +1012,12 @@ fn test() {
         ),
         (
             "
-        			        /**
-        			         * Existing comment.
-        			         *  @type {string}
-        			         */
-        			        let a;
-        			      ",
+                            /**
+                             * Existing comment.
+                             *  @type {string}
+                             */
+                            let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1027,10 +1027,10 @@ fn test() {
         ),
         (
             "
-        			      /** @typedef {Object} MyObject
-        			       * @property {string} id - my id
-        			       */
-        			      ",
+                          /** @typedef {Object} MyObject
+                           * @property {string} id - my id
+                           */
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1040,10 +1040,10 @@ fn test() {
         ),
         (
             "
-        			      /**
-        			       * @property {string} id - my id
-        			       */
-        			      ",
+                          /**
+                           * @property {string} id - my id
+                           */
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1053,8 +1053,8 @@ fn test() {
         ),
         (
             "
-        			      /** @typedef {Object} MyObject */
-        			      ",
+                          /** @typedef {Object} MyObject */
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1064,9 +1064,9 @@ fn test() {
         ),
         (
             "
-        			      /** @typedef {Object} MyObject
-        			       */
-        			      ",
+                          /** @typedef {Object} MyObject
+                           */
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1076,9 +1076,9 @@ fn test() {
         ),
         (
             "
-        			        /** @abstract */
-        			        let a;
-        			      ",
+                            /** @abstract */
+                            let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1088,11 +1088,11 @@ fn test() {
         ),
         (
             "
-        			        const a = {
-        			          /** @abstract */
-        			          b: true,
-        			        };
-        			      ",
+                            const a = {
+                              /** @abstract */
+                              b: true,
+                            };
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1102,9 +1102,9 @@ fn test() {
         ),
         (
             "
-        			        /** @template */
-        			        let a;
-        			      ",
+                            /** @template */
+                            let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1114,13 +1114,13 @@ fn test() {
         ),
         (
             "
-        			        /**
-        			         * Prior description.
-        			         *
-        			         * @template
-        			         */
-        			        let a;
-        			      ",
+                            /**
+                             * Prior description.
+                             *
+                             * @template
+                             */
+                            let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1133,9 +1133,9 @@ fn test() {
     let dts_pass: Vec<(&'static str, Option<serde_json::Value>, Option<serde_json::Value>)> = vec![
         (
             "
-        			        /** @default 0 */
-        			        declare let a;
-        			      ",
+                            /** @default 0 */
+                            declare let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1145,9 +1145,9 @@ fn test() {
         ),
         (
             "
-        			        /** @abstract */
-        			        let a;
-        			      ",
+                            /** @abstract */
+                            let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1157,9 +1157,9 @@ fn test() {
         ),
         (
             "
-        			        /** @abstract */
-        			        declare let a;
-        			      ",
+                            /** @abstract */
+                            declare let a;
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1169,9 +1169,9 @@ fn test() {
         ),
         (
             "
-        			        /** @abstract */
-        			        { declare let a; }
-        			      ",
+                            /** @abstract */
+                            { declare let a; }
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1181,11 +1181,11 @@ fn test() {
         ),
         (
             "
-        			        function test() {
-        			          /** @abstract */
-        			          declare let a;
-        			        }
-        			      ",
+                            function test() {
+                              /** @abstract */
+                              declare let a;
+                            }
+                          ",
             Some(serde_json::json!([
               {
                 "typed": true,
@@ -1197,9 +1197,9 @@ fn test() {
     let dts_fail: Vec<(&'static str, Option<serde_json::Value>, Option<serde_json::Value>)> =
         vec![(
             "
-        			        /** @typoo {string} (fail: invalid name) */
-        			        let a;
-        			      ",
+                            /** @typoo {string} (fail: invalid name) */
+                            let a;
+                          ",
             None,
             None,
         )];

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -282,183 +282,183 @@ fn test() {
     let pass = vec![
         (
             "
-        			          /**
-        			           * @yields Foo.
-        			           */
-        			          function * quux () {
+                              /**
+                               * @yields Foo.
+                               */
+                              function * quux () {
 
-        			            yield foo;
-        			          }
-        			      ",
+                                yield foo;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * pass(without yield, no config)
-        			           */
-        			          function * quux () {
-        			          }
-        			      ",
+                              /**
+                               * pass(without yield, no config)
+                               */
+                              function * quux () {
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           *
-        			           */
-        			          function * quux () {
-        			            yield;
-        			          }
-        			      ",
+                              /**
+                               *
+                               */
+                              function * quux () {
+                                yield;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           *
-        			           */
-        			          function quux (bar) {
-        			            bar.doSomething(function * (baz) {
-        			              yield baz.corge();
-        			            })
-        			          }
-        			      ",
+                              /**
+                               *
+                               */
+                              function quux (bar) {
+                                bar.doSomething(function * (baz) {
+                                  yield baz.corge();
+                                })
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {Array}
-        			           */
-        			          function * quux (bar) {
-        			            yield bar.doSomething(function * (baz) {
-        			              yield baz.corge();
-        			            })
-        			          }
-        			      ",
+                              /**
+                               * @yields {Array}
+                               */
+                              function * quux (bar) {
+                                yield bar.doSomething(function * (baz) {
+                                  yield baz.corge();
+                                })
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @inheritdoc
-        			           */
-        			          function * quux (foo) {
-        			            yield 'inherit!';
-        			          }
-        			      ",
+                              /**
+                               * @inheritdoc
+                               */
+                              function * quux (foo) {
+                                yield 'inherit!';
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @override
-        			           */
-        			          function * quux (foo) {
-        			          }
-        			      ",
+                              /**
+                               * @override
+                               */
+                              function * quux (foo) {
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @constructor
-        			           */
-        			          function * quux (foo) {
-        			          }
-        			      ",
+                              /**
+                               * @constructor
+                               */
+                              function * quux (foo) {
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @implements
-        			           */
-        			          function * quux (foo) {
-        			            yield;
-        			          }
-        			      ",
+                              /**
+                               * @implements
+                               */
+                              function * quux (foo) {
+                                yield;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * pass(`@override` found, settings should be default true)
-        			           * @override
-        			           */
-        			          function * quux (foo) {
+                              /**
+                               * pass(`@override` found, settings should be default true)
+                               * @override
+                               */
+                              function * quux (foo) {
 
-        			            yield foo;
-        			          }
-        			      ",
+                                yield foo;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @class
-        			           */
-        			          function * quux (foo) {
-        			            yield foo;
-        			          }
-        			      ",
+                              /**
+                               * @class
+                               */
+                              function * quux (foo) {
+                                yield foo;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {object}
-        			           */
-        			          function * quux () {
+                              /**
+                               * @yields {object}
+                               */
+                              function * quux () {
 
-        			            yield {a: foo};
-        			          }
-        			      ",
+                                yield {a: foo};
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {undefined}
-        			           */
-        			          function * quux () {
-        			          }
-        			      ",
+                              /**
+                               * @yields {undefined}
+                               */
+                              function * quux () {
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function quux () {
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function quux () {
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -468,25 +468,25 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			            yield undefined;
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                                yield undefined;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			            yield undefined;
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                                yield undefined;
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -496,24 +496,24 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			            yield;
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                                yield;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -523,13 +523,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @yields {void}
-        			           */
-        			          function * quux () {
-        			            yield;
-        			          }
-        			      ",
+                              /**
+                               * @yields {void}
+                               */
+                              function * quux () {
+                                yield;
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -539,22 +539,22 @@ fn test() {
         ),
         (
             "
-        			          /** @type {SpecialIterator} */
-        			          function * quux () {
-        			            yield 5;
-        			          }
-        			      ",
+                              /** @type {SpecialIterator} */
+                              function * quux () {
+                                yield 5;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @yields {Something}
-        			           */
-        			          async function * quux () {
-        			          }
-        			      ",
+                              /**
+                               * @yields {Something}
+                               */
+                              async function * quux () {
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -564,33 +564,33 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           *
-        			           */
-        			          async function * quux () {}
-        			      ",
+                              /**
+                               *
+                               */
+                              async function * quux () {}
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           *
-        			           */
-        			          const quux = async function * () {}
-        			      ",
+                              /**
+                               *
+                               */
+                              const quux = async function * () {}
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @mytype {MyCallback}
-        			           */
-        			          function * quux () {
-        			            yield 2;
-        			          }
-        			      ",
+                              /**
+                               * @mytype {MyCallback}
+                               */
+                              function * quux () {
+                                yield 2;
+                              }
+                          ",
             Some(serde_json::json!([
               {
                 "exemptedBy": ["mytype"],
@@ -600,22 +600,22 @@ fn test() {
         ),
         (
             "
-        			      /**
-        			       * @param {array} a
-        			       */
-        			      async function * foo (a) {
-        			        yield;
-        			      }
-        			      ",
+                          /**
+                           * @param {array} a
+                           */
+                          async function * foo (a) {
+                            yield;
+                          }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * @function
-        			           */
-        			      ",
+                              /**
+                               * @function
+                               */
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -625,10 +625,10 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @callback
-        			           */
-        			      ",
+                              /**
+                               * @callback
+                               */
+                          ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -638,10 +638,10 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @generator
-        			           */
-        			      ",
+                              /**
+                               * @generator
+                               */
+                          ",
             Some(serde_json::json!([
               {
                 "withGeneratorTag": true,
@@ -651,13 +651,13 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * pass(`@generator`+`@yields`, with config)
-        			           * @generator
-        			           * @yields
-        			           */
+                              /**
+                               * pass(`@generator`+`@yields`, with config)
+                               * @generator
+                               * @yields
+                               */
                         function*d() {yield 1;}
-        			      ",
+                          ",
             Some(serde_json::json!([
               {
                 "withGeneratorTag": true,
@@ -667,28 +667,28 @@ fn test() {
         ),
         (
             "
-        			          /**
-        			           * @yields
-        			           */
-        			          function * quux (foo) {
+                              /**
+                               * @yields
+                               */
+                              function * quux (foo) {
 
-        			            const a = yield foo;
-        			          }
-        			      ",
+                                const a = yield foo;
+                              }
+                          ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           *
-        			           */
-        			          function * quux (foo) {
-        			            const a = function * bar () {
-        			              yield foo;
-        			            }
-        			          }
-        			      ",
+                              /**
+                               *
+                               */
+                              function * quux (foo) {
+                                const a = function * bar () {
+                                  yield foo;
+                                }
+                              }
+                          ",
             None,
             None,
         ),
@@ -697,50 +697,50 @@ fn test() {
     let fail = vec![
         (
             "
-      			          /**
-      			           * fail(`yield` with value but no `@yields`)
-      			           */
-      			          function * quux (foo) { yield foo; }
-      			      ",
+                            /**
+                             * fail(`yield` with value but no `@yields`)
+                             */
+                            function * quux (foo) { yield foo; }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux (foo) {
-      			            someLabel: {
-      			              yield foo;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux (foo) {
+                              someLabel: {
+                                yield foo;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux (foo) {
+                            /**
+                             *
+                             */
+                            function * quux (foo) {
 
-      			            const a = yield foo;
-      			          }
-      			      ",
+                              const a = yield foo;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux (foo) {
-      			            yield foo;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux (foo) {
+                              yield foo;
+                            }
+                        ",
             None,
             Some(serde_json::json!({ "settings": {
         "jsdoc": {
@@ -752,13 +752,13 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux() {
-      			            yield 5;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux() {
+                              yield 5;
+                            }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -768,13 +768,13 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux() {
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux() {
+                              yield;
+                            }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -784,13 +784,13 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          const quux = async function * () {
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            const quux = async function * () {
+                              yield;
+                            }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -800,13 +800,13 @@ fn test() {
         ),
         (
             "
-      			           /**
-      			            *
-      			            */
-      			           async function * quux () {
-      			             yield;
-      			           }
-      			      ",
+                             /**
+                              *
+                              */
+                             async function * quux () {
+                               yield;
+                             }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -816,13 +816,13 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              yield;
+                            }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -832,12 +832,12 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           * @function
-      			           * @generator
-      			           */
+                            /**
+                             * @function
+                             * @generator
+                             */
                         function*d() {}
-      			      ",
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -847,27 +847,27 @@ fn test() {
         ),
         (
             "
-      			          /**
-      			           * @yields {undefined}
-      			           * @yields {void}
-      			           */
-      			          function * quux (foo) {
+                            /**
+                             * @yields {undefined}
+                             * @yields {void}
+                             */
+                            function * quux (foo) {
 
-      			            return foo;
-      			          }
-      			      ",
+                              return foo;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           * @param foo
-      			           */
-      			          function * quux (foo) {
-      			            yield 'bar';
-      			          }
-      			      ",
+                            /**
+                             * @param foo
+                             */
+                            function * quux (foo) {
+                              yield 'bar';
+                            }
+                        ",
             Some(serde_json::json!([
               {
                 "exemptedBy": [
@@ -879,13 +879,13 @@ fn test() {
         ),
         (
             "
-      			      /**
-      			       * @param {array} a
-      			       */
-      			      async function * foo(a) {
-      			        return;
-      			      }
-      			      ",
+                        /**
+                         * @param {array} a
+                         */
+                        async function * foo(a) {
+                          return;
+                        }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -895,13 +895,13 @@ fn test() {
         ),
         (
             "
-      			      /**
-      			       * @param {array} a
-      			       */
-      			      async function * foo(a) {
-      			        yield Promise.all(a);
-      			      }
-      			      ",
+                        /**
+                         * @param {array} a
+                         */
+                        async function * foo(a) {
+                          yield Promise.all(a);
+                        }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -911,15 +911,15 @@ fn test() {
         ),
         (
             "
-      			      class quux {
-      			        /**
-      			         *
-      			         */
-      			        * quux () {
-      			          yield;
-      			        }
-      			      }
-      			      ",
+                        class quux {
+                          /**
+                           *
+                           */
+                          * quux () {
+                            yield;
+                          }
+                        }
+                        ",
             Some(serde_json::json!([
               {
                 "forceRequireYields": true,
@@ -929,508 +929,508 @@ fn test() {
         ),
         (
             "
-      			      /**
-      			       * @param {array} a
-      			       */
-      			      async function * foo(a) {
-      			        yield Promise.all(a);
-      			      }
-      			      ",
+                        /**
+                         * @param {array} a
+                         */
+                        async function * foo(a) {
+                          yield Promise.all(a);
+                        }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            if (true) {
-      			              yield;
-      			            }
-      			            yield true;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              if (true) {
+                                yield;
+                              }
+                              yield true;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            if (yield false) {
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              if (yield false) {
 
-      			            }
-      			          }
-      			      ",
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            b ? yield false : true
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              b ? yield false : true
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            try {
-      			              yield true;
-      			            } catch (err) {
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              try {
+                                yield true;
+                              } catch (err) {
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            try {
-      			            } finally {
-      			              yield true;
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              try {
+                              } finally {
+                                yield true;
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            try {
-      			              yield;
-      			            } catch (err) {
-      			            }
-      			            yield true;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              try {
+                                yield;
+                              } catch (err) {
+                              }
+                              yield true;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            try {
-      			              something();
-      			            } catch (err) {
-      			              yield true;
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              try {
+                                something();
+                              } catch (err) {
+                                yield true;
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            switch (true) {
-      			            case 'abc':
-      			              yield true;
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              switch (true) {
+                              case 'abc':
+                                yield true;
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            switch (true) {
-      			            case 'abc':
-      			              yield;
-      			            }
-      			            yield true;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              switch (true) {
+                              case 'abc':
+                                yield;
+                              }
+                              yield true;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            for (const i of abc) {
-      			              yield true;
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              for (const i of abc) {
+                                yield true;
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            for (const a in b) {
-      			              yield true;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              for (const a in b) {
+                                yield true;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            for (let i=0; i<n; i+=1) {
-      			              yield true;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              for (let i=0; i<n; i+=1) {
+                                yield true;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            while(true) {
-      			              yield true
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              while(true) {
+                                yield true
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            do {
-      			              yield true
-      			            }
-      			            while(true)
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              do {
+                                yield true
+                              }
+                              while(true)
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            if (true) {
-      			              yield true;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              if (true) {
+                                yield true;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            var a = {};
-      			            with (a) {
-      			              yield true;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              var a = {};
+                              with (a) {
+                                yield true;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            if (true) {
-      			              yield;
-      			            } else {
-      			              yield true;
-      			            }
-      			            yield;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              if (true) {
+                                yield;
+                              } else {
+                                yield true;
+                              }
+                              yield;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            if (false) {
-      			              return;
-      			            }
-      			            return yield true;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              if (false) {
+                                return;
+                              }
+                              return yield true;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            [yield true];
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              [yield true];
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            const [a = yield true] = [];
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              const [a = yield true] = [];
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            a || (yield true);
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              a || (yield true);
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            (r = yield true);
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              (r = yield true);
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            a + (yield true);
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              a + (yield true);
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            a, yield true;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              a, yield true;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            +(yield);
-      			            [...yield];
-      			            [...+(yield true)];
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              +(yield);
+                              [...yield];
+                              [...+(yield true)];
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            someLabel: {
-      			              yield true;
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              someLabel: {
+                                yield true;
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            var obj = {
-      			              [someKey]: 'val',
-      			              anotherKey: yield true
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              var obj = {
+                                [someKey]: 'val',
+                                anotherKey: yield true
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            var obj = {
-      			              [yield true]: 'val',
-      			            }
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              var obj = {
+                                [yield true]: 'val',
+                              }
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            `abc${yield true}`;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              `abc${yield true}`;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            tagTemp`abc${yield true}`;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              tagTemp`abc${yield true}`;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            a.b[yield true].c;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              a.b[yield true].c;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            abc?.[yield true].d?.e(yield true);
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              abc?.[yield true].d?.e(yield true);
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            const [a = yield true] = arr;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              const [a = yield true] = arr;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            const {a = yield true} = obj;
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              const {a = yield true} = obj;
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-      			          /**
-      			           *
-      			           */
-      			          function * quux () {
-      			            import(yield true);
-      			          }
-      			      ",
+                            /**
+                             *
+                             */
+                            function * quux () {
+                              import(yield true);
+                            }
+                        ",
             None,
             None,
         ),
         (
             "
-        			          /**
-        			           * fail(`@generator`+missing `@yields`, with config)
-        			           * @generator
-        			           */
+                              /**
+                               * fail(`@generator`+missing `@yields`, with config)
+                               * @generator
+                               */
                         function*d() {}
-        			      ",
+                          ",
             Some(serde_json::json!([{ "withGeneratorTag": true, }])),
             None,
         ),

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -89,15 +89,15 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-			export default class MyDocument extends Document {
-			  render() {
-				return (
-				  <Html>
-				  </Html>
-				);
-			  }
-			}
-			"#,
+            export default class MyDocument extends Document {
+              render() {
+                return (
+                  <Html>
+                  </Html>
+                );
+              }
+            }
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document.js")),
@@ -105,15 +105,15 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-				export default class MyDocument extends Document {
-				render() {
-					return (
-					<Html>
-					</Html>
-					);
-				}
-				}
-			"#,
+                export default class MyDocument extends Document {
+                render() {
+                    return (
+                    <Html>
+                    </Html>
+                    );
+                }
+                }
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document.js")),
@@ -121,15 +121,15 @@ fn test() {
         (
             r#"import NextDocument from "next/document"
 
-        	    export default class MyDocument extends NextDocument {
-        	      render() {
-        	        return (
-        	          <Html>
-        	          </Html>
-        	        );
-        	      }
-        	    }
-        	"#,
+                export default class MyDocument extends NextDocument {
+                  render() {
+                    return (
+                      <Html>
+                      </Html>
+                    );
+                  }
+                }
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document.tsx")),
@@ -145,7 +145,7 @@ fn test() {
                 );
               }
             }
-        	"#,
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document.page.tsx")),
@@ -161,7 +161,7 @@ fn test() {
                 );
               }
             }
-        	"#,
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document/index.js")),
@@ -177,7 +177,7 @@ fn test() {
                 );
               }
             }
-        	"#,
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/_document/index.tsx")),
@@ -185,15 +185,15 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export default class MyDocument extends Document {
-        	      render() {
-        	        return (
-        	          <Html>
-        	          </Html>
-        	        );
-        	      }
-        	    }
-        	"#,
+                export default class MyDocument extends Document {
+                  render() {
+                    return (
+                      <Html>
+                      </Html>
+                    );
+                  }
+                }
+            "#,
             None,
             None,
             Some(PathBuf::from("pagesapp/src/pages/_document.js")),
@@ -204,8 +204,8 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export const Test = () => <p>Test</p>
-			"#,
+                export const Test = () => <p>Test</p>
+            "#,
             None,
             None,
             Some(PathBuf::from("components/test.js")),
@@ -213,8 +213,8 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export const Test = () => <p>Test</p>
-        	"#,
+                export const Test = () => <p>Test</p>
+            "#,
             None,
             None,
             Some(PathBuf::from("pages/test.js")),
@@ -222,8 +222,8 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export const Test = () => <p>Test</p>
-			"#,
+                export const Test = () => <p>Test</p>
+            "#,
             None,
             None,
             Some(PathBuf::from("src/pages/user/test.tsx")),
@@ -231,8 +231,8 @@ fn test() {
         (
             r#"import Document from "next/document"
 
-        	    export const Test = () => <p>Test</p>
-			"#,
+                export const Test = () => <p>Test</p>
+            "#,
             None,
             None,
             Some(PathBuf::from("src/pages/user/_document.tsx")),

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -104,18 +104,18 @@ fn test() {
         (
             r"import Head from 'next/head';
 
-			export class MyComponent {
-			  render() {
-				return (
-				  <div>
-					<Head>
-					  <title>My page title</title>
-					</Head>
-				  </div>
-				);
-			  }
-			}
-		",
+            export class MyComponent {
+              render() {
+                return (
+                  <div>
+                    <Head>
+                      <title>My page title</title>
+                    </Head>
+                  </div>
+                );
+              }
+            }
+        ",
             None,
             None,
             Some(PathBuf::from("pages/index.js")),
@@ -123,17 +123,17 @@ fn test() {
         (
             r"import Head from 'next/head';
 
-           	      export class MyComponent {
-           	        render() {
-           	          return (
-           	            <div>
-           	              <Head>
-           	                <title>My page title</title>
-           	              </Head>
-           	            </div>
-           	          );
-           	        }
-           	      }
+                     export class MyComponent {
+                       render() {
+                         return (
+                           <div>
+                             <Head>
+                               <title>My page title</title>
+                             </Head>
+                           </div>
+                         );
+                       }
+                     }
         ",
             None,
             None,
@@ -141,34 +141,34 @@ fn test() {
         ),
         (
             r"
-        	      export default function Layout({ children }) {
-        	        return (
-        	          <html>
-        	            <head>
-        	              <title>layout</title>
-        	            </head>
-        	            <body>{children}</body>
-        	          </html>
-        	        );
-        	      }
-        	",
+                  export default function Layout({ children }) {
+                    return (
+                      <html>
+                        <head>
+                          <title>layout</title>
+                        </head>
+                        <body>{children}</body>
+                      </html>
+                    );
+                  }
+            ",
             None,
             None,
             Some(PathBuf::from("./app/layout.js")),
         ),
         (
             r"
-        	      export default function Layout({ children }) {
-        	        return (
-        	          <html>
-        	            <head>
-        	              <title>layout</title>
-        	            </head>
-        	            <body>{children}</body>
-        	          </html>
-        	        );
-        	      }
-        	",
+                  export default function Layout({ children }) {
+                    return (
+                      <html>
+                        <head>
+                          <title>layout</title>
+                        </head>
+                        <body>{children}</body>
+                      </html>
+                    );
+                  }
+            ",
             None,
             None,
             Some(PathBuf::from("./app/layout.js")),
@@ -178,17 +178,17 @@ fn test() {
     let fail = vec![
         (
             r"
-        	      export class MyComponent {
-        	        render() {
-        	          return (
-        	            <div>
-        	              <head>
-        	                <title>My page title</title>
-        	              </head>
-        	            </div>
-        	          );
-        	        }
-        	}",
+                  export class MyComponent {
+                    render() {
+                      return (
+                        <div>
+                          <head>
+                            <title>My page title</title>
+                          </head>
+                        </div>
+                      );
+                    }
+            }",
             None,
             None,
             Some(PathBuf::from("./pages/index.js")),
@@ -196,20 +196,20 @@ fn test() {
         (
             r"import Head from 'next/head';
 
-        	      export class MyComponent {
-        	        render() {
-        	          return (
-        	            <div>
-        	              <head>
-        	                <title>My page title</title>
-        	              </head>
-        	              <Head>
-        	                <title>My page title</title>
-        	              </Head>
-        	            </div>
-        	          );
-        	        }
-        	}",
+                  export class MyComponent {
+                    render() {
+                      return (
+                        <div>
+                          <head>
+                            <title>My page title</title>
+                          </head>
+                          <Head>
+                            <title>My page title</title>
+                          </Head>
+                        </div>
+                      );
+                    }
+            }",
             None,
             None,
             Some(PathBuf::from("pages/index.tsx")),

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -140,8 +140,7 @@ fn test() {
                 return <div></div>;
                 }
                 export async function getStaticPaths() {};
-                export async function getStaticProps() {};
-           	",
+                export async function getStaticProps() {};",
             None,
             None,
             Some(PathBuf::from("pages/test.tsx")),
@@ -151,8 +150,7 @@ fn test() {
                 export default function Page() {
                 return <div></div>;
                 }
-                export async function getServerSideProps() {};
-        	",
+                export async function getServerSideProps() {};",
             None,
             None,
             Some(PathBuf::from("pages/test.tsx")),

--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -862,492 +862,492 @@ fn test() {
     let pass = vec![
         (
             "
-        	        var Hello = createReactClass({
-        	          displayName: 'Hello',
-        	          render: function() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        });
-        	      ",
+                    var Hello = createReactClass({
+                      displayName: 'Hello',
+                      render: function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
             "
-        	        var Hello = React.createClass({
-        	          displayName: 'Hello',
-        	          render: function() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        });
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            Some(
-                serde_json::json!({ "settings": {        "react": {          "createClass": "createClass",        },      } }),
-            ),
-        ),
-        (
-            "
-        	        class Hello extends React.Component {
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	        Hello.displayName = 'Hello'
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        class Hello {
-        	          render() {
-        	            return 'Hello World';
-        	          }
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        class Hello extends Greetings {
-        	          static text = 'Hello World';
-        	          render() {
-        	            return Hello.text;
-        	          }
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        class Hello {
-        	          method;
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        class Hello extends React.Component {
-        	          static get displayName() {
-        	            return 'Hello';
-        	          }
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        class Hello extends React.Component {
-        	          static displayName = 'Widget';
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var Hello = createReactClass({
-        	          render: function() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        });
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        class Hello extends React.Component {
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        export default class Hello {
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        var Hello;
-        	        Hello = createReactClass({
-        	          render: function() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        });
-        	      ",
-            None,
-            None,
-        ),
-        (
-            r#"
-        	        module.exports = createReactClass({
-        	          "displayName": "Hello",
-        	          "render": function() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        });
-        	      "#,
-            None,
-            None,
-        ),
-        (
-            "
-        	        var Hello = createReactClass({
-        	          displayName: 'Hello',
-        	          render: function() {
-        	            let { a, ...b } = obj;
-        	            let c = { ...d };
-        	            return <div />;
-        	          }
-        	        });
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        export default class {
-        	          render() {
-        	            return <div>Hello {this.props.name}</div>;
-        	          }
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        export const Hello = React.memo(function Hello() {
-        	          return <p />;
-        	        })
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        var Hello = function() {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        function Hello() {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        var Hello = () => {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        module.exports = function Hello() {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-			        function Hello() {
-			          return <div>Hello {this.props.name}</div>;
-			        }
-			        Hello.displayName = 'Hello';
-			      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var Hello = () => {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	        Hello.displayName = 'Hello';
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var Hello = function() {
-        	          return <div>Hello {this.props.name}</div>;
-        	        }
-        	        Hello.displayName = 'Hello';
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var Mixins = {
-        	          Greetings: {
-        	            Hello: function() {
-        	              return <div>Hello {this.props.name}</div>;
-        	            }
-        	          }
-        	        }
-        	        Mixins.Greetings.Hello.displayName = 'Hello';
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var Hello = createReactClass({
-        	          render: function() {
-        	            return <div>{this._renderHello()}</div>;
-        	          },
-        	          _renderHello: function() {
-        	            return <span>Hello {this.props.name}</span>;
-        	          }
-        	        });
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        var Hello = createReactClass({
-        	          displayName: 'Hello',
-        	          render: function() {
-        	            return <div>{this._renderHello()}</div>;
-        	          },
-        	          _renderHello: function() {
-        	            return <span>Hello {this.props.name}</span>;
-        	          }
-        	        });
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        const Mixin = {
-        	          Button() {
-        	            return (
-        	              <button />
-        	            );
-        	          }
-        	        };
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        var obj = {
-        	          pouf: function() {
-        	            return any
-        	          }
-        	        };
-        	      ",
-            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
-            None,
-        ),
-        (
-            "
-        	        var obj = {
-        	          pouf: function() {
-        	            return any
-        	          }
-        	        };
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        export default {
-        	          renderHello() {
-        	            let {name} = this.props;
-        	            return <div>{name}</div>;
-        	          }
-        	        };
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        import React, { createClass } from 'react';
-        	        export default createClass({
-        	          displayName: 'Foo',
-        	          render() {
-        	            return <h1>foo</h1>;
-        	          }
-        	        });
-        	      ",
+                    var Hello = React.createClass({
+                      displayName: 'Hello',
+                      render: function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "createClass": "createClass",        },      } }),
             ),
         ),
         (
-            r#"
-        	        import React, {Component} from "react";
-        	        function someDecorator(ComposedComponent) {
-        	          return class MyDecorator extends Component {
-        	            render() {return <ComposedComponent {...this.props} />;}
-        	          };
-        	        }
-        	        module.exports = someDecorator;
-        	      "#,
-            None,
+            "
+                    class Hello extends React.Component {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                    Hello.displayName = 'Hello'
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
-            r#"
-        	        import React, {createElement} from "react";
-        	        const SomeComponent = (props) => {
-        	          const {foo, bar} = props;
-        	          return someComponentFactory({
-        	            onClick: () => foo(bar("x"))
-        	          });
-        	        };
-        	      "#,
+            "
+                    class Hello {
+                      render() {
+                        return 'Hello World';
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        const element = (
-        	          <Media query={query} render={() => {
-        	            renderWasCalled = true
-        	            return <div/>
-        	          }}/>
-        	        )
-        	      ",
+                    class Hello extends Greetings {
+                      static text = 'Hello World';
+                      render() {
+                        return Hello.text;
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        const element = (
-        	          <Media query={query} render={function() {
-        	            renderWasCalled = true
-        	            return <div/>
-        	          }}/>
-        	        )
-        	      ",
+                    class Hello {
+                      method;
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        module.exports = {
-        	          createElement: tagName => document.createElement(tagName)
-        	        };
-        	      ",
-            None,
+                    class Hello extends React.Component {
+                      static get displayName() {
+                        return 'Hello';
+                      }
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
-            r#"
-        	        const { createElement } = document;
-        	        createElement("a");
-        	      "#,
+            "
+                    class Hello extends React.Component {
+                      static displayName = 'Widget';
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var Hello = createReactClass({
+                      render: function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             None,
             None,
         ),
         (
             "
-        	        import React from 'react'
-        	        import { string } from 'prop-types'
-
-        	        function Component({ world }) {
-        	          return <div>Hello {world}</div>
-        	        }
-
-        	        Component.propTypes = {
-        	          world: string,
-        	        }
-
-        	        export default React.memo(Component)
-        	      ",
+                    class Hello extends React.Component {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        import React from 'react'
-
-        	        const ComponentWithMemo = React.memo(function Component({ world }) {
-        	          return <div>Hello {world}</div>
-        	        })
-        	      ",
+                    export default class Hello {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        import React from 'react'
-
-        	        const Hello = React.memo(function Hello() {
-        	          return;
-        	        });
-        	      ",
-            None,
-            None,
-        ),
-        (
-            "
-        	        import React from 'react'
-
-        	        const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {
-        	          return <div ref={ref}>Hello {world}</div>
-        	        })
-        	      ",
+                    var Hello;
+                    Hello = createReactClass({
+                      render: function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             None,
             None,
         ),
         (
             r#"
-        	        function F() {
-        	          let items = [];
-        	          let testData = [
-        	            {a: "test1", displayName: "test2"}, {a: "test1", displayName: "test2"}];
-        	          for (let item of testData) {
-        	              items.push({a: item.a, b: item.displayName});
-        	          }
-        	          return <div>{items}</div>;
-        	        }
-        	      "#,
+                    module.exports = createReactClass({
+                      "displayName": "Hello",
+                      "render": function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  "#,
+            None,
+            None,
+        ),
+        (
+            "
+                    var Hello = createReactClass({
+                      displayName: 'Hello',
+                      render: function() {
+                        let { a, ...b } = obj;
+                        let c = { ...d };
+                        return <div />;
+                      }
+                    });
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    export default class {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export const Hello = React.memo(function Hello() {
+                      return <p />;
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    var Hello = function() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    function Hello() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    var Hello = () => {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    module.exports = function Hello() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    function Hello() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                    Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var Hello = () => {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                    Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var Hello = function() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                    Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var Mixins = {
+                      Greetings: {
+                        Hello: function() {
+                          return <div>Hello {this.props.name}</div>;
+                        }
+                      }
+                    }
+                    Mixins.Greetings.Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var Hello = createReactClass({
+                      render: function() {
+                        return <div>{this._renderHello()}</div>;
+                      },
+                      _renderHello: function() {
+                        return <span>Hello {this.props.name}</span>;
+                      }
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    var Hello = createReactClass({
+                      displayName: 'Hello',
+                      render: function() {
+                        return <div>{this._renderHello()}</div>;
+                      },
+                      _renderHello: function() {
+                        return <span>Hello {this.props.name}</span>;
+                      }
+                    });
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    const Mixin = {
+                      Button() {
+                        return (
+                          <button />
+                        );
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    var obj = {
+                      pouf: function() {
+                        return any
+                      }
+                    };
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    var obj = {
+                      pouf: function() {
+                        return any
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    export default {
+                      renderHello() {
+                        let {name} = this.props;
+                        return <div>{name}</div>;
+                      }
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import React, { createClass } from 'react';
+                    export default createClass({
+                      displayName: 'Foo',
+                      render() {
+                        return <h1>foo</h1>;
+                      }
+                    });
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            Some(
+                serde_json::json!({ "settings": {        "react": {          "createClass": "createClass",        },      } }),
+            ),
+        ),
+        (
+            r#"
+                    import React, {Component} from "react";
+                    function someDecorator(ComposedComponent) {
+                      return class MyDecorator extends Component {
+                        render() {return <ComposedComponent {...this.props} />;}
+                      };
+                    }
+                    module.exports = someDecorator;
+                  "#,
+            None,
+            None,
+        ),
+        (
+            r#"
+                    import React, {createElement} from "react";
+                    const SomeComponent = (props) => {
+                      const {foo, bar} = props;
+                      return someComponentFactory({
+                        onClick: () => foo(bar("x"))
+                      });
+                    };
+                  "#,
+            None,
+            None,
+        ),
+        (
+            "
+                    const element = (
+                      <Media query={query} render={() => {
+                        renderWasCalled = true
+                        return <div/>
+                      }}/>
+                    )
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    const element = (
+                      <Media query={query} render={function() {
+                        renderWasCalled = true
+                        return <div/>
+                      }}/>
+                    )
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    module.exports = {
+                      createElement: tagName => document.createElement(tagName)
+                    };
+                  ",
+            None,
+            None,
+        ),
+        (
+            r#"
+                    const { createElement } = document;
+                    createElement("a");
+                  "#,
+            None,
+            None,
+        ),
+        (
+            "
+                    import React from 'react'
+                    import { string } from 'prop-types'
+
+                    function Component({ world }) {
+                      return <div>Hello {world}</div>
+                    }
+
+                    Component.propTypes = {
+                      world: string,
+                    }
+
+                    export default React.memo(Component)
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import React from 'react'
+
+                    const ComponentWithMemo = React.memo(function Component({ world }) {
+                      return <div>Hello {world}</div>
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import React from 'react'
+
+                    const Hello = React.memo(function Hello() {
+                      return;
+                    });
+                  ",
+            None,
+            None,
+        ),
+        (
+            "
+                    import React from 'react'
+
+                    const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {
+                      return <div ref={ref}>Hello {world}</div>
+                    })
+                  ",
+            None,
+            None,
+        ),
+        (
+            r#"
+                    function F() {
+                      let items = [];
+                      let testData = [
+                        {a: "test1", displayName: "test2"}, {a: "test1", displayName: "test2"}];
+                      for (let item of testData) {
+                          items.push({a: item.a, b: item.displayName});
+                      }
+                      return <div>{items}</div>;
+                    }
+                  "#,
             None,
             None,
         ),
@@ -1364,194 +1364,194 @@ fn test() {
         // ),
         (
             r#"
-        	        const x = {
-        	          title: "URL",
-        	          dataIndex: "url",
-        	          key: "url",
-        	          render: url => (
-        	            <a href={url} target="_blank" rel="noopener noreferrer">
-        	              <p>lol</p>
-        	            </a>
-        	          )
-        	        }
-        	      "#,
+                    const x = {
+                      title: "URL",
+                      dataIndex: "url",
+                      key: "url",
+                      render: url => (
+                        <a href={url} target="_blank" rel="noopener noreferrer">
+                          <p>lol</p>
+                        </a>
+                      )
+                    }
+                  "#,
             None,
             None,
         ),
         (
             "
-        	        const renderer = a => function Component(listItem) {
-        	          return <div>{a} {listItem}</div>;
-        	        };
-        	      ",
+                    const renderer = a => function Component(listItem) {
+                      return <div>{a} {listItem}</div>;
+                    };
+                  ",
             None,
             None,
         ),
         (
             "
-        	        const Comp = React.forwardRef((props, ref) => <main />);
-        	        Comp.displayName = 'MyCompName';
-        	      ",
+                    const Comp = React.forwardRef((props, ref) => <main />);
+                    Comp.displayName = 'MyCompName';
+                  ",
             None,
             None,
         ),
         (
             r#"
-        	        const Comp = React.forwardRef((props, ref) => <main data-as="yes" />) as SomeComponent;
-        	        Comp.displayName = 'MyCompNameAs';
-        	      "#,
+                    const Comp = React.forwardRef((props, ref) => <main data-as="yes" />) as SomeComponent;
+                    Comp.displayName = 'MyCompNameAs';
+                  "#,
             None,
             None,
         ),
         (
             "
-        	        function Test() {
-        	          const data = [
-        	            {
-        	              name: 'Bob',
-        	            },
-        	          ];
+                    function Test() {
+                      const data = [
+                        {
+                          name: 'Bob',
+                        },
+                      ];
 
-        	          const columns = [
-        	            {
-        	              Header: 'Name',
-        	              accessor: 'name',
-        	              Cell: ({ value }) => <div>{value}</div>,
-        	            },
-        	          ];
+                      const columns = [
+                        {
+                          Header: 'Name',
+                          accessor: 'name',
+                          Cell: ({ value }) => <div>{value}</div>,
+                        },
+                      ];
 
-        	          return <ReactTable columns={columns} data={data} />;
-        	        }
-        	      ",
+                      return <ReactTable columns={columns} data={data} />;
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        const f = (a) => () => {
-        	          if (a) {
-        	            return null;
-        	          }
-        	          return 1;
-        	        };
-        	      ",
+                    const f = (a) => () => {
+                      if (a) {
+                        return null;
+                      }
+                      return 1;
+                    };
+                  ",
             None,
             None,
         ),
         (
             "
-        	        class Test {
-        	          render() {
-        	            const data = [
-        	              {
-        	                name: 'Bob',
-        	                Cell: ({ value }) => <div>{value}</div>,
-        	              },
-        	            ];
+                    class Test {
+                      render() {
+                        const data = [
+                          {
+                            name: 'Bob',
+                            Cell: ({ value }) => <div>{value}</div>,
+                          },
+                        ];
 
-        	            return <ReactTable columns={columns} data={data} />;
-        	          }
-        	        }
-        	      ",
+                        return <ReactTable columns={columns} data={data} />;
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        export const demo = (a) => (b) => {
-        	          if (a == null) return null;
-        	          return b;
-        	        }
-        	      ",
+                    export const demo = (a) => (b) => {
+                      if (a == null) return null;
+                      return b;
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        let demo = null;
-        	        demo = (a) => {
-        	          if (a == null) return null;
-        	          return f(a);
-        	        };",
+                    let demo = null;
+                    demo = (a) => {
+                      if (a == null) return null;
+                      return f(a);
+                    };",
             None,
             None,
         ),
         (
             "
-        	        obj._property = (a) => {
-        	          if (a == null) return null;
-        	          return f(a);
-        	        };
-        	      ",
+                    obj._property = (a) => {
+                      if (a == null) return null;
+                      return f(a);
+                    };
+                  ",
             None,
             None,
         ),
         (
             "
-        	        _variable = (a) => {
-        	          if (a == null) return null;
-        	          return f(a);
-        	        };
-        	      ",
+                    _variable = (a) => {
+                      if (a == null) return null;
+                      return f(a);
+                    };
+                  ",
             None,
             None,
         ),
         (
             "
-        	        demo = () => () => null;
-        	      ",
+                    demo = () => () => null;
+                  ",
             None,
             None,
         ),
         (
             "
-        	        demo = {
-        	          property: () => () => null
-        	        }
-        	      ",
+                    demo = {
+                      property: () => () => null
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        demo = function() {return function() {return null;};};
-        	      ",
+                    demo = function() {return function() {return null;};};
+                  ",
             None,
             None,
         ),
         (
             "
-        	        demo = {
-        	          property: function() {return function() {return null;};}
-        	        }
-        	      ",
+                    demo = {
+                      property: function() {return function() {return null;};}
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-        	        function MyComponent(props) {
-        	          return <b>{props.name}</b>;
-        	        }
+                    function MyComponent(props) {
+                      return <b>{props.name}</b>;
+                    }
 
-        	        const MemoizedMyComponent = React.memo(
-        	          MyComponent,
-        	          (prevProps, nextProps) => prevProps.name === nextProps.name
-        	        )
-        	      ",
+                    const MemoizedMyComponent = React.memo(
+                      MyComponent,
+                      (prevProps, nextProps) => prevProps.name === nextProps.name
+                    )
+                  ",
             None,
             None,
         ),
         (
             "
-        	        import React from 'react'
+                    import React from 'react'
 
-        	        const MemoizedForwardRefComponentLike = React.memo(
-        	          React.forwardRef(function({ world }, ref) {
-        	            return <div ref={ref}>Hello {world}</div>
-        	          })
-        	        )
-        	      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(function({ world }, ref) {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "16.14.0",        },      } }),
@@ -1559,14 +1559,14 @@ fn test() {
         ),
         (
             "
-        	        import React from 'react'
+                    import React from 'react'
 
-        	        const MemoizedForwardRefComponentLike = React.memo(
-        	          React.forwardRef(({ world }, ref) => {
-        	            return <div ref={ref}>Hello {world}</div>
-        	          })
-        	        )
-        	      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(({ world }, ref) => {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "15.7.0",        },      } }),
@@ -1574,14 +1574,14 @@ fn test() {
         ),
         (
             "
-        	        import React from 'react'
+                    import React from 'react'
 
-        	        const MemoizedForwardRefComponentLike = React.memo(
-        	          React.forwardRef(function ComponentLike({ world }, ref) {
-        	            return <div ref={ref}>Hello {world}</div>
-        	          })
-        	        )
-        	      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(function ComponentLike({ world }, ref) {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "16.12.1",        },      } }),
@@ -1589,12 +1589,12 @@ fn test() {
         ),
         (
             "
-        	        export const ComponentWithForwardRef = React.memo(
-        	          React.forwardRef(function Component({ world }) {
-        	            return <div>Hello {world}</div>
-        	          })
-        	        )
-        	      ",
+                    export const ComponentWithForwardRef = React.memo(
+                      React.forwardRef(function Component({ world }) {
+                        return <div>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "0.14.11",        },      } }),
@@ -1602,14 +1602,14 @@ fn test() {
         ),
         (
             "
-        	        import React from 'react'
+                    import React from 'react'
 
-        	        const MemoizedForwardRefComponentLike = React.memo(
-        	          React.forwardRef(function({ world }, ref) {
-        	            return <div ref={ref}>Hello {world}</div>
-        	          })
-        	        )
-        	      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(function({ world }, ref) {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "15.7.1",        },      } }),
@@ -1617,66 +1617,66 @@ fn test() {
         ),
         (
             r#"
-        	        import React from 'react';
+                    import React from 'react';
 
-        	        const Hello = React.createContext();
-        	        Hello.displayName = "HelloContext"
-        	      "#,
+                    const Hello = React.createContext();
+                    Hello.displayName = "HelloContext"
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        const Hello = createContext();
-        	        Hello.displayName = "HelloContext"
-        	      "#,
+                    const Hello = createContext();
+                    Hello.displayName = "HelloContext"
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        const Hello = createContext();
+                    const Hello = createContext();
 
-        	        const obj = {};
-        	        obj.displayName = "False positive";
+                    const obj = {};
+                    obj.displayName = "False positive";
 
-        	        Hello.displayName = "HelloContext"
-        	      "#,
+                    Hello.displayName = "HelloContext"
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             r#"
-        	        import * as React from 'react';
+                    import * as React from 'react';
 
-        	        const Hello = React.createContext();
+                    const Hello = React.createContext();
 
-        	        const obj = {};
-        	        obj.displayName = "False positive";
+                    const obj = {};
+                    obj.displayName = "False positive";
 
-        	        Hello.displayName = "HelloContext";
-        	      "#,
+                    Hello.displayName = "HelloContext";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             r#"
-        	        const obj = {};
-        	        obj.displayName = "False positive";
-        	      "#,
+                    const obj = {};
+                    obj.displayName = "False positive";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        const Hello = createContext();
-        	      ",
+                    const Hello = createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "16.2.0",        },      } }),
@@ -1684,11 +1684,11 @@ fn test() {
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        const Hello = createContext();
-        	        Hello.displayName = "HelloContext";
-        	      "#,
+                    const Hello = createContext();
+                    Hello.displayName = "HelloContext";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "16.4.0",        },      } }),
@@ -1696,21 +1696,21 @@ fn test() {
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        let Hello;
-        	        Hello = createContext();
-        	        Hello.displayName = "HelloContext";
-        	      "#,
+                    let Hello;
+                    Hello = createContext();
+                    Hello.displayName = "HelloContext";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        const Hello = createContext();
-        	      ",
+                    const Hello = createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": false }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "16.4.0",        },      } }),
@@ -1718,23 +1718,23 @@ fn test() {
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        var Hello;
-        	        Hello = createContext();
-        	        Hello.displayName = "HelloContext";
-        	      "#,
+                    var Hello;
+                    Hello = createContext();
+                    Hello.displayName = "HelloContext";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             r#"
-        	        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-        	        var Hello;
-        	        Hello = React.createContext();
-        	        Hello.displayName = "HelloContext";
-        	      "#,
+                    var Hello;
+                    Hello = React.createContext();
+                    Hello.displayName = "HelloContext";
+                  "#,
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
@@ -1743,23 +1743,23 @@ fn test() {
     let fail = vec![
         (
             r#"
-        	        var Hello = createReactClass({
-        	          render: function() {
-        	            return React.createElement("div", {}, "text content");
-        	          }
-        	        });
-        	      "#,
+                    var Hello = createReactClass({
+                      render: function() {
+                        return React.createElement("div", {}, "text content");
+                      }
+                    });
+                  "#,
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
             r#"
-        	        var Hello = React.createClass({
-        	          render: function() {
-        	            return React.createElement("div", {}, "text content");
-        	          }
-        	        });
-        	      "#,
+                    var Hello = React.createClass({
+                      render: function() {
+                        return React.createElement("div", {}, "text content");
+                      }
+                    });
+                  "#,
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "createClass": "createClass",        },      } }),
@@ -1767,23 +1767,23 @@ fn test() {
         ),
         (
             "
-			        var Hello = createReactClass({
-			          render: function() {
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        });
-			      ",
+                    var Hello = createReactClass({
+                      render: function() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
             "
-			        class Hello extends React.Component {
-			          render() {
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        }
-			      ",
+                    class Hello extends React.Component {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
@@ -1796,58 +1796,58 @@ fn test() {
         // which adds significant complexity. This is a rare pattern in practice.
         (
             "
-			        module.exports = () => {
-			          return <div>Hello {props.name}</div>;
-			        }
-			      ",
+                    module.exports = () => {
+                      return <div>Hello {props.name}</div>;
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-			        module.exports = function() {
-			          return <div>Hello {props.name}</div>;
-			        }
-			      ",
+                    module.exports = function() {
+                      return <div>Hello {props.name}</div>;
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-			        module.exports = createReactClass({
-			          render() {
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        });
-			      ",
+                    module.exports = createReactClass({
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    });
+                  ",
             None,
             None,
         ),
         (
             "
-			        var Hello = createReactClass({
-			          _renderHello: function() {
-			            return <span>Hello {this.props.name}</span>;
-			          },
-			          render: function() {
-			            return <div>{this._renderHello()}</div>;
-			          }
-			        });
-			      ",
+                    var Hello = createReactClass({
+                      _renderHello: function() {
+                        return <span>Hello {this.props.name}</span>;
+                      },
+                      render: function() {
+                        return <div>{this._renderHello()}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
             "
-			        var Hello = Foo.createClass({
-			          _renderHello: function() {
-			            return <span>Hello {this.props.name}</span>;
-			          },
-			          render: function() {
-			            return <div>{this._renderHello()}</div>;
-			          }
-			        });
-			      ",
+                    var Hello = Foo.createClass({
+                      _renderHello: function() {
+                        return <span>Hello {this.props.name}</span>;
+                      },
+                      render: function() {
+                        return <div>{this._renderHello()}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "pragma": "Foo",          "createClass": "createClass",        },      } }),
@@ -1855,16 +1855,16 @@ fn test() {
         ),
         (
             "
-			        /** @jsx Foo */
-			        var Hello = Foo.createClass({
-			          _renderHello: function() {
-			            return <span>Hello {this.props.name}</span>;
-			          },
-			          render: function() {
-			            return <div>{this._renderHello()}</div>;
-			          }
-			        });
-			      ",
+                    /** @jsx Foo */
+                    var Hello = Foo.createClass({
+                      _renderHello: function() {
+                        return <span>Hello {this.props.name}</span>;
+                      },
+                      render: function() {
+                        return <div>{this._renderHello()}</div>;
+                      }
+                    });
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             Some(
                 serde_json::json!({ "settings": {        "react": {          "createClass": "createClass",        },      } }),
@@ -1872,92 +1872,92 @@ fn test() {
         ),
         (
             "
-			        const Mixin = {
-			          Button() {
-			            return (
-			              <button />
-			            );
-			          }
-			        };
-			      ",
+                    const Mixin = {
+                      Button() {
+                        return (
+                          <button />
+                        );
+                      }
+                    };
+                  ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
         (
             "
-			        function Hof() {
-			          return function () {
-			            return <div />
-			          }
-			        }
-			      ",
+                    function Hof() {
+                      return function () {
+                        return <div />
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             r#"
-			        import React, { createElement } from "react";
-			        export default (props) => {
-			          return createElement("div", {}, "hello");
-			        };
-			      "#,
+                    import React, { createElement } from "react";
+                    export default (props) => {
+                      return createElement("div", {}, "hello");
+                    };
+                  "#,
             None,
             None,
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const ComponentWithMemo = React.memo(({ world }) => {
-			          return <div>Hello {world}</div>
-			        })
-			      ",
+                    const ComponentWithMemo = React.memo(({ world }) => {
+                      return <div>Hello {world}</div>
+                    })
+                  ",
             None,
             None,
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const ComponentWithMemo = React.memo(function() {
-			          return <div>Hello {world}</div>
-			        })
-			      ",
+                    const ComponentWithMemo = React.memo(function() {
+                      return <div>Hello {world}</div>
+                    })
+                  ",
             None,
             None,
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
-			          return <div ref={ref}>Hello {world}</div>
-			        })
-			      ",
+                    const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
+                      return <div ref={ref}>Hello {world}</div>
+                    })
+                  ",
             None,
             None,
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const ForwardRefComponentLike = React.forwardRef(function({ world }, ref) {
-			          return <div ref={ref}>Hello {world}</div>
-			        })
-			      ",
+                    const ForwardRefComponentLike = React.forwardRef(function({ world }, ref) {
+                      return <div ref={ref}>Hello {world}</div>
+                    })
+                  ",
             None,
             None,
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const MemoizedForwardRefComponentLike = React.memo(
-			          React.forwardRef(({ world }, ref) => {
-			            return <div ref={ref}>Hello {world}</div>
-			          })
-			        )
-			      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(({ world }, ref) => {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "15.6.0",        },      } }),
@@ -1965,14 +1965,14 @@ fn test() {
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const MemoizedForwardRefComponentLike = React.memo(
-			          React.forwardRef(function({ world }, ref) {
-			            return <div ref={ref}>Hello {world}</div>
-			          })
-			        )
-			      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(function({ world }, ref) {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "0.14.2",        },      } }),
@@ -1980,14 +1980,14 @@ fn test() {
         ),
         (
             "
-			        import React from 'react'
+                    import React from 'react'
 
-			        const MemoizedForwardRefComponentLike = React.memo(
-			          React.forwardRef(function ComponentLike({ world }, ref) {
-			            return <div ref={ref}>Hello {world}</div>
-			          })
-			        )
-			      ",
+                    const MemoizedForwardRefComponentLike = React.memo(
+                      React.forwardRef(function ComponentLike({ world }, ref) {
+                        return <div ref={ref}>Hello {world}</div>
+                      })
+                    )
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": {        "react": {          "version": "15.0.1",        },      } }),
@@ -1995,126 +1995,126 @@ fn test() {
         ),
         (
             r#"
-			        import React from "react";
-			        const { createElement } = React;
-			        export default (props) => {
-			          return createElement("div", {}, "hello");
-			        };
-			      "#,
+                    import React from "react";
+                    const { createElement } = React;
+                    export default (props) => {
+                      return createElement("div", {}, "hello");
+                    };
+                  "#,
             None,
             None,
         ),
         (
             r#"
-			        import React from "react";
-			        const createElement = React.createElement;
-			        export default (props) => {
-			          return createElement("div", {}, "hello");
-			        };
-			      "#,
+                    import React from "react";
+                    const createElement = React.createElement;
+                    export default (props) => {
+                      return createElement("div", {}, "hello");
+                    };
+                  "#,
             None,
             None,
         ),
         (
             r#"
-			        module.exports = function () {
-			          function a () {}
-			          const b = function b () {}
-			          const c = function () {}
-			          const d = () => {}
-			          const obj = {
-			            a: function a () {},
-			            b: function b () {},
-			            c () {},
-			            d: () => {},
-			          }
-			          return React.createElement("div", {}, "text content");
-			        }
-			      "#,
+                    module.exports = function () {
+                      function a () {}
+                      const b = function b () {}
+                      const c = function () {}
+                      const d = () => {}
+                      const obj = {
+                        a: function a () {},
+                        b: function b () {},
+                        c () {},
+                        d: () => {},
+                      }
+                      return React.createElement("div", {}, "text content");
+                    }
+                  "#,
             None,
             None,
         ),
         (
             r#"
-			        module.exports = () => {
-			          function a () {}
-			          const b = function b () {}
-			          const c = function () {}
-			          const d = () => {}
-			          const obj = {
-			            a: function a () {},
-			            b: function b () {},
-			            c () {},
-			            d: () => {},
-			          }
+                    module.exports = () => {
+                      function a () {}
+                      const b = function b () {}
+                      const c = function () {}
+                      const d = () => {}
+                      const obj = {
+                        a: function a () {},
+                        b: function b () {},
+                        c () {},
+                        d: () => {},
+                      }
 
-			          return React.createElement("div", {}, "text content");
-			        }
-			      "#,
+                      return React.createElement("div", {}, "text content");
+                    }
+                  "#,
             None,
             None,
         ),
         (
             "
-			        export default class extends React.Component {
-			          render() {
-			            function a () {}
-			            const b = function b () {}
-			            const c = function () {}
-			            const d = () => {}
-			            const obj = {
-			              a: function a () {},
-			              b: function b () {},
-			              c () {},
-			              d: () => {},
-			            }
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        }
-			      ",
+                    export default class extends React.Component {
+                      render() {
+                        function a () {}
+                        const b = function b () {}
+                        const c = function () {}
+                        const d = () => {}
+                        const obj = {
+                          a: function a () {},
+                          b: function b () {},
+                          c () {},
+                          d: () => {},
+                        }
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
             None,
             None,
         ),
         (
             "
-			        export default class extends React.PureComponent {
-			          render() {
-			            return <Card />;
-			          }
-			        }
+                    export default class extends React.PureComponent {
+                      render() {
+                        return <Card />;
+                      }
+                    }
 
-			        const Card = (() => {
-			          return React.memo(({ }) => (
-			            <div />
-			          ));
-			        })();
-			      ",
+                    const Card = (() => {
+                      return React.memo(({ }) => (
+                        <div />
+                      ));
+                    })();
+                  ",
             None,
             None,
         ),
         (
             "
-			        const renderer = a => listItem => (
-			          <div>{a} {listItem}</div>
-			        );
-			      ",
+                    const renderer = a => listItem => (
+                      <div>{a} {listItem}</div>
+                    );
+                  ",
             None,
             None,
         ),
         (
             "
-        	        const processData = (options?: { value: string }) => options?.value || 'no data';
+                    const processData = (options?: { value: string }) => options?.value || 'no data';
 
-        	        export const Component = observer(() => {
-        	          const data = processData({ value: 'data' });
-        	          return <div>{data}</div>;
-        	        });
+                    export const Component = observer(() => {
+                      const data = processData({ value: 'data' });
+                      return <div>{data}</div>;
+                    });
 
-        	        export const Component2 = observer(() => {
-        	          const data = processData();
-        	          return <div>{data}</div>;
-        	        });
-        	      ",
+                    export const Component2 = observer(() => {
+                      const data = processData();
+                      return <div>{data}</div>;
+                    });
+                  ",
             None,
             Some(
                 serde_json::json!({ "settings": { "react": { "componentWrapperFunctions": ["observer"] } } }),
@@ -2122,48 +2122,48 @@ fn test() {
         ),
         (
             "
-			        import React from 'react';
+                    import React from 'react';
 
-			        const Hello = React.createContext();
-			      ",
+                    const Hello = React.createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-			        import * as React from 'react';
+                    import * as React from 'react';
 
-			        const Hello = React.createContext();
-			      ",
+                    const Hello = React.createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-			        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-			        const Hello = createContext();
-			      ",
+                    const Hello = createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-			        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-			        var Hello;
-			        Hello = createContext();
-			      ",
+                    var Hello;
+                    Hello = createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
         (
             "
-			        import { createContext } from 'react';
+                    import { createContext } from 'react';
 
-			        var Hello;
-			        Hello = React.createContext();
-			      ",
+                    var Hello;
+                    Hello = React.createContext();
+                  ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -101,9 +101,9 @@ fn test() {
         ("ReactDOM.render(<div />, document.body);", None),
         (
             "
-        	        let node;
-        	        ReactDOM.render(<div ref={ref => node = ref}/>, document.body);
-        	      ",
+                    let node;
+                    ReactDOM.render(<div ref={ref => node = ref}/>, document.body);
+                  ",
             None,
         ),
         ("ReactDOM.render(<div ref={ref => this.node = ref}/>, document.body);", None),
@@ -122,18 +122,18 @@ fn test() {
         ("var Hello = ReactDOM.render(<div />, document.body);", None),
         (
             "
-        	        var o = {
-        	          inst: ReactDOM.render(<div />, document.body)
-        	        };
-        	      ",
+                    var o = {
+                      inst: ReactDOM.render(<div />, document.body)
+                    };
+                  ",
             None,
         ),
         (
             "
-        	        function render () {
-        	          return ReactDOM.render(<div />, document.body)
-        	        }
-        	      ",
+                    function render () {
+                      return ReactDOM.render(<div />, document.body)
+                    }
+                  ",
             None,
         ),
         ("var render = (a, b) => ReactDOM.render(a, b)", None),

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -246,85 +246,85 @@ fn test() {
     let pass = vec![
         // &too_many_if_else_case,
         r"
-			        class Hello extends React.Component {
-			          render() {
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        }
-			      ",
+                    class Hello extends React.Component {
+                      render() {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
         r"
-			        class Hello extends React.Component {
-			          render = () => {
-			            return <div>Hello {this.props.name}</div>;
-			          }
-			        }
-			      ",
+                    class Hello extends React.Component {
+                      render = () => {
+                        return <div>Hello {this.props.name}</div>;
+                      }
+                    }
+                  ",
         r"
-			        class Hello extends React.Component {
-			          render = () => (
-			            <div>Hello {this.props.name}</div>
-			          )
-			        }
-			      ",
+                    class Hello extends React.Component {
+                      render = () => (
+                        <div>Hello {this.props.name}</div>
+                      )
+                    }
+                  ",
         r"
-			        var Hello = createReactClass({
-			          displayName: 'Hello',
-			          render: function() {
-			            return <div></div>
-			          }
-			        });
-			      ",
+                    var Hello = createReactClass({
+                      displayName: 'Hello',
+                      render: function() {
+                        return <div></div>
+                      }
+                    });
+                  ",
         r"
-			        function Hello() {
-			          return <div></div>;
-			        }
-			      ",
+                    function Hello() {
+                      return <div></div>;
+                    }
+                  ",
         r"
-			        var Hello = () => (
-			          <div></div>
-			        );
-			      ",
+                    var Hello = () => (
+                      <div></div>
+                    );
+                  ",
         r"
-			        var Hello = createReactClass({
-			          render: function() {
-			            switch (this.props.name) {
-			              case 'Foo':
-			                return <div>Hello Foo</div>;
-			              default:
-			                return <div>Hello {this.props.name}</div>;
-			            }
-			          }
-			        });
-			      ",
+                    var Hello = createReactClass({
+                      render: function() {
+                        switch (this.props.name) {
+                          case 'Foo':
+                            return <div>Hello Foo</div>;
+                          default:
+                            return <div>Hello {this.props.name}</div>;
+                        }
+                      }
+                    });
+                  ",
         r"
-			        var Hello = createReactClass({
-			          render: function() {
-			            if (this.props.name === 'Foo') {
-			              return <div>Hello Foo</div>;
-			            } else {
-			              return <div>Hello {this.props.name}</div>;
-			            }
-			          }
-			        });
-			      ",
+                    var Hello = createReactClass({
+                      render: function() {
+                        if (this.props.name === 'Foo') {
+                          return <div>Hello Foo</div>;
+                        } else {
+                          return <div>Hello {this.props.name}</div>;
+                        }
+                      }
+                    });
+                  ",
         r"
-			        class Hello {
-			          render() {}
-			        }
-			      ",
+                    class Hello {
+                      render() {}
+                    }
+                  ",
         r"class Hello extends React.Component {}",
         r"var Hello = createReactClass({});",
         r"
-			        var render = require('./render');
-			        var Hello = createReactClass({
-			          render
-			        });
-			      ",
+                    var render = require('./render');
+                    var Hello = createReactClass({
+                      render
+                    });
+                  ",
         r"
-			        class Foo extends Component {
-			          render
-			        }
-			      ",
+                    class Foo extends Component {
+                      render
+                    }
+                  ",
         r"
            class Foo extends Component {
              render = () => {
@@ -338,32 +338,32 @@ fn test() {
 
     let fail = vec![
         r"
-        	        var Hello = createReactClass({
-        	          displayName: 'Hello',
-        	          render: function() {}
-        	        });
-        	      ",
+                    var Hello = createReactClass({
+                      displayName: 'Hello',
+                      render: function() {}
+                    });
+                  ",
         r"
-        	        class Hello extends React.Component {
-        	          render() {}
-        	        }
-        	      ",
+                    class Hello extends React.Component {
+                      render() {}
+                    }
+                  ",
         r"
-        	        class Hello extends React.Component {
-        	          render() {
-        	            const names = this.props.names.map(function(name) {
-        	              return <div>{name}</div>
-        	            });
-        	          }
-        	        }
-        	      ",
+                    class Hello extends React.Component {
+                      render() {
+                        const names = this.props.names.map(function(name) {
+                          return <div>{name}</div>
+                        });
+                      }
+                    }
+                  ",
         r"
-        	        class Hello extends React.Component {
-        	          render = () => {
-        	            <div>Hello {this.props.name}</div>
-        	          }
-        	        }
-        	      ",
+                    class Hello extends React.Component {
+                      render = () => {
+                        <div>Hello {this.props.name}</div>
+                      }
+                    }
+                  ",
         r"
             class Hello extends React.Component {
               render() {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -39,13 +39,13 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```js
     /// window.addEventListener('keydown', event => {
-    /// 	if (event.keyCode === 8) {
-    /// 		console.log('Backspace was pressed');
-    /// 	}
+    ///     if (event.keyCode === 8) {
+    ///         console.log('Backspace was pressed');
+    ///     }
     /// });
     ///
     /// window.addEventListener('keydown', event => {
-    /// 	console.log(event.keyCode);
+    ///     console.log(event.keyCode);
     /// });
     /// ```
     ///
@@ -53,12 +53,12 @@ declare_oxc_lint!(
     /// ```js
     /// window.addEventListener('keydown', event => {
     ///     if (event.key === 'Backspace') {
-    ///     	console.log('Backspace was pressed');
+    ///       console.log('Backspace was pressed');
     ///     }
     /// });
     ///
     /// window.addEventListener('click', event => {
-    /// 	console.log(event.key);
+    ///     console.log(event.key);
     /// });
     /// ```
     PreferKeyboardEventKey,

--- a/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
@@ -191,114 +191,114 @@ fn test() {
     let pass = vec![
         (
             "
-			      <script setup>
-			        /* ✓ GOOD */
-			        defineEmits({ notify: null })
-			      </script>
-			      ",
+                  <script setup>
+                    /* ✓ GOOD */
+                    defineEmits({ notify: null })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			        /* ✓ GOOD */
-			        defineEmits(['notify'])
-			      </script>
-			      ",
+                  <script setup>
+                    /* ✓ GOOD */
+                    defineEmits(['notify'])
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			        /* ✓ GOOD */
-			        defineEmits<(e: 'notify')=>void>()
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                    /* ✓ GOOD */
+                    defineEmits<(e: 'notify')=>void>()
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") }      },
         (
             "
-        	      <script>
-        	        const def = { notify: null }
-        	      </script>
-        	      <script setup>
-        	        /* ✓ GOOD */
-        	        defineEmits(def)
-        	      </script>
-        	      ",
+                  <script>
+                    const def = { notify: null }
+                  </script>
+                  <script setup>
+                    /* ✓ GOOD */
+                    defineEmits(def)
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-			      <script setup>
-			        defineEmits({
-			          notify (payload) {
-			            return typeof payload === 'string'
-			          }
-			        })
-			      </script>
-			      ",
+                  <script setup>
+                    defineEmits({
+                      notify (payload) {
+                        return typeof payload === 'string'
+                      }
+                    })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			      import type { PropType } from 'vue';
+                  <script setup lang="ts">
+                  import type { PropType } from 'vue';
 
-			      type X = string;
+                  type X = string;
 
-			      const props = defineProps({
-			        myProp: Array as PropType<string[]>,
-			      });
+                  const props = defineProps({
+                    myProp: Array as PropType<string[]>,
+                  });
 
-			      const emit = defineEmits({
-			        myProp: (x: X) => true,
-			      });
-			      </script>
-			      "#,
+                  const emit = defineEmits({
+                    myProp: (x: X) => true,
+                  });
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
         (
             r#"
-			      <script setup lang="ts">
-			      import type { PropType } from 'vue';
+                  <script setup lang="ts">
+                  import type { PropType } from 'vue';
 
-			      const strList = ['a', 'b', 'c']
-			      const str = 'abc'
+                  const strList = ['a', 'b', 'c']
+                  const str = 'abc'
 
-			      const props = defineProps({
-			        myProp: Array as PropType<typeof strList>,
-			      });
+                  const props = defineProps({
+                    myProp: Array as PropType<typeof strList>,
+                  });
 
-			      const emit = defineEmits({
-			        myProp: (x: typeof str) => true,
-			      });
-			      </script>
-			      "#,
+                  const emit = defineEmits({
+                    myProp: (x: typeof str) => true,
+                  });
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
         (
             "
-			      <script setup>
-			      import { propsDef, emitsDef } from './defs';
+                  <script setup>
+                  import { propsDef, emitsDef } from './defs';
 
-			      defineProps(propsDef);
-			      defineEmits(emitsDef);
-			      </script>",
+                  defineProps(propsDef);
+                  defineEmits(emitsDef);
+                  </script>",
             None,
             None,
             Some(PathBuf::from("test.vue")),
@@ -317,9 +317,9 @@ fn test() {
         ),
         (
             "
-			      <script setup>
-			      defineEmits(unResolvedVariable);
-			      </script>",
+                  <script setup>
+                  defineEmits(unResolvedVariable);
+                  </script>",
             None,
             None,
             Some(PathBuf::from("test.vue")),
@@ -329,51 +329,51 @@ fn test() {
     let fail = vec![
         (
             "
-			      <script setup>
-			        /* ✗ BAD */
-			        const def = { notify: null }
-			        defineEmits(def)
-			      </script>
-			      ",
+                  <script setup>
+                    /* ✗ BAD */
+                    const def = { notify: null }
+                    defineEmits(def)
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             r#"
-			      <script setup lang="ts">
-			        /* ✗ BAD */
-			        defineEmits<(e: 'notify')=>void>({ submit: null })
-			      </script>
-			      "#,
+                  <script setup lang="ts">
+                    /* ✗ BAD */
+                    defineEmits<(e: 'notify')=>void>({ submit: null })
+                  </script>
+                  "#,
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") }      },
         (
             "
-			      <script setup>
-			        /* ✗ BAD */
-			        defineEmits({ notify: null })
-			        defineEmits({ submit: null })
-			      </script>
-			      ",
+                  <script setup>
+                    /* ✗ BAD */
+                    defineEmits({ notify: null })
+                    defineEmits({ submit: null })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
         ),
         (
             "
-        	      <script>
-        	      export default {
-        	        emits: ['notify']
-        	      }
-        	      </script>
-        	      <script setup>
-        	        /* ✗ BAD */
-        	        defineEmits({ submit: null })
-        	      </script>
-        	      ",
+                  <script>
+                  export default {
+                    emits: ['notify']
+                  }
+                  </script>
+                  <script setup>
+                    /* ✗ BAD */
+                    defineEmits({ submit: null })
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),
@@ -394,11 +394,11 @@ fn test() {
         ),
         (
             "
-			      <script setup>
-			        /* ✗ BAD */
-			        defineEmits()
-			      </script>
-			      ",
+                  <script setup>
+                    /* ✗ BAD */
+                    defineEmits()
+                  </script>
+                  ",
             None,
             None,
             Some(PathBuf::from("test.vue")),

--- a/crates/oxc_linter/src/snapshots/eslint_max_params.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_max_params.snap
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
   ⚠ eslint(max-params): Function has too many parameters (4). Maximum allowed is 3.
-   ╭─[max_params.tsx:3:20]
+   ╭─[max_params.tsx:3:23]
  2 │               class Foo {
  3 │                 method(this: void, a, b, c, d) {}
    ·                       ────────────────────────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
   ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
-   ╭─[max_params.tsx:3:20]
+   ╭─[max_params.tsx:3:23]
  2 │               class Foo {
  3 │                 method(this: void, a) {}
    ·                       ───────────────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
   ⚠ eslint(max-params): Function has too many parameters (2). Maximum allowed is 1.
-   ╭─[max_params.tsx:3:20]
+   ╭─[max_params.tsx:3:23]
  2 │               class Foo {
  3 │                 method(this: void, a) {}
    ·                       ───────────────
@@ -171,7 +171,7 @@ source: crates/oxc_linter/src/tester.rs
   help: This rule enforces a maximum number of parameters allowed in function definitions.
 
   ⚠ eslint(max-params): Function has too many parameters (4). Maximum allowed is 3.
-   ╭─[max_params.tsx:3:20]
+   ╭─[max_params.tsx:3:23]
  2 │               class Foo {
  3 │                 method(this: Foo, a, b, c) {}
    ·                       ────────────────────

--- a/crates/oxc_linter/src/snapshots/eslint_no_alert.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_alert.snap
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a custom UI instead
 
   ⚠ eslint(no-alert): `alert`, `confirm` and `prompt` functions are not allowed
-   ╭─[no_alert.tsx:2:10]
+   ╭─[no_alert.tsx:2:13]
  1 │ var alert = function() {};
  2 │             window.alert(foo)
    ·             ────────────
@@ -95,7 +95,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a custom UI instead
 
   ⚠ eslint(no-alert): `alert`, `confirm` and `prompt` functions are not allowed
-   ╭─[no_alert.tsx:2:10]
+   ╭─[no_alert.tsx:2:13]
  1 │ function foo() { var alert = function() {}; }
  2 │             alert();
    ·             ─────
@@ -117,7 +117,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a custom UI instead
 
   ⚠ eslint(no-alert): `alert`, `confirm` and `prompt` functions are not allowed
-   ╭─[no_alert.tsx:2:10]
+   ╭─[no_alert.tsx:2:13]
  1 │ function foo() { var window = bar; window.alert(); }
  2 │             window.alert();
    ·             ────────────
@@ -139,7 +139,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a custom UI instead
 
   ⚠ eslint(no-alert): `alert`, `confirm` and `prompt` functions are not allowed
-   ╭─[no_alert.tsx:2:10]
+   ╭─[no_alert.tsx:2:13]
  1 │ function foo() { var globalThis = bar; globalThis.alert(); }
  2 │             globalThis.alert();
    ·             ────────────────

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
@@ -1229,7 +1229,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:19]
+   ╭─[no_shadow.tsx:3:22]
  2 │               {
  3 │                 type A = 1;
    ·                      ┬
@@ -1243,7 +1243,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:24]
+   ╭─[no_shadow.tsx:3:27]
  2 │               {
  3 │                 interface A {}
    ·                           ┬
@@ -1309,7 +1309,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:19]
+   ╭─[no_shadow.tsx:3:22]
  2 │               {
  3 │                 type A = 1;
    ·                      ┬
@@ -1323,7 +1323,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:24]
+   ╭─[no_shadow.tsx:3:27]
  2 │               {
  3 │                 interface A {}
    ·                           ┬
@@ -1350,7 +1350,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'foo' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:21]
+   ╭─[no_shadow.tsx:3:27]
  2 │                 if (true) {
  3 │                     const foo = 6;
    ·                           ─┬─
@@ -1365,7 +1365,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'foo' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'Foo' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:23]
+   ╭─[no_shadow.tsx:3:26]
  2 │                 // types
  3 │                 type Bar<Foo> = 1;
    ·                          ─┬─
@@ -1378,7 +1378,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'Foo' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'b' is already declared in the upper scope.
-    ╭─[no_shadow.tsx:8:21]
+    ╭─[no_shadow.tsx:8:27]
   7 │                 if (true) {
   8 │                     const b = 6;
     ·                           ┬
@@ -1393,7 +1393,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'b' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'Foo' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:23]
+   ╭─[no_shadow.tsx:3:26]
  2 │                 // types
  3 │                 type Bar<Foo> = 1;
    ·                          ─┬─
@@ -1445,7 +1445,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:19]
+   ╭─[no_shadow.tsx:3:22]
  2 │               {
  3 │                 type A = 1;
    ·                      ┬
@@ -1459,7 +1459,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:3:24]
+   ╭─[no_shadow.tsx:3:27]
  2 │               {
  3 │                 interface A {}
    ·                           ┬
@@ -1504,7 +1504,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'has' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:2:22]
+   ╭─[no_shadow.tsx:2:31]
  1 │ 
  2 │                         const A = 2;
    ·                               ┬

--- a/crates/oxc_linter/src/snapshots/eslint_no_unassigned_vars.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unassigned_vars.snap
@@ -80,7 +80,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Variable declared without assignment. Either assign a value or remove the declaration.
 
   ⚠ eslint(no-unassigned-vars): 'y' is always 'undefined' because it's never assigned.
-   ╭─[no_unassigned_vars.tsx:5:12]
+   ╭─[no_unassigned_vars.tsx:5:33]
  4 │                             }
  5 │                             let y: string;
    ·                                 ─

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_private_class_members.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMember' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedMember = 5;
    ·                 ─────────────
@@ -11,7 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMemberInSecondClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:3:8]
+   ╭─[no_unused_private_class_members.tsx:3:17]
  2 │             class Second {
  3 │                 #unusedMemberInSecondClass = 5;
    ·                 ──────────────────────────
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMemberInFirstClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class First {
  2 │                 #unusedMemberInFirstClass = 5;
    ·                 ─────────────────────────
@@ -27,7 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'firstUnusedMemberInSameClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class First {
  2 │                 #firstUnusedMemberInSameClass = 5;
    ·                 ─────────────────────────────
@@ -35,7 +35,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'secondUnusedMemberInSameClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:3:8]
+   ╭─[no_unused_private_class_members.tsx:3:17]
  2 │                 #firstUnusedMemberInSameClass = 5;
  3 │                 #secondUnusedMemberInSameClass = 5;
    ·                 ──────────────────────────────
@@ -43,7 +43,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInWrite' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #usedOnlyInWrite = 5;
    ·                 ────────────────
@@ -51,7 +51,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInWriteStatement' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #usedOnlyInWriteStatement = 5;
    ·                 ─────────────────────────
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInIncrement' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class C {
  2 │                 #usedOnlyInIncrement;
    ·                 ────────────────────
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInOuterClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class C {
  2 │                 #unusedInOuterClass;
    ·                 ───────────────────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedOnlyInSecondNestedClass' is defined but never used.
-    ╭─[no_unused_private_class_members.tsx:20:16]
+    ╭─[no_unused_private_class_members.tsx:20:25]
  19 │                     return class {
  20 │                         #unusedOnlyInSecondNestedClass;
     ·                         ──────────────────────────────
@@ -83,7 +83,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMethod' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedMethod() {}
    ·                 ─────────────
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedMethod' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedMethod() {}
    ·                 ─────────────
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedSetter' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:12]
+   ╭─[no_unused_private_class_members.tsx:2:21]
  1 │ class Foo {
  2 │                 set #unusedSetter(value) {}
    ·                     ─────────────
@@ -107,7 +107,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedForInLoop' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedForInLoop;
    ·                 ────────────────
@@ -115,7 +115,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedForOfLoop' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedForOfLoop;
    ·                 ────────────────
@@ -123,7 +123,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInDestructuring' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedInDestructuring;
    ·                 ──────────────────────
@@ -131,7 +131,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInRestPattern' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedInRestPattern;
    ·                 ────────────────────
@@ -139,7 +139,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInAssignmentPattern' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedInAssignmentPattern;
    ·                 ──────────────────────────
@@ -147,7 +147,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'unusedInAssignmentPattern' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class Foo {
  2 │                 #unusedInAssignmentPattern;
    ·                 ──────────────────────────
@@ -155,7 +155,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-unused-private-class-members): 'usedOnlyInTheSecondInnerClass' is defined but never used.
-   ╭─[no_unused_private_class_members.tsx:2:8]
+   ╭─[no_unused_private_class_members.tsx:2:17]
  1 │ class C {
  2 │                 #usedOnlyInTheSecondInnerClass;
    ·                 ──────────────────────────────

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@eslint-plugin-react.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@eslint-plugin-react.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint(no-unused-vars): Variable 'App' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:2:8]
+   ╭─[no_unused_vars.tsx:2:17]
  1 │ 
  2 │             var App;
    ·                 ─┬─
@@ -13,37 +13,37 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'unused' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:3:16]
+   ╭─[no_unused_vars.tsx:3:19]
  2 │             var App;
- 3 │             var unused;
-   ·                 ───┬──
-   ·                    ╰── 'unused' is declared here
- 4 │             React.render(<App unused=""/>);
+ 3 │               var unused;
+   ·                   ───┬──
+   ·                      ╰── 'unused' is declared here
+ 4 │               React.render(<App unused=""/>);
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'App' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:2:8]
+   ╭─[no_unused_vars.tsx:2:17]
  1 │ 
  2 │             var App;
    ·                 ─┬─
    ·                  ╰── 'App' is declared here
- 3 │             var Hello;
+ 3 │               var Hello;
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'Hello' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:3:16]
+   ╭─[no_unused_vars.tsx:3:19]
  2 │             var App;
- 3 │             var Hello;
-   ·                 ──┬──
-   ·                   ╰── 'Hello' is declared here
- 4 │             React.render(<App:Hello/>);
+ 3 │               var Hello;
+   ·                   ──┬──
+   ·                     ╰── 'Hello' is declared here
+ 4 │               React.render(<App:Hello/>);
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Variable 'Input' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:3:8]
+   ╭─[no_unused_vars.tsx:3:17]
  2 │             var Button;
  3 │             var Input;
    ·                 ──┬──
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Class 'unused' is declared but never used.
-   ╭─[no_unused_vars.tsx:2:10]
+   ╭─[no_unused_vars.tsx:2:19]
  1 │ 
  2 │             class unused {}
    ·                   ───┬──
@@ -63,7 +63,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Class 'HelloMessage' is declared but never used.
-   ╭─[no_unused_vars.tsx:2:10]
+   ╭─[no_unused_vars.tsx:2:19]
  1 │ 
  2 │             class HelloMessage {
    ·                   ──────┬─────
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Identifier 'Hello' is imported but never used.
-   ╭─[no_unused_vars.tsx:2:12]
+   ╭─[no_unused_vars.tsx:2:21]
  1 │ 
  2 │             import {Hello} from 'Hello';
    ·                     ──┬──
@@ -83,17 +83,17 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing this import.
 
   ⚠ eslint(no-unused-vars): Variable 'lowercase' is declared but never used. Unused variables should start with a '_'.
-   ╭─[no_unused_vars.tsx:2:8]
+   ╭─[no_unused_vars.tsx:2:17]
  1 │ 
  2 │             var lowercase;
    ·                 ────┬────
    ·                     ╰── 'lowercase' is declared here
- 3 │             React.render(<lowercase />);
+ 3 │               React.render(<lowercase />);
    ╰────
   help: Consider removing this declaration.
 
   ⚠ eslint(no-unused-vars): Parameter 'div' is declared but never used. Unused parameters should start with a '_'.
-   ╭─[no_unused_vars.tsx:2:23]
+   ╭─[no_unused_vars.tsx:2:32]
  1 │ 
  2 │             function Greetings(div) {
    ·                                ─┬─

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@eslint.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@eslint.snap
@@ -1425,7 +1425,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const [ a, _b ] = items;
    ·            ─┬
    ·             ╰── '_b' is declared here
- 2 │             console.log(a+_b);
+ 2 │              console.log(a+_b);
    ╰────
   help: Consider renaming this variable.
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_destructuring.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_destructuring.snap
@@ -206,7 +206,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use object destructuring rather than direct member access.
 
   ⚠ eslint(prefer-destructuring): Use Object destructuring.
-   ╭─[prefer_destructuring.tsx:2:7]
+   ╭─[prefer_destructuring.tsx:2:16]
  1 │ var foo // comment
  2 │              = object.foo;
    ·                ──────────
@@ -221,7 +221,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use object destructuring rather than direct member access.
 
   ⚠ eslint(prefer-destructuring): Use Object destructuring.
-   ╭─[prefer_destructuring.tsx:2:5]
+   ╭─[prefer_destructuring.tsx:2:14]
  1 │ var foo = // comment
  2 │              object.foo;
    ·              ──────────
@@ -264,7 +264,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Use object destructuring rather than direct member access.
 
   ⚠ eslint(prefer-destructuring): Use Object destructuring.
-   ╭─[prefer_destructuring.tsx:2:7]
+   ╭─[prefer_destructuring.tsx:2:16]
  1 │ var foo // comment
  2 │              = bar(/* comment */).foo;
    ·                ──────────────────────

--- a/crates/oxc_linter/src/snapshots/eslint_sort_keys.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_sort_keys.snap
@@ -608,7 +608,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `a:1, _:2, b:3` with `b:3, a:1, _:2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:36]
+   ╭─[sort_keys.tsx:2:39]
  1 │     
  2 │ ╭─▶                             var obj = {
  3 │ │                                   b: 1,
@@ -618,13 +618,13 @@ source: crates/oxc_linter/src/tester.rs
  7 │                             
    ╰────
   help: Replace `b: 1,
-                	                    c: 2,
-                	                    a: 3` with `a: 3,
-                	                    b: 1,
-                	                    c: 2`.
+                                        c: 2,
+                                        a: 3` with `a: 3,
+                                        b: 1,
+                                        c: 2`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:36]
+   ╭─[sort_keys.tsx:2:39]
  1 │     
  2 │ ╭─▶                             let obj = {
  3 │ │                                   b
@@ -635,12 +635,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `b
         
-                	                    ,a` with `a
+                                        ,a` with `a
         
-                	                    ,b`.
+                                        ,b`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:37]
+   ╭─[sort_keys.tsx:2:40]
  1 │     
  2 │ ╭─▶                              var obj = {
  3 │ │                                   b: 1,
@@ -652,17 +652,17 @@ source: crates/oxc_linter/src/tester.rs
  9 │                              
    ╰────
   help: Replace `b: 1,
-                	                    c () {
+                                        c () {
         
-                	                    },
-                	                    a: 3` with `a: 3,
-                	                    b: 1,
-                	                    c () {
+                                        },
+                                        a: 3` with `a: 3,
+                                        b: 1,
+                                        c () {
         
-                	                    }`.
+                                        }`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-    ╭─[sort_keys.tsx:2:37]
+    ╭─[sort_keys.tsx:2:40]
   1 │     
   2 │ ╭─▶                              var obj = {
   3 │ │                                   a: 1,
@@ -677,7 +677,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:31]
+   ╭─[sort_keys.tsx:2:40]
  1 │     
  2 │ ╭─▶                              var obj = {
  3 │ │                                   b: 1,
@@ -690,7 +690,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:30]
+   ╭─[sort_keys.tsx:2:39]
  1 │     
  2 │ ╭─▶                             var obj = {
  3 │ │                                 b,
@@ -701,7 +701,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-    ╭─[sort_keys.tsx:2:30]
+    ╭─[sort_keys.tsx:2:39]
   1 │     
   2 │ ╭─▶                             var obj = {
   3 │ │                                   c: 1,
@@ -716,7 +716,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-    ╭─[sort_keys.tsx:2:30]
+    ╭─[sort_keys.tsx:2:39]
   1 │     
   2 │ ╭─▶                             var obj = {
   3 │ │                                   c: 1,
@@ -738,7 +738,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:30]
+   ╭─[sort_keys.tsx:2:39]
  1 │     
  2 │ ╭─▶                             var obj = {
  3 │ │                                   b: "/*",
@@ -747,11 +747,11 @@ source: crates/oxc_linter/src/tester.rs
  6 │                             
    ╰────
   help: Replace `b: "/*",
-        			                    a: "*/"` with `a: "*/",
-        			                    b: "/*"`.
+                                        a: "*/"` with `a: "*/",
+                                        b: "/*"`.
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-   ╭─[sort_keys.tsx:2:30]
+   ╭─[sort_keys.tsx:2:39]
  1 │     
  2 │ ╭─▶                             var obj = {
  3 │ │                                   b: 1
@@ -762,7 +762,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(sort-keys): Object keys should be sorted
-    ╭─[sort_keys.tsx:2:30]
+    ╭─[sort_keys.tsx:2:39]
   1 │     
   2 │ ╭─▶                             let obj = {
   3 │ │                                 b,

--- a/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_expect_expect.snap
@@ -94,7 +94,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add assertion(s) in this Test
 
   ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
-   ╭─[expect_expect.tsx:4:10]
+   ╭─[expect_expect.tsx:4:13]
  3 │ 
  4 │             checkThat('this passes', () => {
    ·             ─────────
@@ -103,7 +103,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add assertion(s) in this Test
 
   ⚠ eslint-plugin-jest(expect-expect): Test has no assertions
-   ╭─[expect_expect.tsx:4:10]
+   ╭─[expect_expect.tsx:4:13]
  3 │ 
  4 │             checkThat.skip('this passes', () => {
    ·             ──────────────

--- a/crates/oxc_linter/src/snapshots/jsdoc_check_access.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_check_access.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.
-   ╭─[check_access.tsx:3:25]
+   ╭─[check_access.tsx:3:34]
  2 │                       /**
  3 │                        * @access foo
    ·                                  ───
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
   ⚠ eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.
-   ╭─[check_access.tsx:3:25]
+   ╭─[check_access.tsx:3:34]
  2 │                       /**
  3 │                        * @access foo
    ·                                  ───
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
   ⚠ eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.
-   ╭─[check_access.tsx:3:38]
+   ╭─[check_access.tsx:3:47]
  2 │                               /**
  3 │                                * @accessLevel foo
    ·                                               ───
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
   ⚠ eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.
-   ╭─[check_access.tsx:3:24]
+   ╭─[check_access.tsx:3:33]
  2 │                       /**
  3 │                        * @access
    ·                                 ▲
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
   ⚠ eslint-plugin-jsdoc(check-access): Invalid access level is specified or missing.
-   ╭─[check_access.tsx:4:22]
+   ╭─[check_access.tsx:4:31]
  3 │                     /**
  4 │                      * @access
    ·                               ▲
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Valid access levels are `package`, `private`, `protected`, and `public`.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @access public
  4 │                        * @public
    ·                          ───────
@@ -57,7 +57,7 @@ source: crates/oxc_linter/src/tester.rs
   help: There should be only one instance of access tag in a JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @access public
  4 │                        * @access private
    ·                          ───────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: There should be only one instance of access tag in a JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @access public
  4 │                        * @access private
    ·                          ───────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: There should be only one instance of access tag in a JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @public
  4 │                        * @private
    ·                          ────────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: There should be only one instance of access tag in a JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @public
  4 │                        * @private
    ·                          ────────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: There should be only one instance of access tag in a JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(check-access): Mixing of `@access` with `@public`, `@private`, `@protected`, or `@package` on the same doc block.
-   ╭─[check_access.tsx:4:17]
+   ╭─[check_access.tsx:4:26]
  3 │                        * @public
  4 │                        * @public
    ·                          ───────

--- a/crates/oxc_linter/src/snapshots/jsdoc_check_tag_names.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_check_tag_names.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:24]
+   ╭─[check_tag_names.tsx:2:33]
  1 │ 
  2 │                             /** @typoo {string} (fail: invalid name) */
    ·                                 ──────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@typoo` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @Param (fail: invalid name)
    ·                                  ──────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@Param` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @foo (fail: invalid name)
    ·                                  ────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@foo` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @arg foo (fail: invalid name, default aliased)
    ·                                  ────
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@arg` with `@param`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @param foo (fail: valid name but user preferred)
    ·                                  ──────
@@ -48,7 +48,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@param` with `@arg`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @constructor foo (fail: invalid name and user preferred)
    ·                                  ────────────
@@ -66,7 +66,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@arg` with `@somethingDifferent`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @param foo (fail: valid name but user preferred)
    ·                                  ──────
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@param` with `@parameter`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @bar foo (fail: invalid name)
    ·                                  ────
@@ -84,7 +84,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@bar` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @baz @bar foo (fail: invalid name)
    ·                                  ────
@@ -93,7 +93,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@baz` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:4:27]
+   ╭─[check_tag_names.tsx:4:36]
  3 │                                  * @bar
  4 │                                  * @baz (fail: invalid name)
    ·                                    ────
@@ -102,7 +102,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@baz` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @todo (fail: valid name but blocked)
    ·                                  ─────
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Unexpected tag `@todo`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @todo (fail: valid name but blocked)
    ·                                  ─────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Please resolve to-dos or add to the tracker
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @todo (fail: valid name but blocked)
    ·                                  ─────
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Please use x-todo instead of todo
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:4:25]
+   ╭─[check_tag_names.tsx:4:34]
  3 │                                * @property {object} a
  4 │                                * @prop {boolean} b (fail: invalid name, default aliased)
    ·                                  ─────
@@ -138,7 +138,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@prop` with `@property`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @abc foo (fail: invalid name and user preferred)
    ·                                  ────
@@ -156,7 +156,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@abc` with `@abcd`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:24]
+   ╭─[check_tag_names.tsx:2:33]
  1 │ 
  2 │                             /** @jsx h */
    ·                                 ────
@@ -165,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@jsx` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:24]
+   ╭─[check_tag_names.tsx:3:33]
  2 │                             /** @jsx h */
  3 │                             /** @jsxFrag Fragment */
    ·                                 ────────
@@ -174,7 +174,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@jsxFrag` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:4:24]
+   ╭─[check_tag_names.tsx:4:33]
  3 │                             /** @jsxFrag Fragment */
  4 │                             /** @jsxImportSource preact */
    ·                                 ────────────────
@@ -183,7 +183,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@jsxImportSource` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:5:24]
+   ╭─[check_tag_names.tsx:5:33]
  4 │                             /** @jsxImportSource preact */
  5 │                             /** @jsxRuntime automatic */
    ·                                 ───────────
@@ -192,7 +192,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@jsxRuntime` is invalid tag name.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:21]
+   ╭─[check_tag_names.tsx:3:30]
  2 │                           /**
  3 │                            * @constructor (fail: invalid name)
    ·                              ────────────
@@ -201,7 +201,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace tag `@constructor` with `@class`.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:25]
+   ╭─[check_tag_names.tsx:3:34]
  2 │                               /**
  3 │                                * @todo (fail: valid name but blocked)
    ·                                  ─────
@@ -210,7 +210,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Please don't use todo
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:15]
+   ╭─[check_tag_names.tsx:3:24]
  2 │                     /**
  3 │                      * @module
    ·                        ───────
@@ -227,7 +227,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@type` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:4:24]
+   ╭─[check_tag_names.tsx:4:33]
  3 │                              * Existing comment.
  4 │                              *  @type {string}
    ·                                 ─────
@@ -236,7 +236,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@type` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:22]
+   ╭─[check_tag_names.tsx:2:31]
  1 │ 
  2 │                           /** @typedef {Object} MyObject
    ·                               ────────
@@ -245,7 +245,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@typedef` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:21]
+   ╭─[check_tag_names.tsx:3:30]
  2 │                           /** @typedef {Object} MyObject
  3 │                            * @property {string} id - my id
    ·                              ─────────
@@ -254,7 +254,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@property` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:21]
+   ╭─[check_tag_names.tsx:3:30]
  2 │                           /**
  3 │                            * @property {string} id - my id
    ·                              ─────────
@@ -263,7 +263,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@property` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:22]
+   ╭─[check_tag_names.tsx:2:31]
  1 │ 
  2 │                           /** @typedef {Object} MyObject */
    ·                               ────────
@@ -272,7 +272,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@typedef` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:22]
+   ╭─[check_tag_names.tsx:2:31]
  1 │ 
  2 │                           /** @typedef {Object} MyObject
    ·                               ────────
@@ -281,7 +281,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@typedef` is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:24]
+   ╭─[check_tag_names.tsx:2:33]
  1 │ 
  2 │                             /** @abstract */
    ·                                 ─────────
@@ -290,7 +290,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@abstract` is redundant outside of ambient(`declare` or `.d.ts`) contexts when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:3:26]
+   ╭─[check_tag_names.tsx:3:35]
  2 │                             const a = {
  3 │                               /** @abstract */
    ·                                   ─────────
@@ -299,7 +299,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@abstract` is redundant outside of ambient(`declare` or `.d.ts`) contexts when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:2:24]
+   ╭─[check_tag_names.tsx:2:33]
  1 │ 
  2 │                             /** @template */
    ·                                 ─────────
@@ -308,7 +308,7 @@ source: crates/oxc_linter/src/tester.rs
   help: `@template` without a name is redundant when using a type system.
 
   ⚠ eslint-plugin-jsdoc(check-tag-names): Invalid tag name found.
-   ╭─[check_tag_names.tsx:5:23]
+   ╭─[check_tag_names.tsx:5:32]
  4 │                              *
  5 │                              * @template
    ·                                ─────────

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_yields.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_yields.snap
@@ -3,591 +3,591 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                            */
- 5 │                           function * quux (foo) { yield foo; }
-   ·                           ────────────────────────────────────
- 6 │                       
+   ╭─[require_yields.tsx:5:29]
+ 4 │                              */
+ 5 │                             function * quux (foo) { yield foo; }
+   ·                             ────────────────────────────────────
+ 6 │                         
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux (foo) {
-  6 │ │                               someLabel: {
-  7 │ │                                 yield foo;
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux (foo) {
+  6 │ │                                 someLabel: {
+  7 │ │                                   yield foo;
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux (foo) {
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux (foo) {
  6 │ │   
- 7 │ │                               const a = yield foo;
- 8 │ ╰─▶                           }
- 9 │                           
+ 7 │ │                                 const a = yield foo;
+ 8 │ ╰─▶                             }
+ 9 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux (foo) {
- 6 │ │                               yield foo;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux (foo) {
+ 6 │ │                                 yield foo;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux() {
- 6 │ │                               yield 5;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux() {
+ 6 │ │                                 yield 5;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux() {
- 6 │ │                               yield;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux() {
+ 6 │ │                                 yield;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:33]
- 4 │                                */
- 5 │ ╭─▶                           const quux = async function * () {
- 6 │ │                               yield;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:42]
+ 4 │                                  */
+ 5 │ ╭─▶                             const quux = async function * () {
+ 6 │ │                                 yield;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:21]
- 4 │                                 */
- 5 │ ╭─▶                            async function * quux () {
- 6 │ │                                yield;
- 7 │ ╰─▶                            }
- 8 │                           
+   ╭─[require_yields.tsx:5:30]
+ 4 │                                   */
+ 5 │ ╭─▶                              async function * quux () {
+ 6 │ │                                  yield;
+ 7 │ ╰─▶                              }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               yield;
- 7 │ ╰─▶                           }
- 8 │                           
-   ╰────
-  help: Add `@yields` tag to the JSDoc comment.
-
-  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:6:25]
- 5 │                            */
- 6 │                         function*d() {}
-   ·                         ───────────────
- 7 │                       
-   ╰────
-  help: Add `@yields` tag to the JSDoc comment.
-
-  ⚠ eslint-plugin-jsdoc(require-yields): Duplicate `@yields` tags.
-   ╭─[require_yields.tsx:4:23]
- 3 │                            * @yields {undefined}
- 4 │                            * @yields {void}
-   ·                              ───────
- 5 │                            */
-   ╰────
-  help: Remove redundant `@yields` tag.
-
-  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux (foo) {
- 6 │ │                               yield 'bar';
- 7 │ ╰─▶                           }
- 8 │                           
-   ╰────
-  help: Add `@yields` tag to the JSDoc comment.
-
-  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:16]
- 4 │                            */
- 5 │ ╭─▶                       async function * foo(a) {
- 6 │ │                           return;
- 7 │ ╰─▶                       }
- 8 │                           
-   ╰────
-  help: Add `@yields` tag to the JSDoc comment.
-
-  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:16]
- 4 │                            */
- 5 │ ╭─▶                       async function * foo(a) {
- 6 │ │                           yield Promise.all(a);
- 7 │ ╰─▶                       }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 yield;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
    ╭─[require_yields.tsx:6:25]
  5 │                              */
- 6 │ ╭─▶                         * quux () {
- 7 │ │                             yield;
- 8 │ ╰─▶                         }
- 9 │                           }
+ 6 │                         function*d() {}
+   ·                         ───────────────
+ 7 │                         
+   ╰────
+  help: Add `@yields` tag to the JSDoc comment.
+
+  ⚠ eslint-plugin-jsdoc(require-yields): Duplicate `@yields` tags.
+   ╭─[require_yields.tsx:4:32]
+ 3 │                              * @yields {undefined}
+ 4 │                              * @yields {void}
+   ·                                ───────
+ 5 │                              */
+   ╰────
+  help: Remove redundant `@yields` tag.
+
+  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux (foo) {
+ 6 │ │                                 yield 'bar';
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:16]
- 4 │                            */
- 5 │ ╭─▶                       async function * foo(a) {
- 6 │ │                           yield Promise.all(a);
- 7 │ ╰─▶                       }
- 8 │                           
+   ╭─[require_yields.tsx:5:25]
+ 4 │                              */
+ 5 │ ╭─▶                         async function * foo(a) {
+ 6 │ │                             return;
+ 7 │ ╰─▶                         }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               if (true) {
-  7 │ │                                 yield;
-  8 │ │                               }
-  9 │ │                               yield true;
- 10 │ ╰─▶                           }
- 11 │                           
+   ╭─[require_yields.tsx:5:25]
+ 4 │                              */
+ 5 │ ╭─▶                         async function * foo(a) {
+ 6 │ │                             yield Promise.all(a);
+ 7 │ ╰─▶                         }
+ 8 │                             
+   ╰────
+  help: Add `@yields` tag to the JSDoc comment.
+
+  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
+   ╭─[require_yields.tsx:6:34]
+ 5 │                                */
+ 6 │ ╭─▶                           * quux () {
+ 7 │ │                               yield;
+ 8 │ ╰─▶                           }
+ 9 │                             }
+   ╰────
+  help: Add `@yields` tag to the JSDoc comment.
+
+  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
+   ╭─[require_yields.tsx:5:25]
+ 4 │                              */
+ 5 │ ╭─▶                         async function * foo(a) {
+ 6 │ │                             yield Promise.all(a);
+ 7 │ ╰─▶                         }
+ 8 │                             
+   ╰────
+  help: Add `@yields` tag to the JSDoc comment.
+
+  ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 if (true) {
+  7 │ │                                   yield;
+  8 │ │                                 }
+  9 │ │                                 yield true;
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               if (yield false) {
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 if (yield false) {
   7 │ │   
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               b ? yield false : true
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 b ? yield false : true
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               try {
-  7 │ │                                 yield true;
-  8 │ │                               } catch (err) {
-  9 │ │                               }
- 10 │ │                               yield;
- 11 │ ╰─▶                           }
- 12 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 try {
+  7 │ │                                   yield true;
+  8 │ │                                 } catch (err) {
+  9 │ │                                 }
+ 10 │ │                                 yield;
+ 11 │ ╰─▶                             }
+ 12 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               try {
-  7 │ │                               } finally {
-  8 │ │                                 yield true;
-  9 │ │                               }
- 10 │ │                               yield;
- 11 │ ╰─▶                           }
- 12 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 try {
+  7 │ │                                 } finally {
+  8 │ │                                   yield true;
+  9 │ │                                 }
+ 10 │ │                                 yield;
+ 11 │ ╰─▶                             }
+ 12 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               try {
-  7 │ │                                 yield;
-  8 │ │                               } catch (err) {
-  9 │ │                               }
- 10 │ │                               yield true;
- 11 │ ╰─▶                           }
- 12 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 try {
+  7 │ │                                   yield;
+  8 │ │                                 } catch (err) {
+  9 │ │                                 }
+ 10 │ │                                 yield true;
+ 11 │ ╰─▶                             }
+ 12 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               try {
-  7 │ │                                 something();
-  8 │ │                               } catch (err) {
-  9 │ │                                 yield true;
- 10 │ │                               }
- 11 │ │                               yield;
- 12 │ ╰─▶                           }
- 13 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 try {
+  7 │ │                                   something();
+  8 │ │                                 } catch (err) {
+  9 │ │                                   yield true;
+ 10 │ │                                 }
+ 11 │ │                                 yield;
+ 12 │ ╰─▶                             }
+ 13 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               switch (true) {
-  7 │ │                               case 'abc':
-  8 │ │                                 yield true;
-  9 │ │                               }
- 10 │ │                               yield;
- 11 │ ╰─▶                           }
- 12 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 switch (true) {
+  7 │ │                                 case 'abc':
+  8 │ │                                   yield true;
+  9 │ │                                 }
+ 10 │ │                                 yield;
+ 11 │ ╰─▶                             }
+ 12 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               switch (true) {
-  7 │ │                               case 'abc':
-  8 │ │                                 yield;
-  9 │ │                               }
- 10 │ │                               yield true;
- 11 │ ╰─▶                           }
- 12 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 switch (true) {
+  7 │ │                                 case 'abc':
+  8 │ │                                   yield;
+  9 │ │                                 }
+ 10 │ │                                 yield true;
+ 11 │ ╰─▶                             }
+ 12 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               for (const i of abc) {
-  7 │ │                                 yield true;
-  8 │ │                               }
-  9 │ │                               yield;
- 10 │ ╰─▶                           }
- 11 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 for (const i of abc) {
+  7 │ │                                   yield true;
+  8 │ │                                 }
+  9 │ │                                 yield;
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               for (const a in b) {
-  7 │ │                                 yield true;
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 for (const a in b) {
+  7 │ │                                   yield true;
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               for (let i=0; i<n; i+=1) {
-  7 │ │                                 yield true;
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 for (let i=0; i<n; i+=1) {
+  7 │ │                                   yield true;
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               while(true) {
-  7 │ │                                 yield true
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 while(true) {
+  7 │ │                                   yield true
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               do {
-  7 │ │                                 yield true
-  8 │ │                               }
-  9 │ │                               while(true)
- 10 │ ╰─▶                           }
- 11 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 do {
+  7 │ │                                   yield true
+  8 │ │                                 }
+  9 │ │                                 while(true)
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               if (true) {
-  7 │ │                                 yield true;
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 if (true) {
+  7 │ │                                   yield true;
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               var a = {};
-  7 │ │                               with (a) {
-  8 │ │                                 yield true;
-  9 │ │                               }
- 10 │ ╰─▶                           }
- 11 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 var a = {};
+  7 │ │                                 with (a) {
+  8 │ │                                   yield true;
+  9 │ │                                 }
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               if (true) {
-  7 │ │                                 yield;
-  8 │ │                               } else {
-  9 │ │                                 yield true;
- 10 │ │                               }
- 11 │ │                               yield;
- 12 │ ╰─▶                           }
- 13 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 if (true) {
+  7 │ │                                   yield;
+  8 │ │                                 } else {
+  9 │ │                                   yield true;
+ 10 │ │                                 }
+ 11 │ │                                 yield;
+ 12 │ ╰─▶                             }
+ 13 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               if (false) {
-  7 │ │                                 return;
-  8 │ │                               }
-  9 │ │                               return yield true;
- 10 │ ╰─▶                           }
- 11 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 if (false) {
+  7 │ │                                   return;
+  8 │ │                                 }
+  9 │ │                                 return yield true;
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               [yield true];
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 [yield true];
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               const [a = yield true] = [];
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 const [a = yield true] = [];
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               a || (yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 a || (yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               (r = yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 (r = yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               a + (yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 a + (yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               a, yield true;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 a, yield true;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               +(yield);
-  7 │ │                               [...yield];
-  8 │ │                               [...+(yield true)];
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 +(yield);
+  7 │ │                                 [...yield];
+  8 │ │                                 [...+(yield true)];
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               someLabel: {
-  7 │ │                                 yield true;
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 someLabel: {
+  7 │ │                                   yield true;
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               var obj = {
-  7 │ │                                 [someKey]: 'val',
-  8 │ │                                 anotherKey: yield true
-  9 │ │                               }
- 10 │ ╰─▶                           }
- 11 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 var obj = {
+  7 │ │                                   [someKey]: 'val',
+  8 │ │                                   anotherKey: yield true
+  9 │ │                                 }
+ 10 │ ╰─▶                             }
+ 11 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-    ╭─[require_yields.tsx:5:20]
-  4 │                                */
-  5 │ ╭─▶                           function * quux () {
-  6 │ │                               var obj = {
-  7 │ │                                 [yield true]: 'val',
-  8 │ │                               }
-  9 │ ╰─▶                           }
- 10 │                           
+    ╭─[require_yields.tsx:5:29]
+  4 │                                  */
+  5 │ ╭─▶                             function * quux () {
+  6 │ │                                 var obj = {
+  7 │ │                                   [yield true]: 'val',
+  8 │ │                                 }
+  9 │ ╰─▶                             }
+ 10 │                             
     ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               `abc${yield true}`;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 `abc${yield true}`;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               tagTemp`abc${yield true}`;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 tagTemp`abc${yield true}`;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               a.b[yield true].c;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 a.b[yield true].c;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               abc?.[yield true].d?.e(yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 abc?.[yield true].d?.e(yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               abc?.[yield true].d?.e(yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 abc?.[yield true].d?.e(yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               const [a = yield true] = arr;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 const [a = yield true] = arr;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               const {a = yield true} = obj;
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 const {a = yield true} = obj;
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): Missing JSDoc `@yields` declaration for generator function.
-   ╭─[require_yields.tsx:5:20]
- 4 │                                */
- 5 │ ╭─▶                           function * quux () {
- 6 │ │                               import(yield true);
- 7 │ ╰─▶                           }
- 8 │                           
+   ╭─[require_yields.tsx:5:29]
+ 4 │                                  */
+ 5 │ ╭─▶                             function * quux () {
+ 6 │ │                                 import(yield true);
+ 7 │ ╰─▶                             }
+ 8 │                             
    ╰────
   help: Add `@yields` tag to the JSDoc comment.
 
   ⚠ eslint-plugin-jsdoc(require-yields): `@yields` tag is required when using `@generator` tag.
-   ╭─[require_yields.tsx:4:25]
+   ╭─[require_yields.tsx:4:34]
  3 │                                * fail(`@generator`+missing `@yields`, with config)
  4 │                                * @generator
    ·                                  ──────────

--- a/crates/oxc_linter/src/snapshots/nextjs_no_head_element.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_head_element.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-next(no-head-element): Do not use `<head>` element. Use `<Head />` from `next/head` instead.
-   ╭─[no_head_element.tsx:6:24]
+   ╭─[no_head_element.tsx:6:27]
  5 │                         <div>
  6 │                           <head>
    ·                           ──────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: See https://nextjs.org/docs/messages/no-head-element
 
   ⚠ eslint-plugin-next(no-head-element): Do not use `<head>` element. Use `<Head />` from `next/head` instead.
-   ╭─[no_head_element.tsx:7:24]
+   ╭─[no_head_element.tsx:7:27]
  6 │                         <div>
  7 │                           <head>
    ·                           ──────

--- a/crates/oxc_linter/src/snapshots/react_display_name.snap
+++ b/crates/oxc_linter/src/snapshots/react_display_name.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:22]
+   ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = createReactClass({
    ·                         ─────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:22]
+   ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = React.createClass({
    ·                         ─────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:16]
+   ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = createReactClass({
    ·                         ─────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     class Hello extends React.Component {
  3 │ │                         render() {
@@ -42,7 +42,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     module.exports = () => {
  3 │ │                         return <div>Hello {props.name}</div>;
@@ -52,7 +52,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     module.exports = function() {
  3 │ │                         return <div>Hello {props.name}</div>;
@@ -62,7 +62,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     module.exports = createReactClass({
  3 │ │                         render() {
@@ -74,7 +74,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:16]
+   ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = createReactClass({
    ·                         ─────
@@ -83,7 +83,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:16]
+   ╭─[display_name.tsx:2:25]
  1 │ 
  2 │                     var Hello = Foo.createClass({
    ·                         ─────
@@ -92,7 +92,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:3:16]
+   ╭─[display_name.tsx:3:25]
  2 │                     /** @jsx Foo */
  3 │                     var Hello = Foo.createClass({
    ·                         ─────
@@ -101,7 +101,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:18]
+   ╭─[display_name.tsx:2:27]
  1 │ 
  2 │                     const Mixin = {
    ·                           ─────
@@ -110,7 +110,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     function Hof() {
  3 │ │                         return function () {
@@ -122,7 +122,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:3:12]
+   ╭─[display_name.tsx:3:21]
  2 │                         import React, { createElement } from "react";
  3 │ ╭─▶                     export default (props) => {
  4 │ │                         return createElement("div", {}, "hello");
@@ -132,7 +132,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const ComponentWithMemo = React.memo(({ world }) => {
    ·                           ─────────────────
@@ -141,7 +141,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const ComponentWithMemo = React.memo(function() {
    ·                           ─────────────────
@@ -150,7 +150,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
    ·                           ───────────────────────
@@ -159,7 +159,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const ForwardRefComponentLike = React.forwardRef(function({ world }, ref) {
    ·                           ───────────────────────
@@ -168,7 +168,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const MemoizedForwardRefComponentLike = React.memo(
    ·                           ───────────────────────────────
@@ -177,7 +177,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const MemoizedForwardRefComponentLike = React.memo(
    ·                           ───────────────────────────────
@@ -186,7 +186,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const MemoizedForwardRefComponentLike = React.memo(
    ·                           ───────────────────────────────
@@ -195,7 +195,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:12]
+   ╭─[display_name.tsx:4:21]
  3 │                         const { createElement } = React;
  4 │ ╭─▶                     export default (props) => {
  5 │ │                         return createElement("div", {}, "hello");
@@ -205,7 +205,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:12]
+   ╭─[display_name.tsx:4:21]
  3 │                         const createElement = React.createElement;
  4 │ ╭─▶                     export default (props) => {
  5 │ │                         return createElement("div", {}, "hello");
@@ -215,7 +215,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-    ╭─[display_name.tsx:2:12]
+    ╭─[display_name.tsx:2:21]
   1 │     
   2 │ ╭─▶                     module.exports = function () {
   3 │ │                         function a () {}
@@ -235,7 +235,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-    ╭─[display_name.tsx:2:12]
+    ╭─[display_name.tsx:2:21]
   1 │     
   2 │ ╭─▶                     module.exports = () => {
   3 │ │                         function a () {}
@@ -256,7 +256,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-    ╭─[display_name.tsx:2:12]
+    ╭─[display_name.tsx:2:21]
   1 │     
   2 │ ╭─▶                     export default class extends React.Component {
   3 │ │                         render() {
@@ -278,7 +278,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:12]
+   ╭─[display_name.tsx:2:21]
  1 │     
  2 │ ╭─▶                     export default class extends React.PureComponent {
  3 │ │                         render() {
@@ -290,7 +290,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:2:18]
+   ╭─[display_name.tsx:2:27]
  1 │ 
  2 │                     const renderer = a => listItem => (
    ·                           ────────
@@ -299,7 +299,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-   ╭─[display_name.tsx:4:31]
+   ╭─[display_name.tsx:4:34]
  3 │ 
  4 │                     export const Component = observer(() => {
    ·                                  ─────────
@@ -308,7 +308,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Component definition is missing display name.
-    ╭─[display_name.tsx:9:31]
+    ╭─[display_name.tsx:9:34]
   8 │ 
   9 │                     export const Component2 = observer(() => {
     ·                                  ──────────
@@ -317,7 +317,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the component.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const Hello = React.createContext();
    ·                           ─────
@@ -326,7 +326,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the context.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const Hello = React.createContext();
    ·                           ─────
@@ -335,7 +335,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the context.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
-   ╭─[display_name.tsx:4:18]
+   ╭─[display_name.tsx:4:27]
  3 │ 
  4 │                     const Hello = createContext();
    ·                           ─────
@@ -344,7 +344,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the context.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
-   ╭─[display_name.tsx:5:12]
+   ╭─[display_name.tsx:5:21]
  4 │                     var Hello;
  5 │                     Hello = createContext();
    ·                     ───────────────────────
@@ -353,7 +353,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the context.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
-   ╭─[display_name.tsx:5:12]
+   ╭─[display_name.tsx:5:21]
  4 │                     var Hello;
  5 │                     Hello = React.createContext();
    ·                     ─────────────────────────────

--- a/crates/oxc_linter/src/snapshots/react_no_render_return_value.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_render_return_value.snap
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Using the return value is a legacy feature.
 
   ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
-   ╭─[no_render_return_value.tsx:3:26]
+   ╭─[no_render_return_value.tsx:3:29]
  2 │                     var o = {
  3 │                       inst: ReactDOM.render(<div />, document.body)
    ·                             ───────────────
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Using the return value is a legacy feature.
 
   ⚠ eslint-plugin-react(no-render-return-value): Do not depend on the return value from `ReactDOM.render`.
-   ╭─[no_render_return_value.tsx:3:27]
+   ╭─[no_render_return_value.tsx:3:30]
  2 │                     function render () {
  3 │                       return ReactDOM.render(<div />, document.body)
    ·                              ───────────────

--- a/crates/oxc_linter/src/snapshots/react_require_render_return.snap
+++ b/crates/oxc_linter/src/snapshots/react_require_render_return.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-react(require-render-return): Your `render` method should have a `return` statement.
-   ╭─[require_render_return.tsx:4:20]
+   ╭─[require_render_return.tsx:4:23]
  3 │                       displayName: 'Hello',
  4 │                       render: function() {}
    ·                       ──────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the `return` statement is missing.
 
   ⚠ eslint-plugin-react(require-render-return): Your `render` method should have a `return` statement.
-   ╭─[require_render_return.tsx:3:20]
+   ╭─[require_render_return.tsx:3:23]
  2 │                     class Hello extends React.Component {
  3 │                       render() {}
    ·                       ──────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the `return` statement is missing.
 
   ⚠ eslint-plugin-react(require-render-return): Your `render` method should have a `return` statement.
-   ╭─[require_render_return.tsx:3:20]
+   ╭─[require_render_return.tsx:3:23]
  2 │                     class Hello extends React.Component {
  3 │                       render() {
    ·                       ──────
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
   help: When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the `return` statement is missing.
 
   ⚠ eslint-plugin-react(require-render-return): Your `render` method should have a `return` statement.
-   ╭─[require_render_return.tsx:3:20]
+   ╭─[require_render_return.tsx:3:23]
  2 │                     class Hello extends React.Component {
  3 │                       render = () => {
    ·                       ──────

--- a/crates/oxc_linter/src/snapshots/vue_valid_define_emits.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_define_emits.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ eslint-plugin-vue(valid-define-emits): `defineEmits` is referencing locally declared variables.
-   ╭─[valid_define_emits.tsx:5:12]
+   ╭─[valid_define_emits.tsx:5:21]
  4 │                     const def = { notify: null }
  5 │                     defineEmits(def)
    ·                     ────────────────
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
   help: inline the variable or import it from another module.
 
   ⚠ eslint-plugin-vue(valid-define-emits): `defineEmits` has both a type-only emit and an argument.
-   ╭─[valid_define_emits.tsx:4:12]
+   ╭─[valid_define_emits.tsx:4:21]
  3 │                     /* ✗ BAD */
  4 │                     defineEmits<(e: 'notify')=>void>({ submit: null })
    ·                     ──────────────────────────────────────────────────
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
   help: remove the argument for better type inference.
 
   ⚠ eslint-plugin-vue(valid-define-emits): `defineEmits` has been called multiple times.
-   ╭─[valid_define_emits.tsx:4:12]
+   ╭─[valid_define_emits.tsx:4:21]
  3 │                     /* ✗ BAD */
  4 │                     defineEmits({ notify: null })
    ·                     ──────────────┬──────────────
@@ -34,7 +34,7 @@ source: crates/oxc_linter/src/tester.rs
   help: combine all events into a single `defineEmits` call.
 
   ⚠ eslint-plugin-vue(valid-define-emits): Custom events are defined in both `defineEmits` and `export default {}`.
-    ╭─[valid_define_emits.tsx:9:18]
+    ╭─[valid_define_emits.tsx:9:21]
   8 │                     /* ✗ BAD */
   9 │                     defineEmits({ submit: null })
     ·                     ─────────────────────────────
@@ -53,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove `export default`.
 
   ⚠ eslint-plugin-vue(valid-define-emits): Custom events are not defined.
-   ╭─[valid_define_emits.tsx:4:12]
+   ╭─[valid_define_emits.tsx:4:21]
  3 │                     /* ✗ BAD */
  4 │                     defineEmits()
    ·                     ─────────────


### PR DESCRIPTION
Thankfully, this should be the last one. Sorry for the noise 😅

Benefits of this are 1) standardization/consistency, and 2) regenerating these tests now won't have as many whitespace changes that add a bunch of noise.