### PR TITLE
chore(linter): Improve and update the bug report template for linter bugs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,13 +9,15 @@ type: Bug
 ⚠️ IMPORTANT ⚠️
 Please use the appropriate template for each!
 
-- If you are reporting a bug for Oxlint or the Oxc VS Code extension:
+- If you are reporting a bug for Oxlint:
   - https://github.com/oxc-project/oxc/issues/new?template=linter_bug_report.yaml
-- If you are reporting a bug for Oxfmt, especially difference with Prettier:
+- If you are reporting a bug for the Oxc VS Code extension:
+  - https://github.com/oxc-project/oxc-vscode/issues/new
+- If you are reporting a bug for Oxfmt, especially a difference with Prettier:
   - https://github.com/oxc-project/oxc/issues/new?template=formatter_diff_report.yaml
 
 Other than that, feel free to enter whatever information you like.
 
 Please include as much detail as possible, such as version information.
-Also, if you have steps to reproduce the issue, that would be very helpful.
+Also, if you have steps to reproduce the issue, a reproduction repository, or a link to the Oxc Playground (https://playground.oxc.rs), that would be very helpful.
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,9 @@ contact_links:
     about: For lightweight questions.
 
   - name: Website issues
-    url: https://github.com/oxc-project/website
-    about: For website issues.
+    url: https://github.com/oxc-project/website/issues
+    about: For website issues other than Oxlint rule documentation. For Oxlint rule documentation issues, please file them in this repository.
+
+  - name: VS Code extension issues
+    url: https://github.com/oxc-project/oxc-vscode/issues
+    about: For issues with the Oxc VS Code extension.

--- a/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
@@ -15,7 +15,9 @@ body:
     attributes:
       label: What version of Oxlint are you using?
       description: You can find the version by running `oxlint -V`. If you ran Oxlint using `npx`, use 'latest'. If you're not sure, please say 'not sure'.
-      placeholder: 0.9.8
+      placeholder: x.y.z
+    validations:
+      required: true
 
   - type: input
     id: command
@@ -27,15 +29,27 @@ body:
   - type: textarea
     id: config
     attributes:
-      label: What does your `.oxlintrc.json` config file look like?
+      label: What does your `.oxlintrc.json` (or `oxlint.config.ts`) config file look like?
       description: If you're not using a config file, please say so. Otherwise please paste its contents here.
       value: |
         ```jsonc
-        // your config here
+        // Replace this with your actual config file contents.
+        // It can be helpful to keep it minimal, if possible, but please ensure that it actually reproduces the issue you're reporting.
+        {
+          "categories": {
+            "correctness": "off"
+          },
+          "plugins": ["react"],
+          "rules": {
+            "react/whatever-rule": "error"
+          }
+        }
         ```
 
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: Please describe the issue you're experiencing.
+      description: Please describe the issue you're experiencing and steps to reproduce the issue. If you have a minimal repository that can be used to reproduce the issue, please link it.
+    validations:
+      required: true


### PR DESCRIPTION
Just adding some clarifications, require a 'what happened' section and a version, recommend creating a reproduction repository if possible, add a fuller example config.

And add a link to the Oxc VS Code extension issues for users to be redirected there when relevant.

We can revise this further if desired, maybe we shouldn't include an example config that vaguely works, to avoid reports where people edit the config manually but don't test to ensure it still reproduces the issue? 🤷‍♂️ 