### PR TITLE
fix(linter): Fix syntax error reporting in some output formatters. 

### DIFF
--- a/apps/oxlint/fixtures/output_formatter_diagnostic/parser-error.js
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/parser-error.js
@@ -1,0 +1,8 @@
+export default class Test {
+  commands = [];
+  client: Example
+
+  constructor() {
+    this.client = {};
+  }
+}

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -181,6 +181,21 @@ mod test {
         }
     }
 
+    // Regression test for https://github.com/oxc-project/oxc/issues/19588
+    // Parser errors with colons in their message (e.g. 'Expected `;` but found `:`')
+    // were being truncated to just the character after the first colon.
+    #[test]
+    fn test_output_formatter_diagnostic_formats_with_parser_error() {
+        let formats: Vec<&str> =
+            vec!["checkstyle", "default", "github", "gitlab", "json", "junit", "stylish", "unix"];
+
+        for fmt in &formats {
+            let args_vec = [format!("--format={fmt}"), "parser-error.js".to_string()];
+            let args_ref: Vec<&str> = args_vec.iter().map(std::string::String::as_str).collect();
+            Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(&args_ref);
+        }
+    }
+
     // Test that each of the formatters can output the disable directive violations.
     #[test]
     fn test_output_formatter_diagnostic_formats_with_disable_directive() {

--- a/apps/oxlint/src/output_formatter/unix.rs
+++ b/apps/oxlint/src/output_formatter/unix.rs
@@ -97,4 +97,19 @@ mod test {
         assert!(result.is_some());
         assert_eq!(result.unwrap(), "file://test.ts:1:1: error message [Warning]\n");
     }
+
+    /// Regression test: messages containing colons (e.g. parser errors like
+    /// 'Expected `;` but found `:`') must not be truncated.
+    #[test]
+    fn reporter_error_message_with_colon() {
+        let mut reporter = UnixReporter::default();
+        let error = OxcDiagnostic::error("Expected `;` but found `:`")
+            .with_label(Span::new(0, 1))
+            .with_source_code(NamedSource::new("file://test.js", ":"));
+
+        let result = reporter.render_error(error);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), "file://test.js:1:1: Expected `;` but found `:` [Error]\n");
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle parser-error.js@oxlint.snap
@@ -1,0 +1,11 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=checkstyle parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="parser-error.js"><error line="3" column="9" severity="error" message="Expected `;` but found `:`" source="" /></file></checkstyle>
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default parser-error.js@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=default parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+
+  x Expected `;` but found `:`
+   ,-[parser-error.js:3:9]
+ 2 |   commands = [];
+ 3 |   client: Example
+   :         |
+   :         `-- `;` expected
+ 4 | 
+   `----
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 2 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github parser-error.js@oxlint.snap
@@ -1,0 +1,11 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=github parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+::error file=parser-error.js,line=3,endLine=3,col=9,endColumn=10,title=oxlint::Expected `;` but found `:`
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=gitlab parser-error.js@oxlint.snap
@@ -1,0 +1,24 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=gitlab parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+[
+  {
+    "description": "Expected `;` but found `:`",
+    "check_name": "",
+    "fingerprint": "5f141d44128bf58e",
+    "severity": "critical",
+    "location": {
+      "path": "apps/oxlint/parser-error.js",
+      "lines": {
+        "begin": 3,
+        "end": 3
+      }
+    }
+  }
+]----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json parser-error.js@oxlint.snap
@@ -1,0 +1,16 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=json parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+{ "diagnostics": [{"message": "Expected `;` but found `:`","severity": "error","causes": [],"filename": "parser-error.js","labels": [{"label": "`;` expected","span": {"offset": 53,"length": 1,"line": 3,"column": 9}}],"related": []}],
+              "number_of_files": 1,
+              "number_of_rules": 2,
+              "threads_count": 1,
+              "start_time": <variable>
+            }
+            ----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=junit parser-error.js@oxlint.snap
@@ -1,0 +1,18 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=junit parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Oxlint" tests="1" failures="0" errors="1">
+    <testsuite name="parser-error.js" tests="1" disabled="0" errors="1" failures="0">
+        <testcase name="">
+            <error message="Expected `;` but found `:`">line 3, column 9, Expected `;` but found `:`</error>
+        </testcase>
+    </testsuite>
+</testsuites>
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish parser-error.js@oxlint.snap
@@ -1,0 +1,15 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=stylish parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+
+[4mparser-error.js[0m
+  [2m3:9[0m  [31merror[0m  Expected `;` but found `:`  [2m[0m
+
+[31m✖ 1 problem (1 error, 0 warnings)[0m
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=unix parser-error.js@oxlint.snap
@@ -1,0 +1,13 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=unix parser-error.js
+working directory: fixtures/output_formatter_diagnostic
+----------
+parser-error.js:3:9: Expected `;` but found `:` [Error]
+
+1 problem
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/test/fixtures/comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/comments/output.snap.md
@@ -86,7 +86,16 @@
  4 | 
    `----
 
-  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
+  x test-comments(test-comments): FunctionDeclaration(topLevelFunction):
+  | getCommentsBefore: 0 comments
+  | getCommentsInside: 5 comments
+  |   [0] Line: " Line comment 2" at [163, 180]
+  |   [1] Block: " Block comment 2 " at [183, 204]
+  |   [2] Block: "*\n   * JSDoc comment 2\n   " at [256, 286]
+  |   [3] Line: " Line comment 3" at [321, 338]
+  |   [4] Line: " Line comment 4" at [405, 422]
+  | getCommentsAfter: 1 comment
+  |   [0] Block: " Block comment 3 " at [426, 447]
     ,-[files/comments.js:8:8]
   7 |      */
   8 | ,-> export function topLevelFunction() {
@@ -105,16 +114,7 @@
  21 |     
     `----
 
-  x test-comments(test-comments): FunctionDeclaration(topLevelFunction):
-  | getCommentsBefore: 0 comments
-  | getCommentsInside: 5 comments
-  |   [0] Line: " Line comment 2" at [163, 180]
-  |   [1] Block: " Block comment 2 " at [183, 204]
-  |   [2] Block: "*\n   * JSDoc comment 2\n   " at [256, 286]
-  |   [3] Line: " Line comment 3" at [321, 338]
-  |   [4] Line: " Line comment 4" at [405, 422]
-  | getCommentsAfter: 1 comment
-  |   [0] Block: " Block comment 3 " at [426, 447]
+  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
     ,-[files/comments.js:8:8]
   7 |      */
   8 | ,-> export function topLevelFunction() {
@@ -255,14 +255,6 @@
  7 | `-> export function topLevelFunction() {}
    `----
 
-  x test-comments(test-comments): commentsExistBetween(topLevelVariable2, topLevelFunction): false
-   ,-[files/hashbang.js:5:1]
- 4 | const topLevelVariable1 = 1;
- 5 | const topLevelVariable2 = 2;
-   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 6 | 
-   `----
-
   x test-comments(test-comments): VariableDeclaration(topLevelVariable2):
   | getCommentsBefore: 0 comments
   | getCommentsInside: 0 comments
@@ -275,17 +267,25 @@
  6 | 
    `----
 
-  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
-   ,-[files/hashbang.js:7:8]
+  x test-comments(test-comments): commentsExistBetween(topLevelVariable2, topLevelFunction): false
+   ,-[files/hashbang.js:5:1]
+ 4 | const topLevelVariable1 = 1;
+ 5 | const topLevelVariable2 = 2;
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  6 | 
- 7 | export function topLevelFunction() {}
-   :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
   x test-comments(test-comments): FunctionDeclaration(topLevelFunction):
   | getCommentsBefore: 0 comments
   | getCommentsInside: 0 comments
   | getCommentsAfter: 0 comments
+   ,-[files/hashbang.js:7:8]
+ 6 | 
+ 7 | export function topLevelFunction() {}
+   :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+
+  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
    ,-[files/hashbang.js:7:8]
  6 | 
  7 | export function topLevelFunction() {}
@@ -323,14 +323,6 @@
  16 | `-> const topLevelVariable7 = 7;
     `----
 
-  x test-comments(test-comments): commentsExistBetween(topLevelVariable2, topLevelFunction): false
-   ,-[files/no_comments.js:2:1]
- 1 | const topLevelVariable1 = 1;
- 2 | const topLevelVariable2 = 2;
-   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 3 | 
-   `----
-
   x test-comments(test-comments): VariableDeclaration(topLevelVariable2):
   | getCommentsBefore: 0 comments
   | getCommentsInside: 0 comments
@@ -343,7 +335,18 @@
  3 | 
    `----
 
-  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
+  x test-comments(test-comments): commentsExistBetween(topLevelVariable2, topLevelFunction): false
+   ,-[files/no_comments.js:2:1]
+ 1 | const topLevelVariable1 = 1;
+ 2 | const topLevelVariable2 = 2;
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 3 | 
+   `----
+
+  x test-comments(test-comments): FunctionDeclaration(topLevelFunction):
+  | getCommentsBefore: 0 comments
+  | getCommentsInside: 0 comments
+  | getCommentsAfter: 0 comments
     ,-[files/no_comments.js:4:8]
   3 |     
   4 | ,-> export function topLevelFunction() {
@@ -356,10 +359,7 @@
  11 |     
     `----
 
-  x test-comments(test-comments): FunctionDeclaration(topLevelFunction):
-  | getCommentsBefore: 0 comments
-  | getCommentsInside: 0 comments
-  | getCommentsAfter: 0 comments
+  x test-comments(test-comments): commentsExistBetween(topLevelFunction, topLevelVariable2): false
     ,-[files/no_comments.js:4:8]
   3 |     
   4 | ,-> export function topLevelFunction() {

--- a/apps/oxlint/test/fixtures/createOnce/output.snap.md
+++ b/apps/oxlint/test/fixtures/createOnce/output.snap.md
@@ -15,6 +15,30 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): after hook: filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): after hook: id: create-once-plugin/always-run
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): before hook: filename: <fixture>/files/1.js
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): before hook: id: create-once-plugin/always-run
+   ,-[files/1.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: call count: 1
    ,-[files/1.js:1:1]
  1 | let x;
@@ -28,18 +52,6 @@
    `----
 
   x create-once-plugin(always-run): createOnce: filename error: Cannot access `context.filename` in `createOnce`
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: filename: <fixture>/files/1.js
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -70,18 +82,6 @@
    `----
 
   x create-once-plugin(always-run): createOnce: id error: Cannot access `context.id` in `createOnce`
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: id: create-once-plugin/always-run
-   ,-[files/1.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: id: create-once-plugin/always-run
    ,-[files/1.js:1:1]
  1 | let x;
    : ^
@@ -195,6 +195,30 @@
    : ^
    `----
 
+  x create-once-plugin(always-run): after hook: filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): after hook: id: create-once-plugin/always-run
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): before hook: filename: <fixture>/files/2.js
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
+  x create-once-plugin(always-run): before hook: id: create-once-plugin/always-run
+   ,-[files/2.js:1:1]
+ 1 | let y;
+   : ^
+   `----
+
   x create-once-plugin(always-run): createOnce: call count: 1
    ,-[files/2.js:1:1]
  1 | let y;
@@ -208,18 +232,6 @@
    `----
 
   x create-once-plugin(always-run): createOnce: filename error: Cannot access `context.filename` in `createOnce`
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: filename: <fixture>/files/2.js
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let y;
    : ^
@@ -250,18 +262,6 @@
    `----
 
   x create-once-plugin(always-run): createOnce: id error: Cannot access `context.id` in `createOnce`
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): before hook: id: create-once-plugin/always-run
-   ,-[files/2.js:1:1]
- 1 | let y;
-   : ^
-   `----
-
-  x create-once-plugin(always-run): after hook: id: create-once-plugin/always-run
    ,-[files/2.js:1:1]
  1 | let y;
    : ^

--- a/apps/oxlint/test/fixtures/eslintCompat/output.snap.md
+++ b/apps/oxlint/test/fixtures/eslintCompat/output.snap.md
@@ -10,17 +10,17 @@
    : ^
    `----
 
-  x eslint-compat-plugin(create-once): before hook:
-  | createOnce call count: 1
-  | this === rule: true
+  x eslint-compat-plugin(create-once): after hook:
+  | identNum: 2
   | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
    : ^
    `----
 
-  x eslint-compat-plugin(create-once): after hook:
-  | identNum: 2
+  x eslint-compat-plugin(create-once): before hook:
+  | createOnce call count: 1
+  | this === rule: true
   | filename: <fixture>/files/1.js
    ,-[files/1.js:1:1]
  1 | let a, b;
@@ -162,17 +162,17 @@
    : ^
    `----
 
-  x eslint-compat-plugin(create-once): before hook:
-  | createOnce call count: 1
-  | this === rule: true
+  x eslint-compat-plugin(create-once): after hook:
+  | identNum: 2
   | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
-  x eslint-compat-plugin(create-once): after hook:
-  | identNum: 2
+  x eslint-compat-plugin(create-once): before hook:
+  | createOnce call count: 1
+  | this === rule: true
   | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
@@ -186,14 +186,14 @@
    : ^
    `----
 
-  x eslint-compat-plugin(create-once-before-false): before hook:
+  x eslint-compat-plugin(create-once-before-false): after hook:
   | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;
    : ^
    `----
 
-  x eslint-compat-plugin(create-once-before-false): after hook:
+  x eslint-compat-plugin(create-once-before-false): before hook:
   | filename: <fixture>/files/2.js
    ,-[files/2.js:1:1]
  1 | let c, d;

--- a/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
+++ b/apps/oxlint/test/fixtures/isSpaceBetween/output.snap.md
@@ -136,18 +136,6 @@
     `----
 
   x test-plugin(is-space-between):
-  | isSpaceBetween(node, binaryLeft): false
-  | isSpaceBetweenTokens(node, binaryLeft): false
-  | isSpaceBetween(binaryLeft, node): false
-  | isSpaceBetweenTokens(binaryLeft, node): false
-    ,-[files/index.js:22:1]
- 21 | // prettier-ignore
- 22 | nested = 7 + 8;
-    : ^^^^^^^^^^^^^^
- 23 | 
-    `----
-
-  x test-plugin(is-space-between):
   | isSpaceBetween(left, right): true
   | isSpaceBetweenTokens(left, right): true
   | isSpaceBetween(right, left): true
@@ -160,6 +148,18 @@
   | isSpaceBetweenTokens(right, node): false
   | isSpaceBetween(node, right): false
   | isSpaceBetweenTokens(node, right): false
+    ,-[files/index.js:22:1]
+ 21 | // prettier-ignore
+ 22 | nested = 7 + 8;
+    : ^^^^^^^^^^^^^^
+ 23 | 
+    `----
+
+  x test-plugin(is-space-between):
+  | isSpaceBetween(node, binaryLeft): false
+  | isSpaceBetweenTokens(node, binaryLeft): false
+  | isSpaceBetween(binaryLeft, node): false
+  | isSpaceBetweenTokens(binaryLeft, node): false
     ,-[files/index.js:22:1]
  21 | // prettier-ignore
  22 | nested = 7 + 8;

--- a/apps/oxlint/test/fixtures/languageOptions/output.snap.md
+++ b/apps/oxlint/test/fixtures/languageOptions/output.snap.md
@@ -14,6 +14,17 @@
    : ^
    `----
 
+  x language-options-plugin(lang): languageOptions:
+  | sourceType: script
+  | ecmaVersion: 2026
+  | parserOptions: {"sourceType":"script","ecmaFeatures":{"jsx":true,"globalReturn":false,"impliedStrict":false}}
+  | globals: {}
+  | env: {"builtin":true}
+   ,-[files/index.js:1:1]
+ 1 | let x;
+   : ^
+   `----
+
   x language-options-plugin(lang): parser:
   | object keys: name,version,parse,VisitorKeys,Syntax,latestEcmaVersion,supportedEcmaVersions
   | name: oxlint
@@ -786,17 +797,6 @@
   |     "types"
   |   ]
   | }
-   ,-[files/index.js:1:1]
- 1 | let x;
-   : ^
-   `----
-
-  x language-options-plugin(lang): languageOptions:
-  | sourceType: script
-  | ecmaVersion: 2026
-  | parserOptions: {"sourceType":"script","ecmaFeatures":{"jsx":true,"globalReturn":false,"impliedStrict":false}}
-  | globals: {}
-  | env: {"builtin":true}
    ,-[files/index.js:1:1]
  1 | let x;
    : ^

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -10,48 +10,6 @@
  2 |   fn: <T>(arg: T): T => {
    `----
 
-  x tokens-plugin(tokens): Tokens:
-  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
-  | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
-  | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
-  | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
-  | Identifier        loc= 2:2 - 2:4    range= 16-18   "fn"
-  | Punctuator        loc= 2:4 - 2:5    range= 18-19   ":"
-  | Punctuator        loc= 2:6 - 2:7    range= 20-21   "<"
-  | Identifier        loc= 2:7 - 2:8    range= 21-22   "T"
-  | Punctuator        loc= 2:8 - 2:9    range= 22-23   ">"
-  | Punctuator        loc= 2:9 - 2:10   range= 23-24   "("
-  | Identifier        loc= 2:10 - 2:13  range= 24-27   "arg"
-  | Punctuator        loc= 2:13 - 2:14  range= 27-28   ":"
-  | Identifier        loc= 2:15 - 2:16  range= 29-30   "T"
-  | Punctuator        loc= 2:16 - 2:17  range= 30-31   ")"
-  | Punctuator        loc= 2:17 - 2:18  range= 31-32   ":"
-  | Identifier        loc= 2:19 - 2:20  range= 33-34   "T"
-  | Punctuator        loc= 2:21 - 2:23  range= 35-37   "=>"
-  | Punctuator        loc= 2:24 - 2:25  range= 38-39   "{"
-  | Keyword           loc= 3:4 - 3:10   range= 44-50   "return"
-  | Identifier        loc= 3:11 - 3:14  range= 51-54   "arg"
-  | Punctuator        loc= 3:14 - 3:15  range= 54-55   ";"
-  | Punctuator        loc= 4:2 - 4:3    range= 58-59   "}"
-  | Punctuator        loc= 4:3 - 4:4    range= 59-60   ","
-  | Punctuator        loc= 5:0 - 5:1    range= 61-62   "}"
-  | Punctuator        loc= 5:1 - 5:2    range= 62-63   ";"
-  | Keyword           loc= 8:0 - 8:6    range= 95-101  "export"
-  | Punctuator        loc= 8:7 - 8:8    range= 102-103 "{"
-  | Identifier        loc= 8:9 - 8:12   range= 104-107 "obj"
-  | Punctuator        loc= 8:13 - 8:14  range= 108-109 "}"
-  | Punctuator        loc= 8:14 - 8:15  range= 109-110 ";"
-   ,-[files/generic_arrow.ts:1:1]
- 1 | ,-> const obj = {
- 2 | |     fn: <T>(arg: T): T => {
- 3 | |       return arg;
- 4 | |     },
- 5 | |   };
- 6 | |   
- 7 | |   // A comment after the object
- 8 | `-> export { obj };
-   `----
-
   x tokens-plugin(tokens): Tokens and comments:
   | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
   | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
@@ -79,6 +37,48 @@
   | Punctuator        loc= 5:0 - 5:1    range= 61-62   "}"
   | Punctuator        loc= 5:1 - 5:2    range= 62-63   ";"
   | Line              loc= 7:0 - 7:29   range= 65-94   " A comment after the object"
+  | Keyword           loc= 8:0 - 8:6    range= 95-101  "export"
+  | Punctuator        loc= 8:7 - 8:8    range= 102-103 "{"
+  | Identifier        loc= 8:9 - 8:12   range= 104-107 "obj"
+  | Punctuator        loc= 8:13 - 8:14  range= 108-109 "}"
+  | Punctuator        loc= 8:14 - 8:15  range= 109-110 ";"
+   ,-[files/generic_arrow.ts:1:1]
+ 1 | ,-> const obj = {
+ 2 | |     fn: <T>(arg: T): T => {
+ 3 | |       return arg;
+ 4 | |     },
+ 5 | |   };
+ 6 | |   
+ 7 | |   // A comment after the object
+ 8 | `-> export { obj };
+   `----
+
+  x tokens-plugin(tokens): Tokens:
+  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
+  | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
+  | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
+  | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
+  | Identifier        loc= 2:2 - 2:4    range= 16-18   "fn"
+  | Punctuator        loc= 2:4 - 2:5    range= 18-19   ":"
+  | Punctuator        loc= 2:6 - 2:7    range= 20-21   "<"
+  | Identifier        loc= 2:7 - 2:8    range= 21-22   "T"
+  | Punctuator        loc= 2:8 - 2:9    range= 22-23   ">"
+  | Punctuator        loc= 2:9 - 2:10   range= 23-24   "("
+  | Identifier        loc= 2:10 - 2:13  range= 24-27   "arg"
+  | Punctuator        loc= 2:13 - 2:14  range= 27-28   ":"
+  | Identifier        loc= 2:15 - 2:16  range= 29-30   "T"
+  | Punctuator        loc= 2:16 - 2:17  range= 30-31   ")"
+  | Punctuator        loc= 2:17 - 2:18  range= 31-32   ":"
+  | Identifier        loc= 2:19 - 2:20  range= 33-34   "T"
+  | Punctuator        loc= 2:21 - 2:23  range= 35-37   "=>"
+  | Punctuator        loc= 2:24 - 2:25  range= 38-39   "{"
+  | Keyword           loc= 3:4 - 3:10   range= 44-50   "return"
+  | Identifier        loc= 3:11 - 3:14  range= 51-54   "arg"
+  | Punctuator        loc= 3:14 - 3:15  range= 54-55   ";"
+  | Punctuator        loc= 4:2 - 4:3    range= 58-59   "}"
+  | Punctuator        loc= 4:3 - 4:4    range= 59-60   ","
+  | Punctuator        loc= 5:0 - 5:1    range= 61-62   "}"
+  | Punctuator        loc= 5:1 - 5:2    range= 62-63   ";"
   | Keyword           loc= 8:0 - 8:6    range= 95-101  "export"
   | Punctuator        loc= 8:7 - 8:8    range= 102-103 "{"
   | Identifier        loc= 8:9 - 8:12   range= 104-107 "obj"
@@ -334,28 +334,6 @@
  2 | 
    `----
 
-  x tokens-plugin(tokens): Tokens:
-  | Keyword           loc= 3:0 - 3:3    range= 20-23   "let"
-  | Identifier        loc= 3:4 - 3:5    range= 24-25   "x"
-  | Punctuator        loc= 3:6 - 3:7    range= 26-27   "="
-  | Numeric           loc= 3:29 - 3:30  range= 49-50   "1"
-  | Punctuator        loc= 3:30 - 3:31  range= 50-51   ";"
-  | Keyword           loc= 6:0 - 6:3    range= 72-75   "let"
-  | Identifier        loc= 6:4 - 6:5    range= 76-77   "y"
-  | Punctuator        loc= 6:6 - 6:7    range= 78-79   "="
-  | RegularExpression loc= 6:8 - 6:15   range= 80-87   "/abc/gu"
-  | Punctuator        loc= 6:15 - 6:16  range= 87-88   ";"
-   ,-[files/index.js:1:1]
- 1 | ,-> // Leading comment
- 2 | |   
- 3 | |   let x = /* inline comment */ 1;
- 4 | |   
- 5 | |   // Another comment
- 6 | |   let y = /abc/gu;
- 7 | |   
- 8 | `-> // Trailing comment
-   `----
-
   x tokens-plugin(tokens): Tokens and comments:
   | Line              loc= 1:0 - 1:18   range= 0-18    " Leading comment"
   | Keyword           loc= 3:0 - 3:3    range= 20-23   "let"
@@ -371,6 +349,28 @@
   | RegularExpression loc= 6:8 - 6:15   range= 80-87   "/abc/gu"
   | Punctuator        loc= 6:15 - 6:16  range= 87-88   ";"
   | Line              loc= 8:0 - 8:19   range= 90-109  " Trailing comment"
+   ,-[files/index.js:1:1]
+ 1 | ,-> // Leading comment
+ 2 | |   
+ 3 | |   let x = /* inline comment */ 1;
+ 4 | |   
+ 5 | |   // Another comment
+ 6 | |   let y = /abc/gu;
+ 7 | |   
+ 8 | `-> // Trailing comment
+   `----
+
+  x tokens-plugin(tokens): Tokens:
+  | Keyword           loc= 3:0 - 3:3    range= 20-23   "let"
+  | Identifier        loc= 3:4 - 3:5    range= 24-25   "x"
+  | Punctuator        loc= 3:6 - 3:7    range= 26-27   "="
+  | Numeric           loc= 3:29 - 3:30  range= 49-50   "1"
+  | Punctuator        loc= 3:30 - 3:31  range= 50-51   ";"
+  | Keyword           loc= 6:0 - 6:3    range= 72-75   "let"
+  | Identifier        loc= 6:4 - 6:5    range= 76-77   "y"
+  | Punctuator        loc= 6:6 - 6:7    range= 78-79   "="
+  | RegularExpression loc= 6:8 - 6:15   range= 80-87   "/abc/gu"
+  | Punctuator        loc= 6:15 - 6:16  range= 87-88   ";"
    ,-[files/index.js:1:1]
  1 | ,-> // Leading comment
  2 | |   
@@ -493,43 +493,6 @@
  2 |   return <div className="test">Hello</div>;
    `----
 
-  x tokens-plugin(tokens): Tokens:
-  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
-  | Identifier        loc= 1:6 - 1:15   range= 6-15    "Component"
-  | Punctuator        loc= 1:16 - 1:17  range= 16-17   "="
-  | Punctuator        loc= 1:18 - 1:19  range= 18-19   "("
-  | Punctuator        loc= 1:19 - 1:20  range= 19-20   ")"
-  | Punctuator        loc= 1:21 - 1:23  range= 21-23   "=>"
-  | Punctuator        loc= 1:24 - 1:25  range= 24-25   "{"
-  | Keyword           loc= 2:2 - 2:8    range= 28-34   "return"
-  | Punctuator        loc= 2:9 - 2:10   range= 35-36   "<"
-  | JSXIdentifier     loc= 2:10 - 2:13  range= 36-39   "div"
-  | JSXIdentifier     loc= 2:14 - 2:23  range= 40-49   "className"
-  | Punctuator        loc= 2:23 - 2:24  range= 49-50   "="
-  | JSXText           loc= 2:24 - 2:30  range= 50-56   "\"test\""
-  | Punctuator        loc= 2:30 - 2:31  range= 56-57   ">"
-  | JSXText           loc= 2:31 - 2:36  range= 57-62   "Hello"
-  | Punctuator        loc= 2:36 - 2:37  range= 62-63   "<"
-  | Punctuator        loc= 2:37 - 2:38  range= 63-64   "/"
-  | JSXIdentifier     loc= 2:38 - 2:41  range= 64-67   "div"
-  | Punctuator        loc= 2:41 - 2:42  range= 67-68   ">"
-  | Punctuator        loc= 2:42 - 2:43  range= 68-69   ";"
-  | Punctuator        loc= 3:0 - 3:1    range= 70-71   "}"
-  | Punctuator        loc= 3:1 - 3:2    range= 71-72   ";"
-  | Keyword           loc= 6:0 - 6:6    range= 107-113 "export"
-  | Punctuator        loc= 6:7 - 6:8    range= 114-115 "{"
-  | Identifier        loc= 6:9 - 6:18   range= 116-125 "Component"
-  | Punctuator        loc= 6:19 - 6:20  range= 126-127 "}"
-  | Punctuator        loc= 6:20 - 6:21  range= 127-128 ";"
-   ,-[files/jsx_element.tsx:1:1]
- 1 | ,-> const Component = () => {
- 2 | |     return <div className="test">Hello</div>;
- 3 | |   };
- 4 | |   
- 5 | |   // A comment after the component
- 6 | `-> export { Component };
-   `----
-
   x tokens-plugin(tokens): Tokens and comments:
   | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
   | Identifier        loc= 1:6 - 1:15   range= 6-15    "Component"
@@ -554,6 +517,43 @@
   | Punctuator        loc= 3:0 - 3:1    range= 70-71   "}"
   | Punctuator        loc= 3:1 - 3:2    range= 71-72   ";"
   | Line              loc= 5:0 - 5:32   range= 74-106  " A comment after the component"
+  | Keyword           loc= 6:0 - 6:6    range= 107-113 "export"
+  | Punctuator        loc= 6:7 - 6:8    range= 114-115 "{"
+  | Identifier        loc= 6:9 - 6:18   range= 116-125 "Component"
+  | Punctuator        loc= 6:19 - 6:20  range= 126-127 "}"
+  | Punctuator        loc= 6:20 - 6:21  range= 127-128 ";"
+   ,-[files/jsx_element.tsx:1:1]
+ 1 | ,-> const Component = () => {
+ 2 | |     return <div className="test">Hello</div>;
+ 3 | |   };
+ 4 | |   
+ 5 | |   // A comment after the component
+ 6 | `-> export { Component };
+   `----
+
+  x tokens-plugin(tokens): Tokens:
+  | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
+  | Identifier        loc= 1:6 - 1:15   range= 6-15    "Component"
+  | Punctuator        loc= 1:16 - 1:17  range= 16-17   "="
+  | Punctuator        loc= 1:18 - 1:19  range= 18-19   "("
+  | Punctuator        loc= 1:19 - 1:20  range= 19-20   ")"
+  | Punctuator        loc= 1:21 - 1:23  range= 21-23   "=>"
+  | Punctuator        loc= 1:24 - 1:25  range= 24-25   "{"
+  | Keyword           loc= 2:2 - 2:8    range= 28-34   "return"
+  | Punctuator        loc= 2:9 - 2:10   range= 35-36   "<"
+  | JSXIdentifier     loc= 2:10 - 2:13  range= 36-39   "div"
+  | JSXIdentifier     loc= 2:14 - 2:23  range= 40-49   "className"
+  | Punctuator        loc= 2:23 - 2:24  range= 49-50   "="
+  | JSXText           loc= 2:24 - 2:30  range= 50-56   "\"test\""
+  | Punctuator        loc= 2:30 - 2:31  range= 56-57   ">"
+  | JSXText           loc= 2:31 - 2:36  range= 57-62   "Hello"
+  | Punctuator        loc= 2:36 - 2:37  range= 62-63   "<"
+  | Punctuator        loc= 2:37 - 2:38  range= 63-64   "/"
+  | JSXIdentifier     loc= 2:38 - 2:41  range= 64-67   "div"
+  | Punctuator        loc= 2:41 - 2:42  range= 67-68   ">"
+  | Punctuator        loc= 2:42 - 2:43  range= 68-69   ";"
+  | Punctuator        loc= 3:0 - 3:1    range= 70-71   "}"
+  | Punctuator        loc= 3:1 - 3:2    range= 71-72   ";"
   | Keyword           loc= 6:0 - 6:6    range= 107-113 "export"
   | Punctuator        loc= 6:7 - 6:8    range= 114-115 "{"
   | Identifier        loc= 6:9 - 6:18   range= 116-125 "Component"
@@ -780,11 +780,12 @@
  2 |   // Identifier tokens
    `----
 
-  x tokens-plugin(tokens): Tokens:
+  x tokens-plugin(tokens): Tokens and comments:
   | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
   | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
   | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
   | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
+  | Line              loc= 2:2 - 2:22   range= 16-36   " Identifier tokens"
   | Identifier        loc= 3:2 - 3:5    range= 39-42   "foo"
   | Punctuator        loc= 3:5 - 3:6    range= 42-43   ":"
   | Identifier        loc= 3:7 - 3:10   range= 44-47   "foo"
@@ -793,6 +794,7 @@
   | Punctuator        loc= 4:7 - 4:8    range= 56-57   ":"
   | Identifier        loc= 4:9 - 4:14   range= 58-63   "async"
   | Punctuator        loc= 4:14 - 4:15  range= 63-64   ","
+  | Line              loc= 5:2 - 5:19   range= 67-84   " Keyword tokens"
   | Keyword           loc= 6:2 - 6:5    range= 87-90   "let"
   | Punctuator        loc= 6:5 - 6:6    range= 90-91   ":"
   | Keyword           loc= 6:7 - 6:10   range= 92-95   "let"
@@ -819,12 +821,11 @@
  9 | `-> };
    `----
 
-  x tokens-plugin(tokens): Tokens and comments:
+  x tokens-plugin(tokens): Tokens:
   | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
   | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
   | Punctuator        loc= 1:10 - 1:11  range= 10-11   "="
   | Punctuator        loc= 1:12 - 1:13  range= 12-13   "{"
-  | Line              loc= 2:2 - 2:22   range= 16-36   " Identifier tokens"
   | Identifier        loc= 3:2 - 3:5    range= 39-42   "foo"
   | Punctuator        loc= 3:5 - 3:6    range= 42-43   ":"
   | Identifier        loc= 3:7 - 3:10   range= 44-47   "foo"
@@ -833,7 +834,6 @@
   | Punctuator        loc= 4:7 - 4:8    range= 56-57   ":"
   | Identifier        loc= 4:9 - 4:14   range= 58-63   "async"
   | Punctuator        loc= 4:14 - 4:15  range= 63-64   ","
-  | Line              loc= 5:2 - 5:19   range= 67-84   " Keyword tokens"
   | Keyword           loc= 6:2 - 6:5    range= 87-90   "let"
   | Punctuator        loc= 6:5 - 6:6    range= 90-91   ":"
   | Keyword           loc= 6:7 - 6:10   range= 92-95   "let"

--- a/crates/oxc_diagnostics/src/reporter.rs
+++ b/crates/oxc_diagnostics/src/reporter.rs
@@ -139,15 +139,6 @@ impl Info {
             }
 
             message = diagnostic.to_string();
-            // Our messages usually are in format `eslint(rule): message`.
-            // Trim off before the colon.
-            if let Some((_, msg)) = message.split_once(':') {
-                // Equivalent to `message = msg.trim().to_string()`, but operates in place
-                let msg = msg.trim();
-                let start = msg.as_ptr() as usize - message.as_str().as_ptr() as usize;
-                message.truncate(start + msg.len());
-                message.replace_range(..start, "");
-            }
         }
 
         Self { start, end, filename, message, severity, rule_id }


### PR DESCRIPTION
Add snapshot tests for all the formatters with this case to make sure we don't regress on this for any of them in the future.

Basically, we were being overly aggressive in the stripping of the rule ID from the message, which caused messages with colons in them (e.g. parser errors like `Expected `;` but found `:``) to be truncated to just the character after the first colon.

We don't actually need to do this anymore, as the `diagnostic.to_string()` method doesn't include the rule ID (if it ever did), so we can just use the full string as the message without any additional parsing.

Generated with Claude Code.

Fixes https://github.com/oxc-project/oxc/issues/19588.