### PR TITLE
fix(linter): enhance help diagnostic messages for more eslint rules

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__eslint_and_typescript_alias_rules_-c oxlint-eslint.json test.js -c oxlint-typescript.json test.js@oxlint.snap
@@ -13,6 +13,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    :                                ^^^^
  5 | 
    `----
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.
@@ -32,6 +33,7 @@ working directory: fixtures/eslint_and_typescript_alias_rules
    :                                ^^^^
  5 | 
    `----
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 1 rules using 1 threads.

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -18,11 +18,15 @@ enum NoMagicNumberReportReason {
 }
 
 fn must_use_const_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Number constants declarations must use 'const'.").with_label(span)
+    OxcDiagnostic::warn("Number constants declarations must use 'const'.")
+        .with_help("Use 'const' instead of 'let' or 'var' to declare number constants to make their immutability explicit.")
+        .with_label(span)
 }
 
 fn no_magic_number_diagnostic(span: Span, raw: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("No magic number: {raw}")).with_label(span)
+    OxcDiagnostic::warn(format!("No magic number: {raw}"))
+        .with_help("Use a named constant instead of a magic number to make the code more readable and maintainable.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -24,7 +24,7 @@ fn surrogate_pair_diagnostic(span: Span) -> OxcDiagnostic {
 
 fn combining_class_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected combining class in character class.")
-        .with_help("Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \\u{1F1E6}\\u{0301} for 'Á') instead of combining sequences.")
+        .with_help("Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -17,23 +17,33 @@ use crate::{
 };
 
 fn surrogate_pair_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected surrogate pair in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected surrogate pair in character class.")
+        .with_help("Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \\u{1F44D}) instead of surrogate pairs.")
+        .with_label(span)
 }
 
 fn combining_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected combining class in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected combining class in character class.")
+        .with_help("Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \\u{1F1E6}\\u{0301} for 'Á') instead of combining sequences.")
+        .with_label(span)
 }
 
 fn emoji_modifiers_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected emoji modifier in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected emoji modifier in character class.")
+        .with_help("Use Unicode code point escapes (e.g., \\u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.")
+        .with_label(span)
 }
 
 fn regional_indicator_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected regional indicator in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected regional indicator in character class.")
+        .with_help("Use Unicode code point escapes (e.g., \\u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.")
+        .with_label(span)
 }
 
 fn zwj_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected joined character sequence in character class.").with_label(span)
+    OxcDiagnostic::warn("Unexpected joined character sequence in character class.")
+        .with_help("Use Unicode code point escapes (e.g., \\u{1F468}\\u200D\\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -12,14 +12,17 @@ use crate::{
 };
 
 fn no_redeclare_diagnostic(name: &str, decl_span: Span, re_decl_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{name}' is already defined.")).with_labels([
-        decl_span.label(format!("'{name}' is already defined.")),
-        re_decl_span.label("It can not be redeclared here."),
-    ])
+    OxcDiagnostic::warn(format!("'{name}' is already defined."))
+        .with_help("Use a different variable name or remove the duplicate declaration.")
+        .with_labels([
+            decl_span.label(format!("'{name}' is already defined.")),
+            re_decl_span.label("It can not be redeclared here."),
+        ])
 }
 
 fn no_redeclare_as_builtin_in_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("'{name}' is already defined as a built-in global variable."))
