### PR TITLE
fix(linter): add help text to more eslint diagnostics

### DIFF
--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -21,6 +21,7 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -21,7 +21,9 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt`
+           supports arbitrarily large integers.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -29,7 +29,9 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt`
+           supports arbitrarily large integers.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -29,6 +29,7 @@ working directory:
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ! eslint(no-unused-expressions): Expected expression to be used
    ,-[fixtures/typescript_eslint/test.ts:4:1]

--- a/crates/oxc_linter/src/rules/eslint/no_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_labels.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 
 fn no_labels_diagnostic(message: &'static str, label_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(message).with_label(label_span)
+    OxcDiagnostic::warn(message)
+        .with_help("Consider refactoring the code to eliminate the need for labels.")
+        .with_label(label_span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -10,7 +10,12 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_loss_of_precision_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("This number literal will lose precision at runtime.")
-        .with_help("Use a number literal that can be represented accurately by a 64-bit floating-point number.")
+        .with_help(
+            "Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.",
+        )
+        .with_note(
+            "In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.",
+        )
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -9,7 +9,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_loss_of_precision_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("This number literal will lose precision at runtime.").with_label(span)
+    OxcDiagnostic::warn("This number literal will lose precision at runtime.")
+        .with_help("Use a number literal that can be represented accurately by a 64-bit floating-point number.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 fn no_self_assign_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("this expression is assigned to itself").with_label(span)
+    OxcDiagnostic::warn("this expression is assigned to itself")
+        .with_help("Remove the self-assignment or assign to a different variable.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -10,11 +10,13 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_useless_catch_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary try/catch wrapper")
+        .with_help("Remove the try/catch wrapper, since it does not provide any additional error handling or functionality.")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 
 fn no_useless_catch_finalizer_diagnostic(catch: Span, rethrow: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unnecessary catch clause")
+        .with_help("Remove the catch clause, since it does not provide any additional error handling or functionality beyond what the finalizer already provides.")
         .with_labels([catch.label("is caught here"), rethrow.label("and re-thrown here")])
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -18,7 +18,9 @@ use crate::{
 };
 
 fn prefer_promise_reject_errors_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Expected the Promise rejection reason to be an Error").with_label(span)
+    OxcDiagnostic::warn("Expected the Promise rejection reason to be an Error")
+        .with_help("Only pass an Error object to the reject() function for user-defined errors in Promises.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
@@ -7,231 +7,270 @@ source: crates/oxc_linter/src/tester.rs
  1 │ label: while(true) {}
    · ─────
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ label: while (true) { break label; }
    · ─────
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:29]
  1 │ label: while (true) { break label; }
    ·                             ─────
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ label: while (true) { continue label; }
    · ─────
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in continue statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ label: while (true) { continue label; }
    ·                                ─────
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:31]
  1 │ A: switch (a) { case 0: break A; default: break; };
    ·                               ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    ·                         ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:36]
  1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    ·                                    ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:31]
  1 │ A: switch (a) { case 0: break A; default: break; };
    ·                               ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: var foo = 0;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: break A;
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:10]
  1 │ A: break A;
    ·          ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:25]
  1 │ A: { if (foo()) { break A; } bar(); };
    ·                         ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:32]
  1 │ A: if (a) { if (foo()) { break A; } bar(); };
    ·                                ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: while (a) { break A; }
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:22]
  1 │ A: while (a) { break A; }
    ·                      ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: do { if (b) { break A; } } while (a);
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:24]
  1 │ A: do { if (b) { break A; } } while (a);
    ·                        ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    · ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:63]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    ·                                                               ─
    ╰────
+  help: Consider refactoring the code to eliminate the need for labels.

