### PR TITLE
refactor(tasks/coverage): use tasks_common for printing diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,6 @@ dependencies = [
 name = "oxc_coverage"
 version = "0.0.0"
 dependencies = [
- "console 0.16.2",
  "cow-utils",
  "encoding_rs",
  "encoding_rs_io",

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -27,7 +27,6 @@ oxc = { workspace = true, features = ["full", "isolated_declarations", "serializ
 oxc_formatter = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_tasks_transform_checker = { workspace = true }
-console = { workspace = true }
 encoding_rs = { workspace = true }
 encoding_rs_io = { workspace = true }
 itertools = { workspace = true }

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -15,10 +15,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use console::Style;
 use oxc::{span::SourceType, transformer::BabelOptions};
 use oxc_tasks_common::{Snapshot, normalize_path, project_root};
-use similar::{ChangeTag, TextDiff};
+use similar::TextDiff;
 
 pub use driver::Driver;
 use test262::MetaData as Test262Meta;
@@ -218,14 +217,7 @@ fn print_result(r: &CoverageResult) {
 
 fn print_diff(actual: &str, expected: &str) {
     let diff = TextDiff::from_lines(expected, actual);
-    for change in diff.iter_all_changes() {
-        let (sign, style) = match change.tag() {
-            ChangeTag::Delete => ("-", Style::new().red()),
-            ChangeTag::Insert => ("+", Style::new().green()),
-            ChangeTag::Equal => continue,
-        };
-        print!("{}{}", style.apply_to(sign).bold(), style.apply_to(change));
-    }
+    oxc_tasks_common::print_text_diff(&diff);
 }
 
 pub fn snapshot_results(name: &str, test_root: &Path, results: &[CoverageResult]) {


### PR DESCRIPTION
This makes the diffs more readable by including the surrouding lines.,

This aids debugging and makes the changes easier to comprehend