+        .with_help("Use a different variable name to avoid shadowing the built-in global.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -11,7 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn missing_parameters(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing parameters.").with_label(span)
+    OxcDiagnostic::warn("Missing parameters.")
+        .with_help("Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.")
+        .with_label(span)
 }
 
 fn missing_radix(span: Span) -> OxcDiagnostic {
@@ -22,6 +24,7 @@ fn missing_radix(span: Span) -> OxcDiagnostic {
 
 fn invalid_radix(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Invalid radix parameter, must be an integer between 2 and 36.")
+        .with_help("The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_magic_numbers.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_magic_numbers.snap
@@ -7,510 +7,595 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var foo = 42
    ·           ──
    ╰────
+  help: Use 'const' instead of 'let' or 'var' to declare number constants to make their immutability explicit.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0 + 1;
    ·           ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:15]
  1 │ var foo = 0 + 1;
    ·               ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): Number constants declarations must use 'const'.
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 42n
    ·           ───
    ╰────
+  help: Use 'const' instead of 'let' or 'var' to declare number constants to make their immutability explicit.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0n
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0n + 1n;
    ·           ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1n
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ var foo = 0n + 1n;
    ·                ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:9]
  1 │ a = a + 5;
    ·         ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:6]
  1 │ a += 5;
    ·      ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·           ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:15]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·               ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·                   ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:24]
  1 │ var foo = 0 + 1 + -2 + 2;
    ·                        ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var foo = 0 + 1 + 2;
    ·                   ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 10
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ var foo = { bar:10 }
    ·                 ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x1A
    ╭─[no_magic_numbers.tsx:1:13]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·             ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x02
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·                    ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 071
    ╭─[no_magic_numbers.tsx:1:39]
  1 │ console.log(0x1A + 0x02); console.log(071);
    ·                                       ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 42
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ var stats = {avg: 42};
    ·                   ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:67]
  1 │ var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;
    ·                                                                   ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5
    ╭─[no_magic_numbers.tsx:1:71]
  1 │ var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;
    ·                                                                       ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 60
    ╭─[no_magic_numbers.tsx:1:39]
  1 │ function getSecondsInMinute() {return 60;}
    ·                                       ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -60
    ╭─[no_magic_numbers.tsx:1:47]
  1 │ function getNegativeSecondsInMinute() {return -60;}
    ·                                               ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:52]
  1 │ var data = ['foo', 'bar', 'baz']; var third = data[3];
    ·                                                    ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -100
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-100]
    ·     ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1.5
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1.5]
    ·     ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1]
    ·     ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0.1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0.1]
    ·     ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0b110
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0b110]
    ·     ──────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0o71
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0o71]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0x12
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-0x12]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -012
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-012]
    ·     ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0.1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[0.1]
    ·     ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0.12e1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[0.12e1]
    ·     ──────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.5
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1.5]
    ·     ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.678e2
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1.678e2]
    ·     ───────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 56e-1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[56e-1]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.000000000000001
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[5.000000000000001]
    ·     ─────────────────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100.9
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[100.9]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4294967295
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[4294967295]
    ·     ──────────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e300
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1e300]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e310
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[1e310]
    ·     ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1e310
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[-1e310]
    ·     ──────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[+0]
    ·     ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:5]
  1 │ foo[+1]
    ·     ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:7]
  1 │ foo[-(-1)]
    ·       ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100
    ╭─[no_magic_numbers.tsx:1:1]
  1 │ 100 .toString()
    · ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 200
    ╭─[no_magic_numbers.tsx:1:1]
  1 │ 200[100]
    · ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:26]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                          ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:30]
  1 │ var a = <div arrayProp={[1,2,3]}></div>;
    ·                              ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:27]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                           ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 10
    ╭─[no_magic_numbers.tsx:1:36]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                                    ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:47]
  1 │ var min, max, mean; min = 1; max = 10; mean = 4;
    ·                                               ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100n)
    ·   ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(-100n)
    ·   ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100n)
    ·   ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100
    ╭─[no_magic_numbers.tsx:1:3]
  1 │ f(100)
    ·   ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ const func = (param = 123) => {}
    ·                       ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 123
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ const { param = 123 } = sourceObject;
    ·                 ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:14]
  1 │ const [one = 1, two = 2] = []
    ·              ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ const [one = 1, two = 2] = []
    ·                       ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:22]
  1 │ var one, two; [one = 1, two = 2] = []
    ·                      ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:31]
  1 │ var one, two; [one = 1, two = 2] = []
    ·                               ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2; }
    ·                 ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = -2; }
    ·                 ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:24]
  1 │ class C { static foo = 2; }
    ·                        ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:18]
  1 │ class C { #foo = 2; }
    ·                  ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:25]
  1 │ class C { static #foo = 2; }
    ·                         ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:17]
  1 │ class C { foo = 2 + 3; }
    ·                 ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:21]
  1 │ class C { foo = 2 + 3; }
    ·                     ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:11]
  1 │ class C { 2; }
    ·           ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ class C { [2]; }
    ·            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1;
    ·            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -1;
    ·            ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1 | 2 | 3;
    ·            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = 1 | 2 | 3;
    ·                ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = 1 | 2 | 3;
    ·                    ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1 | -1;
    ·            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = 1 | -1;
    ·                ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:11]
