### PR TITLE
feat(oxfmt): Strip `"experimental"SortXxx` prefix

### DIFF
--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -107,13 +107,13 @@ export async function runMigratePrettier() {
     );
     oxfmtrc.printWidth = 80;
   }
-  // `experimentalSortPackageJson` is enabled by default in Oxfmt, but Prettier does not have this.
+  // `sortPackageJson` is enabled by default in Oxfmt, but Prettier does not have this.
   // Only enable if `prettier-plugin-packagejson` is used.
   if (hasSortPackageJsonPlugin) {
-    oxfmtrc.experimentalSortPackageJson = {};
-    console.error(`  - Migrated "prettier-plugin-packagejson" to "experimentalSortPackageJson"`);
+    oxfmtrc.sortPackageJson = {};
+    console.error(`  - Migrated "prettier-plugin-packagejson" to "sortPackageJson"`);
   } else {
-    oxfmtrc.experimentalSortPackageJson = false;
+    oxfmtrc.sortPackageJson = false;
   }
   // `embeddedLanguageFormatting` is not fully supported for JS-in-XXX yet.
   if (oxfmtrc.embeddedLanguageFormatting !== "off") {
@@ -184,7 +184,7 @@ const TAILWIND_OPTION_MAPPING: Record<string, string> = {
 };
 
 /**
- * Migrate prettier-plugin-tailwindcss options to Oxfmt's experimentalTailwindcss format.
+ * Migrate prettier-plugin-tailwindcss options to Oxfmt's sortTailwindcss format.
  *
  * Prettier format:
  * ```json
@@ -198,7 +198,7 @@ const TAILWIND_OPTION_MAPPING: Record<string, string> = {
  * Oxfmt format:
  * ```json
  * {
- *   "experimentalTailwindcss": {
+ *   "sortTailwindcss": {
  *     "config": "./tailwind.config.js",
  *     "functions": ["clsx", "cn"]
  *   }
@@ -231,7 +231,7 @@ function migrateTailwindOptions(
     }
   }
 
-  // Only add experimentalTailwindcss if plugin is used or options are present
-  oxfmtrc.experimentalTailwindcss = tailwindOptions;
-  console.log("Migrated prettier-plugin-tailwindcss options to experimentalTailwindcss");
+  // Only add sortTailwindcss if plugin is used or options are present
+  oxfmtrc.sortTailwindcss = tailwindOptions;
+  console.log("Migrated prettier-plugin-tailwindcss options to sortTailwindcss");
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -91,15 +91,18 @@ export type FormatOptions = Pick<
   printWidth?: number;
   /** Whether to insert a final newline at the end of the file. (Default: `true`) */
   insertFinalNewline?: boolean;
-  /** Experimental: Sort import statements. Disabled by default. */
+  /** Sort import statements. Disabled by default. */
+  sortImports?: SortImportsOptions;
+  /** @deprecated Use `sortImports` instead. */
   experimentalSortImports?: SortImportsOptions;
-  /** Experimental: Sort `package.json` keys. (Default: `true`) */
+  /** Sort `package.json` keys. (Default: `true`) */
+  sortPackageJson?: boolean;
+  /** @deprecated Use `sortPackageJson` instead. */
   experimentalSortPackageJson?: boolean;
-  /**
-   * Experimental: Enable Tailwind CSS class sorting in JSX class/className attributes.
-   * (Default: disabled)
-   */
-  experimentalTailwindcss?: TailwindcssOptions;
+  /** Enable Tailwind CSS class sorting. (Default: disabled) */
+  sortTailwindcss?: SortTailwindcssOptions;
+  /** @deprecated Use `sortTailwindcss` instead. */
+  experimentalTailwindcss?: SortTailwindcssOptions;
 } & Record<string, unknown>; // Also allow additional options for we don't have typed yet.
 
 /**
@@ -140,7 +143,7 @@ export type SortImportsOptions = {
  * Configuration options for Tailwind CSS class sorting.
  * See https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
  */
