### PR TITLE
fix(linter): add help text to eslint rule diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_await_in_loop.rs
@@ -9,7 +9,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_await_in_loop_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected `await` inside a loop.").with_label(span)
+    OxcDiagnostic::warn("Unexpected `await` inside a loop.")
+        .with_help("Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -9,7 +9,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_case_declarations_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected lexical declaration in case block.").with_label(span)
+    OxcDiagnostic::warn("Unexpected lexical declaration in case block.")
+        .with_help("Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -8,6 +8,7 @@ use crate::{context::LintContext, rule::Rule};
 
 fn no_const_assign_diagnostic(name: &str, decl_span: Span, assign_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Unexpected re-assignment of `const` variable {name}."))
+        .with_help("Use `let` instead of `const` if you need to reassign this variable.")
         .with_labels([
             decl_span.label(format!("{name} is declared here as `const`.")),
             assign_span.label(format!("{name} is re-assigned here.")),

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -10,7 +10,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_constructor_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected return statement in constructor.").with_label(span)
+    OxcDiagnostic::warn("Unexpected return statement in constructor.")
+        .with_help("Remove the return statement from the constructor. If you need early exit, use a bare `return;` with no value.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -7,7 +7,9 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_delete_var_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Variables should not be deleted").with_label(span)
+    OxcDiagnostic::warn("Variables should not be deleted")
+        .with_help("Assign `undefined` to the variable instead of using `delete`. The `delete` operator is intended for removing properties from objects, not for variables.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("eval can be harmful.").with_label(span)
+    OxcDiagnostic::warn("eval can be harmful.")
+        .with_help("Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_lone_blocks.rs
@@ -7,11 +7,15 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Block is unnecessary.").with_label(span)
+    OxcDiagnostic::warn("Block is unnecessary.")
+        .with_help("Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.")
+        .with_label(span)
 }
 
 fn no_nested_lone_blocks_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Nested block is redundant.").with_label(span)
+    OxcDiagnostic::warn("Nested block is redundant.")
+        .with_help("Remove the redundant nested block statement.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn require_yield_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This generator function does not have `yield`").with_label(span)
+    OxcDiagnostic::warn("This generator function does not have `yield`")
+        .with_help("Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_await_in_loop.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_await_in_loop.snap
@@ -7,99 +7,116 @@ source: crates/oxc_linter/src/tester.rs
  1 │ async function foo() { while (baz) { await bar; } }
    ·                                      ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:31]
  1 │ async function foo() { while (await foo()) {  } }
    ·                               ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:42]
  1 │ async function foo() { while (baz) { for await (x of xs); } }
    ·                                          ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var bar of baz) { await bar; } }
    ·                                               ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:45]
  1 │ async function foo() { for (var bar of baz) await bar; }
    ·                                             ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var bar in baz) { await bar; } }
    ·                                               ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:50]
  1 │ async function foo() { for (var i; i < n; i++) { await bar; } }
    ·                                                  ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:36]
  1 │ async function foo() { for (var i; await foo(i); i++) {  } }
    ·                                    ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:47]
  1 │ async function foo() { for (var i; i < n; i = await bar) {  } }
    ·                                               ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:29]
  1 │ async function foo() { do { await bar; } while (baz); }
    ·                             ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:38]
  1 │ async function foo() { do { } while (await bar); }
    ·                                      ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:54]
  1 │ async function foo() { while (true) { if (bar) { foo(await bar); } } }
    ·                                                      ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:42]
  1 │ async function foo() { while (xyz || 5 > await x) {  } }
    ·                                          ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:60]
  1 │ async function foo() { for await (var x of xs) { while (1) await f(x) } }
    ·                                                            ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:16]
  1 │ while (true) { await using resource = getResource(); }
    ·                ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:12]
  1 │ for (;;) { await using resource = getResource(); }
    ·            ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.
 
   ⚠ eslint(no-await-in-loop): Unexpected `await` inside a loop.
    ╭─[no_await_in_loop.tsx:1:6]
  1 │ for (await using resource of resources) {}
    ·      ─────
    ╰────
+  help: Collect all promises into an array and use `Promise.all()` to run them in parallel, rather than awaiting each one sequentially inside the loop.

--- a/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
@@ -7,48 +7,56 @@ source: crates/oxc_linter/src/tester.rs
  1 │ switch (a) { case 1: let x = 1; break; }
    ·                      ───
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: let x = 2; break; }
    ·                       ───
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: const x = 1; break; }
    ·                      ─────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: const x = 2; break; }
    ·                       ─────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: function f() {} break; }
    ·                      ────────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: function f() {} break; }
    ·                       ────────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:22]
  1 │ switch (a) { case 1: class C {} break; }
    ·                      ─────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: class C {} break; }
    ·                       ─────
    ╰────
+  help: Wrap the case body in braces `{}` to create an explicit block scope for the lexical declaration.
 
   × Using declaration cannot appear in the bare case statement.
    ╭─[no_case_declarations.tsx:1:23]

