### PR TITLE
fix(linter/prefer-mock-return-shorthand): avoid unsafe autofixes for call-like returns

### DIFF
--- a/crates/oxc_linter/src/snapshots/jest_prefer_mock_return_shorthand.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_mock_return_shorthand.snap
@@ -40,6 +40,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
    ╭─[prefer_mock_return_shorthand.tsx:1:11]
+ 1 │ jest.fn().mockImplementation(() => console.log(123));
+   ·           ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
+
+  ⚠ eslint-plugin-jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:11]
  1 │ jest.fn().mockImplementation(() => "hello world")
    ·           ──────────────────
    ╰────
@@ -742,6 +749,13 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────────────
    ╰────
   help: Replace `mockImplementationOnce` with `mockReturnValueOnce`.
+
+  ⚠ eslint-plugin-jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
+   ╭─[prefer_mock_return_shorthand.tsx:1:9]
+ 1 │ vi.fn().mockImplementation(() => console.log(123));
+   ·         ──────────────────
+   ╰────
+  help: Replace `mockImplementation` with `mockReturnValue`.
 
   ⚠ eslint-plugin-jest(prefer-mock-return-shorthand): Mock functions that return simple values should use `mockReturnValue/mockReturnValueOnce`.
    ╭─[prefer_mock_return_shorthand.tsx:1:9]


### PR DESCRIPTION
fixes #19580
