### PR TITLE
docs(README.md): map npm package links to npmx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Read more about our [architecture](https://oxc.rs/docs/learn/architecture/parser
 
 ## 📦 Tools & Packages
 
-| Tool        | npm                                                          | crates.io                                                   |
-| ----------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
+| Tool        | npm                                                     | crates.io                                                   |
+| ----------- | ------------------------------------------------------- | ----------------------------------------------------------- |
 | Linter      | [oxlint](https://npmx.dev/package/oxlint)               | -                                                           |
 | Formatter   | [oxfmt](https://npmx.dev/package/oxfmt)                 | -                                                           |
 | Parser      | [oxc-parser](https://npmx.dev/package/oxc-parser)       | [oxc_parser](https://crates.io/crates/oxc_parser)           |

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Read more about our [architecture](https://oxc.rs/docs/learn/architecture/parser
 
 | Tool        | npm                                                          | crates.io                                                   |
 | ----------- | ------------------------------------------------------------ | ----------------------------------------------------------- |
-| Linter      | [oxlint](https://www.npmjs.com/package/oxlint)               | -                                                           |
-| Formatter   | [oxfmt](https://www.npmjs.com/package/oxfmt)                 | -                                                           |
-| Parser      | [oxc-parser](https://www.npmjs.com/package/oxc-parser)       | [oxc_parser](https://crates.io/crates/oxc_parser)           |
-| Transformer | [oxc-transform](https://www.npmjs.com/package/oxc-transform) | [oxc_transformer](https://crates.io/crates/oxc_transformer) |
-| Minifier    | [oxc-minify](https://www.npmjs.com/package/oxc-minify)       | [oxc_minifier](https://crates.io/crates/oxc_minifier)       |
-| Resolver    | [oxc-resolver](https://www.npmjs.com/package/oxc-resolver)   | [oxc_resolver](https://crates.io/crates/oxc_resolver)       |
+| Linter      | [oxlint](https://npmx.dev/package/oxlint)               | -                                                           |
+| Formatter   | [oxfmt](https://npmx.dev/package/oxfmt)                 | -                                                           |
+| Parser      | [oxc-parser](https://npmx.dev/package/oxc-parser)       | [oxc_parser](https://crates.io/crates/oxc_parser)           |
+| Transformer | [oxc-transform](https://npmx.dev/package/oxc-transform) | [oxc_transformer](https://crates.io/crates/oxc_transformer) |
+| Minifier    | [oxc-minify](https://npmx.dev/package/oxc-minify)       | [oxc_minifier](https://crates.io/crates/oxc_minifier)       |
+| Resolver    | [oxc-resolver](https://npmx.dev/package/oxc-resolver)   | [oxc_resolver](https://crates.io/crates/oxc_resolver)       |
 
 See [documentation](https://oxc.rs/) for detailed usage guides for each tool.
 

--- a/napi/parser/README.md
+++ b/napi/parser/README.md
@@ -12,9 +12,9 @@ See https://stackblitz.com/edit/oxc-parser for usage example.
 
 When parsing JS or JSX files, the AST returned is fully conformant with the
 [ESTree standard](https://github.com/estree/estree), the same as produced by
-[Acorn](https://www.npmjs.com/package/acorn).
+[Acorn](https://npmx.dev/package/acorn).
 
-When parsing TypeScript, the AST conforms to [@typescript-eslint/typescript-estree](https://www.npmjs.com/package/@typescript-eslint/typescript-estree)'s TS-ESTree format.
+When parsing TypeScript, the AST conforms to [@typescript-eslint/typescript-estree](https://npmx.dev/package/@typescript-eslint/typescript-estree)'s TS-ESTree format.
 
 If you need all ASTs in the same with-TS-properties format, use the `astType: 'ts'` option.
 
@@ -33,7 +33,7 @@ Any deviation would be considered a bug.
 
 ### AST Types
 
-[@oxc-project/types](https://www.npmjs.com/package/@oxc-project/types) can be used. For example:
+[@oxc-project/types](https://npmx.dev/package/@oxc-project/types) can be used. For example:
 
 ```typescript
 import { Statement } from "@oxc-project/types";
@@ -74,7 +74,7 @@ It is likely that you are writing a parser plugin that requires ESM information.
 
 To avoid walking the AST again, Oxc Parser returns ESM information directly.
 
-This information can be used to rewrite import and exports with the help of [`magic-string`](https://www.npmjs.com/package/magic-string),
+This information can be used to rewrite import and exports with the help of [`magic-string`](https://npmx.dev/package/magic-string),
 without any AST manipulations.
 
 ```ts

--- a/npm/oxfmt/README.md
+++ b/npm/oxfmt/README.md
@@ -30,7 +30,7 @@
 [ci-badge]: https://github.com/oxc-project/oxc/actions/workflows/ci.yml/badge.svg?event=push&branch=main
 [ci-url]: https://github.com/oxc-project/oxc/actions/workflows/ci.yml?query=event%3Apush+branch%3Amain
 [npm-badge]: https://img.shields.io/npm/v/oxfmt/latest?color=brightgreen
-[npm-url]: https://www.npmjs.com/package/oxfmt/v/latest
+[npm-url]: https://npmx.dev/package/oxfmt/v/latest
 [code-size-badge]: https://img.shields.io/github/languages/code-size/oxc-project/oxc
 [code-size-url]: https://github.com/oxc-project/oxc
 [code-coverage-badge]: https://codecov.io/github/oxc-project/oxc/branch/main/graph/badge.svg

--- a/npm/oxlint/README.md
+++ b/npm/oxlint/README.md
@@ -30,7 +30,7 @@
 [ci-badge]: https://github.com/oxc-project/oxc/actions/workflows/ci.yml/badge.svg?event=push&branch=main
 [ci-url]: https://github.com/oxc-project/oxc/actions/workflows/ci.yml?query=event%3Apush+branch%3Amain
 [npm-badge]: https://img.shields.io/npm/v/oxlint/latest?color=brightgreen
-[npm-url]: https://www.npmjs.com/package/oxlint/v/latest
+[npm-url]: https://npmx.dev/package/oxlint/v/latest
 [code-size-badge]: https://img.shields.io/github/languages/code-size/oxc-project/oxc
 [code-size-url]: https://github.com/oxc-project/oxc
 [code-coverage-badge]: https://codecov.io/github/oxc-project/oxc/branch/main/graph/badge.svg


### PR DESCRIPTION
## Summary
- replace npm package links from npmjs.com to https://npmx.dev
- only update documentation files