-export type TailwindcssOptions = {
+export type SortTailwindcssOptions = {
   /** Path to Tailwind config file (v3). e.g., `"./tailwind.config.js"` */
   config?: string;
   /** Path to Tailwind stylesheet (v4). e.g., `"./src/app.css"` */
@@ -160,3 +163,6 @@ export type TailwindcssOptions = {
   /** Preserve duplicate classes. (Default: `false`) */
   preserveDuplicates?: boolean;
 };
+
+/** @deprecated Use `SortTailwindcssOptions` instead. */
+export type TailwindcssOptions = SortTailwindcssOptions;

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -118,7 +118,7 @@ async function loadTailwindPlugin(): Promise<typeof import("prettier-plugin-tail
  * Load Tailwind CSS plugin lazily when `options._useTailwindPlugin` flag is set.
  * The flag is added by Rust side only for relevant parsers.
  *
- * Option mapping (experimentalTailwindcss.xxx → tailwindXxx) is also done in Rust side.
+ * Option mapping (sortTailwindcss.xxx → tailwindXxx) is also done in Rust side.
  */
 async function setupTailwindPlugin(options: Options): Promise<void> {
   if ("_useTailwindPlugin" in options === false) return;

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -201,16 +201,17 @@ pub struct FormatConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_final_newline: Option<bool>,
 
-    /// Experimental: Sort import statements.
+    /// Sort import statements.
     ///
     /// Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
     /// For details, see each field's documentation.
     ///
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental_sort_imports: Option<SortImportsConfig>,
+    #[serde(alias = "experimentalSortImports")]
+    pub sort_imports: Option<SortImportsConfig>,
 
-    /// Experimental: Sort `package.json` keys.
+    /// Sort `package.json` keys.
     ///
     /// The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
     /// But we believe it is clearer and easier to navigate.
@@ -218,9 +219,10 @@ pub struct FormatConfig {
     ///
     /// - Default: `true`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental_sort_package_json: Option<SortPackageJsonUserConfig>,
+    #[serde(alias = "experimentalSortPackageJson")]
+    pub sort_package_json: Option<SortPackageJsonUserConfig>,
 
-    /// Experimental: Sort Tailwind CSS classes.
+    /// Sort Tailwind CSS classes.
     ///
     /// Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
     /// Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
@@ -228,7 +230,8 @@ pub struct FormatConfig {
     ///
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental_tailwindcss: Option<TailwindcssConfig>,
+    #[serde(alias = "experimentalTailwindcss")]
+    pub sort_tailwindcss: Option<TailwindcssConfig>,
 }
 
 impl FormatConfig {
@@ -236,7 +239,7 @@ impl FormatConfig {
     /// Otherwise, the plugin tries to resolve the Prettier's configuration file, not Oxfmt's.
     /// <https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/125a8bc77639529a5a0c7e4e8a02174d7ed2d70b/src/config.ts#L50-L54>
     pub fn resolve_tailwind_paths(&mut self, base_dir: &Path) {
-        let Some(ref mut tw) = self.experimental_tailwindcss else {
+        let Some(ref mut tw) = self.sort_tailwindcss else {
             return;
         };
 
@@ -393,7 +396,7 @@ impl FormatConfig {
 
         // Below are our own extensions
 
-        if let Some(config) = self.experimental_sort_imports {
+        if let Some(config) = self.sort_imports {
             let mut sort_imports = SortImportsOptions::default();
 
             if let Some(v) = config.partition_by_newline {
@@ -511,7 +514,7 @@ impl FormatConfig {
             format_options.sort_imports = Some(sort_imports);
         }
 
-        if let Some(config) = self.experimental_tailwindcss {
+        if let Some(config) = self.sort_tailwindcss {
             format_options.sort_tailwindcss = Some(TailwindcssOptions {
                 config: config.config,
                 stylesheet: config.stylesheet,
@@ -525,7 +528,7 @@ impl FormatConfig {
         // Currently, there is a no options for TOML formatter
         let toml_options = build_toml_options(&format_options);
 
-        let sort_package_json = self.experimental_sort_package_json.map_or_else(
+        let sort_package_json = self.sort_package_json.map_or_else(
             || Some(SortPackageJsonConfig::default().to_sort_options()),
             |c| c.to_sort_options(),
         );
@@ -1006,7 +1009,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
     };
 
     // Determine if Tailwind plugin should be used based on config and strategy
-    let use_tailwind = obj.contains_key("experimentalTailwindcss")
+    let use_tailwind = obj.contains_key("sortTailwindcss")
         && match strategy {
             FormatFileStrategy::OxcFormatter { .. } => true,
             #[cfg(feature = "napi")]
@@ -1019,9 +1022,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
     // Add Tailwind plugin flag and map options
     // See: https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options
     if use_tailwind {
-        if let Some(tailwind) =
-            obj.get("experimentalTailwindcss").and_then(|v| v.as_object()).cloned()
-        {
+        if let Some(tailwind) = obj.get("sortTailwindcss").and_then(|v| v.as_object()).cloned() {
             for (src, dst) in [
                 ("config", "tailwindConfig"),
                 ("stylesheet", "tailwindStylesheet"),
@@ -1058,8 +1059,8 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
             "arrowParens",
             "quoteProps",
             "jsxSingleQuote",
-            "experimentalSortImports",
-            "experimentalTailwindcss",
+            "sortImports",
+            "sortTailwindcss",
         ] {
             if let Some(value) = obj.get(key) {
                 oxfmt_plugin_options.insert(key.to_string(), value.clone());
@@ -1076,9 +1077,9 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
 
     // To minimize payload size, remove Prettier unaware options
     for key in [
-        "experimentalSortImports",
-        "experimentalTailwindcss",
-        "experimentalSortPackageJson",
+        "sortImports",
+        "sortTailwindcss",
+        "sortPackageJson",
         "insertFinalNewline",
         "overrides",
         "ignorePatterns",
@@ -1504,7 +1505,7 @@ mod tests_sync_external_options {
                 { "files": ["*.test.js"], "options": { "tabWidth": 4 } }
             ],
             "ignorePatterns": ["*.min.js"],
-            "experimentalSortImports": { "order": "asc" }
+            "sortImports": { "order": "asc" }
         }"#;
         let mut raw_config: Value = serde_json::from_str(json_string).unwrap();
 
@@ -1518,7 +1519,7 @@ mod tests_sync_external_options {
         // oxfmt extensions are removed by finalize_external_options
         assert!(!obj.contains_key("overrides"));
         assert!(!obj.contains_key("ignorePatterns"));
-        assert!(!obj.contains_key("experimentalSortImports"));
+        assert!(!obj.contains_key("sortImports"));
     }
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/migrate_prettier.test.ts
+++ b/apps/oxfmt/test/cli/migrate_prettier/migrate_prettier.test.ts
@@ -116,7 +116,7 @@ node_modules
     }
   });
 
-  it("should migrate prettier-plugin-tailwindcss options to experimentalTailwindcss", async () => {
+  it("should migrate prettier-plugin-tailwindcss options to sortTailwindcss", async () => {
     const tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-migrate-test"));
 
     try {
@@ -138,8 +138,8 @@ node_modules
       const content = await fs.readFile(join(tempDir, ".oxfmtrc.json"), "utf8");
       const oxfmtrc = JSON.parse(content);
 
-      // Tailwind options should be migrated to experimentalTailwindcss
-      expect(oxfmtrc.experimentalTailwindcss).toEqual({
+      // Tailwind options should be migrated to sortTailwindcss
+      expect(oxfmtrc.sortTailwindcss).toEqual({
         config: "./tailwind.config.js",
         functions: ["clsx", "cn"],
         attributes: ["myClass"],
@@ -155,7 +155,7 @@ node_modules
     }
   });
 
-  it("should enable experimentalTailwindcss when plugin is listed without options", async () => {
+  it("should enable sortTailwindcss when plugin is listed without options", async () => {
     const tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-migrate-test"));
 
     try {
@@ -173,8 +173,8 @@ node_modules
       const content = await fs.readFile(join(tempDir, ".oxfmtrc.json"), "utf8");
       const oxfmtrc = JSON.parse(content);
 
-      // experimentalTailwindcss should be enabled (empty object)
-      expect(oxfmtrc.experimentalTailwindcss).toEqual({});
+      // sortTailwindcss should be enabled (empty object)
+      expect(oxfmtrc.sortTailwindcss).toEqual({});
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
@@ -207,14 +207,14 @@ node_modules
       const oxfmtrc = JSON.parse(content);
 
       // Non-regex values should still be migrated
-      expect(oxfmtrc.experimentalTailwindcss.functions).toEqual(["clsx", "/^tw-/"]);
-      expect(oxfmtrc.experimentalTailwindcss.attributes).toEqual(["className", "/^data-tw-/"]);
+      expect(oxfmtrc.sortTailwindcss.functions).toEqual(["clsx", "/^tw-/"]);
+      expect(oxfmtrc.sortTailwindcss.attributes).toEqual(["className", "/^data-tw-/"]);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 
-  it("should disable experimentalSortPackageJson by default", async () => {
+  it("should disable sortPackageJson by default", async () => {
     const tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-migrate-test"));
 
     try {
@@ -233,13 +233,13 @@ node_modules
       const oxfmtrc = JSON.parse(content);
 
       // Prettier does not have package.json sorting by default
-      expect(oxfmtrc.experimentalSortPackageJson).toBe(false);
+      expect(oxfmtrc.sortPackageJson).toBe(false);
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 
-  it("should enable experimentalSortPackageJson when prettier-plugin-packagejson is used", async () => {
+  it("should enable sortPackageJson when prettier-plugin-packagejson is used", async () => {
     const tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-migrate-test"));
 
     try {
@@ -257,7 +257,7 @@ node_modules
       const content = await fs.readFile(join(tempDir, ".oxfmtrc.json"), "utf8");
       const oxfmtrc = JSON.parse(content);
 
-      expect(oxfmtrc.experimentalSortPackageJson).toBeTruthy();
+      expect(oxfmtrc.sortPackageJson).toBeTruthy();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -56,42 +56,6 @@
       ],
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
-    "experimentalSortImports": {
-      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "experimentalSortPackageJson": {
-      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-    },
-    "experimentalTailwindcss": {
-      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TailwindcssConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
     "htmlWhitespaceSensitivity": {
       "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
       "anyOf": [
@@ -211,6 +175,42 @@
         "null"
       ],
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+    },
+    "sortImports": {
+      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "sortPackageJson": {
+      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortPackageJsonUserConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+    },
+    "sortTailwindcss": {
+      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TailwindcssConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
@@ -370,42 +370,6 @@
           ],
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
-        "experimentalSortImports": {
-          "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SortImportsConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-        },
-        "experimentalSortPackageJson": {
-          "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SortPackageJsonUserConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-        },
-        "experimentalTailwindcss": {
-          "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TailwindcssConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-        },
         "htmlWhitespaceSensitivity": {
           "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
           "anyOf": [
@@ -503,6 +467,42 @@
             "null"
           ],
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+        },
+        "sortImports": {
+          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortImportsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+        },
+        "sortPackageJson": {
+          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortPackageJsonUserConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+        },
+        "sortTailwindcss": {
+          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TailwindcssConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -60,42 +60,6 @@ expression: json
       ],
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
-    "experimentalSortImports": {
-      "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
-    "experimentalSortPackageJson": {
-      "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-    },
-    "experimentalTailwindcss": {
-      "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TailwindcssConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-    },
     "htmlWhitespaceSensitivity": {
       "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
       "anyOf": [
@@ -215,6 +179,42 @@ expression: json
         "null"
       ],
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+    },
+    "sortImports": {
+      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "sortPackageJson": {
+      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SortPackageJsonUserConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+    },
+    "sortTailwindcss": {
+      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TailwindcssConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
@@ -374,42 +374,6 @@ expression: json
           ],
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
-        "experimentalSortImports": {
-          "description": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SortImportsConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-        },
-        "experimentalSortPackageJson": {
-          "description": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SortPackageJsonUserConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
-        },
-        "experimentalTailwindcss": {
-          "description": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TailwindcssConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Experimental: Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
-        },
         "htmlWhitespaceSensitivity": {
           "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
           "anyOf": [
@@ -507,6 +471,42 @@ expression: json
             "null"
           ],
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
+        },
+        "sortImports": {
+          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortImportsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+        },
+        "sortPackageJson": {
+          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortPackageJsonUserConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+        },
+        "sortTailwindcss": {
+          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TailwindcssConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -68,354 +68,6 @@ NOTE: `"auto"` is not supported.
 - Overrides `.editorconfig.end_of_line`
 
 
-## experimentalSortImports
-
-type: `object`
-
-
-Experimental: Sort import statements.
-
-Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
-For details, see each field's documentation.
-
-- Default: Disabled
-
-
-### experimentalSortImports.customGroups
-
-type: `array`
-
-
-Define your own groups for matching very specific imports.
-
-The `customGroups` list is ordered: The first definition that matches an element will be used.
-Custom groups have a higher priority than any predefined group.
-
-If you want a predefined group to take precedence over a custom group,
-you must write a custom group definition that does the same as what the predefined group does, and put it first in the list.
-
-If you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,
-all conditions must be met for an import to match the custom group (AND logic).
-
-- Default: `[]`
-
-
-#### experimentalSortImports.customGroups[n]
-
-type: `object`
-
-
-
-
-
-##### experimentalSortImports.customGroups[n].elementNamePattern
-
-type: `string[]`
-
-default: `[]`
-
-List of glob patterns to match import sources for this group.
-
-
-##### experimentalSortImports.customGroups[n].groupName
-
-type: `string`
-
-default: `""`
-
-Name of the custom group, used in the `groups` option.
-
-
-##### experimentalSortImports.customGroups[n].modifiers
-
-type: `string[]`
-
-
-Modifiers to match the import characteristics.
-All specified modifiers must be present (AND logic).
-
-Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
-
-
-##### experimentalSortImports.customGroups[n].selector
-
-type: `string`
-
-
-Selector to match the import kind.
-
-Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
-
-
-### experimentalSortImports.groups
-
-type: `array`
-
-
-Specifies a list of predefined import groups for sorting.
-
-Each import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).
-The order of items in the `groups` option determines how groups are ordered.
-
-Within a given group, members will be sorted according to the type, order, ignoreCase, etc. options.
-
-Individual groups can be combined together by placing them in an array.
-The order of groups in that array does not matter.
-All members of the groups in the array will be sorted together as if they were part of a single group.
-
-Predefined groups are characterized by a single selector and potentially multiple modifiers.
-You may enter modifiers in any order, but the selector must always come at the end.
-
-The list of selectors is sorted from most to least important:
-- `type` — TypeScript type imports.
-- `side_effect_style` — Side effect style imports.
-- `side_effect` — Side effect imports.
-- `style` — Style imports.
-- `index` — Main file from the current directory.
-- `sibling` — Modules from the same directory.
-- `parent` — Modules from the parent directory.
-- `subpath` — Node.js subpath imports.
-- `internal` — Your internal modules.
-- `builtin` — Node.js Built-in Modules.
-- `external` — External modules installed in the project.
-- `import` — Any import.
-
-The list of modifiers is sorted from most to least important:
-- `side_effect` — Side effect imports.
-- `type` — TypeScript type imports.
-- `value` — Value imports.
-- `default` — Imports containing the default specifier.
-- `wildcard` — Imports containing the wildcard (`* as`) specifier.
-- `named` — Imports containing at least one named specifier.
-
-- Default: See below
-```json
-[
-"builtin",
-"external",
-["internal", "subpath"],
-["parent", "sibling", "index"],
-"style",
-"unknown"
-]
-```
-
-Also, you can override the global `newlinesBetween` setting for specific group boundaries
-by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
-
-
-#### experimentalSortImports.groups[n]
-
-type: `array | string`
-
-
-
-
-
-### experimentalSortImports.ignoreCase
-
-type: `boolean`
-
-
-Specifies whether sorting should be case-sensitive.
-
-- Default: `true`
-
-
-### experimentalSortImports.internalPattern
-
-type: `string[]`
-
-
-Specifies a prefix for identifying internal imports.
-
-This is useful for distinguishing your own modules from external dependencies.
-
-- Default: `["~/", "@/"]`
-
-
-### experimentalSortImports.newlinesBetween
-
-type: `boolean`
-
-
-Specifies whether to add newlines between groups.
-
-When `false`, no newlines are added between groups.
-
-- Default: `true`
-
-
-### experimentalSortImports.order
-
-type: `"asc" | "desc"`
-
-
-Specifies whether to sort items in ascending or descending order.
-
-- Default: `"asc"`
-
-
-### experimentalSortImports.partitionByComment
-
-type: `boolean`
-
-
-Enables the use of comments to separate imports into logical groups.
-
-When `true`, all comments will be treated as delimiters, creating partitions.
-
-```js
-import { b1, b2 } from 'b'
-// PARTITION
-import { a } from 'a'
-import { c } from 'c'
-```
-
-- Default: `false`
-
-
-### experimentalSortImports.partitionByNewline
-
-type: `boolean`
-
-
-Enables the empty line to separate imports into logical groups.
-
-When `true`, formatter will not sort imports if there is an empty line between them.
-This helps maintain the defined order of logically separated groups of members.
-
-```js
-import { b1, b2 } from 'b'
-
-import { a } from 'a'
-import { c } from 'c'
-```
-
-- Default: `false`
-
-
-### experimentalSortImports.sortSideEffects
-
-type: `boolean`
-
-
-Specifies whether side effect imports should be sorted.
-
-By default, sorting side-effect imports is disabled for security reasons.
-
-- Default: `false`
-
-
-## experimentalSortPackageJson
-
-type: `object | boolean`
-
-
-Experimental: Sort `package.json` keys.
-
-The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
-But we believe it is clearer and easier to navigate.
-For details, see each field's documentation.
-
-- Default: `true`
-
-
-### experimentalSortPackageJson.sortScripts
-
-type: `boolean`
-
-
-Sort the `scripts` field alphabetically.
-
-- Default: `false`
-
-
-## experimentalTailwindcss
-
-type: `object`
-
-
-Experimental: Sort Tailwind CSS classes.
-
-Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
-Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
-For details, see each field's documentation.
-
-- Default: Disabled
-
-
-### experimentalTailwindcss.attributes
-
-type: `string[]`
-
-
-List of additional attributes to sort beyond `class` and `className` (exact match).
-
-NOTE: Regex patterns are not yet supported.
-
-- Default: `[]`
-- Example: `["myClassProp", ":class"]`
-
-
-### experimentalTailwindcss.config
-
-type: `string`
-
-
-Path to your Tailwind CSS configuration file (v3).
-
-NOTE: Paths are resolved relative to the Oxfmt configuration file.
-
-- Default: Automatically find `"tailwind.config.js"`
-
-
-### experimentalTailwindcss.functions
-
-type: `string[]`
-
-
-List of custom function names whose arguments should be sorted (exact match).
-
-NOTE: Regex patterns are not yet supported.
-
-- Default: `[]`
-- Example: `["clsx", "cn", "cva", "tw"]`
-
-
-### experimentalTailwindcss.preserveDuplicates
-
-type: `boolean`
-
-
-Preserve duplicate classes.
-
-- Default: `false`
-
-
-### experimentalTailwindcss.preserveWhitespace
-
-type: `boolean`
-
-
-Preserve whitespace around classes.
-
-- Default: `false`
-
-
-### experimentalTailwindcss.stylesheet
-
-type: `string`
-
-
-Path to your Tailwind CSS stylesheet (v4).
-
-NOTE: Paths are resolved relative to the Oxfmt configuration file.
-
-- Default: Installed Tailwind CSS's `theme.css`
-
-
 ## htmlWhitespaceSensitivity
 
 type: `"css" | "strict" | "ignore"`
@@ -571,354 +223,6 @@ NOTE: `"auto"` is not supported.
 - Overrides `.editorconfig.end_of_line`
 
 
-##### overrides[n].options.experimentalSortImports
-
-type: `object`
-
-
-Experimental: Sort import statements.
-
-Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
-For details, see each field's documentation.
-
-- Default: Disabled
-
-
-###### overrides[n].options.experimentalSortImports.customGroups
-
-type: `array`
-
-
-Define your own groups for matching very specific imports.
-
-The `customGroups` list is ordered: The first definition that matches an element will be used.
-Custom groups have a higher priority than any predefined group.
-
-If you want a predefined group to take precedence over a custom group,
-you must write a custom group definition that does the same as what the predefined group does, and put it first in the list.
-
-If you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,
-all conditions must be met for an import to match the custom group (AND logic).
-
-- Default: `[]`
-
-
-####### overrides[n].options.experimentalSortImports.customGroups[n]
-
-type: `object`
-
-
-
-
-
-######## overrides[n].options.experimentalSortImports.customGroups[n].elementNamePattern
-
-type: `string[]`
-
-default: `[]`
-
-List of glob patterns to match import sources for this group.
-
-
-######## overrides[n].options.experimentalSortImports.customGroups[n].groupName
-
-type: `string`
-
-default: `""`
-
-Name of the custom group, used in the `groups` option.
-
-
-######## overrides[n].options.experimentalSortImports.customGroups[n].modifiers
-
-type: `string[]`
-
-
-Modifiers to match the import characteristics.
-All specified modifiers must be present (AND logic).
-
-Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
-
-
-######## overrides[n].options.experimentalSortImports.customGroups[n].selector
-
-type: `string`
-
-
-Selector to match the import kind.
-
-Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
-`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
-
-
-###### overrides[n].options.experimentalSortImports.groups
-
-type: `array`
-
-
-Specifies a list of predefined import groups for sorting.
-
-Each import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).
-The order of items in the `groups` option determines how groups are ordered.
-
-Within a given group, members will be sorted according to the type, order, ignoreCase, etc. options.
-
-Individual groups can be combined together by placing them in an array.
-The order of groups in that array does not matter.
-All members of the groups in the array will be sorted together as if they were part of a single group.
-
-Predefined groups are characterized by a single selector and potentially multiple modifiers.
-You may enter modifiers in any order, but the selector must always come at the end.
-
-The list of selectors is sorted from most to least important:
-- `type` — TypeScript type imports.
-- `side_effect_style` — Side effect style imports.
-- `side_effect` — Side effect imports.
-- `style` — Style imports.
-- `index` — Main file from the current directory.
-- `sibling` — Modules from the same directory.
-- `parent` — Modules from the parent directory.
-- `subpath` — Node.js subpath imports.
-- `internal` — Your internal modules.
-- `builtin` — Node.js Built-in Modules.
-- `external` — External modules installed in the project.
-- `import` — Any import.
-
-The list of modifiers is sorted from most to least important:
-- `side_effect` — Side effect imports.
-- `type` — TypeScript type imports.
-- `value` — Value imports.
-- `default` — Imports containing the default specifier.
-- `wildcard` — Imports containing the wildcard (`* as`) specifier.
-- `named` — Imports containing at least one named specifier.
-
-- Default: See below
-```json
-[
-"builtin",
-"external",
-["internal", "subpath"],
-["parent", "sibling", "index"],
-"style",
-"unknown"
-]
-```
-
-Also, you can override the global `newlinesBetween` setting for specific group boundaries
-by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
-
-
-####### overrides[n].options.experimentalSortImports.groups[n]
-
-type: `array | string`
-
-
-
-
-
-###### overrides[n].options.experimentalSortImports.ignoreCase
-
-type: `boolean`
-
-
-Specifies whether sorting should be case-sensitive.
-
-- Default: `true`
-
-
-###### overrides[n].options.experimentalSortImports.internalPattern
-
-type: `string[]`
-
-
-Specifies a prefix for identifying internal imports.
-
-This is useful for distinguishing your own modules from external dependencies.
-
-- Default: `["~/", "@/"]`
-
-
-###### overrides[n].options.experimentalSortImports.newlinesBetween
-
-type: `boolean`
-
-
-Specifies whether to add newlines between groups.
-
-When `false`, no newlines are added between groups.
-
-- Default: `true`
-
-
-###### overrides[n].options.experimentalSortImports.order
-
-type: `"asc" | "desc"`
-
-
-Specifies whether to sort items in ascending or descending order.
-
-- Default: `"asc"`
-
-
-###### overrides[n].options.experimentalSortImports.partitionByComment
-
-type: `boolean`
-
-
-Enables the use of comments to separate imports into logical groups.
-
-When `true`, all comments will be treated as delimiters, creating partitions.
-
-```js
-import { b1, b2 } from 'b'
-// PARTITION
-import { a } from 'a'
-import { c } from 'c'
-```
-
-- Default: `false`
-
-
-###### overrides[n].options.experimentalSortImports.partitionByNewline
-
-type: `boolean`
-
-
-Enables the empty line to separate imports into logical groups.
-
-When `true`, formatter will not sort imports if there is an empty line between them.
-This helps maintain the defined order of logically separated groups of members.
-
-```js
-import { b1, b2 } from 'b'
-
-import { a } from 'a'
-import { c } from 'c'
-```
-
-- Default: `false`
-
-
-###### overrides[n].options.experimentalSortImports.sortSideEffects
-
-type: `boolean`
-
-
-Specifies whether side effect imports should be sorted.
-
-By default, sorting side-effect imports is disabled for security reasons.
-
-- Default: `false`
-
-
-##### overrides[n].options.experimentalSortPackageJson
-
-type: `object | boolean`
-
-
-Experimental: Sort `package.json` keys.
-
-The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
-But we believe it is clearer and easier to navigate.
-For details, see each field's documentation.
-
-- Default: `true`
-
-
-###### overrides[n].options.experimentalSortPackageJson.sortScripts
-
-type: `boolean`
-
-
-Sort the `scripts` field alphabetically.
-
-- Default: `false`
-
-
-##### overrides[n].options.experimentalTailwindcss
-
-type: `object`
-
-
-Experimental: Sort Tailwind CSS classes.
-
-Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
-Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
-For details, see each field's documentation.
-
-- Default: Disabled
-
-
-###### overrides[n].options.experimentalTailwindcss.attributes
-
-type: `string[]`
-
-
-List of additional attributes to sort beyond `class` and `className` (exact match).
-
-NOTE: Regex patterns are not yet supported.
-
-- Default: `[]`
-- Example: `["myClassProp", ":class"]`
-
-
-###### overrides[n].options.experimentalTailwindcss.config
-
-type: `string`
-
-
-Path to your Tailwind CSS configuration file (v3).
-
-NOTE: Paths are resolved relative to the Oxfmt configuration file.
-
-- Default: Automatically find `"tailwind.config.js"`
-
-
-###### overrides[n].options.experimentalTailwindcss.functions
-
-type: `string[]`
-
-
-List of custom function names whose arguments should be sorted (exact match).
-
-NOTE: Regex patterns are not yet supported.
-
-- Default: `[]`
-- Example: `["clsx", "cn", "cva", "tw"]`
-
-
-###### overrides[n].options.experimentalTailwindcss.preserveDuplicates
-
-type: `boolean`
-
-
-Preserve duplicate classes.
-
-- Default: `false`
-
-
-###### overrides[n].options.experimentalTailwindcss.preserveWhitespace
-
-type: `boolean`
-
-
-Preserve whitespace around classes.
-
-- Default: `false`
-
-
-###### overrides[n].options.experimentalTailwindcss.stylesheet
-
-type: `string`
-
-
-Path to your Tailwind CSS stylesheet (v4).
-
-NOTE: Paths are resolved relative to the Oxfmt configuration file.
-
-- Default: Installed Tailwind CSS's `theme.css`
-
-
 ##### overrides[n].options.htmlWhitespaceSensitivity
 
 type: `"css" | "strict" | "ignore"`
@@ -1032,6 +336,354 @@ For JSX, you can set the `jsxSingleQuote` option.
 - Default: `false`
 
 
+##### overrides[n].options.sortImports
+
+type: `object`
+
+
+Sort import statements.
+
+Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
+For details, see each field's documentation.
+
+- Default: Disabled
+
+
+###### overrides[n].options.sortImports.customGroups
+
+type: `array`
+
+
+Define your own groups for matching very specific imports.
+
+The `customGroups` list is ordered: The first definition that matches an element will be used.
+Custom groups have a higher priority than any predefined group.
+
+If you want a predefined group to take precedence over a custom group,
+you must write a custom group definition that does the same as what the predefined group does, and put it first in the list.
+
+If you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,
+all conditions must be met for an import to match the custom group (AND logic).
+
+- Default: `[]`
+
+
+####### overrides[n].options.sortImports.customGroups[n]
+
+type: `object`
+
+
+
+
+
+######## overrides[n].options.sortImports.customGroups[n].elementNamePattern
+
+type: `string[]`
+
+default: `[]`
+
+List of glob patterns to match import sources for this group.
+
+
+######## overrides[n].options.sortImports.customGroups[n].groupName
+
+type: `string`
+
+default: `""`
+
+Name of the custom group, used in the `groups` option.
+
+
+######## overrides[n].options.sortImports.customGroups[n].modifiers
+
+type: `string[]`
+
+
+Modifiers to match the import characteristics.
+All specified modifiers must be present (AND logic).
+
+Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
+
+
+######## overrides[n].options.sortImports.customGroups[n].selector
+
+type: `string`
+
+
+Selector to match the import kind.
+
+Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
+`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
+
+
+###### overrides[n].options.sortImports.groups
+
+type: `array`
+
+
+Specifies a list of predefined import groups for sorting.
+
+Each import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
+
+Within a given group, members will be sorted according to the type, order, ignoreCase, etc. options.
+
+Individual groups can be combined together by placing them in an array.
+The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector and potentially multiple modifiers.
+You may enter modifiers in any order, but the selector must always come at the end.
+
+The list of selectors is sorted from most to least important:
+- `type` — TypeScript type imports.
+- `side_effect_style` — Side effect style imports.
+- `side_effect` — Side effect imports.
+- `style` — Style imports.
+- `index` — Main file from the current directory.
+- `sibling` — Modules from the same directory.
+- `parent` — Modules from the parent directory.
+- `subpath` — Node.js subpath imports.
+- `internal` — Your internal modules.
+- `builtin` — Node.js Built-in Modules.
+- `external` — External modules installed in the project.
+- `import` — Any import.
+
+The list of modifiers is sorted from most to least important:
+- `side_effect` — Side effect imports.
+- `type` — TypeScript type imports.
+- `value` — Value imports.
+- `default` — Imports containing the default specifier.
+- `wildcard` — Imports containing the wildcard (`* as`) specifier.
+- `named` — Imports containing at least one named specifier.
+
+- Default: See below
+```json
+[
+"builtin",
+"external",
+["internal", "subpath"],
+["parent", "sibling", "index"],
+"style",
+"unknown"
+]
+```
+
+Also, you can override the global `newlinesBetween` setting for specific group boundaries
+by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
+
+
+####### overrides[n].options.sortImports.groups[n]
+
+type: `array | string`
+
+
+
+
+
+###### overrides[n].options.sortImports.ignoreCase
+
+type: `boolean`
+
+
+Specifies whether sorting should be case-sensitive.
+
+- Default: `true`
+
+
+###### overrides[n].options.sortImports.internalPattern
+
+type: `string[]`
+
+
+Specifies a prefix for identifying internal imports.
+
+This is useful for distinguishing your own modules from external dependencies.
+
+- Default: `["~/", "@/"]`
+
+
+###### overrides[n].options.sortImports.newlinesBetween
+
+type: `boolean`
+
+
+Specifies whether to add newlines between groups.
+
+When `false`, no newlines are added between groups.
+
+- Default: `true`
+
+
+###### overrides[n].options.sortImports.order
+
+type: `"asc" | "desc"`
+
+
+Specifies whether to sort items in ascending or descending order.
+
+- Default: `"asc"`
+
+
+###### overrides[n].options.sortImports.partitionByComment
+
+type: `boolean`
+
+
+Enables the use of comments to separate imports into logical groups.
+
+When `true`, all comments will be treated as delimiters, creating partitions.
+
+```js
+import { b1, b2 } from 'b'
+// PARTITION
+import { a } from 'a'
+import { c } from 'c'
+```
+
+- Default: `false`
+
+
+###### overrides[n].options.sortImports.partitionByNewline
+
+type: `boolean`
+
+
+Enables the empty line to separate imports into logical groups.
+
+When `true`, formatter will not sort imports if there is an empty line between them.
+This helps maintain the defined order of logically separated groups of members.
+
+```js
+import { b1, b2 } from 'b'
+
+import { a } from 'a'
+import { c } from 'c'
+```
+
+- Default: `false`
+
+
+###### overrides[n].options.sortImports.sortSideEffects
+
+type: `boolean`
+
+
+Specifies whether side effect imports should be sorted.
+
+By default, sorting side-effect imports is disabled for security reasons.
+
+- Default: `false`
+
+
+##### overrides[n].options.sortPackageJson
+
+type: `object | boolean`
+
+
+Sort `package.json` keys.
+
+The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
+But we believe it is clearer and easier to navigate.
+For details, see each field's documentation.
+
+- Default: `true`
+
+
+###### overrides[n].options.sortPackageJson.sortScripts
+
+type: `boolean`
+
+
+Sort the `scripts` field alphabetically.
+
+- Default: `false`
+
+
+##### overrides[n].options.sortTailwindcss
+
+type: `object`
+
+
+Sort Tailwind CSS classes.
+
+Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
+Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
+For details, see each field's documentation.
+
+- Default: Disabled
+
+
+###### overrides[n].options.sortTailwindcss.attributes
+
+type: `string[]`
+
+
+List of additional attributes to sort beyond `class` and `className` (exact match).
+
+NOTE: Regex patterns are not yet supported.
+
+- Default: `[]`
+- Example: `["myClassProp", ":class"]`
+
+
+###### overrides[n].options.sortTailwindcss.config
+
+type: `string`
+
+
+Path to your Tailwind CSS configuration file (v3).
+
+NOTE: Paths are resolved relative to the Oxfmt configuration file.
+
+- Default: Automatically find `"tailwind.config.js"`
+
+
+###### overrides[n].options.sortTailwindcss.functions
+
+type: `string[]`
+
+
+List of custom function names whose arguments should be sorted (exact match).
+
+NOTE: Regex patterns are not yet supported.
+
+- Default: `[]`
+- Example: `["clsx", "cn", "cva", "tw"]`
+
+
+###### overrides[n].options.sortTailwindcss.preserveDuplicates
+
+type: `boolean`
+
+
+Preserve duplicate classes.
+
+- Default: `false`
+
+
+###### overrides[n].options.sortTailwindcss.preserveWhitespace
+
+type: `boolean`
+
+
+Preserve whitespace around classes.
+
+- Default: `false`
+
+
+###### overrides[n].options.sortTailwindcss.stylesheet
+
+type: `string`
+
+
+Path to your Tailwind CSS stylesheet (v4).
+
+NOTE: Paths are resolved relative to the Oxfmt configuration file.
+
+- Default: Installed Tailwind CSS's `theme.css`
+
+
 ##### overrides[n].options.tabWidth
 
 type: `integer`
@@ -1143,6 +795,354 @@ Use single quotes instead of double quotes.
 For JSX, you can set the `jsxSingleQuote` option.
 
 - Default: `false`
+
+
+## sortImports
+
+type: `object`
+
+
+Sort import statements.
+
+Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
+For details, see each field's documentation.
+
+- Default: Disabled
+
+
+### sortImports.customGroups
+
+type: `array`
+
+
+Define your own groups for matching very specific imports.
+
+The `customGroups` list is ordered: The first definition that matches an element will be used.
+Custom groups have a higher priority than any predefined group.
+
+If you want a predefined group to take precedence over a custom group,
+you must write a custom group definition that does the same as what the predefined group does, and put it first in the list.
+
+If you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,
+all conditions must be met for an import to match the custom group (AND logic).
+
+- Default: `[]`
+
+
+#### sortImports.customGroups[n]
+
+type: `object`
+
+
+
+
+
+##### sortImports.customGroups[n].elementNamePattern
+
+type: `string[]`
+
+default: `[]`
+
+List of glob patterns to match import sources for this group.
+
+
+##### sortImports.customGroups[n].groupName
+
+type: `string`
+
+default: `""`
+
+Name of the custom group, used in the `groups` option.
+
+
+##### sortImports.customGroups[n].modifiers
+
+type: `string[]`
+
+
+Modifiers to match the import characteristics.
+All specified modifiers must be present (AND logic).
+
+Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
+
+
+##### sortImports.customGroups[n].selector
+
+type: `string`
+
+
+Selector to match the import kind.
+
+Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
+`"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
+
+
+### sortImports.groups
+
+type: `array`
+
+
+Specifies a list of predefined import groups for sorting.
+
+Each import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).
+The order of items in the `groups` option determines how groups are ordered.
+
+Within a given group, members will be sorted according to the type, order, ignoreCase, etc. options.
+
+Individual groups can be combined together by placing them in an array.
+The order of groups in that array does not matter.
+All members of the groups in the array will be sorted together as if they were part of a single group.
+
+Predefined groups are characterized by a single selector and potentially multiple modifiers.
+You may enter modifiers in any order, but the selector must always come at the end.
+
+The list of selectors is sorted from most to least important:
+- `type` — TypeScript type imports.
+- `side_effect_style` — Side effect style imports.
+- `side_effect` — Side effect imports.
+- `style` — Style imports.
+- `index` — Main file from the current directory.
+- `sibling` — Modules from the same directory.
+- `parent` — Modules from the parent directory.
+- `subpath` — Node.js subpath imports.
+- `internal` — Your internal modules.
+- `builtin` — Node.js Built-in Modules.
+- `external` — External modules installed in the project.
+- `import` — Any import.
+
+The list of modifiers is sorted from most to least important:
+- `side_effect` — Side effect imports.
+- `type` — TypeScript type imports.
+- `value` — Value imports.
+- `default` — Imports containing the default specifier.
+- `wildcard` — Imports containing the wildcard (`* as`) specifier.
+- `named` — Imports containing at least one named specifier.
+
+- Default: See below
+```json
+[
+"builtin",
+"external",
+["internal", "subpath"],
+["parent", "sibling", "index"],
+"style",
+"unknown"
+]
+```
+
+Also, you can override the global `newlinesBetween` setting for specific group boundaries
+by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
+
+
+#### sortImports.groups[n]
+
+type: `array | string`
+
+
+
+
+
+### sortImports.ignoreCase
+
+type: `boolean`
+
+
+Specifies whether sorting should be case-sensitive.
+
+- Default: `true`
+
+
+### sortImports.internalPattern
+
+type: `string[]`
+
+
+Specifies a prefix for identifying internal imports.
+
+This is useful for distinguishing your own modules from external dependencies.
+
+- Default: `["~/", "@/"]`
+
+
+### sortImports.newlinesBetween
+
+type: `boolean`
+
+
+Specifies whether to add newlines between groups.
+
+When `false`, no newlines are added between groups.
+
+- Default: `true`
+
+
+### sortImports.order
+
+type: `"asc" | "desc"`
+
+
+Specifies whether to sort items in ascending or descending order.
+
+- Default: `"asc"`
+
+
+### sortImports.partitionByComment
+
+type: `boolean`
+
+
+Enables the use of comments to separate imports into logical groups.
+
+When `true`, all comments will be treated as delimiters, creating partitions.
+
+```js
+import { b1, b2 } from 'b'
+// PARTITION
+import { a } from 'a'
+import { c } from 'c'
+```
+
+- Default: `false`
+
+
+### sortImports.partitionByNewline
+
+type: `boolean`
+
+
+Enables the empty line to separate imports into logical groups.
+
+When `true`, formatter will not sort imports if there is an empty line between them.
+This helps maintain the defined order of logically separated groups of members.
+
+```js
+import { b1, b2 } from 'b'
+
+import { a } from 'a'
+import { c } from 'c'
+```
+
+- Default: `false`
+
+
+### sortImports.sortSideEffects
+
+type: `boolean`
+
+
+Specifies whether side effect imports should be sorted.
+
+By default, sorting side-effect imports is disabled for security reasons.
+
+- Default: `false`
+
+
+## sortPackageJson
+
+type: `object | boolean`
+
+
+Sort `package.json` keys.
+
+The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
+But we believe it is clearer and easier to navigate.
+For details, see each field's documentation.
+
+- Default: `true`
+
+
+### sortPackageJson.sortScripts
+
+type: `boolean`
+
+
+Sort the `scripts` field alphabetically.
+
+- Default: `false`
+
+
+## sortTailwindcss
+
+type: `object`
+
+
+Sort Tailwind CSS classes.
+
+Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
+Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
+For details, see each field's documentation.
+
+- Default: Disabled
+
+
+### sortTailwindcss.attributes
+
+type: `string[]`
+
+
+List of additional attributes to sort beyond `class` and `className` (exact match).
+
+NOTE: Regex patterns are not yet supported.
+
+- Default: `[]`
+- Example: `["myClassProp", ":class"]`
+
+
+### sortTailwindcss.config
+
+type: `string`
+
+
+Path to your Tailwind CSS configuration file (v3).
+
+NOTE: Paths are resolved relative to the Oxfmt configuration file.
+
+- Default: Automatically find `"tailwind.config.js"`
+
+
+### sortTailwindcss.functions
+
+type: `string[]`
+
+
+List of custom function names whose arguments should be sorted (exact match).
+
+NOTE: Regex patterns are not yet supported.
+
+- Default: `[]`
+- Example: `["clsx", "cn", "cva", "tw"]`
+
+
+### sortTailwindcss.preserveDuplicates
+
+type: `boolean`
+
+
+Preserve duplicate classes.
+
+- Default: `false`
+
+
+### sortTailwindcss.preserveWhitespace
+
+type: `boolean`
+
+
+Preserve whitespace around classes.
+
+- Default: `false`
+
+
+### sortTailwindcss.stylesheet
+
+type: `string`
+
+
+Path to your Tailwind CSS stylesheet (v4).
+
+NOTE: Paths are resolved relative to the Oxfmt configuration file.
+
+- Default: Installed Tailwind CSS's `theme.css`
 
 
 ## tabWidth


### PR DESCRIPTION
- `experimentalSortImports` 👉🏻 `sortImports`
- `experimentalSortPackageJson` 👉🏻 `sortPackageJson`
- `experimentalTailwindcss` 👉🏻 `sortTailwindcss`

To avoid breaking changes, the old name is retained as an alias.