--- a/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
@@ -7,333 +7,381 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var x = 9007199254740993
    ·         ────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9007199254740.993e3
    ·         ───────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.007199254740993e15
    ·         ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9007199254740993
    ·          ────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719.9254740994
    ·         ─────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900719.9254740994
    ·          ─────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719925474099_3
    ·         ─────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 90_0719925_4740.9_93e3
    ·         ──────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 9.0_0719925_474099_3e15
    ·           ───────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -9_00719_9254_740993
    ·            ───────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 900_719.92_54740_994
    ·           ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -900_719.92_5474_0994
    ·            ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123000000000000000000000000001
    ·         ───────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5123000000000000000000000000001
    ·          ───────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1230000000000000000000000.0
    ·         ───────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0000000000000000000000123
    ·         ───────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 17498005798264095394980017816940970922825355447145699491406164851279623993595007385788105416184430592
    ·         ─────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e999
    ·         ─────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1230000000000000000000000
    ·         ──────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o400000000000000001
    ·         ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O400000000000000001
    ·         ────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0400000000000000001
    ·         ───────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x20000000000001
    ·         ────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X20000000000001
    ·         ────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123_00000000000000000000000000_1
    ·         ─────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5_12300000000000000000000_0000001
    ·          ─────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 123_00000000000000000000_00.0_0
    ·         ───────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0_00000000000000000_0000123
    ·         ─────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 174_980057982_640953949800178169_409709228253554471456994_914061648512796239935950073857881054_1618443059_2
    ·         ───────────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e9_99
    ·         ──────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1_23000000000000_00000_0000_0
    ·         ──────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b1_0000000000000000000000000000000000000000000000000000_1
    ·         ──────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B10000000000_0000000000000000000000000000_000000000000001
    ·         ──────────────────────────────────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o4_00000000000000_001
    ·         ──────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O4_0000000000000000_1
    ·         ──────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x2_0000000000001
    ·         ─────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X200000_0000000_1
    ·         ──────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1e18_446_744_073_709_551_615
    ·         ────────────────────────────
    ╰────
-  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
+  help: Use a number literal representable by a 64-bit floating-point number, or use a `BigInt` literal (for example, `9007199254740993n`) for exact large integers.
+  note: In JavaScript, `Number` values exactly represent integers only in the range -9007199254740991 to 9007199254740991 (`Number.MIN_SAFE_INTEGER` to `Number.MAX_SAFE_INTEGER`). `BigInt` supports arbitrarily large integers.

--- a/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_loss_of_precision.snap
@@ -7,285 +7,333 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var x = 9007199254740993
    ·         ────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9007199254740.993e3
    ·         ───────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.007199254740993e15
    ·         ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9007199254740993
    ·          ────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719.9254740994
    ·         ─────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900719.9254740994
    ·          ─────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900719925474099_3
    ·         ─────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 90_0719925_4740.9_93e3
    ·         ──────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 9.0_0719925_474099_3e15
    ·         ───────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -9_00719_9254_740993
    ·          ───────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ let x = 900_719.92_54740_994
    ·         ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ let x = -900_719.92_5474_0994
    ·          ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 9.0_0719925_474099_3e15
    ·           ───────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -9_00719_9254_740993
    ·            ───────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:11]
  1 │ const x = 900_719.92_54740_994
    ·           ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:12]
  1 │ const x = -900_719.92_5474_0994
    ·            ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123000000000000000000000000001
    ·         ───────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5123000000000000000000000000001
    ·          ───────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1230000000000000000000000.0
    ·         ───────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0000000000000000000000123
    ·         ───────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 17498005798264095394980017816940970922825355447145699491406164851279623993595007385788105416184430592
    ·         ─────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e999
    ·         ─────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1230000000000000000000000
    ·         ──────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B100000000000000000000000000000000000000000000000000001
    ·         ────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o400000000000000001
    ·         ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O400000000000000001
    ·         ────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0400000000000000001
    ·         ───────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x20000000000001
    ·         ────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X20000000000001
    ·         ────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 5123_00000000000000000000000000_1
    ·         ─────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:10]
  1 │ var x = -5_12300000000000000000000_0000001
    ·          ─────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 123_00000000000000000000_00.0_0
    ·         ───────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1.0_00000000000000000_0000123
    ·         ─────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 174_980057982_640953949800178169_409709228253554471456994_914061648512796239935950073857881054_1618443059_2
    ·         ───────────────────────────────────────────────────────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 2e9_99
    ·         ──────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = .1_23000000000000_00000_0000_0
    ·         ──────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0b1_0000000000000000000000000000000000000000000000000000_1
    ·         ──────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0B10000000000_0000000000000000000000000000_000000000000001
    ·         ──────────────────────────────────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0o4_00000000000000_001
    ·         ──────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0O4_0000000000000000_1
    ·         ──────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0x2_0000000000001
    ·         ─────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 0X200000_0000000_1
    ·         ──────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.
 
   ⚠ eslint(no-loss-of-precision): This number literal will lose precision at runtime.
    ╭─[no_loss_of_precision.tsx:1:9]
  1 │ var x = 1e18_446_744_073_709_551_615
    ·         ────────────────────────────
    ╰────
