### PR TITLE
refactor(estree/tokens): use wildcard import for AST types

### DIFF
--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -2,14 +2,7 @@ use rustc_hash::FxHashSet;
 use serde::Serialize;
 
 use oxc_allocator::{Allocator, Vec as ArenaVec};
-use oxc_ast::ast::{
-    BindingIdentifier, IdentifierName, IdentifierReference, JSXAttribute, JSXAttributeValue,
-    JSXElementName, JSXExpressionContainer, JSXIdentifier, JSXMemberExpressionObject,
-    JSXNamespacedName, JSXSpreadAttribute, JSXSpreadChild, LabelIdentifier, MemberExpression,
-    MetaProperty, ObjectPropertyKind, Program, PropertyKey, TSImportType, TSThisParameter,
-    TSTypeName, TSTypeParameterDeclaration, TSTypeQuery, TSTypeQueryExprName, WithClause,
-    WithClauseKeyword,
-};
+use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, utf8_to_utf16::Utf8ToUtf16, walk};
 use oxc_parser::{Kind, Token};
 use oxc_span::Span;


### PR DESCRIPTION
Pure refactor. Import AST types with a wildcard `use oxc_ast::ast::*` instead of a massive list of types.