### PR TITLE
feat(linter): Implement react/prefer-function-component

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2347,6 +2347,11 @@ impl RuleRunner for crate::rules::jest::valid_title::ValidTitle {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::react::prefer_function_component::PreferFunctionComponent {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2347,11 +2347,6 @@ impl RuleRunner for crate::rules::jest::valid_title::ValidTitle {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
-impl RuleRunner for crate::rules::react::prefer_function_component::PreferFunctionComponent {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));
@@ -2645,6 +2640,12 @@ impl RuleRunner for crate::rules::react::only_export_components::OnlyExportCompo
 impl RuleRunner for crate::rules::react::prefer_es6_class::PreferEs6Class {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::react::prefer_function_component::PreferFunctionComponent {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1093,7 +1093,6 @@ pub enum RuleEnum {
     JestValidDescribeCallback(JestValidDescribeCallback),
     JestValidExpect(JestValidExpect),
     JestValidTitle(JestValidTitle),
-    ReactPreferFunctionComponent(ReactPreferFunctionComponent),
     ReactButtonHasType(ReactButtonHasType),
     ReactCheckedRequiresOnchangeOrReadonly(ReactCheckedRequiresOnchangeOrReadonly),
     ReactDisplayName(ReactDisplayName),
@@ -1142,6 +1141,7 @@ pub enum RuleEnum {
     ReactNoWillUpdateSetState(ReactNoWillUpdateSetState),
     ReactOnlyExportComponents(ReactOnlyExportComponents),
     ReactPreferEs6Class(ReactPreferEs6Class),
+    ReactPreferFunctionComponent(ReactPreferFunctionComponent),
     ReactReactInJsxScope(ReactReactInJsxScope),
     ReactRequireRenderReturn(ReactRequireRenderReturn),
     ReactRulesOfHooks(ReactRulesOfHooks),
@@ -1849,8 +1849,7 @@ const JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = JEST_REQUIRE_TO_THROW_MESSAGE_
 const JEST_VALID_DESCRIBE_CALLBACK_ID: usize = JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const JEST_VALID_EXPECT_ID: usize = JEST_VALID_DESCRIBE_CALLBACK_ID + 1usize;
 const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
-const REACT_PREFER_FUNCTION_COMPONENT_ID: usize = JEST_VALID_TITLE_ID + 1usize;
-const REACT_BUTTON_HAS_TYPE_ID: usize = REACT_PREFER_FUNCTION_COMPONENT_ID + 1usize;
+const REACT_BUTTON_HAS_TYPE_ID: usize = JEST_VALID_TITLE_ID + 1usize;
 const REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID: usize = REACT_BUTTON_HAS_TYPE_ID + 1usize;
 const REACT_DISPLAY_NAME_ID: usize = REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
 const REACT_EXHAUSTIVE_DEPS_ID: usize = REACT_DISPLAY_NAME_ID + 1usize;
@@ -1900,7 +1899,8 @@ const REACT_NO_UNSAFE_ID: usize = REACT_NO_UNKNOWN_PROPERTY_ID + 1usize;
 const REACT_NO_WILL_UPDATE_SET_STATE_ID: usize = REACT_NO_UNSAFE_ID + 1usize;
 const REACT_ONLY_EXPORT_COMPONENTS_ID: usize = REACT_NO_WILL_UPDATE_SET_STATE_ID + 1usize;
 const REACT_PREFER_ES_6_CLASS_ID: usize = REACT_ONLY_EXPORT_COMPONENTS_ID + 1usize;
-const REACT_REACT_IN_JSX_SCOPE_ID: usize = REACT_PREFER_ES_6_CLASS_ID + 1usize;
+const REACT_PREFER_FUNCTION_COMPONENT_ID: usize = REACT_PREFER_ES_6_CLASS_ID + 1usize;
+const REACT_REACT_IN_JSX_SCOPE_ID: usize = REACT_PREFER_FUNCTION_COMPONENT_ID + 1usize;
 const REACT_REQUIRE_RENDER_RETURN_ID: usize = REACT_REACT_IN_JSX_SCOPE_ID + 1usize;
 const REACT_RULES_OF_HOOKS_ID: usize = REACT_REQUIRE_RENDER_RETURN_ID + 1usize;
 const REACT_SELF_CLOSING_COMP_ID: usize = REACT_RULES_OF_HOOKS_ID + 1usize;
@@ -2667,7 +2667,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JEST_VALID_DESCRIBE_CALLBACK_ID,
             Self::JestValidExpect(_) => JEST_VALID_EXPECT_ID,
             Self::JestValidTitle(_) => JEST_VALID_TITLE_ID,
-            Self::ReactPreferFunctionComponent(_) => REACT_PREFER_FUNCTION_COMPONENT_ID,
             Self::ReactButtonHasType(_) => REACT_BUTTON_HAS_TYPE_ID,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID
@@ -2722,6 +2721,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => REACT_NO_WILL_UPDATE_SET_STATE_ID,
             Self::ReactOnlyExportComponents(_) => REACT_ONLY_EXPORT_COMPONENTS_ID,
             Self::ReactPreferEs6Class(_) => REACT_PREFER_ES_6_CLASS_ID,
+            Self::ReactPreferFunctionComponent(_) => REACT_PREFER_FUNCTION_COMPONENT_ID,
             Self::ReactReactInJsxScope(_) => REACT_REACT_IN_JSX_SCOPE_ID,
             Self::ReactRequireRenderReturn(_) => REACT_REQUIRE_RENDER_RETURN_ID,
             Self::ReactRulesOfHooks(_) => REACT_RULES_OF_HOOKS_ID,
@@ -3483,7 +3483,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::NAME,
             Self::JestValidExpect(_) => JestValidExpect::NAME,
             Self::JestValidTitle(_) => JestValidTitle::NAME,
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::NAME,
             Self::ReactButtonHasType(_) => ReactButtonHasType::NAME,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::NAME
@@ -3536,6 +3535,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::NAME,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::NAME,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::NAME,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::NAME,
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::NAME,
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::NAME,
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::NAME,
@@ -4315,7 +4315,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::CATEGORY,
             Self::JestValidExpect(_) => JestValidExpect::CATEGORY,
             Self::JestValidTitle(_) => JestValidTitle::CATEGORY,
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::CATEGORY,
             Self::ReactButtonHasType(_) => ReactButtonHasType::CATEGORY,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::CATEGORY
@@ -4370,6 +4369,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::CATEGORY,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::CATEGORY,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::CATEGORY,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::CATEGORY,
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::CATEGORY,
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::CATEGORY,
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::CATEGORY,
@@ -5150,7 +5150,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::FIX,
             Self::JestValidExpect(_) => JestValidExpect::FIX,
             Self::JestValidTitle(_) => JestValidTitle::FIX,
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::FIX,
             Self::ReactButtonHasType(_) => ReactButtonHasType::FIX,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::FIX
@@ -5203,6 +5202,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::FIX,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::FIX,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::FIX,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::FIX,
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::FIX,
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::FIX,
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::FIX,
@@ -6055,7 +6055,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::documentation(),
             Self::JestValidExpect(_) => JestValidExpect::documentation(),
             Self::JestValidTitle(_) => JestValidTitle::documentation(),
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::documentation(),
             Self::ReactButtonHasType(_) => ReactButtonHasType::documentation(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::documentation()
@@ -6110,6 +6109,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::documentation(),
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::documentation(),
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::documentation(),
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::documentation(),
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::documentation(),
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::documentation(),
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::documentation(),
@@ -7581,10 +7581,6 @@ impl RuleEnum {
                 .or_else(|| JestValidExpect::schema(generator)),
             Self::JestValidTitle(_) => JestValidTitle::config_schema(generator)
                 .or_else(|| JestValidTitle::schema(generator)),
-            Self::ReactPreferFunctionComponent(_) => {
-                ReactPreferFunctionComponent::config_schema(generator)
-                    .or_else(|| ReactPreferFunctionComponent::schema(generator))
-            }
             Self::ReactButtonHasType(_) => ReactButtonHasType::config_schema(generator)
                 .or_else(|| ReactButtonHasType::schema(generator)),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -7710,6 +7706,10 @@ impl RuleEnum {
             }
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::config_schema(generator)
                 .or_else(|| ReactPreferEs6Class::schema(generator)),
+            Self::ReactPreferFunctionComponent(_) => {
+                ReactPreferFunctionComponent::config_schema(generator)
+                    .or_else(|| ReactPreferFunctionComponent::schema(generator))
+            }
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::config_schema(generator)
                 .or_else(|| ReactReactInJsxScope::schema(generator)),
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::config_schema(generator)
@@ -8928,7 +8928,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => "jest",
             Self::JestValidExpect(_) => "jest",
             Self::JestValidTitle(_) => "jest",
-            Self::ReactPreferFunctionComponent(_) => "react",
             Self::ReactButtonHasType(_) => "react",
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => "react",
             Self::ReactDisplayName(_) => "react",
@@ -8977,6 +8976,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => "react",
             Self::ReactOnlyExportComponents(_) => "react",
             Self::ReactPreferEs6Class(_) => "react",
+            Self::ReactPreferFunctionComponent(_) => "react",
             Self::ReactReactInJsxScope(_) => "react",
             Self::ReactRequireRenderReturn(_) => "react",
             Self::ReactRulesOfHooks(_) => "react",
@@ -10459,9 +10459,6 @@ impl RuleEnum {
             Self::JestValidTitle(_) => {
                 Ok(Self::JestValidTitle(JestValidTitle::from_configuration(value)?))
             }
-            Self::ReactPreferFunctionComponent(_) => Ok(Self::ReactPreferFunctionComponent(
-                ReactPreferFunctionComponent::from_configuration(value)?,
-            )),
             Self::ReactButtonHasType(_) => {
                 Ok(Self::ReactButtonHasType(ReactButtonHasType::from_configuration(value)?))
             }
@@ -10610,6 +10607,9 @@ impl RuleEnum {
             Self::ReactPreferEs6Class(_) => {
                 Ok(Self::ReactPreferEs6Class(ReactPreferEs6Class::from_configuration(value)?))
             }
+            Self::ReactPreferFunctionComponent(_) => Ok(Self::ReactPreferFunctionComponent(
+                ReactPreferFunctionComponent::from_configuration(value)?,
+            )),
             Self::ReactReactInJsxScope(_) => {
                 Ok(Self::ReactReactInJsxScope(ReactReactInJsxScope::from_configuration(value)?))
             }
@@ -11921,7 +11921,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.to_configuration(),
             Self::JestValidExpect(rule) => rule.to_configuration(),
             Self::JestValidTitle(rule) => rule.to_configuration(),
-            Self::ReactPreferFunctionComponent(rule) => rule.to_configuration(),
             Self::ReactButtonHasType(rule) => rule.to_configuration(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.to_configuration(),
             Self::ReactDisplayName(rule) => rule.to_configuration(),
@@ -11970,6 +11969,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.to_configuration(),
             Self::ReactOnlyExportComponents(rule) => rule.to_configuration(),
             Self::ReactPreferEs6Class(rule) => rule.to_configuration(),
+            Self::ReactPreferFunctionComponent(rule) => rule.to_configuration(),
             Self::ReactReactInJsxScope(rule) => rule.to_configuration(),
             Self::ReactRequireRenderReturn(rule) => rule.to_configuration(),
             Self::ReactRulesOfHooks(rule) => rule.to_configuration(),
@@ -12635,7 +12635,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run(node, ctx),
             Self::JestValidExpect(rule) => rule.run(node, ctx),
             Self::JestValidTitle(rule) => rule.run(node, ctx),
-            Self::ReactPreferFunctionComponent(rule) => rule.run(node, ctx),
             Self::ReactButtonHasType(rule) => rule.run(node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
             Self::ReactDisplayName(rule) => rule.run(node, ctx),
@@ -12684,6 +12683,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.run(node, ctx),
             Self::ReactOnlyExportComponents(rule) => rule.run(node, ctx),
             Self::ReactPreferEs6Class(rule) => rule.run(node, ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run(node, ctx),
             Self::ReactReactInJsxScope(rule) => rule.run(node, ctx),
             Self::ReactRequireRenderReturn(rule) => rule.run(node, ctx),
             Self::ReactRulesOfHooks(rule) => rule.run(node, ctx),
@@ -13347,7 +13347,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_once(ctx),
             Self::JestValidExpect(rule) => rule.run_once(ctx),
             Self::JestValidTitle(rule) => rule.run_once(ctx),
-            Self::ReactPreferFunctionComponent(rule) => rule.run_once(ctx),
             Self::ReactButtonHasType(rule) => rule.run_once(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
             Self::ReactDisplayName(rule) => rule.run_once(ctx),
@@ -13396,6 +13395,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.run_once(ctx),
             Self::ReactOnlyExportComponents(rule) => rule.run_once(ctx),
             Self::ReactPreferEs6Class(rule) => rule.run_once(ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_once(ctx),
             Self::ReactReactInJsxScope(rule) => rule.run_once(ctx),
             Self::ReactRequireRenderReturn(rule) => rule.run_once(ctx),
             Self::ReactRulesOfHooks(rule) => rule.run_once(ctx),
@@ -14127,7 +14127,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
-            Self::ReactPreferFunctionComponent(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactButtonHasType(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
@@ -14180,6 +14179,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactOnlyExportComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPreferEs6Class(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactReactInJsxScope(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactRequireRenderReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactRulesOfHooks(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14871,7 +14871,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.should_run(ctx),
             Self::JestValidExpect(rule) => rule.should_run(ctx),
             Self::JestValidTitle(rule) => rule.should_run(ctx),
-            Self::ReactPreferFunctionComponent(rule) => rule.should_run(ctx),
             Self::ReactButtonHasType(rule) => rule.should_run(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.should_run(ctx),
             Self::ReactDisplayName(rule) => rule.should_run(ctx),
@@ -14920,6 +14919,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.should_run(ctx),
             Self::ReactOnlyExportComponents(rule) => rule.should_run(ctx),
             Self::ReactPreferEs6Class(rule) => rule.should_run(ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.should_run(ctx),
             Self::ReactReactInJsxScope(rule) => rule.should_run(ctx),
             Self::ReactRequireRenderReturn(rule) => rule.should_run(ctx),
             Self::ReactRulesOfHooks(rule) => rule.should_run(ctx),
@@ -15743,7 +15743,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::IS_TSGOLINT_RULE,
             Self::JestValidExpect(_) => JestValidExpect::IS_TSGOLINT_RULE,
             Self::JestValidTitle(_) => JestValidTitle::IS_TSGOLINT_RULE,
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::IS_TSGOLINT_RULE,
             Self::ReactButtonHasType(_) => ReactButtonHasType::IS_TSGOLINT_RULE,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::IS_TSGOLINT_RULE
@@ -15798,6 +15797,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::IS_TSGOLINT_RULE,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::IS_TSGOLINT_RULE,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::IS_TSGOLINT_RULE,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::IS_TSGOLINT_RULE,
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::IS_TSGOLINT_RULE,
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::IS_TSGOLINT_RULE,
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::IS_TSGOLINT_RULE,
@@ -16700,7 +16700,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::HAS_CONFIG,
             Self::JestValidExpect(_) => JestValidExpect::HAS_CONFIG,
             Self::JestValidTitle(_) => JestValidTitle::HAS_CONFIG,
-            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::HAS_CONFIG,
             Self::ReactButtonHasType(_) => ReactButtonHasType::HAS_CONFIG,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::HAS_CONFIG
@@ -16755,6 +16754,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(_) => ReactNoWillUpdateSetState::HAS_CONFIG,
             Self::ReactOnlyExportComponents(_) => ReactOnlyExportComponents::HAS_CONFIG,
             Self::ReactPreferEs6Class(_) => ReactPreferEs6Class::HAS_CONFIG,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::HAS_CONFIG,
             Self::ReactReactInJsxScope(_) => ReactReactInJsxScope::HAS_CONFIG,
             Self::ReactRequireRenderReturn(_) => ReactRequireRenderReturn::HAS_CONFIG,
             Self::ReactRulesOfHooks(_) => ReactRulesOfHooks::HAS_CONFIG,
@@ -17482,7 +17482,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.types_info(),
             Self::JestValidExpect(rule) => rule.types_info(),
             Self::JestValidTitle(rule) => rule.types_info(),
-            Self::ReactPreferFunctionComponent(rule) => rule.types_info(),
             Self::ReactButtonHasType(rule) => rule.types_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.types_info(),
             Self::ReactDisplayName(rule) => rule.types_info(),
@@ -17531,6 +17530,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.types_info(),
             Self::ReactOnlyExportComponents(rule) => rule.types_info(),
             Self::ReactPreferEs6Class(rule) => rule.types_info(),
+            Self::ReactPreferFunctionComponent(rule) => rule.types_info(),
             Self::ReactReactInJsxScope(rule) => rule.types_info(),
             Self::ReactRequireRenderReturn(rule) => rule.types_info(),
             Self::ReactRulesOfHooks(rule) => rule.types_info(),
@@ -18194,7 +18194,6 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_info(),
             Self::JestValidExpect(rule) => rule.run_info(),
             Self::JestValidTitle(rule) => rule.run_info(),
-            Self::ReactPreferFunctionComponent(rule) => rule.run_info(),
             Self::ReactButtonHasType(rule) => rule.run_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_info(),
             Self::ReactDisplayName(rule) => rule.run_info(),
@@ -18243,6 +18242,7 @@ impl RuleEnum {
             Self::ReactNoWillUpdateSetState(rule) => rule.run_info(),
             Self::ReactOnlyExportComponents(rule) => rule.run_info(),
             Self::ReactPreferEs6Class(rule) => rule.run_info(),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_info(),
             Self::ReactReactInJsxScope(rule) => rule.run_info(),
             Self::ReactRequireRenderReturn(rule) => rule.run_info(),
             Self::ReactRulesOfHooks(rule) => rule.run_info(),
@@ -18992,7 +18992,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestValidDescribeCallback(JestValidDescribeCallback::default()),
         RuleEnum::JestValidExpect(JestValidExpect::default()),
         RuleEnum::JestValidTitle(JestValidTitle::default()),
-        RuleEnum::ReactPreferFunctionComponent(ReactPreferFunctionComponent::default()),
         RuleEnum::ReactButtonHasType(ReactButtonHasType::default()),
         RuleEnum::ReactCheckedRequiresOnchangeOrReadonly(
             ReactCheckedRequiresOnchangeOrReadonly::default(),
@@ -19045,6 +19044,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactNoWillUpdateSetState(ReactNoWillUpdateSetState::default()),
         RuleEnum::ReactOnlyExportComponents(ReactOnlyExportComponents::default()),
         RuleEnum::ReactPreferEs6Class(ReactPreferEs6Class::default()),
+        RuleEnum::ReactPreferFunctionComponent(ReactPreferFunctionComponent::default()),
         RuleEnum::ReactReactInJsxScope(ReactReactInJsxScope::default()),
         RuleEnum::ReactRequireRenderReturn(ReactRequireRenderReturn::default()),
         RuleEnum::ReactRulesOfHooks(ReactRulesOfHooks::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -432,6 +432,7 @@ pub use crate::rules::react::no_unsafe::NoUnsafe as ReactNoUnsafe;
 pub use crate::rules::react::no_will_update_set_state::NoWillUpdateSetState as ReactNoWillUpdateSetState;
 pub use crate::rules::react::only_export_components::OnlyExportComponents as ReactOnlyExportComponents;
 pub use crate::rules::react::prefer_es6_class::PreferEs6Class as ReactPreferEs6Class;
+pub use crate::rules::react::prefer_function_component::PreferFunctionComponent as ReactPreferFunctionComponent;
 pub use crate::rules::react::react_in_jsx_scope::ReactInJsxScope as ReactReactInJsxScope;
 pub use crate::rules::react::require_render_return::RequireRenderReturn as ReactRequireRenderReturn;
 pub use crate::rules::react::rules_of_hooks::RulesOfHooks as ReactRulesOfHooks;
@@ -1092,6 +1093,7 @@ pub enum RuleEnum {
     JestValidDescribeCallback(JestValidDescribeCallback),
     JestValidExpect(JestValidExpect),
     JestValidTitle(JestValidTitle),
+    ReactPreferFunctionComponent(ReactPreferFunctionComponent),
     ReactButtonHasType(ReactButtonHasType),
     ReactCheckedRequiresOnchangeOrReadonly(ReactCheckedRequiresOnchangeOrReadonly),
     ReactDisplayName(ReactDisplayName),
@@ -1847,7 +1849,8 @@ const JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = JEST_REQUIRE_TO_THROW_MESSAGE_
 const JEST_VALID_DESCRIBE_CALLBACK_ID: usize = JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const JEST_VALID_EXPECT_ID: usize = JEST_VALID_DESCRIBE_CALLBACK_ID + 1usize;
 const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
-const REACT_BUTTON_HAS_TYPE_ID: usize = JEST_VALID_TITLE_ID + 1usize;
+const REACT_PREFER_FUNCTION_COMPONENT_ID: usize = JEST_VALID_TITLE_ID + 1usize;
+const REACT_BUTTON_HAS_TYPE_ID: usize = REACT_PREFER_FUNCTION_COMPONENT_ID + 1usize;
 const REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID: usize = REACT_BUTTON_HAS_TYPE_ID + 1usize;
 const REACT_DISPLAY_NAME_ID: usize = REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
 const REACT_EXHAUSTIVE_DEPS_ID: usize = REACT_DISPLAY_NAME_ID + 1usize;
@@ -2664,6 +2667,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JEST_VALID_DESCRIBE_CALLBACK_ID,
             Self::JestValidExpect(_) => JEST_VALID_EXPECT_ID,
             Self::JestValidTitle(_) => JEST_VALID_TITLE_ID,
+            Self::ReactPreferFunctionComponent(_) => REACT_PREFER_FUNCTION_COMPONENT_ID,
             Self::ReactButtonHasType(_) => REACT_BUTTON_HAS_TYPE_ID,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID
@@ -3479,6 +3483,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::NAME,
             Self::JestValidExpect(_) => JestValidExpect::NAME,
             Self::JestValidTitle(_) => JestValidTitle::NAME,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::NAME,
             Self::ReactButtonHasType(_) => ReactButtonHasType::NAME,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::NAME
@@ -4310,6 +4315,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::CATEGORY,
             Self::JestValidExpect(_) => JestValidExpect::CATEGORY,
             Self::JestValidTitle(_) => JestValidTitle::CATEGORY,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::CATEGORY,
             Self::ReactButtonHasType(_) => ReactButtonHasType::CATEGORY,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::CATEGORY
@@ -5144,6 +5150,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::FIX,
             Self::JestValidExpect(_) => JestValidExpect::FIX,
             Self::JestValidTitle(_) => JestValidTitle::FIX,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::FIX,
             Self::ReactButtonHasType(_) => ReactButtonHasType::FIX,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::FIX
@@ -6048,6 +6055,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::documentation(),
             Self::JestValidExpect(_) => JestValidExpect::documentation(),
             Self::JestValidTitle(_) => JestValidTitle::documentation(),
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::documentation(),
             Self::ReactButtonHasType(_) => ReactButtonHasType::documentation(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::documentation()
@@ -7573,6 +7581,10 @@ impl RuleEnum {
                 .or_else(|| JestValidExpect::schema(generator)),
             Self::JestValidTitle(_) => JestValidTitle::config_schema(generator)
                 .or_else(|| JestValidTitle::schema(generator)),
+            Self::ReactPreferFunctionComponent(_) => {
+                ReactPreferFunctionComponent::config_schema(generator)
+                    .or_else(|| ReactPreferFunctionComponent::schema(generator))
+            }
             Self::ReactButtonHasType(_) => ReactButtonHasType::config_schema(generator)
                 .or_else(|| ReactButtonHasType::schema(generator)),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -8916,6 +8928,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => "jest",
             Self::JestValidExpect(_) => "jest",
             Self::JestValidTitle(_) => "jest",
+            Self::ReactPreferFunctionComponent(_) => "react",
             Self::ReactButtonHasType(_) => "react",
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => "react",
             Self::ReactDisplayName(_) => "react",
@@ -10446,6 +10459,9 @@ impl RuleEnum {
             Self::JestValidTitle(_) => {
                 Ok(Self::JestValidTitle(JestValidTitle::from_configuration(value)?))
             }
+            Self::ReactPreferFunctionComponent(_) => Ok(Self::ReactPreferFunctionComponent(
+                ReactPreferFunctionComponent::from_configuration(value)?,
+            )),
             Self::ReactButtonHasType(_) => {
                 Ok(Self::ReactButtonHasType(ReactButtonHasType::from_configuration(value)?))
             }
@@ -11905,6 +11921,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.to_configuration(),
             Self::JestValidExpect(rule) => rule.to_configuration(),
             Self::JestValidTitle(rule) => rule.to_configuration(),
+            Self::ReactPreferFunctionComponent(rule) => rule.to_configuration(),
             Self::ReactButtonHasType(rule) => rule.to_configuration(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.to_configuration(),
             Self::ReactDisplayName(rule) => rule.to_configuration(),
@@ -12618,6 +12635,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run(node, ctx),
             Self::JestValidExpect(rule) => rule.run(node, ctx),
             Self::JestValidTitle(rule) => rule.run(node, ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run(node, ctx),
             Self::ReactButtonHasType(rule) => rule.run(node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
             Self::ReactDisplayName(rule) => rule.run(node, ctx),
@@ -13329,6 +13347,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_once(ctx),
             Self::JestValidExpect(rule) => rule.run_once(ctx),
             Self::JestValidTitle(rule) => rule.run_once(ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_once(ctx),
             Self::ReactButtonHasType(rule) => rule.run_once(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
             Self::ReactDisplayName(rule) => rule.run_once(ctx),
@@ -14108,6 +14127,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactButtonHasType(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
@@ -14851,6 +14871,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.should_run(ctx),
             Self::JestValidExpect(rule) => rule.should_run(ctx),
             Self::JestValidTitle(rule) => rule.should_run(ctx),
+            Self::ReactPreferFunctionComponent(rule) => rule.should_run(ctx),
             Self::ReactButtonHasType(rule) => rule.should_run(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.should_run(ctx),
             Self::ReactDisplayName(rule) => rule.should_run(ctx),
@@ -15722,6 +15743,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::IS_TSGOLINT_RULE,
             Self::JestValidExpect(_) => JestValidExpect::IS_TSGOLINT_RULE,
             Self::JestValidTitle(_) => JestValidTitle::IS_TSGOLINT_RULE,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::IS_TSGOLINT_RULE,
             Self::ReactButtonHasType(_) => ReactButtonHasType::IS_TSGOLINT_RULE,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::IS_TSGOLINT_RULE
@@ -16678,6 +16700,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::HAS_CONFIG,
             Self::JestValidExpect(_) => JestValidExpect::HAS_CONFIG,
             Self::JestValidTitle(_) => JestValidTitle::HAS_CONFIG,
+            Self::ReactPreferFunctionComponent(_) => ReactPreferFunctionComponent::HAS_CONFIG,
             Self::ReactButtonHasType(_) => ReactButtonHasType::HAS_CONFIG,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::HAS_CONFIG
@@ -17459,6 +17482,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.types_info(),
             Self::JestValidExpect(rule) => rule.types_info(),
             Self::JestValidTitle(rule) => rule.types_info(),
+            Self::ReactPreferFunctionComponent(rule) => rule.types_info(),
             Self::ReactButtonHasType(rule) => rule.types_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.types_info(),
             Self::ReactDisplayName(rule) => rule.types_info(),
@@ -18170,6 +18194,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_info(),
             Self::JestValidExpect(rule) => rule.run_info(),
             Self::JestValidTitle(rule) => rule.run_info(),
+            Self::ReactPreferFunctionComponent(rule) => rule.run_info(),
             Self::ReactButtonHasType(rule) => rule.run_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_info(),
             Self::ReactDisplayName(rule) => rule.run_info(),
@@ -18967,6 +18992,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestValidDescribeCallback(JestValidDescribeCallback::default()),
         RuleEnum::JestValidExpect(JestValidExpect::default()),
         RuleEnum::JestValidTitle(JestValidTitle::default()),
+        RuleEnum::ReactPreferFunctionComponent(ReactPreferFunctionComponent::default()),
         RuleEnum::ReactButtonHasType(ReactButtonHasType::default()),
         RuleEnum::ReactCheckedRequiresOnchangeOrReadonly(
             ReactCheckedRequiresOnchangeOrReadonly::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -431,6 +431,7 @@ pub(crate) mod react {
     pub mod no_will_update_set_state;
     pub mod only_export_components;
     pub mod prefer_es6_class;
+    pub mod prefer_function_component;
     pub mod react_in_jsx_scope;
     pub mod require_render_return;
     pub mod rules_of_hooks;

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -1021,6 +1021,19 @@ fn test() {
                 serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
             ),
         ),
+        // Non-static getDerivedStateFromError is NOT a valid error boundary,
+        // so allowErrorBoundary should not exempt it.
+        (
+            "class Foo extends React.Component {
+               getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
     ];
 
     Tester::new(PreferFunctionComponent::NAME, PreferFunctionComponent::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -55,6 +55,9 @@ declare_oxc_lint!(
     /// hooks. Class components are a legacy pattern that is discouraged in
     /// modern React.
     ///
+    /// This rule is based on the rule from
+    /// [eslint-plugin-react-prefer-function-component](https://www.npmjs.com/package/eslint-plugin-react-prefer-function-component).
+    ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -85,7 +85,7 @@ declare_oxc_lint!(
     /// ```
     PreferFunctionComponent,
     react,
-    restriction, // TODO: Or style?
+    restriction,
     config = PreferFunctionComponent,
 );
 

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -32,6 +32,9 @@ fn prefer_function_component_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct PreferFunctionComponent {
     /// If `true`, error boundary classes (those implementing `componentDidCatch`
     /// or `static getDerivedStateFromError`) are allowed as class components.
+    ///
+    /// This is because these classes are not easily converted to function components,
+    /// and so they are exempted from this rule by default.
     allow_error_boundary: bool,
     /// If `true`, classes that contain JSX but do not extend `Component` or
     /// `PureComponent` are allowed.

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -23,6 +23,7 @@ use crate::{
 fn prefer_function_component_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Class component should be written as a function component.")
         .with_help("Convert the class component to a function component.")
+        .with_note("See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -88,9 +88,7 @@ impl Rule for PreferFunctionComponent {
             return;
         };
 
-        let is_component = is_es6_component(node);
-
-        if !is_component {
+        if !is_es6_component(node) {
             // Not extending Component/PureComponent. Only flag if it contains
             // JSX and allowJsxUtilityClass is false.
             if self.allow_jsx_utility_class {

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -83,39 +83,40 @@ fn test() {
              }",
             None,
         ),
+        // For now, we are not going to check for other libraries like preact and inferno. Only support React.
         // Extending from preact
-        (
-            "import { Component } from 'preact';
-
-             class Foo extends Component {
-               render() {
-                 return <div>{this.props.foo}</div>;
-               }
-             };",
-            None,
-        ),
+        // (
+        //     "import { Component } from 'preact';
+        //
+        //      class Foo extends Component {
+        //        render() {
+        //          return <div>{this.props.foo}</div>;
+        //        }
+        //      };",
+        //     None,
+        // ),
         // Extending from inferno
-        (
-            "import { Component } from 'inferno';
-
-             class Foo extends Component {
-               render() {
-                 return <div>{this.props.foo}</div>;
-               }
-             };",
-            None,
-        ),
+        // (
+        //     "import { Component } from 'inferno';
+        //
+        //      class Foo extends Component {
+        //        render() {
+        //          return <div>{this.props.foo}</div>;
+        //        }
+        //      };",
+        //     None,
+        // ),
         // Extending from another class (not Component)
-        (
-            "import Document from 'next/document';
-
-             class Foo extends Document {
-               render() {
-                 return <div>{this.props.foo}</div>;
-               }
-             };",
-            None,
-        ),
+        // (
+        //     "import Document from 'next/document';
+        //
+        //      class Foo extends Document {
+        //        render() {
+        //          return <div>{this.props.foo}</div>;
+        //        }
+        //      };",
+        //     None,
+        // ),
         (
             "class Foo extends React.Component {
                render() {

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -64,6 +64,12 @@ declare_oxc_lint!(
     ///     return <div>{this.props.foo}</div>;
     ///   }
     /// }
+    ///
+    /// class Bar extends React.PureComponent {
+    ///   render() {
+    ///     return <div>{this.props.bar}</div>;
+    ///   }
+    /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
@@ -71,10 +77,12 @@ declare_oxc_lint!(
     /// const Foo = function(props) {
     ///   return <div>{props.foo}</div>;
     /// };
+    ///
+    /// const Bar = ({ bar }) => <div>{bar}</div>;
     /// ```
     PreferFunctionComponent,
     react,
-    restriction,
+    restriction, // TODO: Or style?
     config = PreferFunctionComponent,
 );
 

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -1,0 +1,228 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_function_component_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong.")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferFunctionComponent;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// FIXME: Briefly describe the rule's purpose.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// FIXME: Explain why violating this rule is problematic.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// FIXME: Add at least one example of code that violates the rule.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// FIXME: Add at least one example of code that is allowed with the rule.
+    /// ```
+    PreferFunctionComponent,
+    react,
+    restriction,
+    none,
+);
+
+impl Rule for PreferFunctionComponent {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Already a stateless function
+        (
+            "const Foo = function(props) {
+               return <div>{props.foo}</div>;
+             };",
+            None,
+        ),
+        // Already a stateless (arrow) function
+        ("const Foo = ({foo}) => <div>{foo}</div>;", None),
+        // class without JSX
+        (
+            "class Foo {
+               render() {
+                 return 'hello'
+               }
+             };",
+            None,
+        ),
+        // object with JSX
+        ("const foo = { foo: <h>hello</h> };", None),
+    ];
+
+    let fail = vec![
+        // Extending from react
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
+        // Extending from preact
+        (
+            "import { Component } from 'preact';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        // Extending from inferno
+        (
+            "import { Component } from 'inferno';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        // Extending from another class (not Component)
+        (
+            "import Document from 'next/document';
+
+             class Foo extends Document {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        (
+            "export default class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends React.Component.
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends Component.
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return null;
+               }
+             }",
+            None,
+        ),
+        // Does not contain JSX and extends React.Component in an expression context.
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends Component in an expression context.
+        (
+            "import { Component } from 'react';
+
+             const Foo = class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends Component in an expression context.
+        (
+            "import { Component } from 'react';
+
+             const Foo = class Bar extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends Component in an default export expression context.
+        (
+            "import { Component } from 'react';
+
+             export default class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+        // Does not contain JSX and extends Component in an default export expression context.
+        (
+            "import { Component } from 'react';
+
+             export default class Foo extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            None,
+        ),
+    ];
+
+    Tester::new(PreferFunctionComponent::NAME, PreferFunctionComponent::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -1,47 +1,195 @@
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrowFunctionExpression, CallExpression, Class, ClassBody, ClassElement, Function,
+        JSXElement, JSXFragment,
+    },
+};
+use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_syntax::scope::ScopeFlags;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_es6_component,
+};
 
 fn prefer_function_component_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Should be an imperative statement about what is wrong.")
-        .with_help("Should be a command-like statement that tells the user how to fix the issue.")
+    OxcDiagnostic::warn("Class component should be written as a function component.")
+        .with_help("Convert the class component to a function component.")
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct PreferFunctionComponent;
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PreferFunctionComponent {
+    /// If `true`, error boundary classes (those implementing `componentDidCatch`
+    /// or `static getDerivedStateFromError`) are allowed as class components.
+    allow_error_boundary: bool,
+    /// If `true`, classes that contain JSX but do not extend `Component` or
+    /// `PureComponent` are allowed.
+    allow_jsx_utility_class: bool,
+}
+
+impl Default for PreferFunctionComponent {
+    fn default() -> Self {
+        Self { allow_error_boundary: true, allow_jsx_utility_class: false }
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// FIXME: Briefly describe the rule's purpose.
+    /// Enforces that React components are written as function components
+    /// instead of class components.
     ///
     /// ### Why is this bad?
     ///
-    /// FIXME: Explain why violating this rule is problematic.
+    /// Function components are simpler, easier to read, and support React
+    /// hooks. Class components are a legacy pattern that is discouraged in
+    /// modern React.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```js
-    /// FIXME: Add at least one example of code that violates the rule.
+    /// ```jsx
+    /// class Foo extends React.Component {
+    ///   render() {
+    ///     return <div>{this.props.foo}</div>;
+    ///   }
+    /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```js
-    /// FIXME: Add at least one example of code that is allowed with the rule.
+    /// ```jsx
+    /// const Foo = function(props) {
+    ///   return <div>{props.foo}</div>;
+    /// };
     /// ```
     PreferFunctionComponent,
     react,
     restriction,
-    none,
+    config = PreferFunctionComponent,
 );
 
 impl Rule for PreferFunctionComponent {
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+
+        let is_component = is_es6_component(node);
+
+        if !is_component {
+            // Not extending Component/PureComponent. Only flag if it contains
+            // JSX and allowJsxUtilityClass is false.
+            if self.allow_jsx_utility_class {
+                return;
+            }
+            if !class_body_contains_jsx(&class.body) {
+                return;
+            }
+        }
+
+        // Check error boundary exemption
+        if self.allow_error_boundary && is_error_boundary(class) {
+            return;
+        }
+
+        let span = class.id.as_ref().map_or(class.span, |id| id.span);
+        ctx.diagnostic(prefer_function_component_diagnostic(span));
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+/// Returns `true` if the class has `componentDidCatch` method or
+/// `static getDerivedStateFromError` method.
+fn is_error_boundary(class: &Class) -> bool {
+    class.body.body.iter().any(|element| {
+        let key_name = match element {
+            ClassElement::MethodDefinition(method) => {
+                method.key.static_name().map(|n| (n, method.r#static))
+            }
+            ClassElement::PropertyDefinition(prop) => {
+                prop.key.static_name().map(|n| (n, prop.r#static))
+            }
+            _ => None,
+        };
+
+        matches!(key_name, Some((ref name, false)) if name == "componentDidCatch")
+            || matches!(key_name, Some((ref name, true)) if name == "getDerivedStateFromError")
+    })
+}
+
+/// Visitor that searches for JSX elements within a class body.
+/// Walks into direct class method bodies but stops at nested
+/// functions/arrows within those methods.
+struct ClassJsxFinder {
+    found: bool,
+    depth: u32,
+}
+
+impl ClassJsxFinder {
+    fn new() -> Self {
+        Self { found: false, depth: 0 }
+    }
+}
+
+impl<'a> Visit<'a> for ClassJsxFinder {
+    fn visit_jsx_element(&mut self, _elem: &JSXElement<'a>) {
+        self.found = true;
+    }
+
+    fn visit_jsx_fragment(&mut self, _frag: &JSXFragment<'a>) {
+        self.found = true;
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if crate::utils::is_create_element_call(call) {
+            self.found = true;
+        }
+        if !self.found {
+            walk::walk_call_expression(self, call);
+        }
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
+        // depth 0 = class method body, walk into it
+        // depth > 0 = nested function inside a method, skip
+        if self.depth == 0 {
+            self.depth += 1;
+            walk::walk_function(self, func, flags);
+            self.depth -= 1;
+        }
+    }
+
+    fn visit_arrow_function_expression(&mut self, arrow: &ArrowFunctionExpression<'a>) {
+        if self.depth == 0 {
+            self.depth += 1;
+            walk::walk_arrow_function_expression(self, arrow);
+            self.depth -= 1;
+        }
+    }
+}
+
+/// Returns `true` if the class body contains JSX in any of its methods.
+fn class_body_contains_jsx(body: &ClassBody) -> bool {
+    let mut finder = ClassJsxFinder::new();
+    finder.visit_class_body(body);
+    finder.found
 }
 
 #[test]
@@ -69,7 +217,191 @@ fn test() {
         ),
         // object with JSX
         ("const foo = { foo: <h>hello</h> };", None),
+        // Error boundary with componentDidCatch (allowed by default)
+        (
+            "class Foo extends React.Component {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
+        // Error boundary with componentDidCatch extending PureComponent
+        (
+            "class Foo extends React.PureComponent {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
+        // Error boundary in expression context
+        (
+            "const Foo = class extends React.Component {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        // Error boundary with static getDerivedStateFromError
+        (
+            "class Foo extends React.Component {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
+        // getDerivedStateFromError extending PureComponent
+        (
+            "class Foo extends React.PureComponent {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             }",
+            None,
+        ),
+        // getDerivedStateFromError in expression context
+        (
+            "const Foo = class extends React.Component {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             };",
+            None,
+        ),
+        // Error boundary with allowJsxUtilityClass: true (still valid)
+        (
+            "class Foo extends React.Component {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        // JSX utility class with allowJsxUtilityClass: true
+        (
+            "class Foo {
+               getBar() {
+                 return <Bar />;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        // validForAllOptions with allowJsxUtilityClass: true
+        (
+            "const Foo = function(props) {
+               return <div>{props.foo}</div>;
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "const Foo = ({foo}) => <div>{foo}</div>;",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "class Foo {
+               render() {
+                 return 'hello'
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "const foo = { foo: <h>hello</h> };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        // validForAllOptions with allowErrorBoundary: false
+        (
+            "const Foo = function(props) {
+               return <div>{props.foo}</div>;
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const Foo = ({foo}) => <div>{foo}</div>;",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo {
+               render() {
+                 return 'hello'
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const foo = { foo: <h>hello</h> };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        // validForAllOptions with both options
+        (
+            "const Foo = function(props) {
+               return <div>{props.foo}</div>;
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "const Foo = ({foo}) => <div>{foo}</div>;",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "class Foo {
+               render() {
+                 return 'hello'
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "const foo = { foo: <h>hello</h> };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
     ];
+
+    // Note: Many of these test cases are duped for the purpose of testing different config options.
 
     let fail = vec![
         // Extending from react
@@ -83,7 +415,9 @@ fn test() {
              }",
             None,
         ),
-        // For now, we are not going to check for other libraries like preact and inferno. Only support React.
+        // For now, we are not going to check for other libraries like preact and inferno.
+        // This rule only supports React.
+        //
         // Extending from preact
         // (
         //     "import { Component } from 'preact';
@@ -200,7 +534,7 @@ fn test() {
              };",
             None,
         ),
-        // Does not contain JSX and extends Component in an default export expression context.
+        // Does not contain JSX and extends Component in a default export expression context.
         (
             "import { Component } from 'react';
 
@@ -211,7 +545,7 @@ fn test() {
              };",
             None,
         ),
-        // Does not contain JSX and extends Component in an default export expression context.
+        // Does not contain JSX and extends Component in a default export expression context.
         (
             "import { Component } from 'react';
 
@@ -221,6 +555,454 @@ fn test() {
                }
              };",
             None,
+        ),
+        // Error boundaries with allowErrorBoundary: false
+        (
+            "class Foo extends React.Component {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               componentDidCatch(error, errorInfo) {
+                 logErrorToMyService(error, errorInfo);
+               }
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.Component {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               constructor(props) {
+                 super(props);
+                 this.state = { hasError: false };
+               }
+               static getDerivedStateFromError(error) {
+                 return { hasError: true };
+               }
+               render() {
+                 return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        // JSX utility class (fails by default)
+        (
+            "class Foo {
+               getBar() {
+                 return <Bar />;
+               }
+             };",
+            None,
+        ),
+        // JSX utility class with allowErrorBoundary: false (still fails)
+        (
+            "class Foo {
+               getBar() {
+                 return <Bar />;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        // invalidForAllOptions with allowJsxUtilityClass: true
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "export default class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return null;
+               }
+             }",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class Bar extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class Foo extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowJsxUtilityClass": true }])),
+        ),
+        // invalidForAllOptions with allowErrorBoundary: false
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "export default class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return null;
+               }
+             }",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class Bar extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class Foo extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(serde_json::json!([{ "allowErrorBoundary": false }])),
+        ),
+        // invalidForAllOptions with both options
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             }",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "class Foo extends React.PureComponent {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "export default class extends React.Component {
+               render() {
+                 return <div>{this.props.foo}</div>;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "class Foo extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "import { Component } from 'react';
+
+             class Foo extends Component {
+               render() {
+                 return null;
+               }
+             }",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "const Foo = class extends React.Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "import { Component } from 'react';
+
+             const Foo = class Bar extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
+        ),
+        (
+            "import { Component } from 'react';
+
+             export default class Foo extends Component {
+               render() {
+                 return null;
+               }
+             };",
+            Some(
+                serde_json::json!([{ "allowJsxUtilityClass": true, "allowErrorBoundary": false }]),
+            ),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/prefer_function_component.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_function_component.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{Class, ClassElement},
@@ -5,8 +8,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
@@ -1,0 +1,529 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:16]
+ 1 │ ╭─▶ export default class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return null;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:26]
+ 2 │     
+ 3 │ ╭─▶              const Foo = class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:32]
+ 2 │ 
+ 3 │              const Foo = class Bar extends Component {
+   ·                                ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:29]
+ 2 │     
+ 3 │ ╭─▶              export default class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:35]
+ 2 │ 
+ 3 │              export default class Foo extends Component {
+   ·                                   ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                componentDidCatch(error, errorInfo) {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                componentDidCatch(error, errorInfo) {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  componentDidCatch(error, errorInfo) {
+ 3 │ │                    logErrorToMyService(error, errorInfo);
+ 4 │ │                  }
+ 5 │ │                  render() {
+ 6 │ │                    return <div>{this.props.foo}</div>;
+ 7 │ │                  }
+ 8 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                constructor(props) {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                constructor(props) {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+    ╭─[prefer_function_component.tsx:1:13]
+  1 │ ╭─▶ const Foo = class extends React.Component {
+  2 │ │                  constructor(props) {
+  3 │ │                    super(props);
+  4 │ │                    this.state = { hasError: false };
+  5 │ │                  }
+  6 │ │                  static getDerivedStateFromError(error) {
+  7 │ │                    return { hasError: true };
+  8 │ │                  }
+  9 │ │                  render() {
+ 10 │ │                    return <div>{this.state.hasError ? 'Error' : this.props.foo}</div>;
+ 11 │ │                  }
+ 12 │ ╰─▶              };
+    ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo {
+   ·       ───
+ 2 │                getBar() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo {
+   ·       ───
+ 2 │                getBar() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:16]
+ 1 │ ╭─▶ export default class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return null;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:26]
+ 2 │     
+ 3 │ ╭─▶              const Foo = class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:32]
+ 2 │ 
+ 3 │              const Foo = class Bar extends Component {
+   ·                                ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:29]
+ 2 │     
+ 3 │ ╭─▶              export default class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:35]
+ 2 │ 
+ 3 │              export default class Foo extends Component {
+   ·                                   ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:16]
+ 1 │ ╭─▶ export default class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return null;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:26]
+ 2 │     
+ 3 │ ╭─▶              const Foo = class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:32]
+ 2 │ 
+ 3 │              const Foo = class Bar extends Component {
+   ·                                ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:29]
+ 2 │     
+ 3 │ ╭─▶              export default class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:35]
+ 2 │ 
+ 3 │              export default class Foo extends Component {
+   ·                                   ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.PureComponent {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:16]
+ 1 │ ╭─▶ export default class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return <div>{this.props.foo}</div>;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:20]
+ 2 │ 
+ 3 │              class Foo extends Component {
+   ·                    ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:13]
+ 1 │ ╭─▶ const Foo = class extends React.Component {
+ 2 │ │                  render() {
+ 3 │ │                    return null;
+ 4 │ │                  }
+ 5 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:26]
+ 2 │     
+ 3 │ ╭─▶              const Foo = class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:32]
+ 2 │ 
+ 3 │              const Foo = class Bar extends Component {
+   ·                                ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:29]
+ 2 │     
+ 3 │ ╭─▶              export default class extends Component {
+ 4 │ │                  render() {
+ 5 │ │                    return null;
+ 6 │ │                  }
+ 7 │ ╰─▶              };
+   ╰────
+  help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:3:35]
+ 2 │ 
+ 3 │              export default class Foo extends Component {
+   ·                                   ───
+ 4 │                render() {
+   ╰────
+  help: Convert the class component to a function component.

--- a/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
@@ -527,3 +527,11 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+
+  ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
+   ╭─[prefer_function_component.tsx:1:7]
+ 1 │ class Foo extends React.Component {
+   ·       ───
+ 2 │                getDerivedStateFromError(error) {
+   ╰────
+  help: Convert the class component to a function component.

--- a/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
+++ b/crates/oxc_linter/src/snapshots/react_prefer_function_component.snap
@@ -10,6 +10,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -18,6 +19,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -26,6 +28,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -36,6 +39,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:16]
@@ -46,6 +50,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -54,6 +59,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -63,6 +69,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -73,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:26]
@@ -84,6 +92,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:32]
@@ -93,6 +102,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:29]
@@ -104,6 +114,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:35]
@@ -113,6 +124,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -121,6 +133,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                componentDidCatch(error, errorInfo) {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -129,6 +142,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                componentDidCatch(error, errorInfo) {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -142,6 +156,7 @@ source: crates/oxc_linter/src/tester.rs
  8 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -150,6 +165,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                constructor(props) {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -158,6 +174,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                constructor(props) {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
     ╭─[prefer_function_component.tsx:1:13]
@@ -175,6 +192,7 @@ source: crates/oxc_linter/src/tester.rs
  12 │ ╰─▶              };
     ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -183,6 +201,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                getBar() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -191,6 +210,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                getBar() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -200,6 +220,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -208,6 +229,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -216,6 +238,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -226,6 +249,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:16]
@@ -236,6 +260,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -244,6 +269,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -253,6 +279,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -263,6 +290,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:26]
@@ -274,6 +302,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:32]
@@ -283,6 +312,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:29]
@@ -294,6 +324,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:35]
@@ -303,6 +334,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -312,6 +344,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -320,6 +353,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -328,6 +362,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -338,6 +373,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:16]
@@ -348,6 +384,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -356,6 +393,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -365,6 +403,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -375,6 +414,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:26]
@@ -386,6 +426,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:32]
@@ -395,6 +436,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:29]
@@ -406,6 +448,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:35]
@@ -415,6 +458,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -424,6 +468,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -432,6 +477,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -440,6 +486,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -450,6 +497,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:16]
@@ -460,6 +508,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -468,6 +517,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:20]
@@ -477,6 +527,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:13]
@@ -487,6 +538,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:26]
@@ -498,6 +550,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:32]
@@ -507,6 +560,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:29]
@@ -518,6 +572,7 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶              };
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:3:35]
@@ -527,6 +582,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                render() {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function
 
   ⚠ eslint-plugin-react(prefer-function-component): Class component should be written as a function component.
    ╭─[prefer_function_component.tsx:1:7]
@@ -535,3 +591,4 @@ source: crates/oxc_linter/src/tester.rs
  2 │                getDerivedStateFromError(error) {
    ╰────
   help: Convert the class component to a function component.
+  note: See https://react.dev/reference/react/Component#migrating-a-simple-component-from-a-class-to-a-function


### PR DESCRIPTION
This is based on the rule provided in [eslint-plugin-react-prefer-function-component](https://www.npmjs.com/package/eslint-plugin-react-prefer-function-component). This rule is [proposed for eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react/pull/3040), but so far not merged.

The goal of the rule is pretty simple. We want to discourage class components like this, as they are not used very often in modern React:

```jsx
class Foo extends React.Component {
  render() {
    return <div>{this.props.foo}</div>;
  }
}

class Bar extends React.PureComponent {
  render() {
    return <div>{this.props.bar}</div>;
  }
}
```

And encourage function components like this:

```jsx
const Foo = function(props) {
  return <div>{props.foo}</div>;
};

const Bar = ({ bar }) => <div>{bar}</div>;
```

- [Original Rule Source](https://github.com/tatethurston/eslint-plugin-react-prefer-function-component/blob/4682fae095307a73db6bda706ec53a61ad6bd60c/packages/eslint-plugin-react-prefer-function-component/src/prefer-function-component/index.ts)
- [Original Rule Tests](https://github.com/tatethurston/eslint-plugin-react-prefer-function-component/blob/main/packages/eslint-plugin-react-prefer-function-component/src/prefer-function-component/index.test.ts)

The original eslint-plugin-react plugin lacks a lint rule like this, which is very silly as it has one for preferring class components (which are notably [discouraged by React itself](https://react.dev/reference/react/Component) nowadays). It does have `prefer-stateless-functions`, however I would strongly recommend we mark that rule as unsupported in favor of this rule. If you look at [the tests for prefer-stateless-function](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/prefer-stateless-function.js), you can see how lenient it is in allowing class components (anything with a method other than `render()` is allowed, basically). And it has the usual eslint-plugin-react smells of supporting things from many many many years ago. This rule is much more straight-forward, and generally a better implementation of the concept.

We could, alternatively, implement this based on [this rule](https://www.eslint-react.xyz/docs/rules/no-class-component) from `@eslint-react/eslint-plugin` (different from eslint-plugin-react), however I generally prefer the `prefer-function-component` name and the `@eslint-react` rule was generally going to be more complex to implement.

AI Disclosure: Generated with Claude Code w/ Opus 4.5, after prep work by me. Tested and reviewed by me. I created the rule via the rulegen tooling, then manually copied over the initial set of test cases myself. I then had Claude create the remaining tests from the original source code. From looking through the tests, I am confident in the quality/accuracy of the ported tests, and will be doing further testing via oxc-ecosystem-ci.

Ecosystem CI run: https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/22334972119

Bsky for example.

[main](https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/22331033071/job/64613773279):

```
Found 0 warnings and 78356 errors.
Finished in 1.7s on 1553 files with 629 rules using 4 threads.
```

[this PR](https://github.com/oxc-project/oxc-ecosystem-ci/actions/runs/22334972119/job/64625880558):

```
Found 0 warnings and 78361 errors.
Finished in 1.5s on 1553 files with 630 rules using 4 threads.
```

The 5 extra violations are due to this rule, and all 5 are correctly catching class component usage. In terms of performance, there's clearly no noticeable difference here, even on a React codebase of a decent size.