--- a/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_const_assign.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:11]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·           │            ╰── x is re-assigned here.
    ·           ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │           ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable i.
    ╭─[no_const_assign.tsx:1:12]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │                ╰── i is re-assigned here.
    ·            ╰── i is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │      ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │             ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                       ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                        ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                     ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                                          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:1]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    · │              ╰── x is declared here as `const`.
    · ╰── x is re-assigned here.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:24]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │                      ╰── d is re-assigned here.
    ·                        ╰── d is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable d.
    ╭─[no_const_assign.tsx:1:7]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                         ╰── d is re-assigned here.
    ·       ╰── d is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable b.
    ╭─[no_const_assign.tsx:1:7]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │              ╰── b is re-assigned here.
    ·       ╰── b is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -153,6 +171,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │          ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -161,6 +180,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │          ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -169,6 +189,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │          ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -177,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │           ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -185,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             │           ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:7]
@@ -193,6 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    ·       │               ╰── x is re-assigned here.
    ·       ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.
 
   ⚠ eslint(no-const-assign): Unexpected re-assignment of `const` variable x.
    ╭─[no_const_assign.tsx:1:13]
@@ -201,3 +225,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             │               ╰── x is re-assigned here.
    ·             ╰── x is declared here as `const`.
    ╰────
+  help: Use `let` instead of `const` if you need to reassign this variable.

--- a/crates/oxc_linter/src/snapshots/eslint_no_constructor_return.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constructor_return.snap
@@ -7,9 +7,11 @@ source: crates/oxc_linter/src/tester.rs
  1 │ class C { constructor() { return '' } }
    ·                           ─────────
    ╰────
+  help: Remove the return statement from the constructor. If you need early exit, use a bare `return;` with no value.
 
   ⚠ eslint(no-constructor-return): Unexpected return statement in constructor.
    ╭─[no_constructor_return.tsx:1:38]
  1 │ class C { constructor(a) { if (!a) { return '' } else { a() } } }
    ·                                      ─────────
    ╰────
+  help: Remove the return statement from the constructor. If you need early exit, use a bare `return;` with no value.

--- a/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_delete_var.snap
@@ -7,3 +7,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ delete x
    · ────────
    ╰────
+  help: Assign `undefined` to the variable instead of using `delete`. The `delete` operator is intended for removing properties from objects, not for variables.

--- a/crates/oxc_linter/src/snapshots/eslint_no_eval.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_eval.snap
@@ -7,255 +7,298 @@ source: crates/oxc_linter/src/tester.rs
  1 │ eval(foo)
    · ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval('foo')
    · ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:22]
  1 │ function foo(eval) { eval('foo') }
    ·                      ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval(foo)
    · ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:1]
  1 │ eval('foo')
    · ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:22]
  1 │ function foo(eval) { eval('foo') }
    ·                      ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:5]
  1 │ (0, eval)('foo')
    ·     ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ (0, window.eval)('foo')
    ·            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ (0, window['eval'])('foo')
    ·            ──────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ var EVAL = eval; EVAL('foo')
    ·            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:17]
  1 │ var EVAL = this.eval; EVAL('foo')
    ·                 ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ 'use strict'; var EVAL = this.eval; EVAL('foo')
    ·                               ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:39]
  1 │ function foo() { ('use strict'); this.eval; }
    ·                                       ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:14]
  1 │ () => { this.eval('foo'); }
    ·              ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:28]
  1 │ () => { 'use strict'; this.eval('foo'); }
    ·                            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:28]
  1 │ 'use strict'; () => { this.eval('foo'); }
    ·                            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:36]
  1 │ () => { 'use strict'; () => { this.eval('foo'); } }
    ·                                    ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ (function(exe){ exe('foo') })(eval);
    ·                               ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:8]
  1 │ window.eval('foo')
    ·        ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ window.window.eval('foo')
    ·               ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ window.window['eval']('foo')
    ·               ──────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:8]
  1 │ global.eval('foo')
    ·        ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ global.global.eval('foo')
    ·               ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:15]
  1 │ global.global[`eval`]('foo')
    ·               ──────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:6]
  1 │ this.eval('foo')
    ·      ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:20]
  1 │ 'use strict'; this.eval('foo')
    ·                    ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ function foo() { this.eval('foo') }
    ·                       ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ var EVAL = globalThis.eval; EVAL('foo')
    ·                       ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:12]
  1 │ globalThis.eval('foo')
    ·            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ globalThis.globalThis.eval('foo')
    ·                       ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:23]
  1 │ globalThis.globalThis['eval']('foo')
    ·                       ──────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:16]
  1 │ (0, globalThis.eval)('foo')
    ·                ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:16]
  1 │ (0, globalThis['eval'])('foo')
    ·                ──────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:9]
  1 │ window?.eval('foo')
    ·         ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:10]
  1 │ (window?.eval)('foo')
    ·          ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:18]
  1 │ (window?.window).eval('foo')
    ·                  ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:17]
  1 │ class C { [this.eval('foo')] }
    ·                 ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:31]
  1 │ 'use strict'; class C { [this.eval('foo')] }
    ·                               ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:27]
  1 │ class A { static {} [this.eval()]; }
    ·                           ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:26]
  1 │ array.findLast(x => this.eval.includes(x), { eval: 'abc' });
    ·                          ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:51]
  1 │ callbacks.findLastIndex(function (cb) { return cb(eval); }, this);
    ·                                                   ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:46]
  1 │ ['1+1'].flatMap(function (str) { return this.eval(str); });
    ·                                              ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.
 
   ⚠ eslint(no-eval): eval can be harmful.
    ╭─[no_eval.tsx:1:44]
  1 │ ['1'].reduce(function (a, b) { return this.eval(a) ? a : b; }, '0');
    ·                                            ────
    ╰────