@@ -519,6 +604,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─
  4 │             }
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1000
    ╭─[no_magic_numbers.tsx:3:15]
@@ -527,6 +613,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │               NUM = '0123456789',
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:5:12]
@@ -535,6 +622,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──
  6 │               POS = +1,
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:6:12]
@@ -543,6 +631,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──
  7 │             }
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:19]
@@ -551,6 +640,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─
  4 │               readonly B = 2;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:4:19]
@@ -559,6 +649,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ─
  5 │               public static readonly C = 3;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:5:33]
@@ -567,6 +658,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                          ─
  6 │               static readonly D = 4;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:6:26]
@@ -575,6 +667,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ─
  7 │               readonly E = -5;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -5
    ╭─[no_magic_numbers.tsx:7:19]
@@ -583,6 +676,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──
  8 │               readonly F = +6;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 6
    ╭─[no_magic_numbers.tsx:8:19]
@@ -591,6 +685,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──
  9 │               private readonly G = 100n;
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 100n
     ╭─[no_magic_numbers.tsx:9:27]
@@ -599,90 +694,105 @@ source: crates/oxc_linter/src/tester.rs
     ·                                    ────
  10 │             }
     ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[0];
    ·                ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[-1];
    ·                ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0xab
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[0xab];
    ·                ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.6e1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[5.6e1];
    ·                ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 | -2];
    ·                ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = Bar[1 | -2];
    ·                    ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 & -2];
    ·                ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:20]
  1 │ type Foo = Bar[1 & -2];
    ·                    ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:16]
  1 │ type Foo = Bar[1 & number];
    ·                ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:18]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                  ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:22]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                      ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:33]
  1 │ type Foo = Bar[((1 & -2) | 3) | 4];
    ·                                 ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:28]
  1 │ type Foo = Parameters<Bar>[2];
    ·                            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:5:25]
@@ -691,6 +801,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ─
  6 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:7]
@@ -699,6 +810,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:3:11]
@@ -707,6 +819,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:12]
@@ -715,6 +828,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:3:16]
@@ -723,6 +837,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:3:20]
@@ -731,6 +846,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0
    ╭─[no_magic_numbers.tsx:3:24]
@@ -739,141 +855,165 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─
  4 │             };
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1;
    ·            ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -2;
    ·            ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3n
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 3n;
    ·            ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -4n
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -4n;
    ·            ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5.6;
    ·            ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7.8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7.8;
    ·            ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 0x0a
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 0x0a;
    ·            ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -0xbc
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -0xbc;
    ·            ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1e2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1e2;
    ·            ───
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -3e4
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -3e4;
    ·            ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5e-6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5e-6;
    ·            ────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7e-8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7e-8;
    ·            ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1.1e2
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 1.1e2;
    ·            ─────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -3.1e4
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -3.1e4;
    ·            ──────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 5.1e-6
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = 5.1e-6;
    ·            ──────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -7.1e-8
    ╭─[no_magic_numbers.tsx:1:12]
  1 │ type Foo = -7.1e-8;
    ·            ───────
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 42
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ type Foo = { bar: 42 };
    ·                   ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 2
    ╭─[no_magic_numbers.tsx:1:19]
  1 │ type Foo = { bar: 2 | 3 };
    ·                   ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:23]
  1 │ type Foo = { bar: 2 | 3 };
    ·                       ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 1
    ╭─[no_magic_numbers.tsx:1:25]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                         ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: -2
    ╭─[no_magic_numbers.tsx:1:29]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                             ──
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 3
    ╭─[no_magic_numbers.tsx:1:35]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                                   ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.
 
   ⚠ eslint(no-magic-numbers): No magic number: 4
    ╭─[no_magic_numbers.tsx:1:40]
  1 │ type Foo = { bar: Bar[((1 & -2) | 3) | 4] };
    ·                                        ─
    ╰────
