### PR TITLE
test(oxlint/lsp): add test for `.oxlintrc.json` config change

### DIFF
--- a/apps/oxlint/test/lsp/file_config_change/__snapshots__/file_config_change.test.ts.snap
+++ b/apps/oxlint/test/lsp/file_config_change/__snapshots__/file_config_change.test.ts.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`diagnostics after config change > should get refreshed diagnostics config from severity-change/test.ts 1`] = `
+"=== Before Config Change ===
+
+--- FILE -----------
+severity-change/test.ts
+--- Diagnostics ---------
+> 1 | debugger;
+    | ^^^^^^^^^ Error: \`debugger\` statement is not allowed
+help: Remove the debugger statement
+--------------------
+
+=== After Config Change ===
+
+--- FILE -----------
+severity-change/test.ts
+--- Diagnostics ---------
+> 1 | debugger;
+    | ^^^^^^^^^ Warning: \`debugger\` statement is not allowed
+help: Remove the debugger statement
+--------------------"
+`;
+
+exports[`diagnostics after config change > should get refreshed diagnostics config from ts-config/test.ts 1`] = `
+"=== Before Config Change ===
+
+--- FILE -----------
+ts-config/test.ts
+--- Diagnostics ---------
+> 1 | debugger;
+    | ^^^^^^^^^ Error: \`debugger\` statement is not allowed
+help: Remove the debugger statement
+--------------------
+
+=== After Config Change ===
+
+--- FILE -----------
+ts-config/test.ts
+--- Diagnostics ---------
+> 1 | debugger;
+    | ^^^^^^^^^ Error: \`debugger\` statement is not allowed
+help: Remove the debugger statement
+--------------------"
+`;

--- a/apps/oxlint/test/lsp/file_config_change/file_config_change.test.ts
+++ b/apps/oxlint/test/lsp/file_config_change/file_config_change.test.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { lintFixtureWithFileContentChange } from "../utils";
+
+const FIXTURES_DIR = join(import.meta.dirname, "fixtures");
+
+describe("diagnostics after config change", () => {
+  it.each([
+    ["severity-change/test.ts", "typescript", ".oxlintrc.json", ".oxlintrc-new.json"],
+    ["ts-config/test.ts", "typescript", "oxlint.config.ts", "oxlint.config-new.ts"],
+  ])(
+    "should get refreshed diagnostics config from %s",
+    async (path, languageId, oldConfig, newConfig) => {
+      expect(
+        await lintFixtureWithFileContentChange(
+          FIXTURES_DIR,
+          path,
+          languageId,
+          oldConfig,
+          newConfig,
+        ),
+      ).toMatchSnapshot();
+    },
+  );
+});

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/.oxlintrc-new.json
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/.oxlintrc-new.json
@@ -1,0 +1,8 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "warn"
+  }
+}

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/.oxlintrc.json
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "error"
+  }
+}

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/test.ts
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/severity-change/test.ts
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/oxlint.config-new.ts
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/oxlint.config-new.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  categories: {
+    correctness: "off",
+  },
+  rules: {
+    "no-debugger": "warn",
+  },
+});

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/oxlint.config.ts
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/oxlint.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  categories: {
+    correctness: "off",
+  },
+  rules: {
+    "no-debugger": "error",
+  },
+});

--- a/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/test.ts
+++ b/apps/oxlint/test/lsp/file_config_change/fixtures/ts-config/test.ts
@@ -1,0 +1,1 @@
+debugger;


### PR DESCRIPTION
> Adds an LSP regression test to verify diagnostics are refreshed after configuration file content changes (e.g. .oxlintrc.json / oxlint.config.ts) by simulating workspace/didChangeWatchedFiles and waiting for a diagnostic refresh.

This shows the error for https://github.com/oxc-project/oxc/issues/19526 where the config is not refreshed and still shows an error. This is fixed in the downstream PR