### PR TITLE
fix(linter): warning `eslint/no-throw-literal` rule to be deprecated, better use `typescript/only-throw-error`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -22,6 +22,9 @@ declare_oxc_lint!(
     ///
     /// Disallows throwing literals or non-Error objects as exceptions.
     ///
+    /// WARNING: This rule has been deprecated, please instead use [typescript/only-throw-error](https://oxc.rs/docs/guide/usage/linter/rules/typescript/only-throw-error.html).
+    /// The typescript rule is more reliable than the Javascript version, as it has less false positive, and can catch more cases.
+    ///
     /// ### Why is this bad?
     ///
     /// It is considered good practice to only throw the Error object itself or an object using

--- a/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_throw_literal.rs
@@ -22,7 +22,8 @@ declare_oxc_lint!(
     ///
     /// Disallows throwing literals or non-Error objects as exceptions.
     ///
-    /// WARNING: This rule has been deprecated, please instead use [typescript/only-throw-error](https://oxc.rs/docs/guide/usage/linter/rules/typescript/only-throw-error.html).
+    /// ::: warning
+    /// This rule has been deprecated, please instead use [typescript/only-throw-error](https://oxc.rs/docs/guide/usage/linter/rules/typescript/only-throw-error.html).
     /// The typescript rule is more reliable than the Javascript version, as it has less false positive, and can catch more cases.
     ///
     /// ### Why is this bad?


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/19537