### PR TITLE
fix(linter/array-callback-return): Check `allowVoid` option

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_array_callback_return.snap
@@ -1122,3 +1122,93 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: "Array.fromAsync" uses the callback's return value. Add a `return` on every possible code path.
         Return a value on each path (or enable `allowImplicit` to allow `return;`).
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => x);
+   ·     ───┬───      ┬
+   ·        │         ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => !x);
+   ·     ───┬───      ─┬
+   ·        │          ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => (x));
+   ·     ───┬───      ─┬─
+   ·        │          ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { return x; });
+   ·     ───┬───               ┬
+   ·        │                  ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { return !x; });
+   ·     ───┬───               ─┬
+   ·        │                   ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { return (x); });
+   ·     ───┬───               ─┬─
+   ·        │                   ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { return x + 1; });
+   ·     ───┬───               ──┬──
+   ·        │                    ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { if (a === b) { return x; } });
+   ·     ───┬───                              ┬
+   ·        │                                 ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { if (a === b) { return !x; } });
+   ·     ───┬───                              ─┬
+   ·        │                                  ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`
+
+  ⚠ eslint(array-callback-return): Unexpected return value in callback for "Array.prototype.forEach"
+   ╭─[array_callback_return.tsx:1:5]
+ 1 │ foo.forEach(x => { if (a === b) { return (x + a); } });
+   ·     ───┬───                              ───┬───
+   ·        │                                    ╰── Prepend `void` to the expression.
+   ·        ╰── "Array.prototype.forEach" is called here.
+   ╰────
+  help: Expected the return expression to be started with `void`


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/19485

It took me more than time than expected, because `allowVoid` means all expression to be prefixed with `void` and it only works if `checkForEach` is set to true, otherwise, we don't allow `avoid.`