+  help: Use a number literal that can be represented accurately by a 64-bit floating-point number.

--- a/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_self_assign.snap
@@ -7,192 +7,224 @@ source: crates/oxc_linter/src/tester.rs
  1 │ a = a
    ·     ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ [a] = [a]
    ·        ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:11]
  1 │ [a, b] = [a, b]
    ·           ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:14]
  1 │ [a, b] = [a, b]
    ·              ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:11]
  1 │ [a, b] = [a, c]
    ·           ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:13]
  1 │ [a, b] = [, b]
    ·             ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:14]
  1 │ [a, ...b] = [a, ...b]
    ·              ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:16]
  1 │ [[a], {b}] = [[a], {b}]
    ·                ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ [[a], {b}] = [[a], {b}]
    ·                     ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ ({a} = {a})
    ·         ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a: b} = {a: b})
    ·               ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:19]
  1 │ ({'a': b} = {'a': b})
    ·                   ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({a: b} = {'a': b})
    ·                 ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({'a': b} = {a: b})
    ·                 ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({1: b} = {1: b})
    ·               ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({1: b} = {'1': b})
    ·                 ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({'1': b} = {1: b})
    ·                 ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:19]
  1 │ ({['a']: b} = {a: b})
    ·                   ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ ({'a': b} = {[`a`]: b})
    ·                     ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:17]
  1 │ ({1: b} = {[1]: b})
    ·                 ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ ({a, b} = {a, b})
    ·            ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {a, b})
    ·               ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {b, a})
    ·               ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ ({a, b} = {b, a})
    ·            ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:15]
  1 │ ({a, b} = {c, a})
    ·               ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:26]
  1 │ ({a: {b}, c: [d]} = {a: {b}, c: [d]})
    ·                          ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:34]
  1 │ ({a: {b}, c: [d]} = {a: {b}, c: [d]})
    ·                                  ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ ({a, b} = {a, ...x, b})
    ·                     ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a.b
    ·       ───
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ a.b.c = a.b.c
    ·         ─────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ a[b] = a[b]
    ·        ────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ a['b'] = a['b']
    ·          ──────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:3:5]
@@ -201,30 +233,35 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       'b'
  5 │ ╰─▶ ]
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a.b
    ·       ───
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:9]
  1 │ a.b.c = a.b.c
    ·         ─────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:8]
  1 │ a[b] = a[b]
    ·        ────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ a['b'] = a['b']
    ·          ──────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:3:5]
@@ -233,57 +270,67 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       'b'
  5 │ ╰─▶ ]
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:10]
  1 │ this.x = this.x
    ·          ──────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:21]
  1 │ a['/(?<zero>0)/'] = a[/(?<zero>0)/]
    ·                     ───────────────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:12]
  1 │ (a?.b).c = (a?.b).c
    ·            ────────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a.b = a?.b
    ·       ────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:41]
  1 │ class C { #field; foo() { this.#field = this.#field; } }
    ·                                         ───────────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:44]
  1 │ class C { #field; foo() { [this.#field] = [this.#field]; } }
    ·                                            ───────────
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a &&= a
    ·       ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a ||= a
    ·       ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.
 
   ⚠ eslint(no-self-assign): this expression is assigned to itself
    ╭─[no_self_assign.tsx:1:7]
  1 │ a ??= a
    ·       ─
    ╰────
+  help: Remove the self-assignment or assign to a different variable.

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_catch.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_catch.snap
@@ -13,6 +13,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  6 │         }
    ╰────
+  help: Remove the try/catch wrapper, since it does not provide any additional error handling or functionality.
 
   ⚠ eslint(no-useless-catch): Unnecessary catch clause
    ╭─[no_useless_catch.tsx:4:18]
@@ -25,6 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  6 │         } finally {
    ╰────
+  help: Remove the catch clause, since it does not provide any additional error handling or functionality beyond what the finalizer already provides.
 
   ⚠ eslint(no-useless-catch): Unnecessary try/catch wrapper
    ╭─[no_useless_catch.tsx:4:18]
@@ -38,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  7 │         }
    ╰────
