### PR TITLE
fix(linter): no-duplicates false positive for type + side-effect imports with prefer-inline

### DIFF
--- a/crates/oxc_linter/src/snapshots/import_no_duplicates.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_duplicates.snap
@@ -580,3 +580,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ╰── It is first imported here
    ╰────
   help: Merge these imports into a single import statement
+
+  ⚠ eslint-plugin-import(no-duplicates): Module './foo' is imported more than once in this file
+   ╭─[index.ts:1:8]
+ 1 │ import './foo'; import { x } from './foo'
+   ·        ───┬───                    ───────
+   ·           ╰── It is first imported here
+   ╰────
+  help: Merge these imports into a single import statement


### PR DESCRIPTION
## Summary

Fixes #19632

When `prefer-inline: true`, the `import/no-duplicates` rule incorrectly flags a type-only import alongside a side-effect import as duplicates:

```ts
import type { Foo } from "./foo";
import "./foo"; // false positive
```

These can't be merged — `import type` is erased at runtime (especially with `verbatimModuleSyntax`), while the side-effect import triggers module evaluation.

The root cause: with `prefer-inline`, type-named imports are bucketed alongside value imports (bucket 0), and side-effect imports (no specifiers) were also in bucket 0. This gives them a separate bucket so they don't collide with type-only imports, while still correctly flagging `import "./foo"; import { x } from "./foo"` as duplicates.