### PR TITLE
test(linter): Port additional tests from upstream Unicorn and TypeScript rules.

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -140,6 +140,103 @@ fn test() {
         "function foo(bar?: { n: number }) { return (bar!)?.(); }",
     ];
 
+    // TODO: Implement fixer.
+    #[expect(clippy::useless_vec)]
+    let _fix = vec![
+        (
+            "
+            const foo: { bar: number } | null = null;
+            const bar = foo!!.bar;
+                  ",
+            "
+            const foo: { bar: number } | null = null;
+            const bar = foo!.bar;
+                  ",
+        ),
+        (
+            "
+            function foo(bar: number | undefined) {
+              const bar: number = bar!!;
+            }
+                  ",
+            "
+            function foo(bar: number | undefined) {
+              const bar: number = bar!;
+            }
+                  ",
+        ),
+        (
+            "
+            function foo(bar?: { n: number }) {
+              return bar!?.n;
+            }
+                  ",
+            "
+            function foo(bar?: { n: number }) {
+              return bar?.n;
+            }
+                  ",
+        ),
+        (
+            "
+            function foo(bar?: { n: number }) {
+              return bar!?.();
+            }
+                  ",
+            "
+            function foo(bar?: { n: number }) {
+              return bar?.();
+            }
+                  ",
+        ),
+        (
+            "
+            const foo: { bar: number } | null = null;
+            const bar = (foo!)!.bar;
+                  ",
+            "
+            const foo: { bar: number } | null = null;
+            const bar = (foo)!.bar;
+                  ",
+        ),
+        (
+            "
+            function foo(bar?: { n: number }) {
+              return (bar!)?.n;
+            }
+                  ",
+            "
+            function foo(bar?: { n: number }) {
+              return (bar)?.n;
+            }
+                  ",
+        ),
+        (
+            "
+            function foo(bar?: { n: number }) {
+              return (bar)!?.n;
+            }
+                  ",
+            "
+            function foo(bar?: { n: number }) {
+              return (bar)?.n;
+            }
+                  ",
+        ),
+        (
+            "
+            function foo(bar?: { n: number }) {
+              return (bar!)?.();
+            }
+                  ",
+            "
+            function foo(bar?: { n: number }) {
+              return (bar)?.();
+            }
+                  ",
+        ),
+    ];
+
     Tester::new(NoExtraNonNullAssertion::NAME, NoExtraNonNullAssertion::PLUGIN, pass, fail)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -245,6 +245,41 @@ fn test() {
         ),
         ("abstract class Foo { abstract property: string; }", None),
         ("abstract class Foo { abstract method(): string; }", None),
+        (
+            "
+            class Foo {
+              accessor prop: string;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            class Foo {
+              accessor prop = 'bar';
+              static bar() {
+                return false;
+              }
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            abstract class Foo {
+              accessor prop: string;
+            }
+                ",
+            None,
+        ),
+        (
+            "
+            abstract class Foo {
+              abstract accessor prop: string;
+            }
+                ",
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/consistent_assert.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_assert.rs
@@ -159,6 +159,9 @@ fn test() {
             assert(foo);",
         "import assert from 'node:assert/strict';
             console.log(assert)",
+        // TODO: Fix this rule so this test passes.
+        // "import {'strict' as assert} from 'assert';
+        //     assert(foo)",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -159,8 +159,8 @@ fn test() {
         "const foo = new BigInt64Array()",
         "const foo = new BigUint64Array()",
         "const foo = new DataView()",
-        "const foo = new Date()",
         "const foo = new Error()",
+        "const foo = new Float16Array()",
         "const foo = new Float32Array()",
         "const foo = new Float64Array()",
         "const foo = new Function()",
@@ -183,27 +183,29 @@ fn test() {
         "const foo = Number()",
         "const foo = String()",
         "const foo = Symbol()",
-        r"
-            import { Map } from 'immutable';
-            const m = Map();
-        ",
-        r"
-            const {Map} = require('immutable');
-            const foo = Map();
-        ",
-        r"
-            const {String} = require('guitar');
-            const lowE = new String();
-        ",
-        r"
-            import {String} from 'guitar';
-            const lowE = new String();
-        ",
+        "
+                        import { Map } from 'immutable';
+                        const m = Map();
+                    ",
+        "
+                        const {Map} = require('immutable');
+                        const foo = Map();
+                    ",
+        "
+                        const {String} = require('guitar');
+                        const lowE = new String();
+                    ",
+        "
+                        import {String} from 'guitar';
+                        const lowE = new String();
+                    ",
         "new Foo();Bar();",
         "Foo();new Bar();",
         "const isObject = v => Object(v) === v;",
         "const isObject = v => globalThis.Object(v) === v;",
         "(x) !== Object(x)",
+        // r#"new Symbol("")"#, // {"globals": {"Symbol": "off"}},
+        "const foo = new Date();",
     ];
 
     let fail = vec![
@@ -211,24 +213,73 @@ fn test() {
         r#"const symbol = new (Symbol)("");"#,
         r#"const symbol = new /* comment */ Symbol("");"#,
         "const symbol = new Symbol;",
+        "() => {
+                return new // 1
+                    Symbol();
+            }",
+        "() => {
+                return (
+                    new // 2
+                        Symbol()
+                );
+            }",
+        "() => {
+                return new // 3
+                    (Symbol);
+            }",
+        "() => {
+                return new // 4
+                    Symbol;
+            }",
+        "() => {
+                return (
+                    new // 5
+                        Symbol
+                );
+            }",
+        "() => {
+                return (
+                    new // 6
+                        (Symbol)
+                );
+            }",
+        "() => {
+                throw new // 1
+                    Symbol();
+            }",
+        "() => {
+                return new /**/ Symbol;
+            }",
         "new globalThis.String()",
         "new global.String()",
         "new self.String()",
         "new window.String()",
