### PR TITLE
fix(linter): add help text to eslint rule diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_new_native_nonconstructor_diagnostic(fn_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("`{fn_name}` cannot be called as a constructor.")).with_label(span)
+    OxcDiagnostic::warn(format!("`{fn_name}` cannot be called as a constructor."))
+        .with_help(format!("Remove the `new` operator to call `{fn_name}` as a function."))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -13,7 +13,9 @@ use crate::{
 pub struct PreferExponentiationOperator;
 
 fn prefer_exponentian_operator_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `**` over `Math.pow`.").with_label(span)
+    OxcDiagnostic::warn("Prefer `**` over `Math.pow`.")
+        .with_help("Replace `Math.pow(a, b)` with `a ** b`.")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_rest_params.rs
@@ -5,7 +5,9 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span, ident::ARGUMENTS};
 
 fn prefer_rest_params_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use the rest parameters instead of `arguments`.").with_label(span)
+    OxcDiagnostic::warn("Use the rest parameters instead of `arguments`.")
+        .with_help("Replace `arguments` with rest parameters (`...args`).")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
@@ -9,7 +9,9 @@ use oxc_span::{ContentEq, Span};
 use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
 
 fn eslint_prefer_spread_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use spread operators instead of `.apply()`.").with_label(span)
+    OxcDiagnostic::warn("Use spread operators instead of `.apply()`.")
+        .with_help("Replace `.apply()` with spread syntax (`...args`).")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_vars.rs
@@ -13,7 +13,9 @@ use schemars::JsonSchema;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn sort_vars_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Variable declarations should be sorted").with_label(span)
+    OxcDiagnostic::warn("Variable declarations should be sorted")
+        .with_help("Sort variable declarations in ascending order (case-sensitive by default).")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_new_native_nonconstructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_new_native_nonconstructor.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(no-new-native-nonconstructor): `Symbol` cannot be called as a constructor.

--- a/crates/oxc_linter/src/snapshots/eslint_no_new_native_nonconstructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_new_native_nonconstructor.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(no-new-native-nonconstructor): `Symbol` cannot be called as a constructor.
@@ -7,21 +8,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var foo = new Symbol('foo');
    ·           ───
    ╰────
+  help: Remove the `new` operator to call `Symbol` as a function.
 
   ⚠ eslint(no-new-native-nonconstructor): `Symbol` cannot be called as a constructor.
    ╭─[no_new_native_nonconstructor.tsx:1:59]
  1 │ function bar() { return function Symbol() {}; } var baz = new Symbol('baz');
    ·                                                           ───
    ╰────
+  help: Remove the `new` operator to call `Symbol` as a function.
 
   ⚠ eslint(no-new-native-nonconstructor): `BigInt` cannot be called as a constructor.
    ╭─[no_new_native_nonconstructor.tsx:1:11]
  1 │ var foo = new BigInt(9007199254740991);
    ·           ───
    ╰────
+  help: Remove the `new` operator to call `BigInt` as a function.
 
   ⚠ eslint(no-new-native-nonconstructor): `BigInt` cannot be called as a constructor.
    ╭─[no_new_native_nonconstructor.tsx:1:59]
  1 │ function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);
    ·                                                           ───
    ╰────
+  help: Remove the `new` operator to call `BigInt` as a function.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_exponentiation_operator.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_exponentiation_operator.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
@@ -7,14 +8,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ globalThis.Math.pow(a, b)
    · ─────────────────────────
    ╰────
-  help: Replace `globalThis.Math.pow(a, b)` with `a ** b`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ globalThis.Math['pow'](a, b)
    · ────────────────────────────
    ╰────
-  help: Replace `globalThis.Math['pow'](a, b)` with `a ** b`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
@@ -29,15 +30,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ╭─▶ Math.pow(a, b) + Math.pow(c,
  2 │ ╰─▶              d)
    ╰────
-  help: Replace `Math.pow(c,
-        			 d)` with `c ** d`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(Math.pow(a, b), Math.pow(c, d))
    · ────────────────────────────────────────
    ╰────
-  help: Replace `Math.pow(Math.pow(a, b), Math.pow(c, d))` with `Math.pow(a, b) ** Math.pow(c, d)`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:10]
@@ -51,42 +51,42 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Math.pow(Math.pow(a, b), Math.pow(c, d))
    ·                          ──────────────
    ╰────
-  help: Replace `Math.pow(c, d)` with `c ** d`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b)**Math.pow(c, d)
    · ──────────────
    ╰────
-  help: Replace `Math.pow(a, b)` with `(a ** b)`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:17]
  1 │ Math.pow(a, b)**Math.pow(c, d)
    ·                 ──────────────
    ╰────
-  help: Replace `Math.pow(c, d)` with `c ** d`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b as any)
    · ─────────────────────
    ╰────
-  help: Replace `Math.pow(a, b as any)` with `a ** (b as any)`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a as any, b)
    · ─────────────────────
    ╰────
-  help: Replace `Math.pow(a as any, b)` with `(a as any) ** b`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
  1 │ Math.pow(a, b) as any
    · ──────────────
    ╰────
-  help: Replace `Math.pow(a, b)` with `(a ** b)`.
+  help: Replace `Math.pow(a, b)` with `a ** b`.
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.
    ╭─[prefer_exponentiation_operator.tsx:1:1]
