### PR TITLE
docs(linter/plugins): correct doc comments for `initTokens`

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -146,8 +146,6 @@ export let tokensAndComments: TokenOrComment[] | null = null;
 
 /**
  * Initialize TS-ESLint tokens for current file.
- *
- * Caller must ensure `filePath` and `sourceText` are initialized before calling this function.
  */
 export function initTokens() {
   debugAssert(tokens === null, "Tokens already initialized");


### PR DESCRIPTION
Just correct a JSDoc comment. `initTokens` no longer uses `filePath` or `sourceText` since #19498.