### PR TITLE
refactor(formatter): Remove experimental prefix from sort_imports

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -508,7 +508,7 @@ impl FormatConfig {
                 .validate()
                 .map_err(|e| format!("Invalid `sortImports` configuration: {e}"))?;
 
-            format_options.experimental_sort_imports = Some(sort_imports);
+            format_options.sort_imports = Some(sort_imports);
         }
 
         if let Some(config) = self.experimental_tailwindcss {
@@ -1142,7 +1142,7 @@ mod tests {
         assert!(!oxfmt_options.format_options.quote_style.is_double());
         assert!(oxfmt_options.format_options.semicolons.is_as_needed());
 
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert!(sort_imports.partition_by_newline);
         assert!(sort_imports.order.is_desc());
         assert!(!sort_imports.ignore_case);
@@ -1164,7 +1164,7 @@ mod tests {
         assert!(oxfmt_options.format_options.indent_style.is_space());
         assert_eq!(oxfmt_options.format_options.indent_width.value(), 2);
         assert_eq!(oxfmt_options.format_options.line_width.value(), 100);
-        assert_eq!(oxfmt_options.format_options.experimental_sort_imports, None);
+        assert_eq!(oxfmt_options.format_options.sort_imports, None);
     }
 
     #[test]
@@ -1176,7 +1176,7 @@ mod tests {
         assert!(oxfmt_options.format_options.indent_style.is_space());
         assert_eq!(oxfmt_options.format_options.indent_width.value(), 2);
         assert_eq!(oxfmt_options.format_options.line_width.value(), 100);
-        assert_eq!(oxfmt_options.format_options.experimental_sort_imports, None);
+        assert_eq!(oxfmt_options.format_options.sort_imports, None);
     }
 
     #[test]
@@ -1214,7 +1214,7 @@ mod tests {
         )
         .unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -1228,7 +1228,7 @@ mod tests {
         )
         .unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert!(!sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -1242,7 +1242,7 @@ mod tests {
         )
         .unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert!(sort_imports.newlines_between);
         assert!(!sort_imports.partition_by_newline);
 
@@ -1282,7 +1282,7 @@ mod tests {
         )
         .unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 5);
         assert_eq!(
             sort_imports.groups[0],
@@ -1315,7 +1315,7 @@ mod tests {
         )
         .unwrap();
         let oxfmt_options = config.into_oxfmt_options().unwrap();
-        let sort_imports = oxfmt_options.format_options.experimental_sort_imports.unwrap();
+        let sort_imports = oxfmt_options.format_options.sort_imports.unwrap();
         assert_eq!(sort_imports.groups.len(), 3);
         assert_eq!(
             sort_imports.groups[0],

--- a/crates/oxc_formatter/examples/sort_imports.rs
+++ b/crates/oxc_formatter/examples/sort_imports.rs
@@ -56,10 +56,8 @@ fn main() -> Result<(), String> {
     }
 
     // Format the parsed code
-    let options = FormatOptions {
-        experimental_sort_imports: Some(sort_imports_options.clone()),
-        ..Default::default()
-    };
+    let options =
+        FormatOptions { sort_imports: Some(sort_imports_options.clone()), ..Default::default() };
 
     let formatter = Formatter::new(&allocator, options);
     let formatted = formatter.format(&ret.program);

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -424,7 +424,7 @@ impl<'a> Format<'a> for Comment {
             if is_alignable_comment(content) {
                 // Using `write_element` directly instead of `labelled()`
                 // to avoid allocating a `Vec` for `lines` iter
-                let sort_imports_enabled = f.options().experimental_sort_imports.is_some();
+                let sort_imports_enabled = f.options().sort_imports.is_some();
                 if sort_imports_enabled {
                     f.write_element(FormatElement::Tag(Tag::StartLabelled(LabelId::of(
                         JsLabels::AlignableBlockComment,

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -76,7 +76,7 @@ impl<'a> Formatter<'a> {
 
         // Basic formatting and `document.propagate_expand()` are already done here.
         // Now apply additional transforms if enabled.
-        if let Some(sort_imports_options) = &formatted.context().options().experimental_sort_imports
+        if let Some(sort_imports_options) = &formatted.context().options().sort_imports
             && let Some(transformed_elements) = SortImportsTransform::transform(
                 formatted.document(),
                 sort_imports_options,

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -73,7 +73,7 @@ pub struct FormatOptions {
     pub embedded_language_formatting: EmbeddedLanguageFormatting,
 
     /// Sort import statements. By default disabled.
-    pub experimental_sort_imports: Option<SortImportsOptions>,
+    pub sort_imports: Option<SortImportsOptions>,
 
     /// Enable Tailwind CSS class sorting in JSX class/className attributes.
     /// When enabled, class strings will be collected and passed to a callback for sorting.
@@ -146,7 +146,7 @@ impl FormatOptions {
             experimental_operator_position: OperatorPosition::default(),
             experimental_ternaries: false,
             embedded_language_formatting: EmbeddedLanguageFormatting::default(),
-            experimental_sort_imports: None,
+            sort_imports: None,
             experimental_tailwindcss: None,
         }
     }
@@ -174,7 +174,7 @@ impl fmt::Display for FormatOptions {
         writeln!(f, "Expand lists: {}", self.expand)?;
         writeln!(f, "Experimental operator position: {}", self.experimental_operator_position)?;
         writeln!(f, "Embedded language formatting: {}", self.embedded_language_formatting)?;
-        writeln!(f, "Experimental sort imports: {:?}", self.experimental_sort_imports)?;
+        writeln!(f, "Sort imports: {:?}", self.sort_imports)?;
         writeln!(f, "Experimental tailwindcss: {:?}", self.experimental_tailwindcss)
     }
 }

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -55,7 +55,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
             write!(f, [OptionalSemicolon]);
         });
 
-        if f.options().experimental_sort_imports.is_some() {
+        if f.options().sort_imports.is_some() {
             write!(f, [labelled(LabelId::of(JsLabels::ImportDeclaration), decl)]);
         } else {
             write!(f, decl);

--- a/crates/oxc_formatter/tests/ir_transform/mod.rs
+++ b/crates/oxc_formatter/tests/ir_transform/mod.rs
@@ -54,7 +54,7 @@ pub fn assert_format(code: &str, config_json: &str, expected: &str) {
 struct TestConfig {
     single_quote: Option<bool>,
     semi: Option<bool>,
-    experimental_sort_imports: Option<TestSortImportsConfig>,
+    sort_imports: Option<TestSortImportsConfig>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -133,7 +133,7 @@ fn parse_test_config(json: &str) -> FormatOptions {
     if let Some(semi) = config.semi {
         options.semicolons = if semi { Semicolons::Always } else { Semicolons::AsNeeded };
     }
-    if let Some(sort_config) = config.experimental_sort_imports {
+    if let Some(sort_config) = config.sort_imports {
         let mut sort_imports = SortImportsOptions::default();
         if let Some(v) = sort_config.partition_by_newline {
             sort_imports.partition_by_newline = v;
@@ -179,7 +179,7 @@ fn parse_test_config(json: &str) -> FormatOptions {
                 })
                 .collect();
         }
-        options.experimental_sort_imports = Some(sort_imports);
+        options.sort_imports = Some(sort_imports);
     }
 
     options

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -30,7 +30,7 @@ import * as c from "c";
 import d from "d";
 import a from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "a";
 import { b1, type b2, b3 as b33 } from "b";
@@ -46,7 +46,7 @@ import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { log } from "./log";
 import { log1p } from "./log1p";
@@ -61,7 +61,7 @@ import c from "c";
 import b from "b";
 import("a");
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import b from "b";
 import c from "c";
@@ -75,7 +75,7 @@ import internal2 from "@/internal2";
 import external from "external";
 import external2 from "@external2";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import external2 from "@external2";
 import external from "external";
@@ -96,7 +96,7 @@ import { b } from "b";
 // a
 import { a } from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 #!/usr/bin/node
 // a
@@ -115,7 +115,7 @@ import A from "a";
 
 console.log(A);
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import A from "a";
 
@@ -132,7 +132,7 @@ import { z } from "a";
 import { y } from "a";
 import { x } from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { z } from "a";
 import { y } from "a";
@@ -148,7 +148,7 @@ fn should_sort_regardless_of_quotes() {
 import b from "b";
 import a from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "a";
 import b from "b";
@@ -161,7 +161,7 @@ import b from "b";
 import a from "a";
 "#,
         r#"{
-  "experimentalSortImports": {},
+  "sortImports": {},
   "singleQuote": true
 }"#,
         r"
@@ -179,7 +179,7 @@ fn should_sort_by_module_source_not_import_specifier() {
 import { Zoo } from "aaa";
 import { Apple } from "zzz";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { Zoo } from "aaa";
 import { Apple } from "zzz";
@@ -191,7 +191,7 @@ import { Apple } from "zzz";
 import { Named } from "./z-path";
 import { Named } from "./a-path";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { Named } from "./a-path";
 import { Named } from "./z-path";
@@ -203,7 +203,7 @@ import { Named } from "./z-path";
 import { AAA, BBB, CCC } from "./zzz";
 import { XXX, YYY, ZZZ } from "./aaa";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { XXX, YYY, ZZZ } from "./aaa";
 import { AAA, BBB, CCC } from "./zzz";
@@ -219,7 +219,7 @@ import b from "./b.css?raw";
 import a from "./a.css?";
 import c from "./c.css";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "./a.css?";
 import b from "./b.css?raw";
@@ -239,7 +239,7 @@ import c from "~/c";
 
 import b from "~/b";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import b from "~/b";
 import c from "~/c";
@@ -256,7 +256,7 @@ import c from "./c"; // C
 // b
 import b from "./b"; // B
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 // b
 import b from "./b"; // B
@@ -279,7 +279,7 @@ const a = 1;
 
 const b = 2;
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import x1 from "./x1";
 import x2 from "./x2";
@@ -302,7 +302,7 @@ import { a } from "a";
 import { b1, b2 } from "b"; // Comment
 import { c } from "c";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { a } from "a";
 import { b1, b2 } from "b"; // Comment
@@ -321,7 +321,7 @@ export type { U } from "u";
 
 import type { T1, T2 } from "t";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import type { V } from "v";
 
@@ -336,7 +336,7 @@ import type { V } from "v";
 export type { U } from "u";
 import type { T1, T2 } from "t";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import type { V } from "v";
 export type { U } from "u";
@@ -350,7 +350,7 @@ import type { V } from "v";
 const X = 1;
 import type { T1, T2 } from "t";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import type { V } from "v";
 const X = 1;
@@ -369,7 +369,7 @@ export const Y = 2;
 import f from "f";
 import e from "e";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "a";
 import b from "b";
@@ -397,7 +397,7 @@ import { Named } from './folder';
 import { AnotherNamed } from './second-folder';
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "newlinesBetween": false
   }
@@ -423,7 +423,7 @@ import { Named } from './folder';
 import { AnotherNamed } from './second-folder';
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "newlinesBetween": false
   }
@@ -449,7 +449,7 @@ import B from "b";
 import A from "a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "newlinesBetween": false
   }
@@ -476,7 +476,7 @@ import B from "b";
 import A from "a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "newlinesBetween": false
   }
@@ -503,7 +503,7 @@ import X from "x";
 import B from "b";
 import A from "a";
 "#,
-        r#"{ "experimentalSortImports": { "partitionByComment": true } }"#,
+        r#"{ "sortImports": { "partitionByComment": true } }"#,
         r#"
 import X from "x";
 import Y from "y";
@@ -526,7 +526,7 @@ import bb from './bb'
 import e from './e'
 ",
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByComment": true
   },
   "singleQuote": true,
@@ -553,7 +553,7 @@ import C from "c";
 import B from "b";
 import A from "a";
 "#,
-        r#"{ "experimentalSortImports": { "partitionByComment": true } }"#,
+        r#"{ "sortImports": { "partitionByComment": true } }"#,
         r#"
 import C from "c";
 // Comment 1
@@ -577,7 +577,7 @@ import C from "c";
 import B from "b";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "partitionByComment": true,
     "newlinesBetween": false
@@ -602,7 +602,7 @@ import B from "b";
 import A from "a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "partitionByComment": true,
     "newlinesBetween": false
@@ -625,7 +625,7 @@ import B from "b";
 import A from "a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "partitionByComment": true,
     "newlinesBetween": false
@@ -654,7 +654,7 @@ import b from "b";
 
 import a from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 // THIS IS NOT MOVED
 
@@ -671,7 +671,7 @@ import b from "b";
 // AND ALSO THIS CAN BE MOVED
 import a from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 // AND ALSO THIS CAN BE MOVED
 import a from "a";
@@ -692,7 +692,7 @@ import { validateResponse } from "../../validateResponse";
 
 import { z } from "zod";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 // THIS IS A GENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.
 
@@ -715,7 +715,7 @@ import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { z } from "zod";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "partitionByNewline": true,
     "newlinesBetween": false
   }
@@ -739,7 +739,7 @@ import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { z } from "zod";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "newlinesBetween": false
   }
         }"#,
@@ -762,7 +762,7 @@ import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 
 import { z } from "zod";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 // FIXED
 
@@ -784,7 +784,7 @@ import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { z } from "zod";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "newlinesBetween": false,
     "partitionByNewline": true
   }
@@ -814,7 +814,7 @@ import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
 "#,
-        r#"{ "experimentalSortImports": { "order": "desc" } }"#,
+        r#"{ "sortImports": { "order": "desc" } }"#,
         r#"
 import { log10 } from "./log10";
 import { log2 } from "./log2";
@@ -830,7 +830,7 @@ import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
 "#,
-        r#"{ "experimentalSortImports": { "order": "asc" } }"#,
+        r#"{ "sortImports": { "order": "asc" } }"#,
         r#"
 import { log } from "./log";
 import { log1p } from "./log1p";
@@ -845,7 +845,7 @@ import { log10 } from "./log10";
 import { log1p } from "./log1p";
 import { log2 } from "./log2";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { log } from "./log";
 import { log1p } from "./log1p";
@@ -868,7 +868,7 @@ import "s";
 import a from "a";
 import z from "z";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "a";
 import b from "b";
@@ -884,7 +884,7 @@ import "z";
 import "x";
 import a from "a";
 "#,
-        r#"{ "experimentalSortImports": { "sortSideEffects": false } }"#,
+        r#"{ "sortImports": { "sortSideEffects": false } }"#,
         r#"
 import a from "a";
 import "z";
@@ -899,7 +899,7 @@ import "c";
 import "bb";
 import "aaa";
 "#,
-        r#"{ "experimentalSortImports": { "sortSideEffects": false } }"#,
+        r#"{ "sortImports": { "sortSideEffects": false } }"#,
         r#"
 import "c";
 import "bb";
@@ -914,7 +914,7 @@ import a from "a";
 import "z";
 import "x";
 "#,
-        r#"{ "experimentalSortImports": { "sortSideEffects": true } }"#,
+        r#"{ "sortImports": { "sortSideEffects": true } }"#,
         r#"
 import a from "a";
 import "x";
@@ -928,7 +928,7 @@ import "c";
 import "bb";
 import "aaa";
 "#,
-        r#"{ "experimentalSortImports": { "sortSideEffects": true } }"#,
+        r#"{ "sortImports": { "sortSideEffects": true } }"#,
         r#"
 import "aaa";
 import "bb";
@@ -942,7 +942,7 @@ import "./animate.css"
 import "./reset.css"
 
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import "./index.css";
 import "./animate.css";
@@ -961,7 +961,7 @@ fn should_sort_with_ignore_case_option() {
 import { A } from "a";
 import { b } from "B";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import { A } from "a";
 import { b } from "B";
@@ -973,7 +973,7 @@ import { b } from "B";
 import x from "A";
 import y from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import x from "A";
 import y from "a";
@@ -986,7 +986,7 @@ import { z } from "Z";
 import { b } from "B";
 import { a } from "a";
 "#,
-        r#"{ "experimentalSortImports": { "ignoreCase": true } }"#,
+        r#"{ "sortImports": { "ignoreCase": true } }"#,
         r#"
 import { a } from "a";
 import { b } from "B";
@@ -999,7 +999,7 @@ import { z } from "Z";
 import { a } from "a";
 import { B } from "B";
 "#,
-        r#"{ "experimentalSortImports": { "ignoreCase": false } }"#,
+        r#"{ "sortImports": { "ignoreCase": false } }"#,
         r#"
 import { B } from "B";
 import { a } from "a";
@@ -1011,7 +1011,7 @@ import { a } from "a";
 import x from "a";
 import y from "A";
 "#,
-        r#"{ "experimentalSortImports": { "ignoreCase": false } }"#,
+        r#"{ "sortImports": { "ignoreCase": false } }"#,
         r#"
 import y from "A";
 import x from "a";
@@ -1025,7 +1025,7 @@ import { B } from "B";
 import { a } from "a";
 import { Z } from "Z";
 "#,
-        r#"{ "experimentalSortImports": { "ignoreCase": false } }"#,
+        r#"{ "sortImports": { "ignoreCase": false } }"#,
         r#"
 import { B } from "B";
 import { Z } from "Z";
@@ -1048,7 +1048,7 @@ import c from "#c";
 import { b1, b2 } from "#b";
 import { d } from "../d";
 "##,
-        r##"{ "experimentalSortImports": { "internalPattern": ["#"] } }"##,
+        r##"{ "sortImports": { "internalPattern": ["#"] } }"##,
         r##"
 import type { T } from "a";
 import { a } from "a";
@@ -1074,7 +1074,7 @@ fn should_sort_with_multiline_comments_attached_to_each_import() {
 import cn from "classnames"
 import type { Hello } from "pkg"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 /*
  * hi
@@ -1091,7 +1091,7 @@ import type { Hello } from "pkg";
 import cn from "classnames"
 import { Hello } from "pkg"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 /*
  * hi
@@ -1112,7 +1112,7 @@ import b from "b"
  */
 import a from "a"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 /*
  * for a
@@ -1138,7 +1138,7 @@ import b from "b";
 import b from "b"
 import a from "a"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import a from "a";
 /*
@@ -1161,7 +1161,7 @@ import b from "b";
 import b from "b"
 import a from "a"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 /*
  * comment
@@ -1181,7 +1181,7 @@ import b from "b";
  */
 import a from "a"
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 /*
  * multiline
@@ -1206,7 +1206,7 @@ import { e1, e2, e3 } from "../../e";
 
 import { b1, b2 } from "~/b";
 "#,
-        r#"{ "experimentalSortImports": { "newlinesBetween": false } }"#,
+        r#"{ "sortImports": { "newlinesBetween": false } }"#,
         r#"
 import { a1, a2, a3 } from "a";
 import type { T } from "t";
@@ -1229,7 +1229,7 @@ import { e1, e2, e3 } from "../../e";
 
 import { b1, b2 } from "~/b";
 "#,
-        r#"{ "experimentalSortImports": { "newlinesBetween": true } }"#,
+        r#"{ "sortImports": { "newlinesBetween": true } }"#,
         r#"
 import { a1, a2, a3 } from "a";
 import type { T } from "t";
@@ -1253,7 +1253,7 @@ import z from "~/z";
 
 import b from "~/b";
 "#,
-        r#"{ "experimentalSortImports": { "newlinesBetween": false } }"#,
+        r#"{ "sortImports": { "newlinesBetween": false } }"#,
         r#"
 import { A } from "a";
 import b from "~/b";
@@ -1278,7 +1278,7 @@ import {
   xyz,
 } from "a";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import {
   type Data,
@@ -1300,7 +1300,7 @@ fn issue_17788() {
         r"
 `/*`
 ",
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r"
 `/*`;
 ",
@@ -1313,7 +1313,7 @@ acc[path] = `src/${path
 .map((s) => s[0].toUpperCase() + s.slice(1))
 .join('/')}/*`;
 ",
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 acc[path] = `src/${path
   .split("/")

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/custom_groups.rs
@@ -11,7 +11,7 @@ import { t } from "t";
 "#,
         r#"
 {
-    "experimentalSortImports":  {
+    "sortImports":  {
         "groups": [
             "side_effect_style",
             "type-external",
@@ -78,7 +78,7 @@ import CartComponentB from "./cart/CartComponentB.vue";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "elementNamePattern": ["~/validators/**"],
@@ -193,7 +193,7 @@ import ComponentC from "~/components/ComponentC.vue";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "elementNamePattern": ["~/validators/**"],
@@ -296,7 +296,7 @@ import { a } from "./a.ts";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "mocks",
@@ -328,7 +328,7 @@ import Vuetify from "vuetify";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "frameworks",
@@ -360,7 +360,7 @@ import Vuetify from "vuetify";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "vue-core",
@@ -394,7 +394,7 @@ import type { Qux } from "qux";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "types",
@@ -430,7 +430,7 @@ import type { Qux } from "qux";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "type-imports",
@@ -466,7 +466,7 @@ import { externalUtil } from "ext-lib";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "internal-types",
@@ -504,7 +504,7 @@ import { externalUtil } from "ext-lib";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "internal-type-imports",
@@ -541,7 +541,7 @@ import { bar } from "bar";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "types-only",
@@ -574,7 +574,7 @@ import { regular } from "regular";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "type-named",
@@ -610,7 +610,7 @@ import e from "e";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "externalImports",
@@ -651,7 +651,7 @@ import { c } from "c";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "primary",
@@ -698,7 +698,7 @@ import { baz } from "./sibling";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "internalPattern": ["~/"],
         "customGroups": [
             {
@@ -747,7 +747,7 @@ import { bar } from "@scope/bar";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "scope-types",
@@ -791,7 +791,7 @@ import e from "e";
 "#,
         r#"
 {
-    "experimentalSortImports": {
+    "sortImports": {
         "customGroups": [
             {
                 "groupName": "typeSiblings",

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/groups.rs
@@ -27,7 +27,7 @@ import { j } from "../j";
 import { K, L, M } from "../k";
 import "./style.css";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import fs from "fs";
 import path from "path";
@@ -81,7 +81,7 @@ import type { H } from "./index.d.ts";
 
 import "./style.css";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import fs from "fs";
 import path from "path";
@@ -116,7 +116,7 @@ import type { T } from "t";
 // @ts-expect-error missing types
 import { t } from "t";
 "#,
-        r#"{ "experimentalSortImports": {} }"#,
+        r#"{ "sortImports": {} }"#,
         r#"
 import type { T } from "t";
 // @ts-expect-error missing types
@@ -138,7 +138,7 @@ import type { U } from "~/u";
 import type { V } from "v";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": [
         "type",
         ["builtin", "external"],
@@ -163,7 +163,7 @@ import "./cc";
 import "../d";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["external", "side_effect", "unknown"],
     "sortSideEffects": false
   }
@@ -186,7 +186,7 @@ import a from "aaaa";
 import "../d";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["external", "side_effect", "unknown"],
     "sortSideEffects": false
   }
@@ -207,7 +207,7 @@ import "bb";
 import "aaa";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["external", "side_effect", "unknown"],
     "sortSideEffects": true
   }
@@ -229,7 +229,7 @@ import "./a-side-effect";
 import a from "./a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["unknown"]
   }
 }"#,
@@ -253,7 +253,7 @@ import "./a-side-effect";
 import a from "./a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect", "unknown"]
   }
 }"#,
@@ -278,7 +278,7 @@ import "./a-side-effect";
 import a from "./a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": [["side_effect", "side_effect_style"], "unknown"]
   }
 }"#,
@@ -303,7 +303,7 @@ import "./a-side-effect";
 import a from "./a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect", "side_effect_style", "unknown"]
   }
 }"#,
@@ -329,7 +329,7 @@ import "./a-side-effect.css";
 import a from "./a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect_style", "unknown"]
   }
 }"#,
@@ -352,7 +352,7 @@ import { a } from "./a"; // Comment after
 import { c } from "c";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["unknown", "external"],
     "newlinesBetween": true
   }
@@ -372,7 +372,7 @@ import a from "./a";
 import b from "./index";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["index", "sibling"]
   }
 }"#,
@@ -390,7 +390,7 @@ import "something";
 import "style.css";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect_style", "side_effect"]
   }
 }"#,
@@ -408,7 +408,7 @@ import style from "style.css";
 import "something";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect", "style"]
   }
 }"#,
@@ -426,7 +426,7 @@ import a from "./a";
 import b from "b";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["external", "import"]
   }
 }"#,
@@ -444,7 +444,7 @@ import f from "f";
 import "./z";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["side_effect-import", "external", "value-import"],
     "sortSideEffects": true
   }
@@ -463,7 +463,7 @@ import f from "f";
 import z, { z } from "./z";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["default-import", "external", "named-import"]
   }
 }"#,
@@ -481,7 +481,7 @@ import f from "f";
 import * as z from "./z";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["wildcard-import", "external", "named-import"]
   }
 }"#,
@@ -498,7 +498,7 @@ import { b } from "b";
 import { a } from "@/a";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["external", "internal"],
     "newlinesBetween": true
   }
@@ -522,7 +522,7 @@ import d from "d";
 import style from "style.css";
 "##,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": [
         "style",
         [
@@ -557,7 +557,7 @@ import * as c from "c";
 import { b1, type b2, b3 as b33 } from "b";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": []
   }
 }"#,
@@ -576,7 +576,7 @@ import * as c from "c";
 import { b1, type b2, b3 as b33 } from "b";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": [[], []]
   }
 }"#,
@@ -594,7 +594,7 @@ import { writeFile } from "node:fs/promises";
 import { useEffect } from "react";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["builtin", "external"]
   }
 }"#,
@@ -612,7 +612,7 @@ import "~/data";
 import "~/css/globals.css";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["internal", "side_effect_style", "side_effect"]
   }
 }"#,
@@ -634,7 +634,7 @@ import { c } from "c";
 import "node:os";
 "#,
         r#"{
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": ["builtin", "external", "side_effect"]
   }
 }"#,

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/newlines_between_override.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/newlines_between_override.rs
@@ -12,7 +12,7 @@ import { bar } from "./bar";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": true,
                 "groups": [
                     ["value-builtin", "value-external"],
@@ -44,7 +44,7 @@ import { bar } from "./bar";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": false,
                 "groups": [
                     ["value-builtin", "value-external"],
@@ -76,7 +76,7 @@ import { bar } from "./bar";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": true,
                 "groups": [
                     "type-import",
@@ -110,7 +110,7 @@ import { bar } from "./bar";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": false,
                 "groups": [
                     ["value-builtin", "value-external"],
@@ -140,7 +140,7 @@ import { bar } from "./bar";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": true,
                 "groups": [
                     ["value-builtin", "value-external"],
@@ -171,7 +171,7 @@ import { foo } from "../foo";
 import { baz } from "baz";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": true,
                 "groups": [
                     "type-import",
@@ -203,7 +203,7 @@ import { foo } from "../foo";
 import type { T } from "t";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": true,
                 "groups": [
                     "type-import",
@@ -237,7 +237,7 @@ import { foo } from "../foo";
 import type { T } from "t";
 "#,
         r#"{
-            "experimentalSortImports": {
+            "sortImports": {
                 "newlinesBetween": false,
                 "groups": [
                     "type-import",

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -109,7 +109,7 @@ export interface OxcFormatterOptions {
   /** Put each attribute on its own line (default: false) */
   singleAttributePerLine?: boolean
   /** Sort imports configuration (default: None) */
-  experimentalSortImports?: OxcSortImportsOptions
+  sortImports?: OxcSortImportsOptions
 }
 
 export interface OxcInjectOptions {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -510,7 +510,7 @@ impl Oxc {
             }
         }
 
-        if let Some(ref sort_imports_config) = options.experimental_sort_imports {
+        if let Some(ref sort_imports_config) = options.sort_imports {
             let order = sort_imports_config
                 .order
                 .as_ref()
@@ -580,7 +580,7 @@ impl Oxc {
                     },
                 );
 
-            format_options.experimental_sort_imports = Some(SortImportsOptions {
+            format_options.sort_imports = Some(SortImportsOptions {
                 partition_by_newline: sort_imports_config.partition_by_newline.unwrap_or(false),
                 partition_by_comment: sort_imports_config.partition_by_comment.unwrap_or(false),
                 sort_side_effects: sort_imports_config.sort_side_effects.unwrap_or(false),

--- a/napi/playground/src/options.rs
+++ b/napi/playground/src/options.rs
@@ -149,7 +149,7 @@ pub struct OxcFormatterOptions {
     /// Put each attribute on its own line (default: false)
     pub single_attribute_per_line: Option<bool>,
     /// Sort imports configuration (default: None)
-    pub experimental_sort_imports: Option<OxcSortImportsOptions>,
+    pub sort_imports: Option<OxcSortImportsOptions>,
 }
 
 #[napi(object)]

--- a/tasks/benchmark/benches/formatter.rs
+++ b/tasks/benchmark/benches/formatter.rs
@@ -20,7 +20,7 @@ fn bench_formatter(criterion: &mut Criterion) {
                     .parse()
                     .program;
                 let format_options = FormatOptions {
-                    experimental_sort_imports: Some(SortImportsOptions::default()),
+                    sort_imports: Some(SortImportsOptions::default()),
                     ..Default::default()
                 };
                 runner.run(|| {


### PR DESCRIPTION
Internal changes that do not affect Oxfmt users.