### PR TITLE
feat(formatter/sort_imports): merge duplicate adjacent imports

### DIFF
--- a/apps/oxfmt/test/api/sort_imports.test.ts
+++ b/apps/oxfmt/test/api/sort_imports.test.ts
@@ -63,4 +63,25 @@ import { foo } from "@scope/foo";
     );
     expect(result.errors).toStrictEqual([]);
   });
+  
+  it("should merge duplicate imports from same source", async () => {
+    const input = `
+import { join } from "node:path";
+import { styleText } from "node:util";
+import { join, resolve } from "node:path";
+    `;
+    
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+    
+    expect(result.code).toStrictEqual(
+      `
+import { join, resolve } from "node:path";
+import { styleText } from "node:util";
+`.trimStart(),
+    );
+    
+    expect(result.errors).toStrictEqual([]);
+  })
 });

--- a/apps/oxfmt/test/api/sort_imports.test.ts
+++ b/apps/oxfmt/test/api/sort_imports.test.ts
@@ -70,18 +70,175 @@ import { join } from "node:path";
 import { styleText } from "node:util";
 import { join, resolve } from "node:path";
     `;
-    
+
     const result = await format("a.ts", input, {
       experimentalSortImports: {},
     });
-    
+
     expect(result.code).toStrictEqual(
       `
 import { join, resolve } from "node:path";
 import { styleText } from "node:util";
 `.trimStart(),
     );
-    
+
     expect(result.errors).toStrictEqual([]);
-  })
+  });
+
+  it("should merge two imports with different specifiers", async () => {
+    const input = `
+import { a } from "x";
+import { b } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import { a, b } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should deduplicate overlapping specifiers", async () => {
+    const input = `
+import { a } from "x";
+import { a, b } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import { a, b } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should merge three imports from same source", async () => {
+    const input = `
+import { a } from "x";
+import { b } from "x";
+import { c } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import { a, b, c } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should preserve aliases when merging", async () => {
+    const input = `
+import { a as b } from "x";
+import { c } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import { a as b, c } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should preserve per-specifier type annotations when merging", async () => {
+    const input = `
+import { type A } from "x";
+import { b } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import { type A, b } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should merge type imports with same source", async () => {
+    const input = `
+import type { A } from "x";
+import type { B } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import type { A, B } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should not merge type and value imports from same source", async () => {
+    const input = `
+import type { A } from "x";
+import { b } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import type { A } from "x";
+import { b } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should not merge default import with named import", async () => {
+    const input = `
+import foo from "x";
+import { bar } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import foo from "x";
+import { bar } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should not merge namespace import with named import", async () => {
+    const input = `
+import * as ns from "x";
+import { bar } from "x";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toBe(
+      `
+import * as ns from "x";
+import { bar } from "x";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
 });

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -117,9 +117,10 @@ fn diff(before: &StatsCollector, after: &StatsCollector) -> Option<String> {
     errors.extend(diff_block_comments(&before.block_comments, &after.block_comments));
     errors.extend(diff_line_comments(&before.line_comments, &after.line_comments));
     errors.extend(diff_counts(&before.node_counts, &after.node_counts).unwrap_or_default());
-    
+
     if before.import_specifiers != after.import_specifiers {
-        let missing: Vec<_> = before.import_specifiers.difference(&after.import_specifiers).collect();
+        let missing: Vec<_> =
+            before.import_specifiers.difference(&after.import_specifiers).collect();
         let added: Vec<_> = after.import_specifiers.difference(&before.import_specifiers).collect();
         if !missing.is_empty() {
             errors.push(format!("Import specifiers removed: {missing:?}"));
@@ -208,7 +209,7 @@ impl StatsCollector {
         ) {
             return;
         }
-        
+
         if let AstKind::ImportDeclaration(decl) = kind {
             let source = &decl.source.value;
             if let Some(specifiers) = &decl.specifiers {
@@ -217,7 +218,9 @@ impl StatsCollector {
                         ast::ImportDeclarationSpecifier::ImportSpecifier(s) => {
                             format!(
                                 "IMPORT_SPEC({},{},{})",
-                                source, s.imported.name(), s.local.name
+                                source,
+                                s.imported.name(),
+                                s.local.name
                             )
                         }
                         ast::ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
@@ -235,7 +238,7 @@ impl StatsCollector {
             }
             return;
         }
-        
+
         // Skip children of ImportDeclaration – already handled above.
         if matches!(
             kind,
@@ -427,10 +430,7 @@ mod tests {
                 "import { join, path } from 'node:path';",
             ),
             // Import merging: different specifiers from same source
-            (
-                "import { a } from 'x';\nimport { b } from 'x';",
-                "import { a, b } from 'x';",
-            ),
+            ("import { a } from 'x';\nimport { b } from 'x';", "import { a, b } from 'x';"),
             // Import merging: aliased specifier preserved
             (
                 "import { a as b } from 'x';\nimport { c } from 'x';",

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/merge_imports.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/merge_imports.rs
@@ -6,7 +6,8 @@ use crate::{
     },
     options::Semicolons,
 };
-use super::source_line::SpecifierInfo;
+use super::source_line::{SourceLine, SpecifierInfo};
+use super::sortable_imports::SortableImport;
 
 pub fn build_merged_import_elements<'a>(
     is_type_import: bool,
@@ -87,12 +88,12 @@ fn push_specifier<'a>(elements: &mut Vec<FormatElement<'a>>, spec: &SpecifierInf
         elements.push(FormatElement::Token { text: "type" });
         elements.push(FormatElement::Space);
     }
-    
+
     elements.push(FormatElement::Text {
         text: spec.imported,
         width: TextWidth::from_non_whitespace_str(spec.imported),
     });
-    
+
     if let Some(local) = spec.local {
         elements.push(FormatElement::Space);
         elements.push(FormatElement::Token { text: "as" });
@@ -104,10 +105,131 @@ fn push_specifier<'a>(elements: &mut Vec<FormatElement<'a>>, spec: &SpecifierInf
     }
 }
 
+/// Merge adjacent duplicate imports in a sorted import list.
+///
+/// Groups consecutive imports with the same (normalized_source, is_type_import),
+/// where each import is "mergeable" (only named specifiers, no default/namespace/side-effect).
+/// Specifiers are deduplicated by (imported, local, is_type).
+pub fn merge_adjacent_duplicates<'a>(
+    imports: Vec<SortableImport<'a>>,
+    bracket_spacing: bool,
+    semicolons: Semicolons,
+) -> Vec<SortableImport<'a>> {
+    if imports.len() < 2 {
+        return imports;
+    }
+
+    let mut result: Vec<SortableImport<'a>> = Vec::with_capacity(imports.len());
+    let mut iter = imports.into_iter();
+    let mut current_group: Vec<SortableImport<'a>> = vec![iter.next().unwrap()];
+
+    for import in iter {
+        let last = current_group.last().unwrap();
+        let can_merge = is_mergeable_import(last)
+            && is_mergeable_import(&import)
+            && last.normalized_source == import.normalized_source
+            && get_is_type_import(last) == get_is_type_import(&import);
+
+        if can_merge {
+            current_group.push(import);
+        } else {
+            flush_group(&mut result, current_group, bracket_spacing, semicolons);
+            current_group = vec![import];
+        }
+    }
+    flush_group(&mut result, current_group, bracket_spacing, semicolons);
+
+    result
+}
+
+fn flush_group<'a>(
+    result: &mut Vec<SortableImport<'a>>,
+    group: Vec<SortableImport<'a>>,
+    bracket_spacing: bool,
+    semicolons: Semicolons,
+) {
+    if group.len() == 1 {
+        result.extend(group);
+    } else {
+        result.push(merge_group(group, bracket_spacing, semicolons));
+    }
+}
+
+fn merge_group<'a>(
+    group: Vec<SortableImport<'a>>,
+    bracket_spacing: bool,
+    semicolons: Semicolons,
+) -> SortableImport<'a> {
+    debug_assert!(group.len() >= 2);
+
+    let mut group_iter = group.into_iter();
+    let first = group_iter.next().unwrap();
+
+    // Extract metadata from the first import
+    let (source, is_type_import, mut all_specifiers) = match first.import_line {
+        SourceLine::Import(_, meta) => (meta.source, meta.is_type_import, meta.specifiers),
+        _ => unreachable!("merge_group called with non-Import line"),
+    };
+
+    let normalized_source = first.normalized_source;
+    let group_idx = first.group_idx;
+    let leading_lines = first.leading_lines;
+
+    // Add specifiers from remaining imports, deduplicating by (imported, local, is_type)
+    for import in group_iter {
+        if let SourceLine::Import(_, meta) = import.import_line {
+            for spec in meta.specifiers {
+                let is_duplicate = all_specifiers.iter().any(|s| {
+                    s.imported == spec.imported
+                        && s.local == spec.local
+                        && s.is_type == spec.is_type
+                });
+                if !is_duplicate {
+                    all_specifiers.push(spec);
+                }
+            }
+        }
+    }
+
+    let elements =
+        build_merged_import_elements(is_type_import, &all_specifiers, source, bracket_spacing, semicolons);
+
+    SortableImport {
+        leading_lines,
+        import_line: SourceLine::MergedImport(elements),
+        group_idx,
+        normalized_source,
+        is_side_effect: false,
+        is_ignored: false,
+    }
+}
+
+fn is_mergeable_import(import: &SortableImport) -> bool {
+    match &import.import_line {
+        SourceLine::Import(_, meta) => {
+            meta.has_named_specifier
+                && !meta.has_default_specifier
+                && !meta.has_namespace_specifier
+                && !meta.is_side_effect
+        }
+        _ => false,
+    }
+}
+
+fn get_is_type_import(import: &SortableImport) -> bool {
+    match &import.import_line {
+        SourceLine::Import(_, meta) => meta.is_type_import,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use super::*;
-    
+    use super::super::source_line::ImportLineMetadata;
+
     #[test]
     fn two_specifiers() {
         let specs = vec![
@@ -213,5 +335,129 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    fn make_import<'a>(
+        source: &'a str,
+        is_type_import: bool,
+        specifiers: Vec<SpecifierInfo<'a>>,
+    ) -> SortableImport<'a> {
+        SortableImport {
+            leading_lines: vec![],
+            import_line: SourceLine::Import(
+                0..0,
+                ImportLineMetadata {
+                    source,
+                    is_side_effect: false,
+                    is_type_import,
+                    has_default_specifier: false,
+                    has_namespace_specifier: false,
+                    has_named_specifier: true,
+                    specifiers,
+                },
+            ),
+            group_idx: 0,
+            normalized_source: Cow::Borrowed(source),
+            is_side_effect: false,
+            is_ignored: false,
+        }
+    }
+
+    fn spec(name: &str) -> SpecifierInfo<'_> {
+        SpecifierInfo { imported: name, local: None, is_type: false }
+    }
+
+    fn assert_merged_specifiers(import: &SortableImport, expected: &[&str]) {
+        match &import.import_line {
+            SourceLine::MergedImport(elements) => {
+                let texts: Vec<&str> = elements
+                    .iter()
+                    .filter_map(|el| match el {
+                        FormatElement::Text { text, .. } => Some(*text),
+                        _ => None,
+                    })
+                    .filter(|t| !t.starts_with('\'') && !t.starts_with('"'))
+                    .collect();
+                assert_eq!(texts, expected);
+            }
+            _ => panic!("expected MergedImport, got {import:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_two_different_specifiers() {
+        let imports = vec![
+            make_import("'x'", false, vec![spec("a")]),
+            make_import("'x'", false, vec![spec("b")]),
+        ];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 1);
+        assert_merged_specifiers(&result[0], &["a", "b"]);
+    }
+
+    #[test]
+    fn merge_deduplicates_specifiers() {
+        let imports = vec![
+            make_import("'x'", false, vec![spec("a")]),
+            make_import("'x'", false, vec![spec("a"), spec("b")]),
+        ];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 1);
+        assert_merged_specifiers(&result[0], &["a", "b"]);
+    }
+
+    #[test]
+    fn no_merge_different_source() {
+        let imports = vec![
+            make_import("'x'", false, vec![spec("a")]),
+            make_import("'y'", false, vec![spec("b")]),
+        ];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn no_merge_default_import() {
+        let mut import = make_import("'x'", false, vec![spec("a")]);
+        if let SourceLine::Import(_, ref mut meta) = import.import_line {
+            meta.has_default_specifier = true;
+        }
+        let imports = vec![import, make_import("'x'", false, vec![spec("b")])];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn no_merge_namespace_import() {
+        let mut import = make_import("'x'", false, vec![]);
+        if let SourceLine::Import(_, ref mut meta) = import.import_line {
+            meta.has_namespace_specifier = true;
+            meta.has_named_specifier = false;
+        }
+        let imports = vec![import, make_import("'x'", false, vec![spec("b")])];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn no_merge_type_vs_value() {
+        let imports = vec![
+            make_import("'x'", true, vec![spec("A")]),
+            make_import("'x'", false, vec![spec("b")]),
+        ];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn merge_three_imports_same_source() {
+        let imports = vec![
+            make_import("'x'", false, vec![spec("a")]),
+            make_import("'x'", false, vec![spec("b")]),
+            make_import("'x'", false, vec![spec("c")]),
+        ];
+        let result = merge_adjacent_duplicates(imports, true, Semicolons::Always);
+        assert_eq!(result.len(), 1);
+        assert_merged_specifiers(&result[0], &["a", "b", "c"]);
     }
 }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/merge_imports.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/merge_imports.rs
@@ -1,0 +1,217 @@
+use crate::{
+    JsLabels,
+    formatter::format_element::{
+        FormatElement, LineMode, TextWidth,
+        tag::{self, LabelId, Tag},
+    },
+    options::Semicolons,
+};
+use super::source_line::SpecifierInfo;
+
+pub fn build_merged_import_elements<'a>(
+    is_type_import: bool,
+    specifiers: &[SpecifierInfo<'a>],
+    source: &'a str,
+    bracket_spacing: bool,
+    semicolons: Semicolons,
+) -> Vec<FormatElement<'a>> {
+    let mut elements = Vec::new();
+    
+    elements.push(FormatElement::Tag(Tag::StartLabelled(
+        LabelId::of(JsLabels::ImportDeclaration),
+    )));
+    
+    elements.push(FormatElement::Token { text: "import" });
+    elements.push(FormatElement::Space);
+    
+    if is_type_import {
+        elements.push(FormatElement::Token { text: "type" });
+        elements.push(FormatElement::Space);
+    }
+    
+    elements.push(FormatElement::Token { text: "{" });
+    
+    if specifiers.len() == 1 {
+        if bracket_spacing {
+            elements.push(FormatElement::Space);
+        }
+        push_specifier(&mut elements, &specifiers[0]);
+        if bracket_spacing {
+            elements.push(FormatElement::Space);
+        }
+    } else {
+        let line_mode = if bracket_spacing {
+            LineMode::SoftOrSpace
+        } else {
+            LineMode::Soft
+        };
+        
+        elements.push(FormatElement::Tag(Tag::StartGroup(tag::Group::new())));
+        elements.push(FormatElement::Tag(Tag::StartIndent));
+        elements.push(FormatElement::Line(line_mode));
+        
+        for (i, spec) in specifiers.iter().enumerate() {
+            if i > 0 {
+                elements.push(FormatElement::Token { text: "," });
+                elements.push(FormatElement::Line(line_mode));
+            }
+            push_specifier(&mut elements, spec);
+        }
+        
+        elements.push(FormatElement::Tag(Tag::EndIndent));
+        elements.push(FormatElement::Line(line_mode));
+        elements.push(FormatElement::Tag(Tag::EndGroup));
+    }
+    
+    elements.push(FormatElement::Token { text: "}" });
+    elements.push(FormatElement::Space);
+    elements.push(FormatElement::Token { text: "from" });
+    elements.push(FormatElement::Space);
+
+    elements.push(FormatElement::Text {
+        text: source,
+        width: TextWidth::from_non_whitespace_str(source),
+    });
+
+    if matches!(semicolons, Semicolons::Always) {
+        elements.push(FormatElement::Token { text: ";" });
+    }
+    
+    elements.push(FormatElement::Tag(Tag::EndLabelled));
+    
+    elements
+}
+
+fn push_specifier<'a>(elements: &mut Vec<FormatElement<'a>>, spec: &SpecifierInfo<'a>) {
+    if spec.is_type {
+        elements.push(FormatElement::Token { text: "type" });
+        elements.push(FormatElement::Space);
+    }
+    
+    elements.push(FormatElement::Text {
+        text: spec.imported,
+        width: TextWidth::from_non_whitespace_str(spec.imported),
+    });
+    
+    if let Some(local) = spec.local {
+        elements.push(FormatElement::Space);
+        elements.push(FormatElement::Token { text: "as" });
+        elements.push(FormatElement::Space);
+        elements.push(FormatElement::Text {
+            text: local,
+            width: TextWidth::from_non_whitespace_str(local),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn two_specifiers() {
+        let specs = vec![
+            SpecifierInfo { imported: "a", local: None, is_type: false },
+            SpecifierInfo { imported: "b", local: None, is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(false, &specs, "'x'", true, Semicolons::Always);
+        let tokens = collect_tokens(&elements);
+        
+        assert_eq!(tokens, vec!["import", "{", "a", ",", "b", "}", "from", "'x'", ";"]);
+    }
+    
+    #[test]
+    fn single_specifier() {
+        let specs = vec![
+            SpecifierInfo { imported: "a", local: None, is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(false, &specs, "'x'", true, Semicolons::Always);
+        let tokens = collect_tokens(&elements);
+        assert_eq!(tokens, vec!["import", "{", "a", "}", "from", "'x'", ";"]);
+        
+        // No Group/Indent tags
+        let has_group = elements.iter().any(|el| matches!(el, FormatElement::Tag(Tag::StartGroup(_))));
+        assert!(!has_group, "single specifier should not use group");
+    }
+    
+    #[test]
+    fn specifier_with_alias() {
+        let specs = vec![
+            SpecifierInfo { imported: "join", local: Some("j"), is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(false, &specs, "'path'", true, Semicolons::Always);
+        let tokens = collect_tokens(&elements);
+        
+        assert_eq!(tokens, vec!["import", "{", "join", "as", "j", "}", "from", "'path'", ";"]);
+    }
+    
+    #[test]
+    fn per_specifier_type() {
+        let specs = vec![
+            SpecifierInfo { imported: "Foo", local: None, is_type: true },
+            SpecifierInfo { imported: "bar", local: None, is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(false, &specs, "'x'", true, Semicolons::Always);
+        let tokens = collect_tokens(&elements);
+        
+        assert_eq!(tokens, vec!["import", "{", "type", "Foo", ",", "bar", "}", "from", "'x'", ";"]);
+    }
+    
+    #[test]
+    fn type_import() {
+        let specs = vec![
+            SpecifierInfo { imported: "A", local: None, is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(true, &specs, "'x'", true, Semicolons::Always);
+        let tokens = collect_tokens(&elements);
+        
+        assert_eq!(tokens, vec!["import", "type", "{", "A", "}", "from", "'x'", ";"]);
+    }
+    
+    #[test]
+    fn no_semicolon() {
+        let specs = vec![
+            SpecifierInfo { imported: "a", local: None, is_type: false },
+        ];
+        
+        let elements = build_merged_import_elements(false, &specs, "'x'", true, Semicolons::AsNeeded);
+        let tokens = collect_tokens(&elements);
+        
+        assert_eq!(tokens, vec!["import", "{", "a", "}", "from", "'x'"]);
+    }
+    
+    #[test]
+    fn no_bracket_spacing() {
+        let specs = vec![
+            SpecifierInfo { imported: "a", local: None, is_type: false },
+        ];
+
+        let elements = build_merged_import_elements(false, &specs, "'x'", false, Semicolons::Always);
+        // Should be no Space between `{` and `a` and between `a` and `}`
+        let has_space_around_brace = elements.windows(2).any(|w| {
+            matches!(
+                (&w[0], &w[1]),
+                (FormatElement::Token { text: "{" }, FormatElement::Space)
+                    | (FormatElement::Space, FormatElement::Token { text: "}" })
+            )
+        });
+
+        assert!(!has_space_around_brace, "no spaces around braces when bracket_spacing=false");
+    }
+    
+    fn collect_tokens<'a>(elements: &[FormatElement<'a>]) -> Vec<&'a str> {
+        elements
+            .iter()
+            .filter_map(|el| match el {
+                FormatElement::Token { text } => Some(*text),
+                FormatElement::Text { text, .. } => Some(*text),
+                _ => None,
+            })
+            .collect()
+    }
+}

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -1,11 +1,11 @@
 mod compute_metadata;
 mod group_config;
 mod group_matcher;
+mod merge_imports;
 pub mod options;
 mod partitioned_chunk;
 mod sortable_imports;
 mod source_line;
-mod merge_imports;
 
 use oxc_allocator::{Allocator, Vec as ArenaVec};
 
@@ -17,12 +17,10 @@ use crate::{
         tag::{LabelId, Tag},
     },
     ir_transform::sort_imports::{
-        group_matcher::GroupMatcher, 
-        partitioned_chunk::PartitionedChunk, 
-        source_line::SourceLine, 
-        merge_imports::merge_adjacent_duplicates,
+        group_matcher::GroupMatcher, merge_imports::merge_adjacent_duplicates,
+        partitioned_chunk::PartitionedChunk, source_line::SourceLine,
     },
-    options::Semicolons
+    options::Semicolons,
 };
 
 /// An IR transform that sorts import statements according to specified options.
@@ -252,7 +250,8 @@ impl SortImportsTransform {
                     // ```
                     let (sorted_imports, orphan_contents, trailing_lines) =
                         chunk.into_sorted_import_units(&group_matcher, options);
-                    let sorted_imports = merge_adjacent_duplicates(sorted_imports, bracket_spacing, semicolons);
+                    let sorted_imports =
+                        merge_adjacent_duplicates(sorted_imports, bracket_spacing, semicolons);
 
                     // Output leading orphan content (after_slot: None)
                     for orphan in &orphan_contents {

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -17,8 +17,12 @@ use crate::{
         tag::{LabelId, Tag},
     },
     ir_transform::sort_imports::{
-        group_matcher::GroupMatcher, partitioned_chunk::PartitionedChunk, source_line::SourceLine,
+        group_matcher::GroupMatcher, 
+        partitioned_chunk::PartitionedChunk, 
+        source_line::SourceLine, 
+        merge_imports::merge_adjacent_duplicates,
     },
+    options::Semicolons
 };
 
 /// An IR transform that sorts import statements according to specified options.
@@ -36,6 +40,8 @@ impl SortImportsTransform {
     pub fn transform<'a>(
         document: &Document<'a>,
         options: &SortImportsOptions,
+        bracket_spacing: bool,
+        semicolons: Semicolons,
         allocator: &'a Allocator,
     ) -> Option<ArenaVec<'a, FormatElement<'a>>> {
         // Early return for empty files
@@ -246,6 +252,7 @@ impl SortImportsTransform {
                     // ```
                     let (sorted_imports, orphan_contents, trailing_lines) =
                         chunk.into_sorted_import_units(&group_matcher, options);
+                    let sorted_imports = merge_adjacent_duplicates(sorted_imports, bracket_spacing, semicolons);
 
                     // Output leading orphan content (after_slot: None)
                     for orphan in &orphan_contents {

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -5,6 +5,7 @@ pub mod options;
 mod partitioned_chunk;
 mod sortable_imports;
 mod source_line;
+mod merge_imports;
 
 use oxc_allocator::{Allocator, Vec as ArenaVec};
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -149,9 +149,7 @@ impl<'a> PartitionedChunk<'a> {
                 // `MergedImport` is only created later during the merge phase,
                 // after partitioning is already complete.
                 SourceLine::MergedImport(_) => {
-                    unreachable!(
-                        "`MergedImport` cannot appear during partitioning."
-                    );
+                    unreachable!("`MergedImport` cannot appear during partitioning.");
                 }
             }
         }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -146,6 +146,13 @@ impl<'a> PartitionedChunk<'a> {
                         "`PartitionedChunk::Imports` must not contain `SourceLine::Others`."
                     );
                 }
+                // `MergedImport` is only created later during the merge phase,
+                // after partitioning is already complete.
+                SourceLine::MergedImport(_) => {
+                    unreachable!(
+                        "`MergedImport` cannot appear during partitioning."
+                    );
+                }
             }
         }
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -161,10 +161,12 @@ impl<'a> SourceLine<'a> {
                                         } else {
                                             current_imported = Some(text);
                                         }
