### PR TITLE
feat(formatter,oxfmt): Support js-in-vue (partially)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "oxc-schemars",
  "oxc-toml",
  "oxc_allocator",
+ "oxc_ast",
  "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_formatter",

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -28,6 +28,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["pool"] }
+oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }

--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -47,12 +47,9 @@ export interface FormatResult {
  * NAPI based `textToDoc` API entry point for `prettier-plugin-oxfmt`.
  *
  * This API is specialized for JS/TS snippets embedded in non-JS files.
- * Unlike `format()`, it is called only for JS/TS-in-xxx `textToDoc` flow.
- *
- * # Panics
- * Panics if the current working directory cannot be determined.
+ * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(filename: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<TextToDocResult>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -70,10 +67,3 @@ export declare function jsTextToDoc(filename: string, sourceText: string, oxfmtP
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
 export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>
-
-export interface TextToDocResult {
-  /** The formatted code. */
-  doc: string
-  /** Parse and format errors. */
-  errors: Array<OxcError>
-}

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -27,13 +27,13 @@ export async function format(fileName: string, sourceText: string, options?: For
  * Format a JS/TS snippet for Prettier `textToDoc()` plugin flow.
  */
 export async function jsTextToDoc(
-  fileName: string,
+  sourceExt: string,
   sourceText: string,
   oxfmtPluginOptionsJson: string,
   parentContext: string,
 ) {
   return napiJsTextToDoc(
-    fileName,
+    sourceExt,
     sourceText,
     oxfmtPluginOptionsJson,
     parentContext,

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/index.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/index.ts
@@ -32,6 +32,7 @@ const oxfmtParser: Parser<Doc> = {
 export const parsers: Record<string, Parser> = {
   // Override default JS/TS parsers
   babel: oxfmtParser,
+  "babel-ts": oxfmtParser,
   typescript: oxfmtParser,
 };
 

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -1,34 +1,54 @@
-import { doc } from "prettier";
 import { jsTextToDoc } from "../../index";
 import type { Parser, Doc } from "prettier";
 
-const { hardline, join } = doc.builders;
-const LINE_BREAK_RE = /\r?\n/;
-
 export const textToDoc: Parser<Doc>["parse"] = async (embeddedSourceText, textToDocOptions) => {
-  // NOTE: For (j|t)s-in-xxx, default `parser` is either `babel` or `typescript`
-  // In case of ts-in-md, `filepath` is overridden to distinguish TSX or TS
-  // We need to infer `SourceType::from_path(fileName)` for `oxc_formatter`.
+  // `_oxfmtPluginOptionsJson` is a JSON string bundled by Rust (`oxfmtrc::finalize_external_options`),
+  // containing format options + parent filepath for the Rust-side `oxc_formatter`.
   const { parser, parentParser, filepath, _oxfmtPluginOptionsJson } = textToDocOptions;
-  const fileName =
-    parser === "typescript"
-      ? filepath.endsWith(".tsx")
-        ? "dummy.tsx" // tsx-in-md
-        : "dummy.ts" // ts-in-md / ts-in-xxx
-      : "dummy.jsx"; // Otherwise, always enable JSX for js-in-xxx, it's safe
 
-  const { doc: formattedText, errors } = await jsTextToDoc(
-    fileName,
+  // For (j|t)s-in-xxx, default `parser` is either `babel`, `babel-ts` or `typescript`
+  // We need to infer `SourceType::from_extension(ext)` for `oxc_formatter`.
+  // - JS: always enable JSX for js-in-xxx, it's safe
+  // - TS: `typescript` (ts-in-vue|markdown|mdx) or `babel-ts` (ts-in-vue(script generic="..."))
+  //   - In case of ts-in-md, `filepath` is overridden as `dummy.tx(x)` to distinguish TSX or TS
+  //   - NOTE: tsx-in-vue is not supported since there is no signal from Prettier to detect it
+  //     - Prettier is using `maybeJSXRe.test(sourceText)` to detect, but it's slow!
+  const isTS = parser === "typescript" || parser === "babel-ts";
+  const embeddedSourceExt = isTS ? (filepath?.endsWith(".tsx") ? "tsx" : "ts") : "jsx";
+
+  // Detect context from Prettier's internal flags
+  const parentContext = detectParentContext(parentParser!, textToDocOptions);
+
+  const doc = await jsTextToDoc(
+    embeddedSourceExt,
     embeddedSourceText,
     _oxfmtPluginOptionsJson as string,
-    [parentParser].join(":"),
+    parentContext,
   );
 
-  if (0 < errors.length) throw new Error(errors[0].message);
+  if (doc === null) {
+    throw new Error("`oxfmt::textToDoc()` failed. Use `OXC_LOG` env var to see Rust-side logs.");
+  }
 
-  // NOTE: This is required for the parent ((j|t)s-in-xxx) printer
-  // to handle line breaks correctly,
-  // not only for `options.vueIndentScriptAndStyle` but also for basic printing.
-  // TODO: Will be handled in Rust, convert our IR to Prettier's Doc directly.
-  return join(hardline, formattedText.split(LINE_BREAK_RE));
+  // SAFETY: Rust side returns Prettier's `Doc` JSON
+  return JSON.parse(doc) as Doc;
 };
+
+/**
+ * Detects Vue fragment mode from Prettier's internal flags.
+ *
+ * When Prettier formats Vue SFC templates, it calls textToDoc with special flags:
+ * - `__isVueForBindingLeft`: v-for left-hand side (e.g., `(item, index)` in `v-for="(item, index) in items"`)
+ * - `__isVueBindings`: v-slot bindings (e.g., `{ item }` in `#default="{ item }"`)
+ * - `__isEmbeddedTypescriptGenericParameters`: `<script generic="...">` type parameters
+ */
+function detectParentContext(parentParser: string, options: Record<string, unknown>): string {
+  if (parentParser === "vue") {
+    if ("__isVueForBindingLeft" in options) return "vue-for-binding-left";
+    if ("__isVueBindings" in options) return "vue-bindings";
+    if ("__isEmbeddedTypescriptGenericParameters" in options) return "vue-script-generic";
+    return "vue-script";
+  }
+
+  return parentParser;
+}

--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -67,7 +67,7 @@ pub fn run(
 
     // Resolve format options directly from the provided options
     let resolved_options =
-        match resolve_options_from_value(&cwd, options.unwrap_or_default(), &strategy) {
+        match resolve_options_from_value(options.unwrap_or_default(), &strategy, Some(&cwd)) {
             Ok(options) => options,
             Err(err) => {
                 external_formatter.cleanup();

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -1,22 +1,52 @@
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
 use serde_json::Value;
+use tracing::{debug, instrument};
 
-use oxc_napi::OxcError;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_formatter::{
+    AstNode, AstNodes, FormatOptions, FormatVueBindingParams, FormatVueScriptGeneric, Formatter,
+    get_parse_options,
+};
+use oxc_parser::{Parser, ParserReturn};
 use oxc_span::SourceType;
 
-use crate::core::{
-    ExternalFormatter, FormatFileStrategy, FormatResult, JsFormatEmbeddedCb, JsFormatFileCb,
-    JsInitExternalFormatterCb, JsSortTailwindClassesCb, SourceFormatter,
-    resolve_options_from_value,
+use crate::{
+    core::{
+        ExternalFormatter, FormatFileStrategy, FormatResult, JsFormatEmbeddedCb, JsFormatFileCb,
+        JsInitExternalFormatterCb, JsSortTailwindClassesCb, ResolvedOptions, SourceFormatter,
+        resolve_options_from_value,
+    },
+    prettier_compat::to_prettier_doc,
 };
+
+/// Fragment kind for embedded JS/TS contexts.
+#[expect(clippy::enum_variant_names)]
+#[derive(Clone, Copy, Debug)]
+enum FragmentKind {
+    /// `v-for` left-hand side: `(item, index) in items` → formats `item, index` part.
+    VueForBindingLeft,
+    /// `v-slot` / slot binding: `{ item }` → formats the destructured parameters.
+    VueBindings,
+    /// `<script generic="T extends Foo">` → formats type parameters without angle brackets.
+    VueScriptGeneric,
+}
 
 /// `js_text_to_doc()` implementation for NAPI API.
 ///
-/// # Panics
-/// Panics if the current working directory cannot be determined.
+/// Returns `None` on failure.
+/// Prettier's `multiparser.js` silently swallows errors from `textToDoc()` in production,
+/// so detailed error reporting is unnecessary.
+/// Errors are logged via `tracing::debug!` for observability with `OXC_LOG=debug`.
+#[instrument(
+    level = "debug",
+    name = "oxfmt::text_to_doc",
+    skip_all,
+    fields(source_ext = %source_ext, parent_context = %parent_context)
+)]
 pub fn run(
-    filename: &str,
+    source_ext: &str,
     source_text: &str,
     oxfmt_plugin_options_json: &str,
     parent_context: &str,
@@ -24,32 +54,53 @@ pub fn run(
     format_embedded_cb: JsFormatEmbeddedCb,
     format_file_cb: JsFormatFileCb,
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
-) -> Result<String, Vec<OxcError>> {
-    // NOTE: Relative path resolution for external options depends on cwd.
-    let cwd = env::current_dir().expect("Failed to get current working directory");
+) -> Option<String> {
+    let fragment_kind = match parent_context {
+        "vue-for-binding-left" => Some(FragmentKind::VueForBindingLeft),
+        "vue-bindings" => Some(FragmentKind::VueBindings),
+        "vue-script-generic" => Some(FragmentKind::VueScriptGeneric),
+        // "vue-script"
+        _ => None,
+    };
+
+    let doc_json = if let Some(kind) = fragment_kind {
+        run_fragment(source_ext, source_text, oxfmt_plugin_options_json, kind)?
+    } else {
+        run_full(
+            source_ext,
+            source_text,
+            oxfmt_plugin_options_json,
+            init_external_formatter_cb,
+            format_embedded_cb,
+            format_file_cb,
+            sort_tailwind_classes_cb,
+        )?
+    };
+
+    Some(serde_json::to_string(&doc_json).expect("Doc JSON serialization should not fail"))
+}
+
+// ---
+
+/// Full mode:
+/// - Format entire source as text
+/// - Return hardline-joined Doc string
+#[instrument(level = "debug", name = "oxfmt::text_to_doc::full", skip_all, fields(%source_ext))]
+fn run_full(
+    source_ext: &str,
+    source_text: &str,
+    oxfmt_plugin_options_json: &str,
+    init_external_formatter_cb: JsInitExternalFormatterCb,
+    format_embedded_cb: JsFormatEmbeddedCb,
+    format_file_cb: JsFormatFileCb,
+    sort_tailwind_classes_cb: JsSortTailwindClassesCb,
+) -> Option<Value> {
     let num_of_threads = 1;
 
-    let Ok(source_type) = SourceType::from_path(filename) else {
-        return Err(vec![OxcError::new(format!("Unsupported file type: {filename}"))]);
-    };
-
-    let options: Value = match serde_json::from_str(oxfmt_plugin_options_json) {
-        Ok(Value::Object(mut obj)) => {
-            // Embedded snippet output must not include final newline.
-            obj.insert("insertFinalNewline".to_string(), false.into());
-            Value::Object(obj)
-        }
-        Ok(_) => {
-            return Err(vec![OxcError::new(
-                "Failed to parse oxfmt plugin options JSON: expected JSON object".to_string(),
-            )]);
-        }
-        Err(err) => {
-            return Err(vec![OxcError::new(format!(
-                "Failed to parse oxfmt plugin options JSON: {err}"
-            ))]);
-        }
-    };
+    // Options and paths in `_oxfmtPluginOptionsJson` are already resolved to absolute paths
+    // by `finalize_external_options()` when processing the parent file (e.g., App.vue).
+    // No further relative path resolution is needed here.
+    let (options, parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
 
     let external_formatter = ExternalFormatter::new(
         init_external_formatter_cb,
@@ -63,49 +114,166 @@ pub fn run(
         // TODO: Plugins support
         Ok(_) => {}
         Err(err) => {
+            debug!("`external_formatter.init()` failed: {err}");
             external_formatter.cleanup();
-            return Err(vec![OxcError::new(format!("Failed to setup external formatter: {err}"))]);
+            return None;
         }
     }
 
-    let strategy = FormatFileStrategy::OxcFormatter { path: PathBuf::from(filename), source_type }
-        .resolve_relative_path(&cwd);
-
-    let resolved_options = match resolve_options_from_value(&cwd, options, &strategy) {
-        Ok(options) => options,
-        Err(err) => {
-            external_formatter.cleanup();
-            return Err(vec![OxcError::new(format!("Failed to parse configuration: {err}"))]);
-        }
+    let strategy = FormatFileStrategy::OxcFormatter {
+        path: format!("embedded.{source_ext}").into(),
+        source_type: SourceType::from_extension(source_ext)
+            .expect("source_ext should be a valid JS/TS extension"),
     };
+    let mut resolved_options = resolve_options_from_value(options, &strategy, None)
+        .expect("`_oxfmtPluginOptionsJson` should contain valid config");
+    // Override filepath so external callbacks (e.g., Tailwind sorter) receive the parent
+    // file path (e.g., `App.vue`) instead of the dummy `embedded.ts` path.
+    resolved_options.set_filepath_override(parent_filepath);
 
     let formatter = SourceFormatter::new(num_of_threads)
         .with_external_formatter(Some(external_formatter.clone()));
 
-    let mut code = match tokio::task::block_in_place(|| {
+    let code = match tokio::task::block_in_place(|| {
         formatter.format(&strategy, source_text, resolved_options)
     }) {
         FormatResult::Success { code, .. } => code,
         FormatResult::Error(diagnostics) => {
+            debug!("`formatter.format()` failed: {diagnostics:?}");
             external_formatter.cleanup();
-            return Err(OxcError::from_diagnostics(filename, source_text, diagnostics));
+            return None;
         }
     };
 
-    if parent_context.starts_with("markdown") || parent_context.starts_with("mdx") {
-        // TODO: Handle this with `oxc_formatter` option
-        normalize_single_jsx_semicolon_for_markdown(&mut code);
-    }
-
     external_formatter.cleanup();
-    Ok(code)
+    Some(to_prettier_doc::printed_string_to_hardline_doc(&code))
 }
 
-fn normalize_single_jsx_semicolon_for_markdown(code: &mut String) {
-    if code.starts_with('<') && code.ends_with(">;") {
-        code.pop();
+// ---
+
+/// Fragment mode:
+/// - Parse pre-wrapped source
+///   - Prettier already wraps the fragment text before calling `textToDoc()`
+///     - v-for / v-slot: `function _(PARAMS) {}`
+///     - generic: `type T<PARAMS> = any`
+/// - Extract target node
+/// - Format as IR
+/// - Convert to Prettier Doc JSON
+#[instrument(level = "debug", name = "oxfmt::text_to_doc::fragment", skip_all, fields(%source_ext, ?kind))]
+fn run_fragment(
+    source_ext: &str,
+    source_text: &str,
+    oxfmt_plugin_options_json: &str,
+    kind: FragmentKind,
+) -> Option<Value> {
+    let source_type = SourceType::from_extension(source_ext)
+        .expect("source_ext should be a valid JS/TS extension");
+
+    // NOTE: Options and paths are already resolved (see `run_full()` comment).
+    // And `run_fragment()` does not support external formatting, so no need to use `parent_filepath`.
+    let (options, _parent_filepath) = parse_options_and_filepath(oxfmt_plugin_options_json);
+
+    let strategy = FormatFileStrategy::OxcFormatter {
+        path: format!("embedded.{source_ext}").into(),
+        source_type,
+    };
+
+    let resolved_options = resolve_options_from_value(options, &strategy, None)
+        .expect("`_oxfmtPluginOptionsJson` should contain valid config");
+    let ResolvedOptions::OxcFormatter { format_options, .. } = resolved_options else {
+        unreachable!("OxcFormatter strategy should always resolve to OxcFormatter options");
+    };
+
+    let allocator = Allocator::default();
+    let ParserReturn { program, errors, .. } =
+        Parser::new(&allocator, source_text, source_type).with_options(get_parse_options()).parse();
+    if !errors.is_empty() {
+        debug!("`Parser::new().parse()` failed: {errors:?}");
+        return None;
     }
-    if code.starts_with(";<") && code.ends_with('>') {
-        code.remove(0);
-    }
+
+    let formatter = Formatter::new(
+        &allocator,
+        FormatOptions {
+            // TODO: Fragments inside of Vue attributes should always use single quotes,
+            // since double quotes are used for the attribute value itself.
+            //
+            // Prettier also replaces double quotes with `&quot;` in this case,
+            // but to reduce the diff, we set the quote style to single, regardless of the user config.
+            //
+            // However, this option is just a preference, so `singleQuote: true` is not enough.
+            // But it works for most cases, so leave it for now...
+            quote_style: oxc_formatter::QuoteStyle::Single,
+            ..*format_options
+        },
+    );
+
+    let formatted = match kind {
+        FragmentKind::VueForBindingLeft | FragmentKind::VueBindings => {
+            let params = {
+                let Some(Statement::FunctionDeclaration(func)) = program.body.first() else {
+                    unreachable!("Prettier wraps v-for/v-slot as `function _(...) {{}}`");
+                };
+                &*func.params
+            };
+            let node = AstNode::new(params, AstNodes::Dummy(), &allocator);
+            let content = FormatVueBindingParams::new(
+                &node,
+                matches!(kind, FragmentKind::VueForBindingLeft)
+                    && (1 < params.items.len() || params.rest.is_some()),
+            );
+
+            formatter.format_node(
+                &content,
+                program.source_text,
+                source_type,
+                &program.comments,
+                None,
+            )
+        }
+        FragmentKind::VueScriptGeneric => {
+            let type_params = {
+                let Some(Statement::TSTypeAliasDeclaration(decl)) = program.body.first() else {
+                    unreachable!("Prettier wraps script-generic as `type T<...> = any`");
+                };
+                let Some(type_params) = decl.type_parameters.as_deref() else {
+                    unreachable!("Prettier wraps script-generic as `type T<...> = any`");
+                };
+                type_params
+            };
+            let node = AstNode::new(type_params, AstNodes::Dummy(), &allocator);
+            let content = FormatVueScriptGeneric::new(&node);
+
+            formatter.format_node(
+                &content,
+                program.source_text,
+                source_type,
+                &program.comments,
+                None,
+            )
+        }
+    };
+
+    let (elements, sorted_tailwind_classes) =
+        formatted.into_document().into_elements_and_tailwind_classes();
+    Some(
+        to_prettier_doc::format_elements_to_prettier_doc(elements, &sorted_tailwind_classes)
+            .expect("Formatter IR to Prettier Doc conversion should not fail"),
+    )
+}
+
+// ---
+
+/// Parses the plugin options JSON and extracts parent file path for external callbacks.
+///
+/// The `filepath` field (set by `core::oxfmtrc::finalize_external_options`) stores
+/// the parent file path (e.g. `App.vue`) for js-in-xxx formatting.
+fn parse_options_and_filepath(oxfmt_plugin_options_json: &str) -> (Value, PathBuf) {
+    let Ok(Value::Object(mut obj)) = serde_json::from_str(oxfmt_plugin_options_json) else {
+        unreachable!("`_oxfmtPluginOptionsJson` should be a valid JSON object");
+    };
+    let Some(Value::String(s)) = obj.remove("filepath") else {
+        unreachable!("Expected `filepath` in `_oxfmtPluginOptionsJson`");
+    };
+    (Value::Object(obj), PathBuf::from(s))
 }

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -991,7 +991,7 @@ static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
 #[cfg(feature = "napi")]
 static OXFMT_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     // "html",
-    // "vue",
+    "vue",
     // "markdown",
     // "mdx",
 };
@@ -1041,7 +1041,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
 
     // Build oxfmt plugin options JSON for js-in-xxx parsers
     #[cfg(feature = "napi")]
-    if let FormatFileStrategy::ExternalFormatter { parser_name, .. } = strategy
+    if let FormatFileStrategy::ExternalFormatter { path, parser_name } = strategy
         && OXFMT_PARSERS.contains(parser_name)
     {
         let mut oxfmt_plugin_options = serde_json::Map::new();
@@ -1067,8 +1067,15 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
             }
         }
 
-        // In embedded contexts, final newline is useless
-        oxfmt_plugin_options.insert("insertFinalNewline".to_string(), false.into());
+        // NOTE: Pass the parent file path so embedded JS/TS formatting
+        // uses the same path for Tailwind config resolution as the parent file.
+        // This is needed for ts-in-(markdown|mdx),
+        // which Prettier overrides the full path with a `dummy.ts(x)`...
+        // This filepath roundtrips:
+        // Rust → JS (Prettier plugin options) → Rust (text_to_doc_api),
+        // where it becomes `filepath_override` in `ResolvedOptions::OxcFormatter`.
+        oxfmt_plugin_options
+            .insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
 
         if let Ok(json_str) = serde_json::to_string(&Value::Object(oxfmt_plugin_options)) {
             obj.insert("_oxfmtPluginOptionsJson".to_string(), Value::String(json_str));
@@ -1520,6 +1527,38 @@ mod tests_sync_external_options {
         assert!(!obj.contains_key("overrides"));
         assert!(!obj.contains_key("ignorePatterns"));
         assert!(!obj.contains_key("sortImports"));
+    }
+
+    #[test]
+    #[cfg(feature = "napi")]
+    fn test_finalize_external_options_sets_oxfmt_plugin_filepath() {
+        use std::path::PathBuf;
+
+        let json_string = r#"{
+            "printWidth": 100,
+            "singleQuote": true,
+            "experimentalSortImports": { "order": "asc" }
+        }"#;
+        let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
+
+        let strategy = super::super::FormatFileStrategy::ExternalFormatter {
+            path: PathBuf::from("/tmp/foo/bar/App.vue"),
+            parser_name: "vue",
+        };
+        finalize_external_options(&mut raw_config, &strategy);
+
+        let obj = raw_config.as_object().unwrap();
+        let plugin_options_json = obj
+            .get("_oxfmtPluginOptionsJson")
+            .and_then(Value::as_str)
+            .expect("Expected `_oxfmtPluginOptionsJson` to be set");
+
+        let plugin_options: Value = serde_json::from_str(plugin_options_json).unwrap();
+        let plugin_obj = plugin_options.as_object().unwrap();
+        assert_eq!(
+            plugin_obj.get("filepath"),
+            Some(&Value::String("/tmp/foo/bar/App.vue".to_string()))
+        );
     }
 }
 

--- a/apps/oxfmt/src/lib.rs
+++ b/apps/oxfmt/src/lib.rs
@@ -2,6 +2,8 @@
 mod api;
 pub mod cli;
 mod core;
+#[cfg(feature = "napi")]
+mod prettier_compat;
 
 pub use core::oxfmtrc;
 #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/prettier_compat/mod.rs
+++ b/apps/oxfmt/src/prettier_compat/mod.rs
@@ -1,0 +1,1 @@
+pub mod to_prettier_doc;

--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -1,0 +1,416 @@
+use rustc_hash::FxHashMap;
+use serde_json::{Value, json};
+
+use oxc_formatter::{
+    BestFittingElement, DedentMode, FormatElement, GroupId, LineMode, PrintMode, Tag,
+};
+
+// TODO: Currently, we build a Prettier Doc tree using `serde_json::Value`,
+// then serialize it to a string.
+//
+// It might be more efficient to construct the Doc string directly.
+// This would also allow for optimizations like:
+// - caching interned elements
+// - reusing constant Doc structures like `{type: "line", hard: true}`
+
+/// Splits a printed string by newlines and joins with Prettier `hardline` docs.
+pub fn printed_string_to_hardline_doc(text: &str) -> Value {
+    // `lines()` will remove trailing newlines, but it is fine.
+    // For js-in-xxx fragments, do not need to preserve trailing newlines.
+    let lines: Vec<&str> = text.lines().collect();
+
+    if lines.len() <= 1 {
+        return Value::String(text.to_string());
+    }
+
+    let mut parts: Vec<Value> = Vec::with_capacity(lines.len() * 3);
+    for (i, line) in lines.iter().enumerate() {
+        if 0 < i {
+            // hardline = [{ type: "line", hard: true } + break-parent]
+            // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/document/builders/line.js#L27
+            parts.push(json!({"type": "line", "hard": true}));
+            parts.push(json!({"type": "break-parent"}));
+        }
+        parts.push(Value::String((*line).to_string()));
+    }
+
+    normalize_array(parts)
+}
+
+/// Converts `oxc_formatter` IR (`FormatElement` slice) into Prettier Doc.
+///
+/// This is used for js-in-xxx fragment formatting
+/// where the IR must be returned to Prettier as an unresolved Doc (rather than a printed string)
+/// so that Prettier can handle line-wrapping in the parent context.
+pub fn format_elements_to_prettier_doc(
+    elements: &[FormatElement],
+    sorted_tailwind_classes: &[String],
+) -> Result<Value, String> {
+    let mut state = ConvertState::new(sorted_tailwind_classes);
+    let children = convert_elements(elements, &mut state)?;
+    Ok(normalize_array(children))
+}
+
+type InternedCacheKey = (usize, usize);
+
+struct ConvertState<'a> {
+    sorted_tailwind_classes: &'a [String],
+    interned_cache: FxHashMap<InternedCacheKey, Vec<Value>>,
+}
+
+impl<'a> ConvertState<'a> {
+    fn new(sorted_tailwind_classes: &'a [String]) -> Self {
+        Self { sorted_tailwind_classes, interned_cache: FxHashMap::default() }
+    }
+}
+
+/// Stack entry that stores start tag info alongside accumulated children.
+struct StackEntry {
+    start_tag: Option<Tag>,
+    start_info: Option<StartTagInfo>,
+    children: Vec<Value>,
+}
+
+/// Information extracted from start tags, needed when processing the matching end tag.
+enum StartTagInfo {
+    Indent,
+    Align(u8),
+    Dedent(DedentMode),
+    Group { id: Option<GroupId>, should_break: bool },
+    ConditionalContent { mode: PrintMode, group_id: Option<GroupId> },
+    IndentIfGroupBreaks(GroupId),
+    Fill,
+    Entry,
+    LineSuffix,
+    Labelled,
+}
+
+fn convert_elements(
+    elements: &[FormatElement],
+    state: &mut ConvertState,
+) -> Result<Vec<Value>, String> {
+    let mut stack: Vec<StackEntry> =
+        vec![StackEntry { start_tag: None, start_info: None, children: vec![] }];
+
+    for element in elements {
+        match element {
+            FormatElement::Space | FormatElement::HardSpace => {
+                concat_string(current_children_mut(&mut stack)?, " ");
+            }
+            FormatElement::Token { text } => {
+                concat_string(current_children_mut(&mut stack)?, text);
+            }
+            FormatElement::Text { text, .. } => {
+                push_text(current_children_mut(&mut stack)?, text);
+            }
+            FormatElement::Line(mode) => {
+                push_line(current_children_mut(&mut stack)?, *mode);
+            }
+            FormatElement::ExpandParent => {
+                current_children_mut(&mut stack)?.push(json!({"type": "break-parent"}));
+            }
+            FormatElement::LineSuffixBoundary => {
+                current_children_mut(&mut stack)?.push(json!({"type": "line-suffix-boundary"}));
+            }
+            FormatElement::Tag(tag) => {
+                if tag.is_start() {
+                    stack.push(StackEntry {
+                        start_tag: Some(tag.clone()),
+                        start_info: Some(extract_start_tag_info(tag)),
+                        children: vec![],
+                    });
+                } else {
+                    if stack.len() == 1 {
+                        return Err(format!(
+                            "Invalid formatter IR: found unmatched end tag `{tag:?}` while converting to Prettier Doc"
+                        ));
+                    }
+                    let entry = stack.pop().ok_or_else(|| {
+                        "Invalid formatter IR: stack underflow while processing end tag".to_string()
+                    })?;
+                    if let Some(start_tag) = &entry.start_tag
+                        && start_tag.kind() != tag.kind()
+                    {
+                        return Err(format!(
+                            "Invalid formatter IR: mismatched tags (start: `{start_tag:?}`, end: `{tag:?}`)"
+                        ));
+                    }
+                    let doc = build_doc(entry.start_info.as_ref(), entry.children);
+                    current_children_mut(&mut stack)?.push(doc);
+                }
+            }
+            FormatElement::Interned(interned) => {
+                let key = interned_cache_key(interned);
+                if let Some(cached) = state.interned_cache.get(&key) {
+                    current_children_mut(&mut stack)?.extend(cached.iter().cloned());
+                } else {
+                    let converted = convert_elements(interned, state)?;
+                    state.interned_cache.insert(key, converted.clone());
+                    current_children_mut(&mut stack)?.extend(converted);
+                }
+            }
+            FormatElement::BestFitting(best_fitting) => {
+                let doc = convert_best_fitting(best_fitting, state)?;
+                current_children_mut(&mut stack)?.push(doc);
+            }
+            FormatElement::TailwindClass(index) => {
+                if let Some(class) = state.sorted_tailwind_classes.get(*index) {
+                    concat_string(current_children_mut(&mut stack)?, class);
+                }
+            }
+        }
+    }
+
+    if stack.len() != 1 {
+        if let Some(unclosed_tag) = stack.iter().rev().find_map(|entry| entry.start_tag.as_ref()) {
+            return Err(format!(
+                "Invalid formatter IR: unclosed start tag `{unclosed_tag:?}` while converting to Prettier Doc"
+            ));
+        }
+        return Err(
+            "Invalid formatter IR: unclosed tags while converting to Prettier Doc".to_string()
+        );
+    }
+
+    stack.pop().map_or_else(
+        || Err("Invalid formatter IR: missing root stack entry".to_string()),
+        |e| Ok(e.children),
+    )
+}
+
+fn current_children_mut(stack: &mut [StackEntry]) -> Result<&mut Vec<Value>, String> {
+    stack.last_mut().map(|entry| &mut entry.children).ok_or_else(|| {
+        "Invalid formatter IR: stack underflow while appending converted doc".to_string()
+    })
+}
+
+fn interned_cache_key(elements: &[FormatElement]) -> InternedCacheKey {
+    (elements.as_ptr() as usize, elements.len())
+}
+
+fn push_text(children: &mut Vec<Value>, text: &str) {
+    // `FormatElement::Text` may contain embedded newlines (e.g., template literals).
+    // Convert them to Prettier's `literalline` docs instead of raw '\n' in strings,
+    // so parent groups can remeasure and break correctly.
+    if !text.as_bytes().iter().any(|b| *b == b'\n' || *b == b'\r') {
+        concat_string(children, text);
+        return;
+    }
+
+    let bytes = text.as_bytes();
+    let mut segment_start = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => {
+                if segment_start < i {
+                    concat_string(children, &text[segment_start..i]);
+                }
+                push_literal_line(children);
+                i += 1;
+                segment_start = i;
+            }
+            b'\r' => {
+                if segment_start < i {
+                    concat_string(children, &text[segment_start..i]);
+                }
+                push_literal_line(children);
+                i += 1;
+                // Treat CRLF as a single line break.
+                if i < bytes.len() && bytes[i] == b'\n' {
+                    i += 1;
+                }
+                segment_start = i;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    if segment_start < bytes.len() {
+        concat_string(children, &text[segment_start..]);
+    }
+}
+
+fn push_line(children: &mut Vec<Value>, mode: LineMode) {
+    match mode {
+        LineMode::SoftOrSpace => {
+            children.push(json!({"type": "line"}));
+        }
+        LineMode::Soft => {
+            children.push(json!({"type": "line", "soft": true}));
+        }
+        LineMode::Hard => {
+            children.push(json!({"type": "line", "hard": true}));
+            children.push(json!({"type": "break-parent"}));
+        }
+        LineMode::Empty => {
+            // hardline x2
+            children.push(json!({"type": "line", "hard": true}));
+            children.push(json!({"type": "break-parent"}));
+            children.push(json!({"type": "line", "hard": true}));
+            children.push(json!({"type": "break-parent"}));
+        }
+    }
+}
+
+fn push_literal_line(children: &mut Vec<Value>) {
+    children.push(json!({"type": "line", "hard": true, "literal": true}));
+    children.push(json!({"type": "break-parent"}));
+}
+
+fn extract_start_tag_info(tag: &Tag) -> StartTagInfo {
+    match tag {
+        Tag::StartIndent => StartTagInfo::Indent,
+        Tag::StartAlign(align) => StartTagInfo::Align(align.count().get()),
+        Tag::StartDedent(mode) => StartTagInfo::Dedent(*mode),
+        Tag::StartGroup(group) => {
+            StartTagInfo::Group { id: group.id(), should_break: !group.mode().is_flat() }
+        }
+        Tag::StartConditionalContent(condition) => StartTagInfo::ConditionalContent {
+            mode: condition.mode(),
+            group_id: condition.group_id(),
+        },
+        Tag::StartIndentIfGroupBreaks(gid) => StartTagInfo::IndentIfGroupBreaks(*gid),
+        Tag::StartFill => StartTagInfo::Fill,
+        Tag::StartEntry => StartTagInfo::Entry,
+        Tag::StartLineSuffix => StartTagInfo::LineSuffix,
+        Tag::StartLabelled(_) => StartTagInfo::Labelled,
+        _ => unreachable!("end tags should not be passed to `extract_start_tag_info()`"),
+    }
+}
+
+fn build_doc(start_info: Option<&StartTagInfo>, children: Vec<Value>) -> Value {
+    let Some(info) = start_info else {
+        return normalize_array(children);
+    };
+
+    match info {
+        StartTagInfo::Indent => {
+            json!({"type": "indent", "contents": normalize_array(children)})
+        }
+        StartTagInfo::Align(count) => {
+            json!({"type": "align", "n": *count, "contents": normalize_array(children)})
+        }
+        StartTagInfo::Dedent(mode) => {
+            let n: Value = match mode {
+                DedentMode::Level => Value::from(-1),
+                // NOTE: Prettier expects `n: Number.NEGATIVE_INFINITY` for `dedent-to-root`,
+                // but JSON cannot represent `Infinity`.
+                // It will be `null`, which makes Prettier's `makeAlign()` treat it as a no-op.
+                // If that becomes a problem, we need a JSON reviver to fix it back to `-Infinity` on the JS side.
+                DedentMode::Root => Value::from(f64::NEG_INFINITY),
+            };
+            json!({"type": "align", "n": n, "contents": normalize_array(children)})
+        }
+        StartTagInfo::Group { id, should_break } => {
+            let contents = normalize_array(children);
+            let mut doc = json!({"type": "group", "contents": contents});
+            if *should_break {
+                doc["break"] = json!(true);
+            }
+            if let Some(gid) = id {
+                doc["id"] = Value::String(group_id_string(*gid));
+            }
+            doc
+        }
+        StartTagInfo::ConditionalContent { mode, group_id } => {
+            let contents = normalize_array(children);
+            let mut doc = match mode {
+                PrintMode::Expanded => {
+                    json!({"type": "if-break", "breakContents": contents, "flatContents": ""})
+                }
+                PrintMode::Flat => {
+                    json!({"type": "if-break", "breakContents": "", "flatContents": contents})
+                }
+            };
+            if let Some(gid) = group_id {
+                doc["groupId"] = Value::String(group_id_string(*gid));
+            }
+            doc
+        }
+        // NOTE: Prettier's `indent-if-break` also supports a `negate` property
+        // that inverts the behavior (indent when flat, no indent when broken).
+        // oxc_formatter's `Tag::StartIndentIfGroupBreaks` doesn't have this option yet.
+        StartTagInfo::IndentIfGroupBreaks(gid) => {
+            json!({
+                "type": "indent-if-break",
+                "contents": normalize_array(children),
+                "groupId": group_id_string(*gid)
+            })
+        }
+        StartTagInfo::Fill => {
+            // Children from Entry pairs become fill parts
+            json!({"type": "fill", "parts": Value::Array(children)})
+        }
+        StartTagInfo::Entry => {
+            // Entry contents are returned directly
+            normalize_array(children)
+        }
+        StartTagInfo::LineSuffix => {
+            json!({"type": "line-suffix", "contents": normalize_array(children)})
+        }
+        // NOTE: Prettier's `label` doc wraps contents
+        // with an arbitrary label value used by doc utilities (e.g., `stripTrailingHardline`).
+        // We drop the label here since `LabelId` is opaque and the printer ignores it.
+        StartTagInfo::Labelled => normalize_array(children),
+    }
+}
+
+fn convert_best_fitting(
+    best_fitting: &BestFittingElement,
+    state: &mut ConvertState,
+) -> Result<Value, String> {
+    let variants = best_fitting.variants();
+    if variants.is_empty() {
+        return Ok(json!({"type": "group", "contents": ""}));
+    }
+
+    let first_contents = normalize_array(convert_elements(variants[0], state)?);
+
+    if variants.len() == 1 {
+        return Ok(json!({"type": "group", "contents": first_contents}));
+    }
+
+    let expanded_states: Vec<Value> = variants
+        .iter()
+        .map(|v| convert_elements(v, state).map(normalize_array))
+        .collect::<Result<_, _>>()?;
+
+    Ok(json!({
+        "type": "group",
+        "contents": first_contents,
+        "expandedStates": Value::Array(expanded_states)
+    }))
+}
+
+/// Formats a `GroupId` as `"G<N>"` string for Prettier.
+fn group_id_string(id: GroupId) -> String {
+    format!("G{}", u32::from(id))
+}
+
+/// Concatenates a string onto the last element if it's also a string,
+/// otherwise pushes a new string value.
+fn concat_string(children: &mut Vec<Value>, s: &str) {
+    if let Some(Value::String(last)) = children.last_mut() {
+        last.push_str(s);
+    } else {
+        children.push(Value::String(s.to_string()));
+    }
+}
+
+// ---
+
+/// Normalizes a `Vec<Value>` into a single `Value`:
+/// - Empty vec -> empty string
+/// - Single element -> that element
+/// - Multiple -> JSON array
+fn normalize_array(mut arr: Vec<Value>) -> Value {
+    match arr.len() {
+        0 => Value::String(String::new()),
+        1 => arr.pop().unwrap(),
+        _ => Value::Array(arr),
+    }
+}

--- a/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ sort-imports 1`] = `
 "<script lang="ts">
-  import z from "z";
   import a from "a";
   import m from "m";
+  import z from "z";
 </script>
 <script lang="ts" setup>
-  import z from "z";
   import a from "a";
   import m from "m";
+  import z from "z";
 </script>
 <template>
   <div>{{ a + m + z }}</div>
@@ -19,8 +19,8 @@ exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ sor
 
 exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ sort-tailwindcss 1`] = `
 "<script setup>
-  import { ref } from "vue";
   import clsx from "clsx";
+  import { ref } from "vue";
 
   const count = ref(0);
   const cls = clsx("flex p-4");

--- a/apps/oxfmt/test/api/js-in-vue.test.ts
+++ b/apps/oxfmt/test/api/js-in-vue.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
-// NOTE: For now, Vue files are still handled by Prettier
+// NOTE: For now, Vue files are partially handled by Prettier
+
 describe("Format js-in-vue with prettier-plugin-oxfmt", () => {
   it("should format .vue w/ sort-imports", async () => {
     const input = `

--- a/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
+++ b/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
@@ -214,9 +214,9 @@ const count = ref(0);
 
 --- AFTER ----------
 <script setup lang="ts">
-  import z from "z";
   import a from "a";
   import m from "m";
+  import z from "z";
 
   const count = ref(0);
 </script>
@@ -255,14 +255,14 @@ const count = ref(0);
 
 --- AFTER ----------
 <script lang="ts">
-  import z from "z";
   import a from "a";
+  import z from "z";
 
   export default { name: "App" };
 </script>
 <script setup lang="ts">
-  import m from "m";
   import b from "b";
+  import m from "m";
 
   const count = ref(0);
 </script>

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -115,8 +115,8 @@ impl<'a, T> AstNode<'a, T> {
     }
 }
 
-impl<'a> AstNode<'a, Program<'a>> {
-    pub fn new(inner: &'a Program<'a>, parent: AstNodes<'a>, allocator: &'a Allocator) -> Self {
+impl<'a, T> AstNode<'a, T> {
+    pub fn new(inner: &'a T, parent: AstNodes<'a>, allocator: &'a Allocator) -> Self {
         AstNode { inner, parent, allocator, following_span_start: 0 }
     }
 }

--- a/crates/oxc_formatter/src/formatter/format_element/tag.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/tag.rs
@@ -12,10 +12,10 @@ pub enum Tag {
     StartIndent,
     EndIndent,
 
-    /// Variant of [TagKind::Indent] that indents content by a number of spaces. For example, `Align(2)`
+    /// Variant of `Indent` that indents content by a number of spaces. For example, `Align(2)`
     /// indents any content following a line break by an additional two spaces.
     ///
-    /// Nesting (Aligns)[TagKind::Align] has the effect that all except the most inner align are handled as (Indent)[TagKind::Indent].
+    /// Nesting Aligns has the effect that all except the most inner align are handled as `Indent`.
     StartAlign(Align),
     EndAlign,
 
@@ -215,6 +215,10 @@ impl Condition {
 
     pub fn mode(&self) -> PrintMode {
         self.mode
+    }
+
+    pub fn group_id(&self) -> Option<GroupId> {
+        self.group_id
     }
 }
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -88,6 +88,10 @@ impl<'a> Formatted<'a> {
 }
 
 impl Formatted<'_> {
+    /// Prints the formatted document to a string.
+    ///
+    /// # Errors
+    /// Returns `PrintError` if the document contains invalid structure.
     pub fn print(self) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let (elements, sorted_tailwind_classes) =
@@ -96,6 +100,10 @@ impl Formatted<'_> {
         Ok(printed)
     }
 
+    /// Prints the formatted document to a string, starting at the given indentation level.
+    ///
+    /// # Errors
+    /// Returns `PrintError` if the document contains invalid structure.
     pub fn print_with_indent(self, indent: u16) -> PrintResult<Printed> {
         let print_options = self.context.options().as_print_options();
         let (elements, sorted_tailwind_classes) =

--- a/crates/oxc_formatter/src/print/fragment.rs
+++ b/crates/oxc_formatter/src/print/fragment.rs
@@ -1,0 +1,93 @@
+use oxc_ast::ast::*;
+
+use crate::{
+    ast_nodes::AstNode,
+    format_args,
+    formatter::{Format, Formatter, prelude::*, trivia::format_dangling_comments},
+    options::TrailingSeparator,
+    write,
+};
+
+use super::parameters::{ParameterLayout, ParameterList};
+
+/// Formats `FormalParameters` for Vue `v-for`(LHS) / `v-slot` binding contexts.
+///
+/// Prettier wraps the source as `function _(...) {}` before calling `textToDoc()`,
+/// so the input is always a `FormalParameters` node extracted from the synthetic function.
+///
+/// Trailing commas at the parameter list level are suppressed,
+/// while trailing commas inside nested patterns (e.g., destructured objects/arrays)
+/// follow the normal `trailingComma` setting.
+///
+/// For `v-for` with multiple params (e.g., `(item, index) in items`),
+/// - call `.with_parens()` to wrap the list with parentheses
+/// - apply the nested indent/group structure from Prettier's `html-binding.js`
+///   - <https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/print/html-binding.js#L14>
+///
+/// For `v-slot` bindings (e.g., `{ item }`), use the default (no parens).
+pub struct FormatVueBindingParams<'a, 'b> {
+    node: &'b AstNode<'a, FormalParameters<'a>>,
+    with_parens: bool,
+}
+
+impl<'a, 'b> FormatVueBindingParams<'a, 'b> {
+    pub fn new(node: &'b AstNode<'a, FormalParameters<'a>>, with_parens: bool) -> Self {
+        Self { node, with_parens }
+    }
+}
+
+impl<'a> Format<'a> for FormatVueBindingParams<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let list = ParameterList::with_layout(self.node, None, ParameterLayout::Default)
+            .with_omit_trailing_separator();
+
+        if self.with_parens {
+            write!(
+                f,
+                [
+                    "(",
+                    indent(&format_args!(soft_line_break(), group(&list))),
+                    soft_line_break(),
+                    ")"
+                ]
+            );
+        } else {
+            write!(f, list);
+        }
+    }
+}
+
+/// Formats `TSTypeParameterDeclaration` for Vue `<script generic="...">`.
+///
+/// Prettier wraps the source as `type T<...> = any` before calling `textToDoc()`,
+/// so the input is always a `TSTypeParameterDeclaration` extracted from the synthetic type alias.
+///
+/// Outputs the comma-separated type parameter list with `soft_block_indent` wrapping with comments.
+/// Does NOT include angle bracket delimiters `<`/`>` or group wrapping.
+/// And trailing commas are suppressed.
+pub struct FormatVueScriptGeneric<'a, 'b> {
+    decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>,
+}
+
+impl<'a, 'b> FormatVueScriptGeneric<'a, 'b> {
+    pub fn new(decl: &'b AstNode<'a, TSTypeParameterDeclaration<'a>>) -> Self {
+        Self { decl }
+    }
+}
+
+impl<'a> Format<'a> for FormatVueScriptGeneric<'a, '_> {
+    fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        let params = self.decl.params();
+
+        soft_block_indent(&format_with(|f| {
+            f.join_with(soft_line_break_or_space()).entries_with_trailing_separator(
+                params,
+                ",",
+                TrailingSeparator::Omit,
+            );
+        }))
+        .fmt(f);
+
+        format_dangling_comments(self.decl.span).with_soft_block_indent().fmt(f);
+    }
+}

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -11,6 +11,7 @@ mod call_like_expression;
 mod class;
 mod decorators;
 mod export_declarations;
+mod fragment;
 mod function;
 mod function_type;
 mod import_declaration;
@@ -37,6 +38,7 @@ pub use arrow_function_expression::{
     FormatJsArrowFunctionExpression, FormatJsArrowFunctionExpressionOptions,
 };
 pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
+pub use fragment::{FormatVueBindingParams, FormatVueScriptGeneric};
 pub use function::FormatFunctionOptions;
 
 use cow_utils::CowUtils;


### PR DESCRIPTION
### Overview

Part of #16608

This PR applies `oxc_formatter` to the js-in-vue section.

However, it is not complete and is only applied to the following parts within js-in-vue:

- `script` block
  - and `generic="..."`
- `v-for` LHS
- `v-slot`

In the `script` block, `external_callback` is used like a regular JS file, but it isn't for others.

TL;DR: Now you can use sort-imports for Vue files.

### Review points

The points I'd like to ask your review are the following:

- Addition of `format_node()` to `oxc_formatter`
  - Made it possible to process any type that implements `Format`, not just `Program`
- The implementation of `js-in-vue` fragment was separated as much as possible to avoid impacting existing code
- `oxc_formatter` IR to prettier `Doc`

### TODOs

- [x] Planning
- [x] Implementation
- [x] Check benchmark
- [x] Check coverage
- [x] Understand & refactor
  - [x] oxfmt: JS side
  - [x] oxfmt: Rust side
  - [x] oxfmt: to_doc.rs
  - [x] oxc_formatter: fragment_format
- [x] Check benchmark again
- [x] Check coverage again
- [x] Check ecosystem-ci
- [x] Tests 👉🏻 #19563