### PR TITLE
fix(linter): catch missing return type on exported arrow/function expressions

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -232,7 +232,10 @@ impl ExplicitModuleBoundaryTypes {
                 Self::run_on_identifier_reference(ctx, id, &mut checker);
             }
             Expression::ArrowFunctionExpression(arrow) => {
-                walk::walk_arrow_function_expression(&mut checker, arrow);
+                checker.visit_arrow_function_expression(arrow);
+            }
+            Expression::FunctionExpression(func) => {
+                checker.visit_function(func, ScopeFlags::Function);
             }
             // const foo = arg => arg;
             // export default [foo];
@@ -2000,6 +2003,23 @@ mod test {
                 None,
             ),
             ("function App() { return 42; } export default App", None),
+            (
+                "
+            export default ({
+                a,
+                b,
+                c,
+            }: {
+                a: string;
+                b: string;
+                c: string;
+            }) => {
+                return `${a} ${b} ${c}`;
+            };
+            ",
+                None,
+            ),
+            ("export default (function() { return 'test'; });", None),
         ];
 
         Tester::new(

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function test(a: number, b: number) { return; }
@@ -115,9 +114,9 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
-   ╭─[explicit_module_boundary_types.tsx:1:30]
+   ╭─[explicit_module_boundary_types.tsx:1:16]
  1 │ export default () => (true ? () => {} : (): void => {});
-   ·                              ──
+   ·                ──
    ╰────
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
@@ -716,4 +715,25 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[explicit_module_boundary_types.tsx:1:10]
  1 │ function App() { return 42; } export default App
    ·          ───
+   ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+    ╭─[explicit_module_boundary_types.tsx:2:28]
+  1 │     
+  2 │ ╭─▶             export default ({
+  3 │ │                   a,
+  4 │ │                   b,
+  5 │ │                   c,
+  6 │ │               }: {
+  7 │ │                   a: string;
+  8 │ │                   b: string;
+  9 │ │                   c: string;
+ 10 │ ╰─▶             }) => {
+ 11 │                     return `${a} ${b} ${c}`;
+    ╰────
+
+  ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
+   ╭─[explicit_module_boundary_types.tsx:1:17]
+ 1 │ export default (function() { return 'test'; });
+   ·                 ────────
    ╰────


### PR DESCRIPTION
## Summary

- `run_on_exported_expression_inner` called `walk::walk_arrow_function_expression` (the raw walk function) instead of `checker.visit_arrow_function_expression`. The raw walk visits AST children but bypasses `ExplicitTypesChecker::visit_arrow_function_expression`, which is the method that calls `check_arrow_without_return`. Block-body arrow functions with no inner function expressions produced no diagnostic.
- Added symmetric fix for `FunctionExpression`: `export default (function() { ... })` was silently ignored by the `_` arm.

### Incorrect behavior before fix

```ts
// Not flagged by oxlint, but should be
export default ({
    connectorTypeEnumCase,
    connectorFriendlyName,
}: {
    connectorTypeEnumCase: string;
    connectorFriendlyName: string;
}) => {
    return `${connectorTypeEnumCase}`;
};
```

### Snapshot correction

`export default () => (true ? () => {} : (): void => {})` now points to the outer exported arrow (the module boundary) instead of the inner `() => {}`.

## Test plan

- [ ] Existing `explicit_module_boundary_types` tests all pass
- [ ] New fail test: destructured-param arrow with block body
- [ ] New fail test: `export default (function() { ... })`

🤖 Generated with [Claude Code](https://claude.com/claude-code)