### PR TITLE
refactor(formatter): add `speculate_will_break` and fix `is_complex_type_arguments`

### DIFF
--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-call-expression.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-call-expression.js
@@ -1,0 +1,6 @@
+// Minimum repro from issue #19436:
+// Comments before call expressions must be preserved
+const r = /* THIS */ f()
+
+// @__PURE__ comments must not be deleted
+export const globalRegistry = /*@__PURE__*/ registry();

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignment-call-expression.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignment-call-expression.js.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Minimum repro from issue #19436:
+// Comments before call expressions must be preserved
+const r = /* THIS */ f()
+
+// @__PURE__ comments must not be deleted
+export const globalRegistry = /*@__PURE__*/ registry();
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Minimum repro from issue #19436:
+// Comments before call expressions must be preserved
+const r = /* THIS */ f();
+
+// @__PURE__ comments must not be deleted
+export const globalRegistry = /*@__PURE__*/ registry();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Minimum repro from issue #19436:
+// Comments before call expressions must be preserved
+const r = /* THIS */ f();
+
+// @__PURE__ comments must not be deleted
+export const globalRegistry = /*@__PURE__*/ registry();
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/assignment-call-with-type-args.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/assignment-call-with-type-args.ts
@@ -1,0 +1,6 @@
+// Type arguments with speculative formatting should not lose comments
+export const globalRegistry: $ZodRegistry = /*@__PURE__*/ registry();
+
+// Comments before call expressions with type arguments should be preserved
+const r = /* THIS */ f<Type>()
+const s = /* comment */ foo<A | B | C>()

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/assignment-call-with-type-args.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/assignment-call-with-type-args.ts.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Type arguments with speculative formatting should not lose comments
+export const globalRegistry: $ZodRegistry = /*@__PURE__*/ registry();
+
+// Comments before call expressions with type arguments should be preserved
+const r = /* THIS */ f<Type>()
+const s = /* comment */ foo<A | B | C>()
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Type arguments with speculative formatting should not lose comments
+export const globalRegistry: $ZodRegistry = /*@__PURE__*/ registry();
+
+// Comments before call expressions with type arguments should be preserved
+const r = /* THIS */ f<Type>();
+const s = /* comment */ foo<A | B | C>();
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Type arguments with speculative formatting should not lose comments
+export const globalRegistry: $ZodRegistry = /*@__PURE__*/ registry();
+
+// Comments before call expressions with type arguments should be preserved
+const r = /* THIS */ f<Type>();
+const s = /* comment */ foo<A | B | C>();
+
+===================== End =====================


### PR DESCRIPTION
Closes:  #19436
## Summary

- Add `Formatter::speculate_will_break` to encapsulate the snapshot/skip/intern/restore pattern for safely checking if formatted content would break across lines
- Replace the approximation heuristics in `is_complex_type_arguments` with Prettier's actual `willBreak(print(typeArgs))` logic
- Add `Comments::snapshot`, `restore`, and `skip_comments_before` methods to support speculative formatting without losing comments

## Details

The old `is_complex_type_arguments` couldn't call `f.intern()` because it would permanently advance the comment cursor, causing comments to be lost. It used heuristic checks (complex type references, mapped types, etc.) as an approximation instead.

With the new comment snapshot/restore infrastructure, we can now match Prettier's behavior exactly:

```rust
// Before: ~30 lines of heuristic checks
// After:
f.speculate_will_break(type_arguments)
```

Prettier ref: https://github.com/prettier/prettier/blob/a043ac0d733c4d53f980aa73807a63fc914f23bd/src/language-js/print/assignment.js#L432-L459

## Test plan

- [x] Existing formatter tests pass (193/193)
- [x] Clippy clean
- [x] Added snapshot tests for comment preservation with call expressions and type arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)