+        // TODO: Fix.
+        // "const {String} = globalThis;
+        //     new String();",
+        // "const {String: RenamedString} = globalThis;
+        //     new RenamedString();",
+        // "const RenamedString = globalThis.String;
+        //     new RenamedString();",
         "globalThis.Array()",
         "global.Array()",
         "self.Array()",
         "window.Array()",
-        "globalThis.Array()",
+        // "const {Array: RenamedArray} = globalThis;
+        //     RenamedArray();",
+        // We do not support configuring globals like this:
+        // "globalThis.Array()", // {"globals": {"Array": "off"}},
+        // "const {Array} = globalThis;
+        //     Array();", // {"globals": {"Symbol": "off"}},
         "const foo = Object()",
         "const foo = Array()",
         "const foo = ArrayBuffer()",
         "const foo = BigInt64Array()",
         "const foo = BigUint64Array()",
         "const foo = DataView()",
-        "const foo = Date()",
         "const foo = Error()",
         "const foo = Error('Foo bar')",
+        // "const foo = Float16Array()",
         "const foo = Float32Array()",
         "const foo = Float64Array()",
         "const foo = Function()",
@@ -252,8 +303,7 @@ fn test() {
         "const foo = new Number('123')",
         "const foo = new String()",
         "const foo = new Symbol()",
-        r"
-            function varCheck() {
+        "function varCheck() {
                 {
                     var WeakMap = function() {};
                 }
@@ -271,8 +321,18 @@ fn test() {
                     let Map = function() {};
                 }
                 return Map()
-            }
-        ",
+            }",
+        // "function foo() {
+        //         return(globalThis).Map()
+        //     }",
+        "const foo = Date();",
+        "const foo = globalThis.Date();",
+        // "function foo() {
+        //         return(globalThis).Date();
+        //     }",
+        "const foo = Date(/*comment*/);",
+        "const foo = globalThis/*comment*/.Date();",
+        "const foo = Date(bar);",
     ];
 
     Tester::new(NewForBuiltins::NAME, NewForBuiltins::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -345,6 +345,8 @@ fn test() {
         ("_.fromPairs()", None),
         ("new _.fromPairs(pairs)", None),
         ("_.fromPairs(...[pairs])", None),
+        // TODO: Fix this rule so this test passes.
+        // ("_?.fromPairs(pairs)", None),
         ("_.foo(pairs)", Some(serde_json::json!([{"functions": ["foo"]}]))),
         ("foo(pairs)", Some(serde_json::json!([{"functions": ["utils.object.foo"]}]))),
         ("object.foo(pairs)", Some(serde_json::json!([{"functions": ["utils.object.foo"]}]))),
@@ -417,6 +419,10 @@ fn test() {
         ),
         ("pairs.reduce(object => ({...object, method: async () => {}}), {});", None),
         ("pairs.reduce(object => ({...object, method: async function * (){}}), {});", None),
+        (
+            "array.reduce<Record<string, Data & {b?: string}>>((result, entry) => ({...result, [entry.id]: entry.data}), {});",
+            None,
+        ),
         ("_.fromPairs(pairs)", None),
         ("lodash.fromPairs(pairs)", None),
         (

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -158,6 +158,16 @@ fn test() {
         "foo.bar.bind(bar)",
         "foo[{}].call(bar)",
         "Object.hasOwn(bar)",
+        "const foo = [].push.notApply(bar, elements);",
+        "const push = [].push.notBind(foo)",
+        "[].forEach.notCall(foo, () => {})",
+        // "/* globals foo: readonly */ foo.call(bar)",
+        "const toString = () => {}; toString.call(bar)",
+        // "/* globals toString: off */ toString.call(bar)",
+        "const _hasOwnProperty = globalThis.hasOwnProperty; _hasOwnProperty.call(bar)",
+        "const _globalThis = globalThis; globalThis[hasOwnProperty].call(bar)",
+        r#"const _ = globalThis, TO_STRING = "toString"; _[TO_STRING].call(bar)"#,
+        "const _ = [globalThis.toString]; _[0].call(bar)",
     ];
 
     let fail = vec![
@@ -184,6 +194,19 @@ fn test() {
         "[][Symbol.iterator].call(foo)", // TODO: Improve error message for this case.
         "const foo = [].at.call(bar)",
         "const foo = [].findLast.call(bar)",
+        // "/* globals hasOwnProperty: readonly */ hasOwnProperty.call(bar)",
+        // "/* globals toString: readonly */ toString.apply(bar, [])",
+        // "/* globals toString: readonly */ Reflect.apply(toString, baz, [])",
+        // TODO: Fix the rule so these tests pass.
+        // "globalThis.toString.call(bar)",
+        // "const _ = globalThis; _.hasOwnProperty.call(bar)",
+        // r#"const _ = globalThis; _["hasOwnProperty"].call(bar)"#,
+        // r#"const _ = globalThis; _["hasOwn" + "Property"].call(bar)"#,
+        // "Reflect.apply(globalThis.toString, baz, [])",
+        // "Reflect.apply(window.toString, baz, [])",
+        // "Reflect.apply(global.toString, baz, [])",
+        // "/* globals toString: readonly */ Reflect.apply(toString, baz, [])", // Inline globals are not supported.
+        // r#"Reflect.apply(globalThis["toString"], baz, [])"#,
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_new_for_builtins.snap
@@ -26,6 +26,70 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──────────
    ╰────
 
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:2:24]
+ 1 │     () => {
+ 2 │ ╭─▶                 return new // 1
+ 3 │ ╰─▶                     Symbol();
+ 4 │                 }
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:3:21]
+ 2 │                     return (
+ 3 │ ╭─▶                     new // 2
+ 4 │ ╰─▶                         Symbol()
+ 5 │                     );
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:2:24]
+ 1 │     () => {
+ 2 │ ╭─▶                 return new // 3
+ 3 │ ╰─▶                     (Symbol);
+ 4 │                 }
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:2:24]
+ 1 │     () => {
+ 2 │ ╭─▶                 return new // 4
+ 3 │ ╰─▶                     Symbol;
+ 4 │                 }
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:3:21]
+ 2 │                     return (
+ 3 │ ╭─▶                     new // 5
+ 4 │ ╰─▶                         Symbol
+ 5 │                     );
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:3:21]
+ 2 │                     return (
+ 3 │ ╭─▶                     new // 6
+ 4 │ ╰─▶                         (Symbol)
+ 5 │                     );
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:2:23]
+ 1 │     () => {
+ 2 │ ╭─▶                 throw new // 1
+ 3 │ ╰─▶                     Symbol();
+ 4 │                 }
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `Symbol()` instead of `new Symbol()`
+   ╭─[new_for_builtins.tsx:2:24]
+ 1 │ () => {
+ 2 │                 return new /**/ Symbol;
+   ·                        ───────────────
+ 3 │             }
+   ╰────
+
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `String()` instead of `new String()`
    ╭─[new_for_builtins.tsx:1:1]
  1 │ new globalThis.String()
