### PR TITLE
fix(linter): improve extends resolution for node_modules configs

### DIFF
--- a/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["prettier", "next/core-web-vitals"]
+}

--- a/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/next/core-web-vitals.js
+++ b/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/next/core-web-vitals.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/next/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/next/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "next",
+  "version": "1.0.0",
+  "exports": {
+    "./core-web-vitals": "./core-web-vitals.js"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/prettier/index.js
+++ b/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/prettier/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/prettier/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/named_config_with_node_modules/node_modules/prettier/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "prettier",
+  "version": "1.0.0",
+  "exports": "./index.js"
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "oxlint-standard",
+    "oxlint-standard/configs/recommended.json",
+    "@private/oxlint-rules"
+  ],
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/@private/oxlint-rules/index.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/@private/oxlint-rules/index.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-alert": "warn"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/@private/oxlint-rules/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/@private/oxlint-rules/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@private/oxlint-rules",
+  "version": "1.0.0",
+  "exports": "./index.json"
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/configs/recommended.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/configs/recommended.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-var": "warn"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/index.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/index.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-debugger": "error",
+    "no-console": "warn"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends/node_modules/oxlint-standard/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "oxlint-standard",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.json",
+    "./configs/recommended.json": "./configs/recommended.json"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["oxlint-js-config"]
+}

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/node_modules/oxlint-js-config/index.js
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/node_modules/oxlint-js-config/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/node_modules/oxlint-js-config/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/node_modules_extends_non_json/node_modules/oxlint-js-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "oxlint-js-config",
+  "version": "1.0.0",
+  "exports": "./index.js"
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["configs/recommended.json"]
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/node_modules/configs/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/node_modules/configs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "configs",
+  "version": "1.0.0",
+  "exports": {
+    "./recommended.json": "./recommended.js"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/node_modules/configs/recommended.js
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_non_json_error/node_modules/configs/recommended.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/.oxlintrc.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["configs/recommended.json"]
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/configs/recommended.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/configs/recommended.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/node_modules/configs/package.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/node_modules/configs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "configs",
+  "version": "1.0.0"
+}

--- a/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/node_modules/configs/recommended.json
+++ b/crates/oxc_linter/fixtures/extends_config/path_like_extends_precedence/node_modules/configs/recommended.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-debugger": "off"
+  }
+}

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1484,6 +1484,31 @@ mod test {
     }
 
     #[test]
+    fn test_extends_path_like_specifier_resolved_non_json_package_errors() {
+        let invalid_config = {
+            let mut external_plugin_store = ExternalPluginStore::default();
+            ConfigStoreBuilder::from_oxlintrc(
+                true,
+                Oxlintrc::from_file(&PathBuf::from(
+                    "fixtures/extends_config/path_like_extends_non_json_error/.oxlintrc.json",
+                ))
+                .unwrap(),
+                None,
+                &mut external_plugin_store,
+                None,
+            )
+        };
+
+        let err = invalid_config.unwrap_err();
+        assert!(matches!(err, ConfigBuilderError::InvalidConfigFile { .. }));
+        if let ConfigBuilderError::InvalidConfigFile { file, reason } = err {
+            assert_eq!(file, "configs/recommended.json");
+            assert!(reason.contains("recommended.js"));
+            assert!(reason.contains("Only JSON configuration files are supported."));
+        }
+    }
+
+    #[test]
     fn test_not_extends_named_configs() {
         // Named configs are unsupported and should be ignored, even if they resolve in node_modules.
         let config = config_store_from_path(


### PR DESCRIPTION
<!--
Instead of this:
```json
{
  "$schema": "./node_modules/oxlint/configuration_schema.json",
  "jsPlugins": ["eslint-plugin-solid"],
  "rules": {
    "solid/components-return-once": "error",
    "solid/event-handlers": "error",
    "solid/imports": "error",
    "solid/jsx-no-duplicate-props": "error",
    "solid/jsx-no-script-url": "error",
    "solid/jsx-no-undef": "error",
    "solid/jsx-uses-vars": "error",
    "solid/no-destructure": "error",
    "solid/no-innerhtml": "error",
    "solid/no-react-deps": "error",
    "solid/no-react-specific-props": "error",
    "solid/no-unknown-namespaces": "error",
    "solid/prefer-for": "error",
    "solid/reactivity": "error",
    "solid/self-closing-comp": "error",
    "solid/style-prop": "error",
    "solid/prefer-classlist": "warn",
    "solid/prefer-show": "warn",
  }
}
```

Let's do this:
```json
{
  "$schema": "./node_modules/oxlint/configuration_schema.json",
  "jsPlugins": ["eslint-plugin-solid"],
  "extends": ["plugin:solid/recommended"]
}
```
-->

Resolve `extends` package specifiers from `node_modules`, including package subpaths (e.g.`pkg/configs/recommended.json`).

Preserve legacy semantics for path-like specifiers by preferring local filesystem paths first, and only falling back to resolver-based package resolution when needed.

Keep unsupported named configs ignored (`eslint:`, `plugin:`, and bare non-JSON package entries), while raising an explicit config error when a path-like package target resolves to a non-JSON file.

Add regression fixtures/tests for scoped/unscoped packages, subpath extends, non-JSON package entries, named-config resolution, and path-vs-package precedence.

Fixes #15538