### PR TITLE
fix(linter/react/no-unknown-property): add missing `fetchPriority` prop

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -108,6 +108,8 @@ const ATTRIBUTE_TAGS_MAP: Map<&'static str, Set<&'static str>> = phf_map! {
     "displaystyle" => phf_set! {"math"},
     // https://html.spec.whatwg.org/multipage/links.html#downloading-resources
     "download" => phf_set! {"a", "area"},
+    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+    "fetchPriority" => phf_set! {"img", "link", "script"},
     "fill" => phf_set! {
          // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill
          // Fill color
@@ -340,6 +342,7 @@ const DOM_ATTRIBUTES_TO_CAMEL: Map<&'static str, &'static str> = phf_map! {
     "class" => "className",
     "http-equiv" => "httpEquiv",
     "crossorigin" => "crossOrigin",
+    "fetchpriority" => "fetchPriority",
     "for" => "htmlFor",
     "nomodule" => "noModule",
     "popovertarget" => "popoverTarget",
@@ -692,6 +695,12 @@ fn test() {
             r#"<input type="button" popoverTarget="locale-switcher" popoverTargetAction="show" />"#,
             None,
         ),
+        // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes
+        (r#"<img fetchPriority="high" src="foo.jpg" />"#, None),
+        (r#"<img fetchPriority="low" src="foo.jpg" />"#, None),
+        (r#"<img fetchPriority="auto" src="foo.jpg" />"#, None),
+        (r#"<link fetchPriority="high" href="style.css" rel="stylesheet" />"#, None),
+        (r#"<script fetchPriority="high" src="script.js" />"#, None),
         (
             r#"
 			        <table align="top">
@@ -773,6 +782,7 @@ fn test() {
         (r#"<div imageSizes="someImageSizes" />"#, None),
         (r#"<div popoverTarget="locale-switcher" />"#, None),
         (r#"<div popoverTargetAction="show" />"#, None),
+        (r#"<div fetchPriority="high" />"#, None),
         (r#"<div data-xml-anything="invalid" />"#, None),
         (
             r#"<div data-testID="bar" data-under_sCoRe="bar" />;"#,

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -783,6 +783,9 @@ fn test() {
         (r#"<div popoverTarget="locale-switcher" />"#, None),
         (r#"<div popoverTargetAction="show" />"#, None),
         (r#"<div fetchPriority="high" />"#, None),
+        (r#"<img fetchpriority="high" src="foo.jpg" />"#, None),
+        (r#"<link fetchpriority="high" href="style.css" rel="stylesheet" />"#, None),
+        (r#"<script fetchpriority="high" src="script.js" />"#, None),
         (r#"<div data-xml-anything="invalid" />"#, None),
         (
             r#"<div data-testID="bar" data-under_sCoRe="bar" />;"#,

--- a/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
@@ -277,6 +277,27 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-react(no-unknown-property): Unknown property found
    ╭─[no_unknown_property.tsx:1:6]
+ 1 │ <img fetchpriority="high" src="foo.jpg" />
+   ·      ─────────────
+   ╰────
+  help: Use 'fetchPriority' instead
+
+  ⚠ eslint-plugin-react(no-unknown-property): Unknown property found
+   ╭─[no_unknown_property.tsx:1:7]
+ 1 │ <link fetchpriority="high" href="style.css" rel="stylesheet" />
+   ·       ─────────────
+   ╰────
+  help: Use 'fetchPriority' instead
+
+  ⚠ eslint-plugin-react(no-unknown-property): Unknown property found
+   ╭─[no_unknown_property.tsx:1:9]
+ 1 │ <script fetchpriority="high" src="script.js" />
+   ·         ─────────────
+   ╰────
+  help: Use 'fetchPriority' instead
+
+  ⚠ eslint-plugin-react(no-unknown-property): Unknown property found
+   ╭─[no_unknown_property.tsx:1:6]
  1 │ <div data-xml-anything="invalid" />
    ·      ─────────────────
    ╰────

--- a/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unknown_property.snap
@@ -268,6 +268,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Property 'popoverTargetAction' is only allowed on: input, button
 
+  ⚠ eslint-plugin-react(no-unknown-property): Invalid property found
+   ╭─[no_unknown_property.tsx:1:6]
+ 1 │ <div fetchPriority="high" />
+   ·      ─────────────
+   ╰────
+  help: Property 'fetchPriority' is only allowed on: link, img, script
+
   ⚠ eslint-plugin-react(no-unknown-property): Unknown property found
    ╭─[no_unknown_property.tsx:1:6]
  1 │ <div data-xml-anything="invalid" />


### PR DESCRIPTION
I noticed `fetchPriority` was throwing an unknown property error on my codebase.

```
× eslint-plugin-react(no-unknown-property): Unknown property found
╭─[app/[language]/dispatch/(homepage)/_components/Delight/DelightPhone.tsx:45:11]
44 │           loading="lazy"
45 │           fetchPriority="low"
·           ─────────────
46 │           src="/img/teams/map.webp"
╰────
help: Remove unknown property
```

Since `fetchPriority` is a valid HTML attribute ([WHATWG spec](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes)) supported on `<img>`, `<link>`, and `<script>` elements, I added it to the `no_unknown_property` file with the assistance from AI.