### PR TITLE
fix(minifier): preserve side effects for meta property url reads

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -547,8 +547,6 @@ fn property_access_may_have_side_effects<'a>(
             !(matches!(object, Expression::ArrayExpression(_))
                 || object.value_type(ctx).is_string())
         }
-        // `import.meta.url` is spec-defined and side-effect free.
-        "url" if matches!(object.without_parentheses(), Expression::MetaProperty(_)) => false,
         _ => true,
     }
 }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -783,9 +783,10 @@ fn test_property_access() {
     test("[...'a'][0]", false);
     test("[...'a'][1]", true);
 
-    test("import.meta.url", false);
-    test("import.meta['url']", false);
-    test("import.meta[`url`]", false);
+    test("import.meta.url", true);
+    test("import.meta['url']", true);
+    test("import.meta[`url`]", true);
+    test_in_function("function f() { new.target.url }", true);
     test("[...'😀'][0]", false);
     test("[...'😀'][1]", true);
     test("[...a, 1][0]", true); // "...a" may have a sideeffect

--- a/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
+++ b/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
@@ -409,7 +409,7 @@ fn test_esm_minification_edge_cases() {
     );
 
     // Import.meta (should be preserved mostly)
-    test("import.meta.url", "");
+    test_same("import.meta.url");
     test_same("import.meta.resolve('./module.js')");
     test_same("import.meta.hot");
     test_same("import.meta.env");
@@ -590,6 +590,17 @@ fn test_esm_module_patterns() {
     // Import with computed expressions
     test("import('module-' + (version || 'latest'))", "import('module-' + (version || 'latest'))");
     test("import('module-' + (2 + 3))", "import('module-5')");
+}
+
+#[test]
+fn test_meta_property_url_getter_side_effects() {
+    test(
+        "Object.defineProperty(import.meta, 'url', { get() { console.log('import.meta.url'); return 'virtual:' } }); import.meta.url;",
+        "Object.defineProperty(import.meta, 'url', { get() { return console.log('import.meta.url'), 'virtual:'; } }), import.meta.url;",
+    );
+    test_same(
+        "class A { constructor() { new.target.url; } } class B extends A { static get url() { console.log('url!'); } constructor() { super(); } } new B();",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the `MetaProperty.url` side-effect-free special-case from property read analysis
- treat `import.meta.url` reads as side-effectful in side-effect tests
- add regression coverage for both `import.meta.url` and `new.target.url` getter side effects

Closes #19466
Closes #19467

## Testing
- `just fmt`
- `cargo test -p oxc_minifier test_property_access`
- `cargo test -p oxc_minifier test_esm_minification_edge_cases`
- `cargo test -p oxc_minifier test_meta_property_url_getter_side_effects`

## AI Disclosure
This PR was prepared with AI assistance (OpenAI Codex) and reviewed by the contributor.