-                                    } else if source.is_none() {
-                                        source = Some(text);
+                                    } else {
+                                        if source.is_none() {
+                                            source = Some(text);
+                                        }
+                                        has_default_specifier = true;
                                     }
-                                    has_default_specifier = true;
                                 }
                                 _ => {}
                             }

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -267,7 +267,7 @@ pub struct ImportLineMetadata<'a> {
     pub has_named_specifier: bool,
     /// Individual named specifiers extracted from the import.
     /// Empty if this import has no named specifiers (e.g., side-effect or namespace imports).
-    pub specifiers: Vec<SpecifierInfo<'a>>
+    pub specifiers: Vec<SpecifierInfo<'a>>,
 }
 
 /// Information about single import specifier, extracted from IR elements

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -80,6 +80,8 @@ impl<'a> Formatter<'a> {
             && let Some(transformed_elements) = SortImportsTransform::transform(
                 formatted.document(),
                 sort_imports_options,
+                formatted.context().options().bracket_spacing.value(),
+                formatted.context().options().semicolons,
                 self.allocator,
             )
         {

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -134,9 +134,7 @@ import { x } from "a";
 "#,
         r#"{ "sortImports": {} }"#,
         r#"
-import { z } from "a";
-import { y } from "a";
-import { x } from "a";
+import { z, y, x } from "a";
 "#,
     );
 }


### PR DESCRIPTION
When sorting imports, adjacent duplicate import statements from the same module are now merged and their specifiers deduplicated. This commonly occurs after merge conflicts ("accept both").

```js
// Before
import { join } from "node:path";
import { styleText } from "node:util";
import { join, resolve } from "node:path";

// After (sorted + merged)
import { join, resolve } from "node:path";
import { styleText } from "node:util";
```

## What's included

- Extract named specifiers (SpecifierInfo) from import IR elements
- Build merged import IR from deduplicated specifier list
- Merge algorithm: groups adjacent imports by (source, is_type_import), deduplicates by (imported, local, is_type)
- Only named imports are merged — default, namespace, and side-effect imports are left as-is
- detect_code_removal updated to track individual import specifiers (prevents false positives)
- 13 Rust unit tests + 12 E2E tests (Vitest)

Closes [#19511](https://github.com/oxc-project/oxc/issues/19511)