### PR TITLE
fix(linter): `typescript/no-use-before-define` silently ignored in config

### DIFF
--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -321,8 +321,10 @@ mod test {
     fn test_typescript_compatible_rules_not_misrouted() {
         use crate::rules::RULES;
         for rule_name in TYPESCRIPT_COMPATIBLE_ESLINT_RULES {
-            let in_typescript = RULES.iter().any(|r| r.plugin_name() == "typescript" && r.name() == rule_name);
-            let in_eslint = RULES.iter().any(|r| r.plugin_name() == "eslint" && r.name() == rule_name);
+            let in_typescript =
+                RULES.iter().any(|r| r.plugin_name() == "typescript" && r.name() == rule_name);
+            let in_eslint =
+                RULES.iter().any(|r| r.plugin_name() == "eslint" && r.name() == rule_name);
             assert!(
                 !in_typescript || in_eslint,
                 "Rule '{rule_name}' exists in the typescript plugin but not eslint. \


### PR DESCRIPTION
## Summary

- `no-use-before-define` was incorrectly listed in `TYPESCRIPT_COMPATIBLE_ESLINT_RULES`, which redirects `typescript/<rule>` config entries to `eslint/<rule>`. Since oxlint only implements this rule in the typescript plugin (no `eslint/no-use-before-define` exists), the redirect caused the rule to be silently dropped when configured via `rules`.
- Removed it from the compatibility list so config correctly resolves to the typescript plugin implementation.
- Added a regression test that catches this class of bug: any rule in the compatibility list that exists in the typescript plugin but not eslint would be silently misrouted.

### Reproduction

```json
{
  "plugins": ["typescript"],
  "rules": {
    "typescript/no-use-before-define": "error",
    "typescript/no-explicit-any": "error"
  }
}
```

`no-explicit-any` fires correctly; `no-use-before-define` is silently ignored. After this fix, both work.

## Test plan

- [x] `cargo test -p oxc_linter -- utils::test` — all pass including new regression test
- [x] `cargo test -p oxc_linter -- config` — 121 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)