### PR TITLE
fix(linter/no-barrel-file): respect disable directives with threshold 0

### DIFF
--- a/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
@@ -21,10 +21,10 @@ source: crates/oxc_linter/src/tester.rs
   note: See: https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7
 
   ⚠ oxc(no-barrel-file): Barrel file detected, 1 modules are loaded which exceeds the threshold of 0.
-   ╭─[index.ts:1:1]
+   ╭─[index.ts:1:15]
  1 │ export * from './a';
-   · ──────────┬─────────
-   ·           ╰── File defined here.
+   ·               ──┬──
+   ·                 ╰── Barrel file detected here.
    ╰────
   help: Consider importing directly from the specific modules instead of using `export *` or `import *`.
         Loading 1 modules may be slow for runtimes and bundlers.

--- a/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_barrel_file.snap
@@ -19,3 +19,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider importing directly from the specific modules instead of using `export *` or `import *`.
         Loading 10 modules may be slow for runtimes and bundlers.
   note: See: https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7
+
+  ⚠ oxc(no-barrel-file): Barrel file detected, 1 modules are loaded which exceeds the threshold of 0.
+   ╭─[index.ts:1:1]
+ 1 │ export * from './a';
+   · ──────────┬─────────
+   ·           ╰── File defined here.
+   ╰────
+  help: Consider importing directly from the specific modules instead of using `export *` or `import *`.
+        Loading 1 modules may be slow for runtimes and bundlers.
+  note: See: https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7


### PR DESCRIPTION
The `oxc/no-barrel-file` rule was not respecting `oxlint-disable` or `eslint-disable` directives when threshold was set to 0. This occurred because the rule used `Span::new(0, 0)` when no specific module spans were available, causing the disable directive overlap check to fail. This is similar handled like `unicorn/no-empty-file`.

Root Cause:
- When labels were empty, the rule created a label with Span::new(0, 0)
- The Message::new() function extracts the span from the first label
- DisableDirectives::contains() checks span overlap with disabled intervals
- For non-next-line directives: span.start < interval.stop && span.end > interval.start
- With span = (0, 0), the check becomes: 0 < interval.stop && 0 > interval.start
- The second condition (0 > interval.start) is always false since interval.start >= 0