### PR TITLE
fix(formatter): drop blank line between terminal call and first chain member

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/member-chains/blank-line.js
+++ b/crates/oxc_formatter/tests/fixtures/js/member-chains/blank-line.js
@@ -11,3 +11,17 @@ Promise.all(writeIconFiles)
   // TO DO -- END
 
   .then(() => writeRegistry())
+
+// https://github.com/oxc-project/oxc/issues/19469
+const x = fn()
+
+.c1();
+
+const y = fn()
+
+.c1()
+
+.c2()
+
+
+.c3();

--- a/crates/oxc_formatter/tests/fixtures/js/member-chains/blank-line.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/member-chains/blank-line.js.snap
@@ -16,6 +16,20 @@ Promise.all(writeIconFiles)
 
   .then(() => writeRegistry())
 
+// https://github.com/oxc-project/oxc/issues/19469
+const x = fn()
+
+.c1();
+
+const y = fn()
+
+.c1()
+
+.c2()
+
+
+.c3();
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -34,6 +48,16 @@ Promise.all(writeIconFiles)
 
   .then(() => writeRegistry());
 
+// https://github.com/oxc-project/oxc/issues/19469
+const x = fn().c1();
+
+const y = fn()
+  .c1()
+
+  .c2()
+
+  .c3();
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -50,5 +74,15 @@ Promise.all(writeIconFiles)
   // TO DO -- END
 
   .then(() => writeRegistry());
+
+// https://github.com/oxc-project/oxc/issues/19469
+const x = fn().c1();
+
+const y = fn()
+  .c1()
+
+  .c2()
+
+  .c3();
 
 ===================== End =====================


### PR DESCRIPTION
## Summary

- Fix blank line handling between a terminal base call (like `fn()`) and the first chain member (like `.c1()`) to match Prettier's behavior
- Add early return in `needs_empty_line_before()` to skip blank line detection when the object before the dot is a terminal call (callee is not part of the chain)

**Before:**
```js
// Input: fn()\n\n.c1()
const x =
  fn()

    .c1();
```

**After (matches Prettier):**
```js
const x = fn().c1();
```

Fixes #19469

## Test plan

- [x] Added test fixtures for both cases from the issue
- [x] All 191 formatter unit tests pass
- [x] All Prettier conformance tests pass (746/753 JS, 591/601 TS — unchanged)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)