@@ -74,12 +138,6 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Array()` instead of `Array()`
-   ╭─[new_for_builtins.tsx:1:1]
- 1 │ globalThis.Array()
-   · ──────────────────
-   ╰────
-
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Object()` instead of `Object()`
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = Object()
@@ -114,12 +172,6 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[new_for_builtins.tsx:1:13]
  1 │ const foo = DataView()
    ·             ──────────
-   ╰────
-
-  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
-   ╭─[new_for_builtins.tsx:1:13]
- 1 │ const foo = Date()
-   ·             ──────
    ╰────
 
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Error()` instead of `Error()`
@@ -273,17 +325,47 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Array()` instead of `Array()`
-    ╭─[new_for_builtins.tsx:13:24]
- 12 │                 }
- 13 │                 return Array()
+    ╭─[new_for_builtins.tsx:12:24]
+ 11 │                 }
+ 12 │                 return Array()
     ·                        ───────
- 14 │             }
+ 13 │             }
     ╰────
 
   ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Map()` instead of `Map()`
-    ╭─[new_for_builtins.tsx:19:24]
- 18 │                 }
- 19 │                 return Map()
+    ╭─[new_for_builtins.tsx:18:24]
+ 17 │                 }
+ 18 │                 return Map()
     ·                        ─────
- 20 │             }
+ 19 │             }
     ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = Date();
+   ·             ──────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = globalThis.Date();
+   ·             ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = Date(/*comment*/);
+   ·             ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = globalThis/*comment*/.Date();
+   ·             ────────────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(new-for-builtins): Use `new Date()` instead of `Date()`
+   ╭─[new_for_builtins.tsx:1:13]
+ 1 │ const foo = Date(bar);
+   ·             ─────────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_length_check.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_length_check.snap
@@ -31,6 +31,24 @@ source: crates/oxc_linter/src/tester.rs
   help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
 
   ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:2:17]
+ 1 │ if (
+ 2 │                 array.length !== 0 &&
+   ·                 ──────────────────
+ 3 │                 array.some(Boolean) &&
+   ╰────
+  help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:2:17]
+ 1 │ if (
+ 2 │                 array.length !== 0 &&
+   ·                 ──────────────────
+ 3 │                 array.some(Boolean) &&
+   ╰────
+  help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
    ╭─[no_useless_length_check.tsx:1:2]
  1 │ (array.length === 0 || array.every(Boolean)) || foo
    ·  ──────────────────
@@ -190,3 +208,48 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────
    ╰────
   help: The empty check is useless as `Array#every()` returns `true` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:2:19]
