### PR TITLE
fix(tasks/website_linter): fix clippy warning on Windows

### DIFF
--- a/tasks/website_linter/src/rules/doc_page.rs
+++ b/tasks/website_linter/src/rules/doc_page.rs
@@ -58,10 +58,11 @@ impl Context {
         let default = if *turned_on_by_default { "true" } else { "false" };
         let type_aware = if *is_tsgolint_rule { "true" } else { "false" };
         let fix = autofix.to_string();
-        #[cfg(windows)]
-        let file = file!().replace('\\', "/");
-        #[cfg(not(windows))]
+
         let file = file!();
+        #[cfg(windows)]
+        #[expect(clippy::disallowed_methods, reason = "file path always contains slashes")]
+        let file = &*file.replace('\\', "/");
 
         writeln!(
             self.page,


### PR DESCRIPTION
Fix a clippy warning on Windows.

Use of `str::replace` produced `disallowed_methods` warning, but only in the `#[cfg(windows)]` gated code.

Discovered in #19208.