### PR TITLE
refactor(formatter): Remove experimental prefix from tailwindcss w/ renaming

### DIFF
--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -240,7 +240,7 @@ impl ExternalFormatter {
             None
         };
 
-        let needs_tailwind = format_options.experimental_tailwindcss.is_some();
+        let needs_tailwind = format_options.sort_tailwindcss.is_some();
         let tailwind_callback: Option<TailwindCallback> = if needs_tailwind {
             let sort_tailwindcss_classes = Arc::clone(&self.sort_tailwindcss_classes);
             Some(Arc::new(move |classes: Vec<String>| {

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -512,7 +512,7 @@ impl FormatConfig {
         }
 
         if let Some(config) = self.experimental_tailwindcss {
-            format_options.experimental_tailwindcss = Some(TailwindcssOptions {
+            format_options.sort_tailwindcss = Some(TailwindcssOptions {
                 config: config.config,
                 stylesheet: config.stylesheet,
                 functions: config.functions.unwrap_or_default(),

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -78,7 +78,7 @@ pub struct FormatOptions {
     /// Enable Tailwind CSS class sorting in JSX class/className attributes.
     /// When enabled, class strings will be collected and passed to a callback for sorting.
     /// Defaults to None (disabled).
-    pub experimental_tailwindcss: Option<TailwindcssOptions>,
+    pub sort_tailwindcss: Option<TailwindcssOptions>,
 }
 
 /// Options for Tailwind CSS class sorting.
@@ -147,7 +147,7 @@ impl FormatOptions {
             experimental_ternaries: false,
             embedded_language_formatting: EmbeddedLanguageFormatting::default(),
             sort_imports: None,
-            experimental_tailwindcss: None,
+            sort_tailwindcss: None,
         }
     }
 
@@ -175,7 +175,7 @@ impl fmt::Display for FormatOptions {
         writeln!(f, "Experimental operator position: {}", self.experimental_operator_position)?;
         writeln!(f, "Embedded language formatting: {}", self.embedded_language_formatting)?;
         writeln!(f, "Sort imports: {:?}", self.sort_imports)?;
-        writeln!(f, "Experimental tailwindcss: {:?}", self.experimental_tailwindcss)
+        writeln!(f, "Sort tailwindcss: {:?}", self.sort_tailwindcss)
     }
 }
 

--- a/crates/oxc_formatter/src/print/call_like_expression/mod.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/mod.rs
@@ -28,7 +28,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
         // Check if this is a Tailwind function call (e.g., clsx, cn, tw)
         let is_tailwind_call = f
             .options()
-            .experimental_tailwindcss
+            .sort_tailwindcss
             .as_ref()
             .is_some_and(|opts| is_tailwind_function_call(&self.callee, opts));
 
@@ -94,7 +94,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, CallExpression<'a>> {
                 // If this IS a Tailwind function call, push the Tailwind context
                 let tailwind_ctx_to_push = if is_tailwind_call {
                     f.options()
-                        .experimental_tailwindcss
+                        .sort_tailwindcss
                         .as_ref()
                         .map(|opts| TailwindContextEntry::new(opts.preserve_whitespace))
                 } else {

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -329,7 +329,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXAttribute<'a>> {
             // Extract context entry before mutating f
             let tailwind_ctx_to_push = f
                 .options()
-                .experimental_tailwindcss
+                .sort_tailwindcss
                 .as_ref()
                 .filter(|opts| is_tailwind_jsx_attribute(&self.name, opts))
                 .map(|opts| TailwindContextEntry::new(opts.preserve_whitespace));

--- a/crates/oxc_formatter/src/print/template.rs
+++ b/crates/oxc_formatter/src/print/template.rs
@@ -67,7 +67,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TaggedTemplateExpression<'a>> {
         // Extract context entry before mutating f
         let tailwind_ctx_to_push = f
             .options()
-            .experimental_tailwindcss
+            .sort_tailwindcss
             .as_ref()
             .filter(|opts| is_tailwind_function_call(&self.tag, opts))
             .map(|opts| TailwindContextEntry::new(opts.preserve_whitespace));


### PR DESCRIPTION
Internal changes that do not affect Oxfmt users.

If just removed the prefix, it would become "tailwind", so I added "sort_" to standardize it.