+  help: Avoid eval(). For JSON parsing use JSON.parse(); for dynamic property access use bracket notation (obj[key]); for other cases refactor to avoid evaluating strings as code.

--- a/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
@@ -7,36 +7,42 @@ source: crates/oxc_linter/src/tester.rs
  1 │ {}
    · ──
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ {var x = 1;}
    · ────────────
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:8]
  1 │ foo(); {} bar();
    ·        ──
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:19]
  1 │ function test() { { console.log(6); } }
    ·                   ───────────────────
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:1:19]
  1 │ if (foo) { bar(); {} baz(); }
    ·                   ──
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ ╭─▶ {
  2 │ ╰─▶             { } }
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -44,24 +50,28 @@ source: crates/oxc_linter/src/tester.rs
  2 │             { } }
    ·             ───
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:25]
  1 │ function foo() { bar(); {} baz(); }
    ·                         ──
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:1:15]
  1 │ while (foo) { {} }
    ·               ──
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
  1 │ {var x = 1;}
    · ────────────
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -70,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             let y = 2; } {let z = 1;}
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
@@ -77,6 +88,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │               {let x = 1;}
  3 │ ╰─▶             var y = 2; } {let z = 1;}
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:1:1]
@@ -85,6 +97,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ ╰─▶             var y = 2; }
  4 │                 {var z = 1;}
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:2:4]
@@ -93,6 +106,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────
  3 │             var y = 2; }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:4:4]
@@ -100,6 +114,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │             {var z = 1;}
    ·             ────────────
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:5:17]
@@ -109,6 +124,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                 }
  8 │                 }
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -118,6 +134,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         foo();
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:3:17]
@@ -127,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                 }
  6 │                 }
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Block is unnecessary.
    ╭─[no_lone_blocks.tsx:3:17]
@@ -136,6 +154,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶                 }
  6 │                 }
    ╰────
+  help: Remove the unnecessary block statement. If you need to limit variable scope, consider using a function or module instead.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:25]
@@ -145,6 +164,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                         }
  8 │                         }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:25]
@@ -154,6 +174,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                         }
  8 │                             something;
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -163,6 +184,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -172,6 +194,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -181,6 +204,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -190,6 +214,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -199,6 +224,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -208,6 +234,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         something;
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:21]
@@ -217,6 +244,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                     }
  8 │                     }
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:4:21]
@@ -226,6 +254,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │ ╰─▶                     }
  7 │                         something;
    ╰────
+  help: Remove the redundant nested block statement.
 
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:5:21]
@@ -235,3 +264,4 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶                     }
  8 │                     }
    ╰────
+  help: Remove the redundant nested block statement.

--- a/crates/oxc_linter/src/snapshots/eslint_require_yield.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_require_yield.snap
@@ -7,33 +7,39 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function* foo() { return 0; }
    ·           ───
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:12]
  1 │ (function* foo() { return 0; })();
    ·            ───
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:17]
  1 │ var obj = { *foo() { return 0; } }
    ·                 ────────────────
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:15]
  1 │ class A { *foo() { return 0; } }
    ·               ────────────────
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:11]
  1 │ function* foo() { function* bar() { yield 0; } }
    ·           ───
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.
 
   ⚠ eslint(require-yield): This generator function does not have `yield`
    ╭─[require_yield.tsx:1:29]
  1 │ function* foo() { function* bar() { return 0; } yield 0; }
    ·                             ───
    ╰────
+  help: Add a `yield` expression inside the generator body, or convert it to a regular function if iteration behavior is not needed.


### PR DESCRIPTION
## Summary

Fixes #19121

Adds actionable `.with_help()` messages to 8 eslint linter rules that were missing them, as requested in #19121.

## Changes

| Rule | Help message added |
|------|-------------------|
| `no_eval` | Suggest `JSON.parse()` and bracket notation as alternatives to `eval()` |
| `no_await_in_loop` | Suggest `Promise.all()` for parallel async execution |
| `no_case_declarations` | Suggest wrapping the case body in braces `{}` to create explicit block scope |
| `no_constructor_return` | Clarify that a bare `return;` is allowed for early exit |
| `no_delete_var` | Suggest assigning `undefined` instead of using `delete` on variables |
| `no_lone_blocks` | Suggest removing unnecessary / redundant block statements (both diagnostics) |
| `require_yield` | Suggest adding a `yield` expression or converting to a regular function |
| `no_const_assign` | Suggest using `let` when a variable needs to be reassigned |

All help messages are actionable — they tell the user what to do to fix the issue.