### PR TITLE
fix(semantic/jsdoc): handle even-numbered backtick sequences in JSDoc parsing

### DIFF
--- a/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc/parser/jsdoc.rs
@@ -329,6 +329,33 @@ line2
         assert_eq!(tag.kind.parsed(), "example");
     }
 
+    // https://github.com/oxc-project/oxc/issues/19137
+    #[test]
+    fn parses_with_double_backticks() {
+        let source = "\
+ * Handle whitespace rendering based on meta string
+ *
+ * `` ```js :whitespace[=all|boundary|trailing] ``
+ *
+ * @param parser - Code parser instance
+ * @param meta - Meta string
+ * @param globalOption - Global whitespace option
+ *
+ * @example
+ * ```ts
+ * metaWhitespace(parser, ':whitespace=all', true)
+ * ```
+ ";
+        #[expect(clippy::cast_possible_truncation)]
+        let jsdoc = super::JSDoc::new(source, Span::new(0, source.len() as u32));
+        let tags = jsdoc.tags();
+        assert_eq!(tags.len(), 4);
+        assert_eq!(tags[0].kind.parsed(), "param");
+        assert_eq!(tags[1].kind.parsed(), "param");
+        assert_eq!(tags[2].kind.parsed(), "param");
+        assert_eq!(tags[3].kind.parsed(), "example");
+    }
+
     #[test]
     fn parses_issue_11992() {
         let allocator = Allocator::default();


### PR DESCRIPTION
## Summary

Fixes #19137.

- The JSDoc parser only handled odd-numbered backtick sequences (1, 3, 5, ...) for toggling in/out of code sections. Double backticks (`` `` ``) used in CommonMark to escape backticks inside inline code were silently ignored, causing the parser to stay in "code mode" and miss all subsequent `@tags`.
- Replace the boolean `in_backticks` flag with a `backtick_count` tracker that records the opening sequence length and only closes when an equal-length closing sequence is found, matching CommonMark semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)