### PR TITLE
fix(linter/no-unused-vars): allow unused type params in ambient module blocks

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -159,6 +159,20 @@ impl NoUnusedVars {
             return true;
         }
 
+        let is_interface_type_parameter = match nodes.parent_kind(declaration_id) {
+            AstKind::TSInterfaceDeclaration(_) => true,
+            AstKind::TSTypeParameterDeclaration(_) => {
+                matches!(
+                    nodes.parent_kind(nodes.parent_id(declaration_id)),
+                    AstKind::TSInterfaceDeclaration(_)
+                )
+            }
+            _ => false,
+        };
+        if !is_interface_type_parameter {
+            return false;
+        }
+
         // type parameters used within type declarations in ambient ts module
         // blocks are required for declaration merging to work, since signatures
         // must match.

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1246,9 +1246,26 @@ fn test_namespaces() {
         export { Foo }
         ",
         "declare module 'tsdown' { function bar(): void; }",
+        "
+        declare module 'vitest' {
+            interface Matchers<T> {
+                toBeFoo(value: unknown): unknown;
+            }
+        }
+        ",
     ];
 
-    let fail = vec!["namespace N {}", "export namespace N { function foo() }"];
+    let fail = vec![
+        "namespace N {}",
+        "export namespace N { function foo() }",
+        "
+        export namespace NonAmbientModuleDeclaration {
+            export interface Matchers<T> extends MatcherOverride {
+                toBeFoo(value: unknown): unknown;
+            }
+        }
+        ",
+    ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
         .intentionally_allow_no_fix_tests()

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1265,6 +1265,8 @@ fn test_namespaces() {
             }
         }
         ",
+        "declare module 'bun:test' { type Matchers2<T> = {} }",
+        "declare module 'bun:test' { class MyClass<T> {} }",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint(no-unused-vars): Variable 'N' is declared but never used.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ namespace N {}
@@ -24,5 +25,29 @@ source: crates/oxc_linter/src/tester.rs
    ·                                       ┬
    ·                                       ╰── 'T' is declared here
  4 │                 toBeFoo(value: unknown): unknown;
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+   ╭─[no_unused_vars.tsx:1:44]
+ 1 │ declare module 'bun:test' { type Matchers2<T> = {} }
+   ·                                            ┬
+   ·                                            ╰── 'T' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Class 'MyClass' is declared but never used.
+   ╭─[no_unused_vars.tsx:1:35]
+ 1 │ declare module 'bun:test' { class MyClass<T> {} }
+   ·                                   ───┬───
+   ·                                      ╰── 'MyClass' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+   ╭─[no_unused_vars.tsx:1:43]
+ 1 │ declare module 'bun:test' { class MyClass<T> {} }
+   ·                                           ┬
+   ·                                           ╰── 'T' is declared here
    ╰────
   help: Consider removing this declaration.

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint(no-unused-vars): Variable 'N' is declared but never used.
    ╭─[no_unused_vars.tsx:1:11]
  1 │ namespace N {}
@@ -15,5 +14,15 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export namespace N { function foo() }
    ·                               ─┬─
    ·                                ╰── 'foo' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+   ╭─[no_unused_vars.tsx:3:39]
+ 2 │         export namespace NonAmbientModuleDeclaration {
+ 3 │             export interface Matchers<T> extends MatcherOverride {
+   ·                                       ┬
+   ·                                       ╰── 'T' is declared here
+ 4 │                 toBeFoo(value: unknown): unknown;
    ╰────
   help: Consider removing this declaration.


### PR DESCRIPTION
## What This PR Does

Fixes a bug in `eslint/no-unused-vars` where type parameters used in merged interfaces were marked as unused.

### Example
```ts
declare module 'bun:test' {
  // `T` is marked as unused, but removing it causes a type error.
  // This PR flags this param as allowed.
  interface Matchers<T> {
    toBeFoo(value: unknown): unknown;
  }
}
```