### PR TITLE
fix(linter/prefer-object-from-entries): require exact path match in unicorn helper

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -345,6 +345,7 @@ fn test() {
         ("underscore.fromPairs(pairs)", None),
         ("_.fromPairs", None),
         ("_.fromPairs()", None),
+        ("_(pairs)", None),
         ("new _.fromPairs(pairs)", None),
         ("_.fromPairs(...[pairs])", None),
         ("_?.fromPairs(pairs)", None),

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -438,7 +438,10 @@ where
     let path = path.iter().rev();
 
     for e in paths {
-        if e.as_ref().iter().zip(path.clone()).all(|(x, y)| x == y) {
+        let expected_path = e.as_ref();
+        if expected_path.len() == path.len()
+            && expected_path.iter().zip(path.clone()).all(|(x, y)| x == y)
+        {
             return true;
         }
     }


### PR DESCRIPTION
fixes #19686