+  help: Use a named constant instead of a magic number to make the code more readable and maintainable.

--- a/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
@@ -91,70 +91,70 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var r = /[Á]/
    ·           ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[Á]/u
    ·           ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/
    ·           ────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/u
    ·           ────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{41}\u{301}]/u
    ·           ─────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/
    ·           ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/u
    ·           ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/
    ·           ────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/u
    ·           ────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{2747}\u{FE0F}]/u
    ·           ────────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
@@ -471,7 +471,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                             [❇️]`)
    ·                              ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:2:5]
@@ -479,7 +479,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             [❇️]`)
    ·              ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
@@ -577,98 +577,98 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var r = new RegExp("[Á]", "")
    ·                      ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[Á]", "u")
    ·                      ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "")
    ·                      ──────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "u")
    ·                      ──────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{41}\\u{301}]", "u")
    ·                      ───────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "")
    ·                      ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "u")
    ·                      ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "")
    ·              ────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "u")
    ·              ────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·              ────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·                        ────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "")
    ·                      ──────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "u")
    ·                      ──────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{2747}\\u{FE0F}]", "u")
    ·                      ──────────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
@@ -1004,7 +1004,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var r = new globalThis.RegExp("[❇️]", "")
    ·                                 ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
@@ -1095,28 +1095,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ new RegExp("\x5B \\ufe0f\u005D")
    ·                 ────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \u{5c}ufe0f]")
    ·              ────────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe\60f]")
    ·              ──────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\uf\e0f]")
    ·              ─────────
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
@@ -1144,21 +1144,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ /[Á]/
    ·   ─
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\\̶]/
    ·   ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\n̅]/
    ·   ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
@@ -1172,7 +1172,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ RegExp('[\è]')
    ·          ──
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
@@ -1193,7 +1193,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ RegExp('[\❇️]')
    ·          ───
    ╰────
-  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]

--- a/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_misleading_character_class.snap
@@ -7,390 +7,455 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC4D]/
    ·           ────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC4D-\uffff]/
    ·           ────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /before[\uD83D\uDC4D]after/
    ·                 ────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /[before\uD83D\uDC4Dafter]/
    ·                 ────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ var r = /\uDC4D[\uD83D\uDC4D]/
    ·                 ────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👍]\a/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:13]
  1 │ var r = /\a[👍]\a/
    ·             ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /(?<=[👍])/
    ·               ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /(?<=[👍])/
    ·               ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[Á]/
    ·           ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[Á]/u
    ·           ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/
    ·           ────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u0041\u0301]/u
    ·           ────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{41}\u{301}]/u
    ·           ─────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/
    ·           ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[❇️]/u
    ·           ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/
    ·           ────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u2747\uFE0F]/u
    ·           ────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{2747}\u{FE0F}]/u
    ·           ────────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👶🏻]/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[👶🏻]/
    ·             ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👶🏻]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[a\uD83C\uDFFB]/u
    ·           ─────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC76\uD83C\uDFFB]/u
    ·           ────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F476}\u{1F3FB}]/u
    ·           ──────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/
    ·           ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[🇯🇵]/
    ·            ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/i
    ·           ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[🇯🇵]/i
    ·            ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[🇯🇵]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83C\uDDEF\uD83C\uDDF5]/u
    ·           ────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F1EF}\u{1F1F5}]/u
    ·           ──────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:15]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]/
    ·           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:25]
  1 │ var r = /[👨‍👩‍👦]/
    ·             ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]/u
    ·             ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👩‍👦]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👩‍👦][👩‍👦]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = /[👩‍👦][👩‍👦]/u
    ·               ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·             ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:34]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·                  ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:41]
  1 │ var r = /[👨‍👩‍👦]foo[👨‍👩‍👦]/u
    ·                    ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·           ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·             ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = /[👨‍👩‍👦👩‍👦]/u
    ·             ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66]/u
    ·           ──────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66]/u
    ·                             ──────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·           ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                            ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\uD83D\uDC68\u200D\uD83D\uDC69]/u
    ·           ──────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}]/u
    ·           ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:11]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·           ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                            ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:59]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                                                           ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:76]
  1 │ var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]foo[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u
    ·                                                                            ──────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = RegExp("[👍]", "")
    ·                  ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp('[👍]', ``)
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:2:21]
@@ -398,6 +463,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                             [👍]`)
    ·                              ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:2:21]
@@ -405,6 +471,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │                             [❇️]`)
    ·                              ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:2:5]