+ 1 │ array1.every(Boolean)
+ 2 │             || (( array1.length === 0 || array2.length === 0 )) // Both useless
+   ·                   ───────────────────
+ 3 │             || array2.every(Boolean)
+   ╰────
+  help: The empty check is useless as `Array#every()` returns `true` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:2:42]
+ 1 │ array1.every(Boolean)
+ 2 │             || (( array1.length === 0 || array2.length === 0 )) // Both useless
+   ·                                          ───────────────────
+ 3 │             || array2.every(Boolean)
+   ╰────
+  help: The empty check is useless as `Array#every()` returns `true` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:2:19]
+ 1 │ array1.every(Boolean)
+ 2 │             || (( array1.length === 0 || array2.length === 0 )) // Both useless
+   ·                   ───────────────────
+ 3 │             || array2.every(Boolean)
+   ╰────
+  help: The empty check is useless as `Array#every()` returns `true` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+   ╭─[no_useless_length_check.tsx:6:25]
+ 5 │                         zeroLengthChecks.has(node) &&
+ 6 │                         siblings.length > 0 &&
+   ·                         ───────────────────
+ 7 │                         siblings.some(condition =>
+   ╰────
+  help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.
+
+  ⚠ eslint-plugin-unicorn(no-useless-length-check): Found a useless array length check
+    ╭─[no_useless_length_check.tsx:15:25]
+ 14 │                         nonZeroLengthChecks.has(node) &&
+ 15 │                         siblings.length > 0 &&
+    ·                         ───────────────────
+ 16 │                         siblings.some(condition =>
+    ╰────
+  help: The non-empty check is useless as `Array#some()` returns `false` for an empty array.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_object_from_entries.snap
@@ -271,6 +271,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `Object.fromEntries(pairs)` instead of manually building objects with `reduce` or `forEach`.
 
   ⚠ eslint-plugin-unicorn(prefer-object-from-entries): Prefer `Object.fromEntries` over manual object construction from entries.
+   ╭─[prefer_object_from_entries.tsx:1:7]
+ 1 │ array.reduce<Record<string, Data & {b?: string}>>((result, entry) => ({...result, [entry.id]: entry.data}), {});
+   ·       ──────
+   ╰────
+  help: Use `Object.fromEntries(pairs)` instead of manually building objects with `reduce` or `forEach`.
+
+  ⚠ eslint-plugin-unicorn(prefer-object-from-entries): Prefer `Object.fromEntries` over manual object construction from entries.
    ╭─[prefer_object_from_entries.tsx:1:1]
  1 │ _.fromPairs(pairs)
    · ───────────


### PR DESCRIPTION
Many of these pass, but some had to be commented-out. This updates tests for a handful of rules by regenerating the tests using our rulegen tooling.