### PR TITLE
fix(formatter): wrap long single-identifier class implements clauses

### DIFF
--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -467,7 +467,7 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
 /// 2. Superclass is a member expression and has no type arguments
 ///   - ClassExpression: its parent is not an AssignmentExpression
 ///   - ClassDeclaration: always
-/// 3. Implements is a qualified name and has no type arguments
+/// 3. Implements is an identifier or qualified name and has no type arguments
 /// 4. There are comments in the heritage clause area
 /// 5. There are trailing line comments after type parameters
 fn should_group<'a>(class: &AstNode<Class<'a>>, f: &Formatter<'_, 'a>) -> bool {
@@ -484,7 +484,9 @@ fn should_group<'a>(class: &AstNode<Class<'a>>, f: &Formatter<'_, 'a>) -> bool {
                 matches!(&super_class, Expression::ChainExpression(chain) if chain.expression.is_member_expression())
             ) && class.super_type_arguments.is_none()
         || class.implements.first().is_some_and(|implements| {
-            implements.type_arguments.is_none() && implements.expression.is_qualified_name()
+            implements.type_arguments.is_none()
+                && (implements.expression.is_identifier()
+                    || implements.expression.is_qualified_name())
         })
     {
         return true;

--- a/crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts
@@ -1,0 +1,3 @@
+export class longlonglonglonglonglonglonglonglonglonglongclassname implements xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {
+  method() {}
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+export class longlonglonglonglonglonglonglonglonglonglongclassname implements xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {
+  method() {}
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+export class longlonglonglonglonglonglonglonglonglonglongclassname
+  implements xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+{
+  method() {}
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+export class longlonglonglonglonglonglonglonglonglonglongclassname
+  implements xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+{
+  method() {}
+}
+
+===================== End =====================


### PR DESCRIPTION
## Summary

- Fix class heritage grouping so long single-identifier `implements` clauses can wrap correctly at `printWidth`.
- Preserve existing behavior for qualified-name scenarios.
- Add a focused regression fixture in `ts/class` using placeholder-style names.
- This should bring parity with prettier

## Root cause

`should_group` in `crates/oxc_formatter/src/print/class.rs` previously grouped a single `implements` clause only when the type was a qualified name (`foo.Bar`) with no type args.

For long simple identifiers (`implements Xxxxxxxxx...`), the formatter did not enter grouped layout for the class head/heritage split, so output could exceed `printWidth`.

## Tests
- Added regression fixture:
  - `crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts`
  - `crates/oxc_formatter/tests/fixtures/ts/class/implements-wrap.ts.snap`
