### PR TITLE
fix(oxlint/lsp): load js config with reforcing fs read

### DIFF
--- a/apps/oxlint/src-js/js_config.ts
+++ b/apps/oxlint/src-js/js_config.ts
@@ -1,6 +1,6 @@
 import { getErrorMessage } from "./utils/utils.ts";
 import { isDefineConfig } from "./package/config.ts";
-import { JSONStringify } from "./utils/globals.ts";
+import { DateNow, JSONStringify } from "./utils/globals.ts";
 
 interface JsConfigResult {
   path: string;
@@ -89,9 +89,11 @@ function validateConfigExtends(root: object): void {
  */
 export async function loadJsConfigs(paths: string[]): Promise<string> {
   try {
+    const cacheKey = DateNow();
     const results = await Promise.allSettled(
       paths.map(async (path): Promise<JsConfigResult> => {
-        const fileUrl = new URL(`file://${path}`);
+        // Bypass Node.js module cache to allow reloading changed config files (used for LSP, where we reload configs after important changes)
+        const fileUrl = new URL(`file://${path}?cache=${cacheKey}`);
         const module = await import(fileUrl.href);
         const config = module.default;
 

--- a/apps/oxlint/src-js/utils/globals.ts
+++ b/apps/oxlint/src-js/utils/globals.ts
@@ -34,3 +34,5 @@ export const { ownKeys: ReflectOwnKeys } = Reflect;
 export const { iterator: SymbolIterator } = Symbol;
 
 export const { fromCodePoint: StringFromCodePoint } = String;
+
+export const { now: DateNow } = Date;

--- a/apps/oxlint/test/lsp/file_config_change/__snapshots__/file_config_change.test.ts.snap
+++ b/apps/oxlint/test/lsp/file_config_change/__snapshots__/file_config_change.test.ts.snap
@@ -39,7 +39,7 @@ help: Remove the debugger statement
 ts-config/test.ts
 --- Diagnostics ---------
 > 1 | debugger;
-    | ^^^^^^^^^ Error: \`debugger\` statement is not allowed
+    | ^^^^^^^^^ Warning: \`debugger\` statement is not allowed
 help: Remove the debugger statement
 --------------------"
 `;

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -243,6 +243,9 @@ export function normalizeStdout(stdout: string, fixtureName: string, isESLint: b
       return `${prefix}${content.replaceAll("\\", "/")}${suffix}`;
     });
 
+    // Handle uris with `?cache=...` query param, which are used to bypass Node.js module cache when loading config files in LSP tests.
+    line = line.replaceAll(/\?cache=\d+/g, "");
+
     // Handle stack trace lines.
     // e.g. ` at file:///path/to/oxc/apps/oxlint/test/fixtures/foo/bar.js:1:1`
     // e.g. ` at whatever (file:///path/to/oxc/apps/oxlint/test/fixtures/foo/bar.js:1:1)`


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/19526

> This PR fixes a bug in the LSP where JavaScript/TypeScript config files were not being reloaded when changed. The fix implements cache-busting by appending a timestamp query parameter to file URLs during import, forcing Node.js to bypass its module cache.