@@ -100,3 +100,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Math.pow(a, b) + Math.pow(c, /* comment */ d)
    ·                  ────────────────────────────
    ╰────
+  help: Replace `Math.pow(a, b)` with `a ** b`.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_exponentiation_operator.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_exponentiation_operator.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(prefer-exponentiation-operator): Prefer `**` over `Math.pow`.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
@@ -7,21 +8,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo() { arguments; }
    ·                  ─────────
    ╰────
+  help: Replace `arguments` with rest parameters (`...args`).
 
   ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
    ╭─[prefer_rest_params.tsx:1:18]
  1 │ function foo() { arguments[0]; }
    ·                  ─────────
    ╰────
+  help: Replace `arguments` with rest parameters (`...args`).
 
   ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
    ╭─[prefer_rest_params.tsx:1:18]
  1 │ function foo() { arguments[1]; }
    ·                  ─────────
    ╰────
+  help: Replace `arguments` with rest parameters (`...args`).
 
   ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.
    ╭─[prefer_rest_params.tsx:1:18]
  1 │ function foo() { arguments[Symbol.iterator]; }
    ·                  ─────────
    ╰────
+  help: Replace `arguments` with rest parameters (`...args`).

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_rest_params.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(prefer-rest-params): Use the rest parameters instead of `arguments`.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_spread.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
@@ -7,42 +8,49 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo.apply(undefined, args);
    · ──────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply(void 0, args);
    · ───────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply(null, args);
    · ─────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ obj.foo.apply(obj, args);
    · ────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a.b.c.foo.apply(a.b.c, args);
    · ────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a.b(x, y).c.foo.apply(a.b(x, y).c, args);
    · ────────────────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ [].concat.apply([ ], args);
    · ──────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
@@ -50,63 +58,74 @@ source: crates/oxc_linter/src/tester.rs
  2 │ │               /*empty*/
  3 │ ╰─▶             ], args);
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo.apply?.(undefined, args);
    · ────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo?.apply(undefined, args);
    · ───────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ foo?.apply?.(undefined, args);
    · ─────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (foo?.apply)(undefined, args);
    · ─────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (foo?.apply)?.(undefined, args);
    · ───────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (obj?.foo).apply(obj, args);
    · ───────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ a?.b.c.foo.apply(a?.b.c, args);
    · ──────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (a?.b.c).foo.apply(a?.b.c, args);
    · ────────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:1]
  1 │ (a?.b).c.foo.apply((a?.b).c, args);
    · ──────────────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).
 
   ⚠ eslint(prefer-spread): Use spread operators instead of `.apply()`.
    ╭─[prefer_spread.tsx:1:25]
  1 │ class C { #foo; foo() { obj.#foo.apply(obj, args); } }
    ·                         ─────────────────────────
    ╰────
+  help: Replace `.apply()` with spread syntax (`...args`).

--- a/crates/oxc_linter/src/snapshots/eslint_sort_vars.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_sort_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
@@ -7,12 +8,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var b, a
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:9]
  1 │ var b , a
    ·         ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:2:8]
@@ -20,135 +23,158 @@ source: crates/oxc_linter/src/tester.rs
  2 │                 a;
    ·                 ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var b=10, a=20;
    ·           ────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var b=10, a=20, c=30;
    ·           ────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:13]
  1 │ var all=10, a = 1
    ·             ─────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var b, c, a, d
    ·           ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var c, d, a, b
    ·           ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var a, A;
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var a, B;
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var a, B, c;
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var B, a;
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var B, A, c;
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var d, a, [b, c] = {};
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var d, a, [b, {x: {c, e}}] = {};
    ·        ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:16]
  1 │ var {} = 1, b, a
    ·                ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var b=10, a=f();
    ·           ─────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:11]
  1 │ var b=10, a=b;
    ·           ───
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:12]
  1 │ var b = 0, a = `${b}`;
    ·            ──────────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:12]
  1 │ var b = 0, a = `${f()}`
    ·            ────────────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:19]
  1 │ var b = 0, c = b, a;
    ·                   ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:19]
  1 │ var b = 0, c = 0, a = b + c;
    ·                   ─────────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:20]
  1 │ var b = f(), c, d, a;
    ·                    ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:25]
  1 │ var b = `${f()}`, c, d, a;
    ·                         ─
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted
    ╭─[sort_vars.tsx:1:8]
  1 │ var c, a = b = 0
    ·        ─────────
    ╰────
+  help: Sort variable declarations in ascending order (case-sensitive by default).

--- a/crates/oxc_linter/src/snapshots/eslint_sort_vars.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_sort_vars.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 444
 ---
 
   ⚠ eslint(sort-vars): Variable declarations should be sorted


### PR DESCRIPTION
What PR covers:

- Closes #19121 (partially)
- Add `.with_help()` to 5 ESLint rule diagnostics to provide actionable guidance:
- `no-new-native-nonconstructor`: "Remove the `new` operator to call `{fn_name}` as a function."
- `prefer-rest-params`: "Replace `arguments` with rest parameters (`...args`)."
- `prefer-spread`: "Replace `.apply()` with spread syntax (`...args`)."
- `sort-vars`: "Sort variable declarations in ascending order (case-sensitive by default)."
- `prefer-exponentiation-operator`: "Replace `Math.pow(a, b)` with `a ** b`."

5 rule files changed + 5 corresponding snapshot updates.