### PR TITLE
fix(oxlint): add configuration_schema.json to package exports

### DIFF
--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -42,6 +42,9 @@
     "./plugins-dev": {
       "types": "./dist/plugins-dev.d.ts",
       "default": "./dist/plugins-dev.js"
+    },
+    "./configuration_schema.json": {
+      "default": "./configuration_schema.json"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
The `configuration_schema.json` file was not accessible after adding the `exports` field in #18601. This adds the missing export entry.

Fixes the import: `import schema from 'oxlint/configuration_schema.json'`