### PR TITLE
docs(linter): Add `import/order` rule to unsupported rules list.

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -38,6 +38,7 @@
     "import/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
     "n/no-restricted-import": "No need to implement, already implemented by `no-restricted-imports` rule.",
     "n/no-restricted-require": "No need to implement, already implemented by `no-restricted-imports` rule.",
+    "import/order": "Not implementing this in Oxlint as its behavior is covered very well by [Oxfmt's import sorting](https://oxc.rs/docs/guide/usage/formatter/sorting.html).",
 
     "jsdoc/type-formatting": "Experimental rule in the original plugin, may reconsider once stable.",
     "jsdoc/convert-to-jsdoc-comments": "Experimental rule in the original plugin, may reconsider once stable.",


### PR DESCRIPTION
We are not going to implement the rule, as it's incredibly complex and its behavior is already covered very well by Oxfmt's import sorting. There's no good reason for us to implement the same complex behavior twice.