### PR TITLE
fix(react/display-name): handle merged type+value context symbols

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_display_name.snap
+++ b/crates/oxc_linter/src/snapshots/react_display_name.snap
@@ -344,6 +344,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Add a `displayName` property to the context.
 
   ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
+   ╭─[display_name.tsx:8:27]
+ 7 │ 
+ 8 │                     const PostHogGroupContext = createContext<PostHogGroupContext | null>(null);
+   ·                           ───────────────────
+ 9 │                   
+   ╰────
+  help: Add a `displayName` property to the context.
+
+  ⚠ eslint-plugin-react(display-name): Context definition is missing display name.
    ╭─[display_name.tsx:5:21]
  4 │                     var Hello;
  5 │                     Hello = createContext();


### PR DESCRIPTION
## Summary
- scan all symbol redeclarations in `react/display-name` when detecting components/context objects
- keep existing displayName assignment checks, but avoid missing value declarations hidden behind TS type redeclarations
- add a regression test for `interface` + `const` sharing the same context name

Fixes #19607
