### PR TITLE
ci(workflows): skip release and sensitive workflows on forks

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   coverage:
+    if: github.repository == 'oxc-project/oxc'
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_rules.yml
+++ b/.github/workflows/lint_rules.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   lint_rules:
+    if: github.repository == 'oxc-project/oxc'
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/prepare_release_apps.yml
+++ b/.github/workflows/prepare_release_apps.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   prepare:
+    if: github.repository == 'oxc-project/oxc'
     name: Prepare Release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/prepare_release_crates.yml
+++ b/.github/workflows/prepare_release_crates.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'oxc-project/oxc'
     name: Check
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +27,7 @@ jobs:
       - run: cargo release-oxc publish --release crates --dry-run # zizmor: ignore[use-trusted-publishing]
 
   prepare:
+    if: github.repository == 'oxc-project/oxc'
     name: Prepare Release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'oxc-project/oxc'
     name: Check version
     runs-on: ubuntu-slim
     outputs:

--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'oxc-project/oxc'
     name: Release crates
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release_napi_minify.yml
+++ b/.github/workflows/release_napi_minify.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'oxc-project/oxc'
     name: Release NAPI Minify
     uses: ./.github/workflows/reusable_release_napi.yml
     with:

--- a/.github/workflows/release_napi_parser.yml
+++ b/.github/workflows/release_napi_parser.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'oxc-project/oxc'
     name: Release NAPI Parser
     uses: ./.github/workflows/reusable_release_napi.yml
     with:

--- a/.github/workflows/release_napi_transform.yml
+++ b/.github/workflows/release_napi_transform.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'oxc-project/oxc'
     name: Release NAPI Transform
     uses: ./.github/workflows/reusable_release_napi.yml
     with:

--- a/.github/workflows/release_runtime.yml
+++ b/.github/workflows/release_runtime.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'oxc-project/oxc'
     name: Check version
     runs-on: ubuntu-slim
     outputs:

--- a/.github/workflows/release_types.yml
+++ b/.github/workflows/release_types.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'oxc-project/oxc'
     name: Check version
     runs-on: ubuntu-slim
     outputs:


### PR DESCRIPTION
Add `if: github.repository == 'oxc-project/oxc'` to jobs in release, codecov, and lint_rules workflows to prevent them from running on fork repositories.

**Affected workflows:**
- `codecov.yml`
- `lint_rules.yml`
- `prepare_release_apps.yml`
- `prepare_release_crates.yml` (2 jobs)
- `release_apps.yml`
- `release_crates.yml`
- `release_napi_minify.yml`
- `release_napi_parser.yml`
- `release_napi_transform.yml`
- `release_runtime.yml`
- `release_types.yml`