@@ -412,627 +479,732 @@ source: crates/oxc_linter/src/tester.rs
  2 │             [❇️]`)
    ·              ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ const flags = ""; var r = new RegExp("[👍]", flags)
    ·                                        ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:18]
  1 │ var r = RegExp("[\\uD83D\\uDC4D]", "")
    ·                  ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = RegExp("before[\\uD83D\\uDC4D]after", "")
    ·                        ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = RegExp("[before\\uD83D\\uDC4Dafter]", "")
    ·                        ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = RegExp("\t\t\t👍[👍]")
    ·                          ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = new RegExp("\u1234[\\uD83D\\uDC4D]")
    ·                            ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("\\u1234\\u5678👎[👍]")
    ·                                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("\\u1234\\u5678👍[👍]")
    ·                                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👍]\\a", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp("/(?<=[👍])", "")
    ·                           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp("/(?<=[👍])", "")
    ·                           ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[Á]", "")
    ·                      ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[Á]", "u")
    ·                      ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "")
    ·                      ──────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u0041\\u0301]", "u")
    ·                      ──────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{41}\\u{301}]", "u")
    ·                      ───────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "")
    ·                      ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[❇️]", "u")
    ·                      ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "")
    ·              ────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f]", "u")
    ·              ────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·              ────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ new RegExp("[ \\ufe0f][ \\ufe0f]")
    ·                        ────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "")
    ·                      ──────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u2747\\uFE0F]", "u")
    ·                      ──────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{2747}\\u{FE0F}]", "u")
    ·                      ──────────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👶🏻]", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[👶🏻]", "")
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👶🏻]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83D\\uDC76\\uD83C\\uDFFB]", "u")
    ·                      ────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F476}\\u{1F3FB}]", "u")
    ·                      ────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:25]
  1 │ var r = RegExp(`            👍[👍]`)
    ·                             ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = RegExp(`\t\t\t👍[👍]`)
    ·                          ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "")
    ·                      ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]", "")
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "i")
    ·                      ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]", "i")
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp('[🇯🇵]', `i`)
    ·                      ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp('[🇯🇵]', `i`)
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]")
    ·                      ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]")
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]",)
    ·                      ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[🇯🇵]",)
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:23]
  1 │ var r = new RegExp(("[🇯🇵]"))
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp(("[🇯🇵]"))
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:24]
  1 │ var r = new RegExp((("[🇯🇵]")))
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:28]
  1 │ var r = new RegExp((("[🇯🇵]")))
    ·                         ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:23]
  1 │ var r = new RegExp(("[🇯🇵]"),)
    ·                       ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:27]
  1 │ var r = new RegExp(("[🇯🇵]"),)
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[🇯🇵]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83C\\uDDEF\\uD83C\\uDDF5]", "u")
    ·                      ────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected regional indicator in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F1EF}\\u{1F1F5}]", "u")
    ·                      ────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F1EF} for the regional indicator symbol for 'J') instead of regional indicator symbol pairs in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:26]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                      ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:36]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "")
    ·                        ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]", "u")
    ·                        ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👩‍👦]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👩‍👦][👩‍👦]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:35]
  1 │ var r = new RegExp("[👩‍👦][👩‍👦]", "u")
    ·                          ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                        ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:45]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                             ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:52]
  1 │ var r = new RegExp("[👨‍👩‍👦]foo[👨‍👩‍👦]", "u")
    ·                               ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                      ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:29]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                        ─
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:40]
  1 │ var r = new RegExp("[👨‍👩‍👦👩‍👦]", "u")
    ·                        ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\uD83D\\uDC68\\u200D\\uD83D\\uDC69\\u200D\\uD83D\\uDC66]", "u")
    ·                      ───────────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:43]
  1 │ var r = new RegExp("[\\uD83D\\uDC68\\u200D\\uD83D\\uDC69\\u200D\\uD83D\\uDC66]", "u")
    ·                                           ───────────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:22]
  1 │ var r = new RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                      ─────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:41]
  1 │ var r = new RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                         ─────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[❇️]", "")
    ·                                 ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[👶🏻]", "u")
    ·                                 ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[🇯🇵]", "")
    ·                                 ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:37]
  1 │ var r = new globalThis.RegExp("[🇯🇵]", "")
    ·                                  ─
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:33]
  1 │ var r = new globalThis.RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                 ─────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:52]
  1 │ var r = new globalThis.RegExp("[\\u{1F468}\\u{200D}\\u{1F469}\\u{200D}\\u{1F466}]", "u")
    ·                                                    ─────────────────────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\ud83d\u{dc4d}]/u
    ·   ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u{d83d}\udc4d]/u
    ·   ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u{d83d}\u{dc4d}]/u
    ·   ────────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\uD83D\u{DC4d}]/u
    ·   ──────────────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/)
    ·          ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/, 'i');
    ·          ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(/[👍]/, 'g');
    ·          ──
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:17]
  1 │ new RegExp("\x5B \\ufe0f\u005D")
    ·                 ────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \u{5c}ufe0f]")
    ·              ────────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\ufe\60f]")
    ·              ──────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp("[ \\uf\e0f]")
    ·              ─────────
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp(`[.\\u200D.]`)
    ·              ─────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:14]
  1 │ new RegExp(`[.\\\x75200D.]`)
    ·              ────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected emoji modifier in character class.
    ╭─[no_misleading_character_class.tsx:1:12]
  1 │ var r = /[[👶🏻]]/v
    ·            ──
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F3FB} for the light skin tone modifier) instead of emoji modifier sequences in character classes.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[Á]/
    ·   ─
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\\̶]/
    ·   ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\n̅]/
    ·   ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\👍]/
    ·   ───
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\è]')
    ·          ──
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\👍]')
    ·          ───
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\\👍]')
    ·          ────
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected combining class in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp('[\❇️]')
    ·          ───
    ╰────
+  help: Replace the character with its normalized form (NFC) or use Unicode code point escapes (e.g., \u{1F1E6}\u{0301} for 'Á') instead of combining sequences.
 
   ⚠ eslint(no-misleading-character-class): Unexpected surrogate pair in character class.
    ╭─[no_misleading_character_class.tsx:1:10]
  1 │ RegExp(`[\👍]`) // Backslash + U+D83D + U+DC4D
    ·          ───
    ╰────
+  help: Add the Unicode flag 'u' to the regular expression or use Unicode code point escapes (e.g., \u{1F44D}) instead of surrogate pairs.
 
   ⚠ eslint(no-misleading-character-class): Unexpected joined character sequence in character class.
    ╭─[no_misleading_character_class.tsx:1:3]
  1 │ /[\u200c\u200d\p{ID_Continue}.]/
    ·   ──────────────
    ╰────
+  help: Use Unicode code point escapes (e.g., \u{1F468}\u200D\u{1F469} for '👨‍👩') instead of zero-width joiner sequences in character classes.

--- a/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
@@ -11,6 +11,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ┬
    ·             ╰── It can not be redeclared here.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -19,6 +20,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │          ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -27,6 +29,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │           ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   × Identifier `a` has already been declared
    ╭─[no_redeclare..cts:1:5]
@@ -43,6 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ·          │               ╰── It can not be redeclared here.
    ·          ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -51,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │                       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -59,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │                       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -67,6 +73,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │          ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:16]
@@ -75,6 +82,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                │           ╰── It can not be redeclared here.
    ·                ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -83,6 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     │      ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:12]
@@ -91,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │      ╰── It can not be redeclared here.
    ·            ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:24]
@@ -99,6 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │      ╰── It can not be redeclared here.
    ·                        ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:24]
@@ -107,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        │        ╰── It can not be redeclared here.
    ·                        ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:26]
@@ -115,6 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │        ╰── It can not be redeclared here.
    ·                          ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:26]
@@ -123,24 +136,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                          │          ╰── It can not be redeclared here.
    ·                          ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:5]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·     ──────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:21]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                     ──────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:37]
  1 │ var Object = 0; var Object = 0; var globalThis = 0;
    ·                                     ──────────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -149,12 +166,14 @@ source: crates/oxc_linter/src/tester.rs
    ·     │       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'Object' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:23]
  1 │ var a; var {a = 0, b: Object = 0} = {};
    ·                       ──────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:5]
@@ -163,12 +182,14 @@ source: crates/oxc_linter/src/tester.rs
    ·     │       ╰── It can not be redeclared here.
    ·     ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'globalThis' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:23]
  1 │ var a; var {a = 0, b: globalThis = 0} = {};
    ·                       ──────────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:20]
@@ -177,6 +198,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │      ╰── It can not be redeclared here.
    ·                    ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:12]
@@ -185,6 +207,7 @@ source: crates/oxc_linter/src/tester.rs
    ·            │               ╰── It can not be redeclared here.
    ·            ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'b' is already defined.
    ╭─[no_redeclare..cts:1:15]
@@ -193,6 +216,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               │                   ╰── It can not be redeclared here.
    ·               ╰── 'b' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:20]
@@ -201,6 +225,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    │                  ╰── It can not be redeclared here.
    ·                    ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare..cts:1:10]
@@ -209,18 +234,21 @@ source: crates/oxc_linter/src/tester.rs
    ·          │  ╰── It can not be redeclared here.
    ·          ╰── 'a' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:17]
  1 │ export function undefined(): void; export function undefined() { }
    ·                 ─────────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'undefined' is already defined as a built-in global variable.
    ╭─[no_redeclare..cts:1:52]
  1 │ export function undefined(): void; export function undefined() { }
    ·                                                    ─────────
    ╰────
+  help: Use a different variable name to avoid shadowing the built-in global.
 
   ⚠ eslint(no-redeclare): 'foo' is already defined.
    ╭─[no_redeclare..cts:1:6]
@@ -229,3 +257,4 @@ source: crates/oxc_linter/src/tester.rs
    ·       │                                                     ╰── It can not be redeclared here.
    ·       ╰── 'foo' is already defined.
    ╰────
+  help: Use a different variable name or remove the duplicate declaration.

--- a/crates/oxc_linter/src/snapshots/eslint_radix.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_radix.snap
@@ -1,11 +1,13 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ parseInt();
    · ──────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -40,54 +42,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("10", null);
    ·                ────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", undefined);
    ·                ─────────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", true);
    ·                ────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", "foo");
    ·                ─────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", "123");
    ·                ─────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 1);
    ·                ─
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 37);
    ·                ──
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 10.5);
    ·                ────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();
    · ─────────────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -101,18 +112,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Number.parseInt("10", 1);
    ·                       ─
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:23]
  1 │ Number.parseInt("10", 37);
    ·                       ──
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:23]
  1 │ Number.parseInt("10", 10.5);
    ·                       ────
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -147,12 +161,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt();
    · ──────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ parseInt();
    · ──────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.
 
   ⚠ eslint(radix): Missing radix parameter.
    ╭─[radix.tsx:1:1]
@@ -173,21 +189,25 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parseInt("10", 1);
    ·                ─
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
    ╭─[radix.tsx:1:16]
  1 │ parseInt("10", 1);
    ·                ─
    ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();
    · ─────────────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.
 
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();
    · ─────────────────
    ╰────
+  help: Add parameters for parsing numbers, e.g., `parseInt('10', 10)`.


### PR DESCRIPTION
Add `.with_help()` to diagnostics that only provide a warning message, giving developers actionable guidance on how to resolve each issue.

- `no_redeclare`: Use a different variable name or remove the duplicate
- `no_misleading_character_class`: Use Unicode flag or code point escapes
- `no_magic_numbers`: Extract into named constants, use `const`
- `radix`: Provide valid parameters to parseInt()

Part of #19121