### PR TITLE
refactor(formatter,oxfmt): Use Sort prefix for tailwind options

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -9,7 +9,7 @@ use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CustomGroupDefinition,
     EmbeddedLanguageFormatting, Expand, FormatOptions, GroupEntry, ImportModifier, ImportSelector,
     IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle, Semicolons,
-    SortImportsOptions, SortOrder, TailwindcssOptions, TrailingCommas,
+    SortImportsOptions, SortOrder, SortTailwindcssOptions, TrailingCommas,
 };
 use oxc_toml::Options as TomlFormatterOptions;
 
@@ -231,7 +231,7 @@ pub struct FormatConfig {
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalTailwindcss")]
-    pub sort_tailwindcss: Option<TailwindcssConfig>,
+    pub sort_tailwindcss: Option<SortTailwindcssConfig>,
 }
 
 impl FormatConfig {
@@ -515,7 +515,7 @@ impl FormatConfig {
         }
 
         if let Some(config) = self.sort_tailwindcss {
-            format_options.sort_tailwindcss = Some(TailwindcssOptions {
+            format_options.sort_tailwindcss = Some(SortTailwindcssOptions {
                 config: config.config,
                 stylesheet: config.stylesheet,
                 functions: config.functions.unwrap_or_default(),
@@ -867,7 +867,7 @@ impl SortPackageJsonConfig {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
-pub struct TailwindcssConfig {
+pub struct SortTailwindcssConfig {
     /// Path to your Tailwind CSS configuration file (v3).
     ///
     /// NOTE: Paths are resolved relative to the Oxfmt configuration file.

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -78,7 +78,7 @@ pub struct FormatOptions {
     /// Enable Tailwind CSS class sorting in JSX class/className attributes.
     /// When enabled, class strings will be collected and passed to a callback for sorting.
     /// Defaults to None (disabled).
-    pub sort_tailwindcss: Option<TailwindcssOptions>,
+    pub sort_tailwindcss: Option<SortTailwindcssOptions>,
 }
 
 /// Options for Tailwind CSS class sorting.
@@ -86,7 +86,7 @@ pub struct FormatOptions {
 ///
 /// See <https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options>
 #[derive(Debug, Default, Clone)]
-pub struct TailwindcssOptions {
+pub struct SortTailwindcssOptions {
     /// Path to your Tailwind CSS configuration file (v3).
     ///
     /// Note: Paths are resolved relative to the Oxfmt configuration file.

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -11,7 +11,7 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    Buffer, TailwindcssOptions,
+    Buffer, SortTailwindcssOptions,
     ast_nodes::{AstNode, AstNodes},
     formatter::{FormatElement, Formatter, TailwindContextEntry, prelude::*},
     write,
@@ -51,7 +51,7 @@ pub fn tailwind_context_for_string_literal<'a>(
 /// - Custom attributes specified in `attributes` option
 pub fn is_tailwind_jsx_attribute(
     attr_name: &JSXAttributeName<'_>,
-    options: &TailwindcssOptions,
+    options: &SortTailwindcssOptions,
 ) -> bool {
     let JSXAttributeName::Identifier(ident) = attr_name else {
         return false;
@@ -79,7 +79,10 @@ pub fn is_tailwind_jsx_attribute(
 /// - `foo().clsx(...)` - chained calls
 ///
 /// Based on [prettier-plugin-tailwindcss's `isSortableExpression`](https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/28beb4e008b913414562addec4abb8ab261f3828/src/index.ts#L584-L605).
-pub fn is_tailwind_function_call(callee: &Expression<'_>, options: &TailwindcssOptions) -> bool {
+pub fn is_tailwind_function_call(
+    callee: &Expression<'_>,
+    options: &SortTailwindcssOptions,
+) -> bool {
     if options.functions.is_empty() {
         return false;
     }

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -204,7 +204,7 @@
       "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
       "anyOf": [
         {
-          "$ref": "#/definitions/TailwindcssConfig"
+          "$ref": "#/definitions/SortTailwindcssConfig"
         },
         {
           "type": "null"
@@ -496,7 +496,7 @@
           "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
           "anyOf": [
             {
-              "$ref": "#/definitions/TailwindcssConfig"
+              "$ref": "#/definitions/SortTailwindcssConfig"
             },
             {
               "type": "null"
@@ -771,7 +771,7 @@
         }
       ]
     },
-    "TailwindcssConfig": {
+    "SortTailwindcssConfig": {
       "type": "object",
       "properties": {
         "attributes": {

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -208,7 +208,7 @@ expression: json
       "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
       "anyOf": [
         {
-          "$ref": "#/definitions/TailwindcssConfig"
+          "$ref": "#/definitions/SortTailwindcssConfig"
         },
         {
           "type": "null"
@@ -500,7 +500,7 @@ expression: json
           "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
           "anyOf": [
             {
-              "$ref": "#/definitions/TailwindcssConfig"
+              "$ref": "#/definitions/SortTailwindcssConfig"
             },
             {
               "type": "null"
@@ -775,7 +775,7 @@ expression: json
         }
       ]
     },
-    "TailwindcssConfig": {
+    "SortTailwindcssConfig": {
       "type": "object",
       "properties": {
         "attributes": {


### PR DESCRIPTION
Internal changes to ensure consistency.