### PR TITLE
perf(estree/tokens): serialize tokens to compact JSON

### DIFF
--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -82,6 +82,23 @@ pub fn to_estree_tokens_json(
 ) -> String {
     let estree_tokens =
         to_estree_tokens(tokens, program, source_text, span_converter, options, allocator);
+    serde_json::to_string(&estree_tokens).unwrap_or_default()
+}
+
+/// Serialize tokens to pretty-printed JSON.
+///
+/// `source_text` must be the original source text, prior to BOM removal.
+/// i.e. BOM must be present on start of `source_text`, if the file has a BOM.
+pub fn to_estree_tokens_pretty_json(
+    tokens: &[Token],
+    program: &Program<'_>,
+    source_text: &str,
+    span_converter: &Utf8ToUtf16,
+    options: EstreeTokenOptions,
+    allocator: &Allocator,
+) -> String {
+    let estree_tokens =
+        to_estree_tokens(tokens, program, source_text, span_converter, options, allocator);
     serde_json::to_string_pretty(&estree_tokens).unwrap_or_default()
 }
 

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -11,7 +11,7 @@ use oxc::{
     span::{ModuleKind, SourceType, Span},
     transformer::{JsxOptions, JsxRuntime, TransformOptions},
 };
-use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_pretty_json};
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, FormatOptions,
     Formatter, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle,
@@ -854,7 +854,7 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
             let span_converter = Utf8ToUtf16::new(source_text);
             span_converter.convert_program_with_ascending_order_checks(&mut program);
 
-            let oxc_tokens_json = to_estree_tokens_json(
+            let oxc_tokens_json = to_estree_tokens_pretty_json(
                 &tokens,
                 &program,
                 source_text,
@@ -904,7 +904,7 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
             let span_converter = Utf8ToUtf16::new(source_text);
             span_converter.convert_program_with_ascending_order_checks(&mut program);
 
-            let oxc_tokens_json = to_estree_tokens_json(
+            let oxc_tokens_json = to_estree_tokens_pretty_json(
                 &tokens,
                 &program,
                 source_text,
@@ -1087,7 +1087,7 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
                 let span_converter = Utf8ToUtf16::new(source_text);
                 span_converter.convert_program_with_ascending_order_checks(&mut program);
 
-                let oxc_tokens_json = to_estree_tokens_json(
+                let oxc_tokens_json = to_estree_tokens_pretty_json(
                     &tokens,
                     &program,
                     source_text,


### PR DESCRIPTION
Perf optimization to converting tokens to ESTree JSON. Previously we serialized to pretty-printed JSON. Instead use compact JSON - it's just passed to `JSON.parse` on JS side, so there's no need for whitespace.