### PR TITLE
fix(linter): fix false negatives in typescript/no-require-imports

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -169,10 +169,10 @@ impl Rule for NoRequireImports {
                         return;
                     }
 
-                    if !self.allow.is_empty() {
-                        if match_argument_value_with_regex(&self.allow, &mod_ref.expression.value) {
-                            return;
-                        }
+                    if !self.allow.is_empty()
+                        && match_argument_value_with_regex(&self.allow, &mod_ref.expression.value)
+                    {
+                        return;
                     }
 
                     ctx.diagnostic(no_require_imports_diagnostic(decl.span));

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -197,7 +197,6 @@ fn test() {
         ("import lib9 = lib2.anotherSubImport;", None),
         ("import lib10 from 'lib10';", None),
         ("var lib3 = load?.('not_an_import');", None),
-        // locally-defined require with dynamic arg — root scope
         (
             "
             import { createRequire } from 'module';
@@ -206,7 +205,6 @@ fn test() {
                 ",
             None,
         ),
-        // locally-defined require with dynamic arg — nested scope
         (
             "
             function foo() {

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -212,6 +212,25 @@ fn test() {
         ("import lib9 = lib2.anotherSubImport;", None),
         ("import lib10 from 'lib10';", None),
         ("var lib3 = load?.('not_an_import');", None),
+        // locally-defined require with dynamic arg — root scope
+        (
+            "
+            import { createRequire } from 'module';
+            const require = createRequire();
+            require(someModule);
+                ",
+            None,
+        ),
+        // locally-defined require with dynamic arg — nested scope
+        (
+            "
+            function foo() {
+                let require = bazz;
+                require(someModule);
+            }
+                ",
+            None,
+        ),
         (
             "
             import { createRequire } from 'module';

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -385,10 +385,8 @@ fn test() {
             }",
             None,
         ),
-        // Bug 1: dynamic argument
         ("const m = require(someVariable);", None),
         ("const m = require(path.join(dir, file));", None),
-        // Bug 2: class method named require
         (
             r"class Foo {
             require(module: string) {

--- a/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
    ╭─[no_require_imports.ts:1:11]
  1 │ var lib = require('lib');

--- a/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_require_imports.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
    ╭─[no_require_imports.ts:1:11]
  1 │ var lib = require('lib');
@@ -81,23 +80,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:1:21]
- 1 │ const pkg = require('./package.jsonc');
-   ·                     ─────────────────
-   ╰────
-  help: Do not use CommonJS `require` calls
-
-  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
    ╭─[no_require_imports.ts:1:13]
  1 │ const pkg = require('./package.jsonc');
    ·             ──────────────────────────
-   ╰────
-  help: Do not use CommonJS `require` calls
-
-  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:1:22]
- 1 │ const pkg = require(`./package.jsonc`);
-   ·                      ───────────────
    ╰────
   help: Do not use CommonJS `require` calls
 
@@ -116,23 +101,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Do not use CommonJS `require` calls
 
   ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:1:14]
- 1 │ import pkg = require('./package.jsonc');
-   ·              ──────────────────────────
-   ╰────
-  help: Do not use CommonJS `require` calls
-
-  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
    ╭─[no_require_imports.ts:1:1]
  1 │ import pkg = require('./package.jsonc');
    · ────────────────────────────────────────
-   ╰────
-  help: Do not use CommonJS `require` calls
-
-  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
-   ╭─[no_require_imports.ts:1:14]
- 1 │ import pkg = require('./package.json');
-   ·              ─────────────────────────
    ╰────
   help: Do not use CommonJS `require` calls
 
@@ -223,5 +194,37 @@ source: crates/oxc_linter/src/tester.rs
  2 │             require('foo')
    ·             ──────────────
  3 │             }
+   ╰────
+  help: Do not use CommonJS `require` calls
+
+  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
+   ╭─[no_require_imports.ts:1:11]
+ 1 │ const m = require(someVariable);
+   ·           ─────────────────────
+   ╰────
+  help: Do not use CommonJS `require` calls
+
+  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
+   ╭─[no_require_imports.ts:1:11]
+ 1 │ const m = require(path.join(dir, file));
+   ·           ─────────────────────────────
+   ╰────
+  help: Do not use CommonJS `require` calls
+
+  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
+   ╭─[no_require_imports.ts:3:24]
+ 2 │             require(module: string) {
+ 3 │                 return require(module);
+   ·                        ───────────────
+ 4 │             }
+   ╰────
+  help: Do not use CommonJS `require` calls
+
+  ⚠ typescript-eslint(no-require-imports): Expected "import" statement instead of "require" call
+   ╭─[no_require_imports.ts:3:24]
+ 2 │             require(module: string) {
+ 3 │                 return require('foo');
+   ·                        ──────────────
+ 4 │             }
    ╰────
   help: Do not use CommonJS `require` calls


### PR DESCRIPTION
## Summary

The `typescript/no-require-imports` rule had two false negatives:

**`require()` with dynamic arguments was not flagged:**
```ts
const m = require(someVariable);        // not flagged (should be)
const m = require(path.join(dir, file)); // not flagged (should be)
const m = require('./foo');              // correctly flagged
```

**`require()` inside a class method named `require` was not flagged:**
```ts
class Foo {
  require(module: string) {
    return require(module); // not flagged (should be)
  }
}
```

Both cases share the same root cause: the rule used `CallExpression::is_require_call()` to detect `require` calls, which only matches when the argument is a `StringLiteral` or `TemplateLiteral`. Calls with dynamic arguments were silently skipped.

**Fix:** Replace `is_require_call()` with a direct callee identifier check. The rule now flags any `CallExpression` where the callee is the unqualified identifier `require` resolving to the global, regardless of argument type.

**Also fixed:** double-diagnostics when the `allow` config option is set. Non-matching string/template literal arguments previously emitted a diagnostic on the argument span *and* then fell through to emit a second diagnostic on the call expression span. Now a single diagnostic is emitted on the call expression span. The same issue was present in the `TSImportEqualsDeclaration` path and is fixed there too.

## Test plan

- Added `fail` cases: `require(someVariable)`, `require(path.join(dir, file))`, `require(module)` and `require('foo')` inside a class method named `require`
- Updated snapshot to reflect single diagnostic per call and new cases
- `cargo test -p oxc_linter --lib no_require_imports` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)