### PR TITLE
perf(linter/plugins): remove `typescript` from bundle

### DIFF
--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -60,7 +60,6 @@
     "tsdown": "catalog:",
     "tsx": "^4.21.0",
     "type-fest": "^5.2.0",
-    "typescript": "catalog:",
     "vitest": "catalog:",
     "vscode-languageserver-protocol": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12"

--- a/apps/oxlint/src-js/plugins/typescript.cjs
+++ b/apps/oxlint/src-js/plugins/typescript.cjs
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = require("typescript");

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -91,18 +91,6 @@ export default defineConfig([
     },
   },
 
-  // TypeScript.
-  // Bundled separately and lazy-loaded, as it's a lot of code.
-  // Only used for tokens APIs.
-  {
-    ...commonConfig,
-    entry: "src-js/plugins/typescript.cjs",
-    format: "commonjs",
-    // Minify as this bundle is just dependencies. We don't need to be able to debug it.
-    // Minification halves the size of the bundle.
-    minify: true,
-  },
-
   // `@oxlint/plugins` package.
   // Dual package - both ESM and CommonJS.
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@napi-rs/cli':
       specifier: 3.5.1
       version: 3.5.1
-    '@napi-rs/wasm-runtime':
-      specifier: 1.1.1
-      version: 1.1.1
     '@types/node':
       specifier: 24.1.0
       version: 24.1.0
@@ -24,18 +21,12 @@ catalogs:
     eslint:
       specifier: 9.39.2
       version: 9.39.2
-    publint:
-      specifier: 0.3.17
-      version: 0.3.17
     rolldown:
       specifier: 1.0.0-rc.5
       version: 1.0.0-rc.5
     tsdown:
       specifier: 0.20.3
       version: 0.20.3
-    typescript:
-      specifier: 5.9.3
-      version: 5.9.3
     vitest:
       specifier: 4.0.18
       version: 4.0.18
@@ -171,9 +162,6 @@ importers:
       type-fest:
         specifier: ^5.2.0
         version: 5.4.4
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.18(@types/node@24.1.0)(@vitest/browser-playwright@4.0.18)(happy-dom@20.0.11)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,6 @@ catalog:
   publint: 0.3.17
   rolldown: 1.0.0-rc.5
   tsdown: 0.20.3
-  typescript: 5.9.3
   vitest: 4.0.18
 
 onlyBuiltDependencies:


### PR DESCRIPTION
#19498 removed the usage of TypeScript parser for tokenizing source. We now use the tokens produced by Oxc parser.

So we can remove TypeScript parser from the bundle. This reduces the size of `oxlint` package 4.7K -> 1.2K.