### PR TITLE
fix(linter): handle additional cases in `typescript/consistent-generic-constructors` rule.

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1396,6 +1396,7 @@ impl RuleRunner
     for crate::rules::typescript::consistent_generic_constructors::ConsistentGenericConstructors
 {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::AccessorProperty,
         AstType::FormalParameter,
         AstType::PropertyDefinition,
         AstType::VariableDeclarator,

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_generic_constructors.snap
@@ -85,6 +85,33 @@ source: crates/oxc_linter/src/tester.rs
   help: Move the type annotation to the constructor
 
   ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
+   ╭─[consistent_generic_constructors.tsx:3:25]
+ 2 │             class Foo {
+ 3 │               accessor a: Foo<string> = new Foo();
+   ·                         ─────────────
+ 4 │             }
+   ╰────
+  help: Move the type annotation to the constructor
+
+  ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the type annotation.
+   ╭─[consistent_generic_constructors.tsx:3:35]
+ 2 │             class Foo {
+ 3 │               accessor a = new Foo<string>();
+   ·                                   ────────
+ 4 │             }
+   ╰────
+  help: Move the generic type to the type annotation
+
+  ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
+   ╭─[consistent_generic_constructors.tsx:3:27]
+ 2 │             class Foo {
+ 3 │               accessor [a]: Foo<string> = new Foo();
+   ·                           ─────────────
+ 4 │             }
+   ╰────
+  help: Move the type annotation to the constructor
+
+  ⚠ typescript-eslint(consistent-generic-constructors): The generic type arguments should be specified as part of the constructor type arguments.
    ╭─[consistent_generic_constructors.tsx:2:27]
  1 │ 
  2 │             function foo(a: Foo<string> = new Foo()) {}


### PR DESCRIPTION
- Fix the `accessor` cases in `consistent-generic-constructor`, uncomment tests.
- Fix typed array cases in `consistent-generic-constructor`, uncomment tests.

Generated with Claude Code.