### PR TITLE
test(linter): retry flaky napi tests on windows

### DIFF
--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -32,8 +32,15 @@ describe("oxlint CLI", { concurrent: process.platform !== "win32" }, () => {
     if (!fixture.options.oxlint) continue;
 
     // oxlint-disable-next-line jest/expect-expect
-    it(`fixture: ${fixture.name}`, { concurrent: process.platform !== "win32" }, ({ expect }) =>
-      runFixture(fixture, expect),
+    it(
+      `fixture: ${fixture.name}`,
+      {
+        concurrent: process.platform !== "win32",
+        // Windows can be flaky due to memory allocation failures
+        // Ref: https://github.com/oxc-project/oxc/issues/19395
+        retry: process.platform === "win32" ? 2 : 0,
+      },
+      ({ expect }) => runFixture(fixture, expect),
     );
   }
 });


### PR DESCRIPTION
The goal here is hopefully to make our CI a bit greener.

9/10 times, the failure of windows napi CI is due to memory failing to allocate. This PR retries the test, (hopefully) making it less flaky).

We should remove this once https://github.com/oxc-project/oxc/issues/19395 is fixed