### PR TITLE
fix(linter/no-shadow): align initializer shadow handling with typescript-eslint

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow/tests.rs
@@ -1719,28 +1719,31 @@ fn test_eslint() {
             None,
             None,
         ), // { "ecmaVersion": 6 },
-        (
-            "let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });",
-            Some(serde_json::json!([{ "hoist": "all" }])),
-            None,
-            None,
-        ), // { "ecmaVersion": 6, "sourceType": "module" },
-        ("const a = wrap(function a() {});", None, None, None), // { "ecmaVersion": 6 },
-        ("const a = foo || wrap(function a() {});", None, None, None), // { "ecmaVersion": 6 },
-        ("const { a = wrap(function a() {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
-        ("const { a = foo || wrap(function a() {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
+        // The following tests are disabled as the behaviour of eslint vs typescript-eslint
+        // differs. We are following typescript-eslint's behaviour, but these tests are left
+        // here for clarity.
+        // (
+        //     "let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });",
+        //     Some(serde_json::json!([{ "hoist": "all" }])),
+        //     None,
+        //     None,
+        // ), // { "ecmaVersion": 6, "sourceType": "module" },
+        // ("const a = wrap(function a() {});", None, None, None), // { "ecmaVersion": 6 },
+        // ("const a = foo || wrap(function a() {});", None, None, None), // { "ecmaVersion": 6 },
+        // ("const { a = wrap(function a() {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
+        // ("const { a = foo || wrap(function a() {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
         ("const { a = foo, b = function a() {} } = {}", None, None, None), // { "ecmaVersion": 6 },
         ("const { A = Foo, B = class A {} } = {}", None, None, None),      // { "ecmaVersion": 6 },
         ("function foo(a = wrap(function a() {})) {}", None, None, None),  // { "ecmaVersion": 6 },
         ("function foo(a = foo || wrap(function a() {})) {}", None, None, None), // { "ecmaVersion": 6 },
-        ("const A = wrap(class A {});", None, None, None), // { "ecmaVersion": 6 },
-        ("const A = foo || wrap(class A {});", None, None, None), // { "ecmaVersion": 6 },
-        ("const { A = wrap(class A {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
-        ("const { A = foo || wrap(class A {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
+        // ("const A = wrap(class A {});", None, None, None), // { "ecmaVersion": 6 },
+        // ("const A = foo || wrap(class A {});", None, None, None), // { "ecmaVersion": 6 },
+        // ("const { A = wrap(class A {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
+        // ("const { A = foo || wrap(class A {}) } = obj;", None, None, None), // { "ecmaVersion": 6 },
         ("function foo(A = wrap(class A {})) {}", None, None, None), // { "ecmaVersion": 6 },
         ("function foo(A = foo || wrap(class A {})) {}", None, None, None), // { "ecmaVersion": 6 },
-        ("var a = function a() {} ? foo : bar", None, None, None),
-        ("var A = class A {} ? foo : bar", None, None, None), // { "ecmaVersion": 6, },
+        // ("var a = function a() {} ? foo : bar", None, None, None),
+        // ("var A = class A {} ? foo : bar", None, None, None), // { "ecmaVersion": 6, },
         (
             "(function Array() {})",
             Some(serde_json::json!([{ "builtinGlobals": true }])),
@@ -2303,6 +2306,18 @@ fn test_typescript_eslint() {
             None,
             None,
             None,
+        ),
+        (
+            "
+            import { memo } from 'react';
+
+            const FooBarComponent = memo(function FooBarComponent() {
+              return <div>Foo</div>;
+            });
+                ",
+            None,
+            None,
+            Some(PathBuf::from("test.tsx")),
         ),
         (
             "

--- a/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_shadow.snap
@@ -665,51 +665,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'x' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:29]
- 1 │ let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });
-   ·                             ┬                 ┬
-   ·                             │                 ╰── 'a' is declared here
-   ·                             ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:7]
- 1 │ const a = wrap(function a() {});
-   ·       ┬                 ┬
-   ·       │                 ╰── 'a' is declared here
-   ·       ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:7]
- 1 │ const a = foo || wrap(function a() {});
-   ·       ┬                        ┬
-   ·       │                        ╰── 'a' is declared here
-   ·       ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:9]
- 1 │ const { a = wrap(function a() {}) } = obj;
-   ·         ┬                 ┬
-   ·         │                 ╰── 'a' is declared here
-   ·         ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:9]
- 1 │ const { a = foo || wrap(function a() {}) } = obj;
-   ·         ┬                        ┬
-   ·         │                        ╰── 'a' is declared here
-   ·         ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
    ╭─[no_shadow.tsx:1:9]
  1 │ const { a = foo, b = function a() {} } = {}
    ·         ┬                     ┬
@@ -746,42 +701,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
 
   ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:7]
- 1 │ const A = wrap(class A {});
-   ·       ┬              ┬
-   ·       │              ╰── 'A' is declared here
-   ·       ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:7]
- 1 │ const A = foo || wrap(class A {});
-   ·       ┬                     ┬
-   ·       │                     ╰── 'A' is declared here
-   ·       ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:9]
- 1 │ const { A = wrap(class A {}) } = obj;
-   ·         ┬              ┬
-   ·         │              ╰── 'A' is declared here
-   ·         ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:9]
- 1 │ const { A = foo || wrap(class A {}) } = obj;
-   ·         ┬                     ┬
-   ·         │                     ╰── 'A' is declared here
-   ·         ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
    ╭─[no_shadow.tsx:1:14]
  1 │ function foo(A = wrap(class A {})) {}
    ·              ┬              ┬
@@ -796,24 +715,6 @@ source: crates/oxc_linter/src/tester.rs
    ·              ┬                     ┬
    ·              │                     ╰── 'A' is declared here
    ·              ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'a' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:5]
- 1 │ var a = function a() {} ? foo : bar
-   ·     ┬            ┬
-   ·     │            ╰── 'a' is declared here
-   ·     ╰── shadowed declaration is here
-   ╰────
-  help: Consider renaming 'a' to avoid shadowing the variable from the outer scope.
-
-  ⚠ eslint(no-shadow): 'A' is already declared in the upper scope.
-   ╭─[no_shadow.tsx:1:5]
- 1 │ var A = class A {} ? foo : bar
-   ·     ┬         ┬
-   ·     │         ╰── 'A' is declared here
-   ·     ╰── shadowed declaration is here
    ╰────
   help: Consider renaming 'A' to avoid shadowing the variable from the outer scope.
 


### PR DESCRIPTION
fixes #19461