### PR TITLE
test(estree/tokens): do not skip tokens conformance tests for files with hashbangs

### DIFF
--- a/tasks/coverage/snapshots/estree_test262_tokens.snap
+++ b/tasks/coverage/snapshots/estree_test262_tokens.snap
@@ -1,5 +1,5 @@
 commit: 3aa9cb2c
 
 estree_test262_tokens Summary:
-AST Parsed     : 46532/46532 (100.00%)
-Positive Passed: 46532/46532 (100.00%)
+AST Parsed     : 46542/46542 (100.00%)
+Positive Passed: 46542/46542 (100.00%)

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -825,9 +825,6 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
             if should_fail {
                 return false;
             }
-            if f.path.starts_with("test262/test/language/comments/hashbang/") {
-                return false;
-            }
             workspace_root()
                 .join("estree-conformance/tests/test262-tokens")
                 .join(f.path.strip_prefix("test262/").unwrap_or(&f.path))


### PR DESCRIPTION
We were skipping some ESTree tokens conformance tests for files containing hashbangs. We have to skip these tests for ESTree AST tests due to our non-standard `hashbang` field on `Program`, but we don't have to skip them for tokens tests - hashbangs are handled correctly.