### PR TITLE
feat(linter): per-rule timing support

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -40,8 +40,7 @@ export const buffers: (BufferWithArrays | null)[] = [];
 const afterHooks: AfterHook[] = [];
 
 // Whether per-rule timing is enabled (set via `TIMING` environment variable).
-const TIMING_ENABLED =
-  typeof process !== "undefined" && process.env["TIMING"] !== undefined;
+const TIMING_ENABLED = typeof process !== "undefined" && process.env["TIMING"] !== undefined;
 
 // Per-rule timing accumulator for the current file (ms). Indexed parallel to `ruleIds`.
 // `null` when timing is disabled.

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -27,7 +27,7 @@ import { walkProgram } from '../generated/walk.js';
 
 import { walkProgram, ancestors } from "../generated/walk.js";
 
-import type { AfterHook, BufferWithArrays } from "./types.ts";
+import type { AfterHook, BufferWithArrays, Visitor } from "./types.ts";
 
 // Buffers cache.
 //
@@ -38,6 +38,27 @@ export const buffers: (BufferWithArrays | null)[] = [];
 
 // Array of `after` hooks to run after traversal. This array reused for every file.
 const afterHooks: AfterHook[] = [];
+
+// Whether per-rule timing is enabled (set via `TIMING` environment variable).
+const TIMING_ENABLED =
+  typeof process !== "undefined" && process.env["TIMING"] !== undefined;
+
+// Per-rule timing accumulator for the current file (ms). Indexed parallel to `ruleIds`.
+// `null` when timing is disabled.
+let currentRuleTimes: number[] | null = null;
+
+function wrapVisitorForTiming(visitor: Visitor, times: number[], idx: number): Visitor {
+  const wrapped: Visitor = Object.create(null);
+  for (const key of Object.keys(visitor) as (keyof Visitor)[]) {
+    const fn = visitor[key] as (node: never) => void;
+    wrapped[key] = (node: never) => {
+      const t0 = performance.now();
+      fn(node);
+      times[idx] += performance.now() - t0;
+    };
+  }
+  return wrapped;
+}
 
 /**
  * Lint a file.
@@ -78,11 +99,18 @@ export function lintFile(
 
     let ret: string | null = null;
 
-    // Avoid JSON serialization in common case that there are no diagnostics to report
-    if (diagnostics.length !== 0) {
+    if (TIMING_ENABLED) {
+      // When timing, always serialize so Rust receives the timings even for files with no diagnostics.
       // Note: `messageId` field of `DiagnosticReport` is not needed on Rust side, but we assume it's cheaper to leave it
       // in place and let `serde` skip over it on Rust side, than to iterate over all diagnostics and remove it here.
-      ret = JSON.stringify({ Success: diagnostics });
+      ret = JSON.stringify({ Success: { diagnostics, timings: currentRuleTimes } });
+      diagnostics.length = 0;
+      currentRuleTimes = null;
+    } else if (diagnostics.length !== 0) {
+      // Avoid JSON serialization in common case that there are no diagnostics to report
+      // Note: `messageId` field of `DiagnosticReport` is not needed on Rust side, but we assume it's cheaper to leave it
+      // in place and let `serde` skip over it on Rust side, than to iterate over all diagnostics and remove it here.
+      ret = JSON.stringify({ Success: { diagnostics, timings: null } });
 
       // Empty `diagnostics` array, so it starts empty when linting next file
       diagnostics.length = 0;
@@ -178,6 +206,11 @@ export function lintFileImpl(
   setSettingsForFile(settingsJSON);
   setGlobalsForFile(globalsJSON);
 
+  // Initialize per-rule timing array if timing is enabled
+  if (TIMING_ENABLED) {
+    currentRuleTimes = new Array(ruleIds.length).fill(0);
+  }
+
   // Get visitors for this file from all rules
   initCompiledVisitor();
 
@@ -202,20 +235,49 @@ export function lintFileImpl(
     if (visitor === null) {
       // Rule defined with `create` method
       debugAssertIsNonNull(ruleDetails.rule.create);
-      visitor = ruleDetails.rule.create(ruleDetails.context);
+      if (TIMING_ENABLED) {
+        const t0 = performance.now();
+        visitor = ruleDetails.rule.create(ruleDetails.context);
+        currentRuleTimes![i] += performance.now() - t0;
+      } else {
+        visitor = ruleDetails.rule.create(ruleDetails.context);
+      }
     } else {
       // Rule defined with `createOnce` method
       const { beforeHook, afterHook } = ruleDetails;
       if (beforeHook !== null) {
         // If `before` hook returns `false`, skip this rule
-        const shouldRun = beforeHook();
+        let shouldRun: boolean | void;
+        if (TIMING_ENABLED) {
+          const t0 = performance.now();
+          shouldRun = beforeHook();
+          currentRuleTimes![i] += performance.now() - t0;
+        } else {
+          shouldRun = beforeHook();
+        }
         if (shouldRun === false) continue;
       }
       // Note: If `before` hook returned `false`, `after` hook is not called
-      if (afterHook !== null) afterHooks.push(afterHook);
+      if (afterHook !== null) {
+        if (TIMING_ENABLED) {
+          const idx = i;
+          const originalHook = afterHook;
+          afterHooks.push(() => {
+            const t0 = performance.now();
+            originalHook();
+            currentRuleTimes![idx] += performance.now() - t0;
+          });
+        } else {
+          afterHooks.push(afterHook);
+        }
+      }
     }
 
-    addVisitorToCompiled(visitor);
+    if (TIMING_ENABLED) {
+      addVisitorToCompiled(wrapVisitorForTiming(visitor, currentRuleTimes!, i));
+    } else {
+      addVisitorToCompiled(visitor);
+    }
   }
 
   const visitorState = finalizeCompiledVisitor();

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -247,6 +247,11 @@ pub struct OutputOptions {
     /// `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
     #[bpaf(long, short, fallback(OutputFormat::Default), hide_usage)]
     pub format: OutputFormat,
+
+    /// Print a table of per-rule execution times at the end of the run.
+    /// Can also be enabled by setting the `TIMING` environment variable.
+    #[bpaf(switch, hide_usage)]
+    pub timing: bool,
 }
 
 /// Enable/Disable Plugins

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -415,8 +415,7 @@ impl CliRunner {
         if let Some(ref store) = timing_store {
             lint_runner_builder = lint_runner_builder.with_timing(Arc::clone(store));
         }
-        let lint_runner = match lint_runner_builder.build()
-        {
+        let lint_runner = match lint_runner_builder.build() {
             Ok(runner) => runner,
             Err(err) => {
                 print_and_flush_stdout(stdout, &err);

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -179,6 +179,8 @@ mod test {
                 number_of_rules: Some(0),
                 start_time: Duration::new(0, 0),
                 threads_count: 1,
+                rule_timings: None,
+                overhead_timings: None,
             })
             .unwrap();
         assert_eq!(

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -67,6 +67,12 @@ pub struct LintCommandInfo {
     pub threads_count: usize,
     /// Some reporters want to output the duration it took to finished the task
     pub start_time: Duration,
+    /// Per-rule timing data, sorted by total duration descending.
+    /// `None` when `--timing` / `TIMING` env var was not set.
+    pub rule_timings: Option<Vec<(String, Duration, u64)>>,
+    /// Non-rule overhead timings (e.g. tsgolint program load, JS plugin bridge).
+    /// `None` when `--timing` / `TIMING` env var was not set.
+    pub overhead_timings: Option<Vec<(String, Duration)>>,
 }
 
 /// An Interface for the different output formats.

--- a/crates/oxc_linter/src/external_linter.rs
+++ b/crates/oxc_linter/src/external_linter.rs
@@ -58,7 +58,7 @@ pub type ExternalLinterLintFileCb = Arc<
                 Option<String>,
                 // Allocator
                 &Allocator,
-            ) -> Result<Vec<LintFileResult>, String>
+            ) -> Result<(Vec<LintFileResult>, Option<Vec<f64>>), String>
             + Sync
             + Send,
     >,

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -12,6 +12,8 @@ use std::{
     ptr::{self, NonNull},
     rc::Rc,
     string::ToString,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
 use oxc_allocator::{Allocator, AllocatorPool, CloneIn};
@@ -22,6 +24,7 @@ use oxc_data_structures::box_macros::boxed_array;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::AstNode;
 use oxc_span::Span;
+use rustc_hash::FxHashMap;
 
 mod ast_util;
 mod config;
@@ -37,6 +40,7 @@ mod module_record;
 mod options;
 mod rule;
 mod service;
+mod timing;
 mod tsgolint;
 mod utils;
 
@@ -61,6 +65,7 @@ pub use crate::disable_directives::{
     DisableDirectives, DisableRuleComment, RuleCommentRule, RuleCommentType,
     create_unused_directives_diagnostics,
 };
+pub use crate::timing::TimingStore;
 pub use crate::{
     config::{
         Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintIgnoreMatcher,
@@ -114,6 +119,7 @@ pub struct Linter {
     config: ConfigStore,
     external_linter: Option<ExternalLinter>,
     workspace_uri: Option<Box<str>>,
+    timing_store: Option<Arc<TimingStore>>,
 }
 
 impl Linter {
@@ -122,7 +128,7 @@ impl Linter {
         config: ConfigStore,
         external_linter: Option<ExternalLinter>,
     ) -> Self {
-        Self { options, config, external_linter, workspace_uri: None }
+        Self { options, config, external_linter, workspace_uri: None, timing_store: None }
     }
 
     #[must_use]
@@ -141,6 +147,14 @@ impl Linter {
     #[must_use]
     pub fn with_report_unused_directives(mut self, report_config: Option<AllowWarnDeny>) -> Self {
         self.options.report_unused_directive = report_config;
+        self
+    }
+
+    /// Enable per-rule timing. Timings are accumulated into `store` and can be
+    /// retrieved after linting via [`TimingStore::collect`].
+    #[must_use]
+    pub fn with_timing(mut self, store: Arc<TimingStore>) -> Self {
+        self.timing_store = Some(store);
         self
     }
 
@@ -189,6 +203,27 @@ impl Linter {
     ) -> (Vec<Message>, Option<DisableDirectives>) {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
 
+        // Per-file local timing accumulator — no locking per rule call.
+        // Merged into the shared store once at end of this function.
+        let mut local_timings: Option<FxHashMap<String, (Duration, u64)>> =
+            self.timing_store.as_ref().map(|_| FxHashMap::default());
+
+        // Conditionally time a rule call. When timing is disabled (`lt` is `None`)
+        // the call is a direct pass-through with no overhead at the call site.
+        macro_rules! timed_call {
+            ($lt:expr, $rule:expr, $call:expr) => {
+                if let Some(ref mut __map) = *$lt {
+                    let __start = Instant::now();
+                    $call;
+                    let __e = __map.entry($rule.name().to_owned()).or_default();
+                    __e.0 += __start.elapsed();
+                    __e.1 += 1;
+                } else {
+                    $call;
+                }
+            };
+        }
+
         let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
 
         #[cfg(debug_assertions)]
@@ -224,121 +259,132 @@ impl Linter {
             let should_run_on_jest_node =
                 ctx_host.plugins().has_test() && ctx_host.frameworks().is_test();
 
-            let execute_rules = |with_runtime_optimization: bool| {
-                // IMPORTANT: We have two branches here for performance reasons:
-                //
-                // 1) Branch where we iterate over each node, then each rule
-                // 2) Branch where we iterate over each rule, then each node
-                //
-                // When the number of nodes is relatively small, most of them can fit
-                // in the cache and we can save iterating over the rules multiple times.
-                // But for large files, the number of nodes can be so large that it
-                // starts to not fit into the cache and pushes out other data, like the rules.
-                // So we end up thrashing the cache with each rule iteration. In this case,
-                // it's better to put rules in the inner loop, as the rules data is smaller
-                // and is more likely to fit in the cache.
-                //
-                // The threshold here is chosen to balance between performance improvement
-                // from not iterating over rules multiple times, but also ensuring that we
-                // don't thrash the cache too much. Feel free to tweak based on benchmarking.
-                //
-                // See https://github.com/oxc-project/oxc/pull/6600 for more context.
-                if semantic.nodes().len() > 200_000 {
-                    // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-                    // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-                    // compile-time since we know all of the rules and their AST node type information ahead of time.
+            let execute_rules =
+                |with_runtime_optimization: bool,
+                 lt: &mut Option<FxHashMap<String, (Duration, u64)>>| {
+                    // IMPORTANT: We have two branches here for performance reasons:
                     //
-                    // Use boxed array to help compiler see that indexing into it with an `AstType`
-                    // cannot go out of bounds, and remove bounds checks.
-                    let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-                    // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-                    // node types, but it at least guarantees we won't need to realloc.
-                    let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+                    // 1) Branch where we iterate over each node, then each rule
+                    // 2) Branch where we iterate over each rule, then each node
+                    //
+                    // When the number of nodes is relatively small, most of them can fit
+                    // in the cache and we can save iterating over the rules multiple times.
+                    // But for large files, the number of nodes can be so large that it
+                    // starts to not fit into the cache and pushes out other data, like the rules.
+                    // So we end up thrashing the cache with each rule iteration. In this case,
+                    // it's better to put rules in the inner loop, as the rules data is smaller
+                    // and is more likely to fit in the cache.
+                    //
+                    // The threshold here is chosen to balance between performance improvement
+                    // from not iterating over rules multiple times, but also ensuring that we
+                    // don't thrash the cache too much. Feel free to tweak based on benchmarking.
+                    //
+                    // See https://github.com/oxc-project/oxc/pull/6600 for more context.
+                    if semantic.nodes().len() > 200_000 {
+                        // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
+                        // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
+                        // compile-time since we know all of the rules and their AST node type information ahead of time.
+                        //
+                        // Use boxed array to help compiler see that indexing into it with an `AstType`
+                        // cannot go out of bounds, and remove bounds checks.
+                        let mut rules_by_ast_type =
+                            boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
+                        // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
+                        // node types, but it at least guarantees we won't need to realloc.
+                        let mut rules_any_ast_type = Vec::with_capacity(rules.len());
 
-                    for (rule, ctx) in &rules {
-                        let rule = *rule;
-                        let run_info = rule.run_info();
-                        // Collect node type information for rules. In large files, benchmarking showed it was worth
-                        // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
-                        if with_runtime_optimization
-                            && let Some(ast_types) = rule.types_info()
-                            && run_info.is_run_implemented()
-                        {
-                            for ty in ast_types {
-                                rules_by_ast_type[ty as usize].push((rule, ctx));
-                            }
-                        } else {
-                            rules_any_ast_type.push((rule, ctx));
-                        }
-
-                        if !with_runtime_optimization || run_info.is_run_once_implemented() {
-                            rule.run_once(ctx);
-                        }
-                    }
-
-                    // Run rules on nodes
-                    for node in semantic.nodes() {
-                        for (rule, ctx) in &rules_by_ast_type[node.kind().ty() as usize] {
-                            rule.run(node, ctx);
-                        }
-                        for (rule, ctx) in &rules_any_ast_type {
-                            rule.run(node, ctx);
-                        }
-                    }
-
-                    if should_run_on_jest_node {
-                        for jest_node in iter_possible_jest_call_node(semantic) {
-                            for (rule, ctx) in &rules {
-                                if !with_runtime_optimization
-                                    || rule.run_info().is_run_on_jest_node_implemented()
-                                {
-                                    rule.run_on_jest_node(&jest_node, ctx);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    for (rule, ctx) in &rules {
-                        let run_info = rule.run_info();
-                        if !with_runtime_optimization || run_info.is_run_once_implemented() {
-                            rule.run_once(ctx);
-                        }
-
-                        if !with_runtime_optimization || run_info.is_run_implemented() {
-                            // For smaller files, benchmarking showed it was faster to iterate over all rules and just check the
-                            // node types as we go, rather than pre-bucketing rules by AST node type and doing extra allocations.
-                            if with_runtime_optimization && let Some(ast_types) = rule.types_info()
+                        for (rule, ctx) in &rules {
+                            let rule = *rule;
+                            let run_info = rule.run_info();
+                            // Collect node type information for rules. In large files, benchmarking showed it was worth
+                            // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
+                            if with_runtime_optimization
+                                && let Some(ast_types) = rule.types_info()
+                                && run_info.is_run_implemented()
                             {
-                                for node in semantic.nodes() {
-                                    if ast_types.has(node.kind().ty()) {
-                                        rule.run(node, ctx);
-                                    }
+                                for ty in ast_types {
+                                    rules_by_ast_type[ty as usize].push((rule, ctx));
                                 }
                             } else {
-                                for node in semantic.nodes() {
-                                    rule.run(node, ctx);
+                                rules_any_ast_type.push((rule, ctx));
+                            }
+
+                            if !with_runtime_optimization || run_info.is_run_once_implemented() {
+                                timed_call!(lt, rule, rule.run_once(ctx));
+                            }
+                        }
+
+                        // Run rules on nodes
+                        for node in semantic.nodes() {
+                            for (rule, ctx) in &rules_by_ast_type[node.kind().ty() as usize] {
+                                timed_call!(lt, rule, rule.run(node, ctx));
+                            }
+                            for (rule, ctx) in &rules_any_ast_type {
+                                timed_call!(lt, rule, rule.run(node, ctx));
+                            }
+                        }
+
+                        if should_run_on_jest_node {
+                            for jest_node in iter_possible_jest_call_node(semantic) {
+                                for (rule, ctx) in &rules {
+                                    if !with_runtime_optimization
+                                        || rule.run_info().is_run_on_jest_node_implemented()
+                                    {
+                                        timed_call!(
+                                            lt,
+                                            rule,
+                                            rule.run_on_jest_node(&jest_node, ctx)
+                                        );
+                                    }
                                 }
                             }
                         }
+                    } else {
+                        for (rule, ctx) in &rules {
+                            let run_info = rule.run_info();
+                            if !with_runtime_optimization || run_info.is_run_once_implemented() {
+                                timed_call!(lt, rule, rule.run_once(ctx));
+                            }
 
-                        if should_run_on_jest_node
-                            && (!with_runtime_optimization
-                                || run_info.is_run_on_jest_node_implemented())
-                        {
-                            for jest_node in iter_possible_jest_call_node(semantic) {
-                                rule.run_on_jest_node(&jest_node, ctx);
+                            if !with_runtime_optimization || run_info.is_run_implemented() {
+                                // For smaller files, benchmarking showed it was faster to iterate over all rules and just check the
+                                // node types as we go, rather than pre-bucketing rules by AST node type and doing extra allocations.
+                                if with_runtime_optimization
+                                    && let Some(ast_types) = rule.types_info()
+                                {
+                                    for node in semantic.nodes() {
+                                        if ast_types.has(node.kind().ty()) {
+                                            timed_call!(lt, rule, rule.run(node, ctx));
+                                        }
+                                    }
+                                } else {
+                                    for node in semantic.nodes() {
+                                        timed_call!(lt, rule, rule.run(node, ctx));
+                                    }
+                                }
+                            }
+
+                            if should_run_on_jest_node
+                                && (!with_runtime_optimization
+                                    || run_info.is_run_on_jest_node_implemented())
+                            {
+                                for jest_node in iter_possible_jest_call_node(semantic) {
+                                    timed_call!(lt, rule, rule.run_on_jest_node(&jest_node, ctx));
+                                }
                             }
                         }
                     }
-                }
-            };
+                };
 
-            execute_rules(true);
+            execute_rules(true, &mut local_timings);
 
             #[cfg(debug_assertions)]
             {
                 let diagnostics_after_optimized = ctx_host.diagnostic_count();
-                execute_rules(false);
+                // Validation pass: run without optimizations to verify diagnostic counts match.
+                // Timing is intentionally excluded from this pass.
+                let mut no_timing = None;
+                execute_rules(false, &mut no_timing);
                 let diagnostics_after_unoptimized = ctx_host.diagnostic_count();
                 ctx_host.get_diagnostics(|diagnostics| {
                     let optimized_diagnostics = &diagnostics[current_diagnostic_index..diagnostics_after_optimized];
@@ -382,6 +428,7 @@ impl Linter {
                 &mut ctx_host,
                 allocator,
                 js_allocator_pool,
+                &mut local_timings,
             );
 
             // Report unused directives is now handled differently with type-aware linting
@@ -404,6 +451,10 @@ impl Linter {
             }
         }
 
+        if let (Some(store), Some(lt)) = (&self.timing_store, local_timings) {
+            store.merge(lt);
+        }
+
         let diagnostics = ctx_host.take_diagnostics();
         let disable_directives = if is_partial_loader_file {
             None
@@ -422,6 +473,7 @@ impl Linter {
         ctx_host: &mut Rc<ContextHost<'a>>,
         allocator: &'a Allocator,
         js_allocator_pool: Option<&AllocatorPool>,
+        local_timings: &mut Option<FxHashMap<String, (Duration, u64)>>,
     ) {
         if external_rules.is_empty() {
             return;
@@ -468,12 +520,20 @@ impl Linter {
                 ctx_host,
                 program,
                 js_allocator_pool,
+                local_timings,
             );
             return;
         }
 
         // `allocator` is a fixed-size allocator, so no need to clone AST into a new one
-        self.convert_and_call_external_linter(external_rules, path, ctx_host, program, allocator);
+        self.convert_and_call_external_linter(
+            external_rules,
+            path,
+            ctx_host,
+            program,
+            allocator,
+            local_timings,
+        );
     }
 
     #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
@@ -484,6 +544,7 @@ impl Linter {
         _ctx_host: &mut Rc<ContextHost<'a>>,
         _allocator: &'a Allocator,
         _js_allocator_pool: Option<&AllocatorPool>,
+        _local_timings: &mut Option<FxHashMap<String, (Duration, u64)>>,
     ) {
         // External rules (JS plugins) are not supported on non-64-bit or big-endian platforms
     }
@@ -501,6 +562,7 @@ impl Linter {
         ctx_host: &ContextHost<'_>,
         original_program: &mut Program<'_>,
         js_allocator_pool: &AllocatorPool,
+        local_timings: &mut Option<FxHashMap<String, (Duration, u64)>>,
     ) {
         let js_allocator = js_allocator_pool.get();
 
@@ -529,6 +591,7 @@ impl Linter {
             ctx_host,
             program,
             &js_allocator,
+            local_timings,
         );
 
         // The `AllocatorGuard` (`js_allocator`) is dropped here, returning the allocator to the pool.
@@ -546,6 +609,7 @@ impl Linter {
         ctx_host: &ContextHost<'_>,
         program: &mut Program<'_>,
         allocator: &Allocator,
+        local_timings: &mut Option<FxHashMap<String, (Duration, u64)>>,
     ) {
         // If has BOM, remove it
         const BOM: &str = "\u{feff}";
@@ -610,6 +674,7 @@ impl Linter {
         let external_linter = self.external_linter.as_ref().unwrap();
 
         // Pass AST and rule IDs + options IDs to JS
+        let js_call_start = std::time::Instant::now();
         let result = (external_linter.lint_file)(
             path.to_owned(),
             external_rules.iter().map(|(rule_id, _, _)| rule_id.raw()).collect(),
@@ -619,8 +684,33 @@ impl Linter {
             self.workspace_uri.as_ref().map(ToString::to_string),
             allocator,
         );
+        let js_call_dur = js_call_start.elapsed();
         match result {
-            Ok(diagnostics) => {
+            Ok((diagnostics, js_timings)) => {
+                // Record JS plugin bridge overhead: total call time minus JS rule execution time.
+                // When js_timings is None (JS runtime doesn't support timing), the full call
+                // duration is recorded (includes rule execution time in that case).
+                if let Some(store) = &self.timing_store {
+                    let js_rules_ms: f64 =
+                        js_timings.as_ref().map(|t| t.iter().sum()).unwrap_or(0.0);
+                    let bridge_dur = js_call_dur
+                        .saturating_sub(Duration::from_secs_f64(js_rules_ms / 1000.0));
+                    store.record_overhead("JS plugin bridge", bridge_dur);
+                }
+
+                if let (Some(lt), Some(timings)) = (local_timings, js_timings) {
+                    for (rule_pos, time_ms) in timings.iter().enumerate() {
+                        if rule_pos < external_rules.len() && *time_ms > 0.0 {
+                            let (rule_id, _, _) = external_rules[rule_pos];
+                            let (plugin_name, rule_name) =
+                                self.config.resolve_plugin_rule_names(rule_id);
+                            let key = format!("{plugin_name}/{rule_name}");
+                            let entry = lt.entry(key).or_default();
+                            entry.0 += Duration::from_secs_f64(time_ms / 1000.0);
+                            entry.1 += 1;
+                        }
+                    }
+                }
                 for diagnostic in diagnostics {
                     // Convert UTF-16 offsets back to UTF-8.
                     // TODO: Validate span offsets are within bounds and `start <= end`.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -693,8 +693,8 @@ impl Linter {
                 if let Some(store) = &self.timing_store {
                     let js_rules_ms: f64 =
                         js_timings.as_ref().map(|t| t.iter().sum()).unwrap_or(0.0);
-                    let bridge_dur = js_call_dur
-                        .saturating_sub(Duration::from_secs_f64(js_rules_ms / 1000.0));
+                    let bridge_dur =
+                        js_call_dur.saturating_sub(Duration::from_secs_f64(js_rules_ms / 1000.0));
                     store.record_overhead("JS plugin bridge", bridge_dur);
                 }
 

--- a/crates/oxc_linter/src/lint_runner.rs
+++ b/crates/oxc_linter/src/lint_runner.rs
@@ -200,8 +200,7 @@ impl LintRunnerBuilder {
                 self.fix_kind,
             ) {
                 Ok(state) => {
-                    let mut state =
-                        state.with_silent(self.silent).with_type_check(self.type_check);
+                    let mut state = state.with_silent(self.silent).with_type_check(self.type_check);
                     if let Some(store) = &self.timing_store {
                         state = state.with_timing(Arc::clone(store));
                     }

--- a/crates/oxc_linter/src/timing.rs
+++ b/crates/oxc_linter/src/timing.rs
@@ -1,0 +1,61 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use rustc_hash::FxHashMap;
+
+/// Accumulates per-rule execution timings across files.
+///
+/// Files accumulate timings locally (no locking per rule call), then merge
+/// into this shared store once per file.
+#[derive(Debug, Default)]
+pub struct TimingStore {
+    inner: Mutex<FxHashMap<String, (Duration, u64)>>,
+    /// Overhead durations not attributable to specific rules (e.g. tsgolint
+    /// program load, JS plugin bridge).  Keyed by a human-readable label.
+    overhead: Mutex<FxHashMap<String, Duration>>,
+}
+
+impl TimingStore {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Merge per-file timing data. Called once per file.
+    pub(crate) fn merge(&self, local: FxHashMap<String, (Duration, u64)>) {
+        let mut inner = self.inner.lock().unwrap();
+        for (name, (dur, count)) in local {
+            let entry = inner.entry(name).or_default();
+            entry.0 += dur;
+            entry.1 += count;
+        }
+    }
+
+    /// Collect all timing data sorted by total duration descending.
+    pub fn collect(&self) -> Vec<(String, Duration, u64)> {
+        let inner = self.inner.lock().unwrap();
+        let mut entries: Vec<(String, Duration, u64)> =
+            inner.iter().map(|(name, &(dur, count))| (name.clone(), dur, count)).collect();
+        entries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        entries
+    }
+
+    /// Record an overhead duration (bridge/setup cost, not a specific rule).
+    /// Zero durations are ignored.
+    pub(crate) fn record_overhead(&self, name: &str, dur: Duration) {
+        if dur.is_zero() {
+            return;
+        }
+        *self.overhead.lock().unwrap().entry(name.to_owned()).or_default() += dur;
+    }
+
+    /// Collect overhead entries sorted by duration descending.
+    pub fn collect_overhead(&self) -> Vec<(String, Duration)> {
+        let overhead = self.overhead.lock().unwrap();
+        let mut entries: Vec<(String, Duration)> =
+            overhead.iter().map(|(name, &dur)| (name.clone(), dur)).collect();
+        entries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+        entries
+    }
+}

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -236,13 +236,11 @@ impl TsGoLintState {
             let stdout_result = stdout_handler.join();
 
             if !exit_status.success() {
-                return Err(
-                    if let Some(err) = &stdout_result.ok().and_then(|r| r.err()) {
-                        format!("exit status: {exit_status}, error: {err}")
-                    } else {
-                        format!("exit status: {exit_status}")
-                    },
-                );
+                return Err(if let Some(err) = &stdout_result.ok().and_then(|r| r.err()) {
+                    format!("exit status: {exit_status}, error: {err}")
+                } else {
+                    format!("exit status: {exit_status}")
+                });
             }
 
             match stdout_result {

--- a/crates/oxc_linter/src/tsgolint.rs
+++ b/crates/oxc_linter/src/tsgolint.rs
@@ -6,6 +6,7 @@ use std::{
     iter, mem,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use oxc_allocator::Allocator;
@@ -17,7 +18,9 @@ use oxc_span::{SourceType, Span};
 
 use super::{AllowWarnDeny, ConfigStore, DisableDirectives, ResolvedLinterState, read_to_string};
 
-use crate::{CompositeFix, FixKind, Fixer, Message, PossibleFixes, WEBSITE_BASE_RULES_URL};
+use crate::{
+    CompositeFix, FixKind, Fixer, Message, PossibleFixes, TimingStore, WEBSITE_BASE_RULES_URL,
+};
 
 /// State required to initialize the `tsgolint` linter.
 #[derive(Debug, Clone)]
@@ -37,6 +40,8 @@ pub struct TsGoLintState {
     fix_suggestions: bool,
     /// If `true`, include TypeScript compiler syntactic and semantic diagnostics.
     type_check: bool,
+    /// Optional timing store for per-rule timing data.
+    timing_store: Option<Arc<TimingStore>>,
 }
 
 impl TsGoLintState {
@@ -52,6 +57,7 @@ impl TsGoLintState {
             fix: fix_kind.contains(FixKind::Fix),
             fix_suggestions: fix_kind.contains(FixKind::Suggestion),
             type_check: false,
+            timing_store: None,
         }
     }
 
@@ -74,6 +80,7 @@ impl TsGoLintState {
             fix: fix_kind.contains(FixKind::Fix),
             fix_suggestions: fix_kind.contains(FixKind::Suggestion),
             type_check: false,
+            timing_store: None,
         })
     }
 
@@ -93,6 +100,13 @@ impl TsGoLintState {
     #[must_use]
     pub fn with_type_check(mut self, yes: bool) -> Self {
         self.type_check = yes;
+        self
+    }
+
+    /// Enable per-rule timing. Timings are accumulated into `store`.
+    #[must_use]
+    pub fn with_timing(mut self, store: Arc<TimingStore>) -> Self {
+        self.timing_store = Some(store);
         self
     }
 
@@ -125,6 +139,12 @@ impl TsGoLintState {
         let cwd = self.cwd.clone();
         let sender_for_fixes = error_sender.clone();
 
+        let timing_store = self.timing_store.clone();
+
+        // Record wall-clock start for the entire subprocess invocation so we can
+        // compute program-load time = total - sum(per-rule times).
+        let subprocess_start = std::time::Instant::now();
+
         let handler = std::thread::spawn(move || {
             let mut child = self.spawn_tsgolint(&json_input)?;
 
@@ -132,7 +152,7 @@ impl TsGoLintState {
 
             // Process stdout stream in a separate thread to send diagnostics as they arrive
             let stdout_handler = std::thread::spawn(
-                move || -> Result<Vec<(PathBuf, String, Vec<Message>)>, String> {
+                move || -> Result<(Vec<(PathBuf, String, Vec<Message>)>, rustc_hash::FxHashMap<String, f64>), String> {
                     let disable_directives_map = disable_directives_map
                         .lock()
                         .expect("disable_directives_map mutex poisoned");
@@ -144,12 +164,16 @@ impl TsGoLintState {
                         error_sender,
                     );
 
+                    let mut rule_timings: rustc_hash::FxHashMap<String, f64> = rustc_hash::FxHashMap::default();
                     let msg_iter = TsGoLintMessageStream::new(stdout);
 
                     for msg in msg_iter {
                         match msg {
                             Ok(TsGoLintMessage::Error(err)) => {
                                 return Err(err.error);
+                            }
+                            Ok(TsGoLintMessage::Timing(timings)) => {
+                                rule_timings = timings;
                             }
                             Ok(TsGoLintMessage::Diagnostic(tsgolint_diagnostic)) => {
                                 match tsgolint_diagnostic {
@@ -203,7 +227,7 @@ impl TsGoLintState {
                         }
                     }
 
-                    Ok(diagnostic_handler.into_messages_requiring_fixes())
+                    Ok((diagnostic_handler.into_messages_requiring_fixes(), rule_timings))
                 },
             );
 
@@ -213,7 +237,7 @@ impl TsGoLintState {
 
             if !exit_status.success() {
                 return Err(
-                    if let Some(err) = &stdout_result.ok().and_then(std::result::Result::err) {
+                    if let Some(err) = &stdout_result.ok().and_then(|r| r.err()) {
                         format!("exit status: {exit_status}, error: {err}")
                     } else {
                         format!("exit status: {exit_status}")
@@ -222,14 +246,32 @@ impl TsGoLintState {
             }
 
             match stdout_result {
-                Ok(Ok(messages)) => Ok(messages),
+                Ok(Ok((messages, timings))) => Ok((messages, timings)),
                 Ok(Err(err)) => Err(format!("exit status: {exit_status}, error: {err}")),
                 Err(_) => Err("Failed to join stdout processing thread".to_string()),
             }
         });
 
-        match handler.join() {
-            Ok(Ok(messages_requiring_fixes)) => {
+        let handler_result = handler.join();
+        let subprocess_dur = subprocess_start.elapsed();
+
+        match handler_result {
+            Ok(Ok((messages_requiring_fixes, rule_timings))) => {
+                if let Some(store) = timing_store {
+                    // Overhead = total subprocess time minus sum of per-rule times reported by
+                    // tsgolint. This captures TypeScript program loading and other setup costs.
+                    let rule_total_ms: f64 = rule_timings.values().sum();
+                    let rule_total_dur = Duration::from_secs_f64(rule_total_ms / 1000.0);
+                    let setup_dur = subprocess_dur.saturating_sub(rule_total_dur);
+                    store.record_overhead("Type-aware linting setup", setup_dur);
+
+                    let local: rustc_hash::FxHashMap<String, (Duration, u64)> = rule_timings
+                        .into_iter()
+                        .map(|(name, ms)| (name, (Duration::from_secs_f64(ms / 1000.0), 1)))
+                        .collect();
+                    store.merge(local);
+                }
+
                 for (path, source_text, messages) in messages_requiring_fixes {
                     let source_type = SourceType::from_path(&path)
                         .ok()
@@ -437,6 +479,9 @@ impl TsGoLintState {
                                     result.push(Message::new(diagnostic, PossibleFixes::None));
                                 }
                             }
+                        }
+                        Ok(TsGoLintMessage::Timing(_)) => {
+                            // lint_source is used in tests/LSP; timing data is ignored here.
                         }
                         Err(e) => {
                             return Err(e);
@@ -664,6 +709,8 @@ struct TsGoLintErrorPayload {
 pub enum TsGoLintMessage {
     Diagnostic(TsGoLintDiagnostic),
     Error(TsGoLintError),
+    /// Per-rule timing data: rule_name → milliseconds.
+    Timing(rustc_hash::FxHashMap<String, f64>),
 }
 
 #[derive(Debug, Clone)]
@@ -824,6 +871,13 @@ pub struct LabeledRange {
 pub enum MessageType {
     Error = 0,
     Diagnostic = 1,
+    Timing = 2,
+}
+
+/// Per-rule timing payload from tsgolint: rule_name → milliseconds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TsGoLintTimingPayload {
+    pub timings: rustc_hash::FxHashMap<String, f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -844,6 +898,7 @@ impl TryFrom<u8> for MessageType {
         match value {
             0 => Ok(Self::Error),
             1 => Ok(Self::Diagnostic),
+            2 => Ok(Self::Timing),
             _ => Err(InvalidMessageType(value)),
         }
     }
@@ -1110,6 +1165,11 @@ fn parse_single_message(
                 .map_err(TsGoLintMessageParseError::InvalidErrorPayload)?;
 
             Ok(TsGoLintMessage::Error(TsGoLintError { error: error_payload.error }))
+        }
+        MessageType::Timing => {
+            let timing_payload = serde_json::from_str::<TsGoLintTimingPayload>(&payload_str)
+                .map_err(TsGoLintMessageParseError::InvalidDiagnosticPayload)?;
+            Ok(TsGoLintMessage::Timing(timing_payload.timings))
         }
         MessageType::Diagnostic => {
             let diagnostic_payload =


### PR DESCRIPTION
## Summary

Adds `--timing` flag (and `TIMING=1` env var) that prints a per-rule execution time table at the end of a lint run, covering all three rule types:

- **Built-in Rust rules** — accumulated via a `timed_call!` macro using a per-file local map to avoid per-call lock contention
- **Type-aware rules (tsgolint)** — consumed from a new binary-framed timing message sent by the subprocess ([tsgolint PR #740](https://github.com/oxc-project/tsgolint/pull/740)); wall-clock minus rule-sum gives TypeScript program-load overhead
- **JS plugin rules** — the JS runtime times visitor callbacks and returns them as `timings: number[]`; NAPI bridge time minus JS rule time gives bridge overhead

## Output

```
Rule                            | Time (ms) | Relative
--------------------------------|----------:|---------:
basic-custom-plugin/no-debugger |      0.13 |     0.2%
no-debugger                     |      0.09 |     0.1%
...

Overhead         | Time (ms)
-----------------|----------:
JS plugin bridge |      4.18
```

`Relative` is percentage of total wall-clock run time.

## Protocol change

`LintFileReturnValue::Success` changes from a tuple to a struct variant (`{ diagnostics, timings }`) so the JS runtime can return optional per-rule timing data. This is an internal NAPI protocol change.

## Test plan

- [ ] `TIMING=1 oxlint --timing <files>` shows rule timing table for built-in rules
- [ ] `TIMING=1 oxlint --timing --type-aware <files>` shows type-aware rules + "Type-aware linting setup" overhead (requires [tsgolint #740](https://github.com/oxc-project/tsgolint/pull/740))
- [ ] JS plugin rules appear in table with "JS plugin bridge" overhead entry
- [ ] Without `TIMING` / `--timing`, no overhead and no table
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)