### PR TITLE
fix(linter): add help text to `symbol-description` diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -9,7 +9,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct SymbolDescription;
 
 fn symbol_description_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected Symbol to have a description.").with_label(span)
+    OxcDiagnostic::warn("Expected Symbol to have a description.")
+        .with_help("Pass a description argument to the Symbol()")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(symbol-description): Expected Symbol to have a description.

--- a/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_symbol_description.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(symbol-description): Expected Symbol to have a description.
@@ -7,9 +8,11 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Symbol();
    · ────────
    ╰────
+  help: Pass a description argument to the Symbol()
 
   ⚠ eslint(symbol-description): Expected Symbol to have a description.
    ╭─[symbol_description.tsx:1:1]
  1 │ Symbol(); Symbol = function () {};
    · ────────
    ╰────
+  help: Pass a description argument to the Symbol()


### PR DESCRIPTION
Closes #19121 (partially)

- Before: only shows "Expected Symbol to have a description."
- After: also shows `help: Pass a description argument to the Symbol()`