+  help: Remove the try/catch wrapper, since it does not provide any additional error handling or functionality.
 
   ⚠ eslint(no-useless-catch): Unnecessary catch clause
    ╭─[no_useless_catch.tsx:4:18]
@@ -51,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── and re-thrown here
  7 │         } finally {
    ╰────
+  help: Remove the catch clause, since it does not provide any additional error handling or functionality beyond what the finalizer already provides.
 
   ⚠ eslint(no-useless-catch): Unnecessary try/catch wrapper
    ╭─[no_useless_catch.tsx:5:20]
@@ -63,3 +67,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ╰── and re-thrown here
  7 │           }
    ╰────
+  help: Remove the try/catch wrapper, since it does not provide any additional error handling or functionality.

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_promise_reject_errors.snap
@@ -7,108 +7,126 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.reject(5)
    · ─────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject('foo')
    · ─────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(`foo`)
    · ─────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(!foo)
    · ────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(void foo)
    · ────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject()
    · ────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(undefined)
    · ─────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject({ foo: 1 })
    · ──────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject([1, 2, 3])
    · ─────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject()
    · ────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:41]
  1 │ new Promise(function(resolve, reject) { reject() })
    ·                                         ────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(undefined)
    · ─────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject('foo', somethingElse)
    · ────────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:41]
  1 │ new Promise(function(resolve, reject) { reject(5) })
    ·                                         ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:36]
  1 │ new Promise((resolve, reject) => { reject(5) })
    ·                                    ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise((resolve, reject) => reject(5))
    ·                                  ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise((resolve, reject) => reject())
    ·                                  ────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:33]
  1 │ new Promise(function(yes, no) { no(5) })
    ·                                 ─────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:4:26]
@@ -117,135 +135,158 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────────────────────────
  5 │                 else resolve(file)
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:42]
  1 │ new Promise(({foo, bar, baz}, reject) => reject(5))
    ·                                          ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:40]
  1 │ new Promise(function(reject, reject) { reject(5) })
    ·                                        ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:40]
  1 │ new Promise(function(foo, arguments) { arguments(5) })
    ·                                        ────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:33]
  1 │ new Promise((foo, arguments) => arguments(5))
    ·                                 ────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:36]
  1 │ new Promise(function({}, reject) { reject(5) })
    ·                                    ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:29]
  1 │ new Promise(({}, reject) => reject(5))
    ·                             ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:47]
  1 │ new Promise((resolve, reject, somethingElse = reject(5)) => {})
    ·                                               ─────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject?.(5)
    · ───────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise?.reject(5)
    · ──────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise?.reject?.(5)
    · ────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ (Promise?.reject)(5)
    · ────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ (Promise?.reject)?.(5)
    · ──────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo += new Error())
    · ──────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo -= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo **= new Error())
    · ───────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo <<= new Error())
    · ───────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo |= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo &= new Error())
    · ──────────────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo && 5)
    · ────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:1]
  1 │ Promise.reject(foo &&= 5)
    · ─────────────────────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:43]
  1 │ new Promise(function (resolve, ...rest) { rest[0](5); });
    ·                                           ──────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.
 
   ⚠ eslint(prefer-promise-reject-errors): Expected the Promise rejection reason to be an Error
    ╭─[prefer_promise_reject_errors.tsx:1:34]
  1 │ new Promise(function (...rest) { rest[1](5); });
    ·                                  ──────────
    ╰────
+  help: Only pass an Error object to the reject() function for user-defined errors in Promises.


### PR DESCRIPTION
…sion, no_self_assign,

PR covers:

Add `.with_help()` to diagnostics that only provide a warning message, giving developers actionable guidance on how to resolve each issue.

Part of #19121

- `no_loss_of_precision`: Use a number literal that fits 64-bit floating-point precision
- `no_self_assign`: Remove the self-assignment or assign to a different variable
- `prefer_promise_reject_errors`: Pass an Error object to reject()
- `no_labels`: Refactor code to eliminate the need for labels
- `no_useless_catch`: Remove unnecessary try/catch wrapper or catch clause

  