### PR TITLE
refactor(oxfmt): Apply rethrow error for all `pool.run()` calls

### DIFF
--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -35,41 +35,43 @@ export async function formatEmbeddedCode(
   options: FormatEmbeddedCodeParam["options"],
   code: string,
 ): Promise<string> {
-  return pool!.run({ options, code } satisfies FormatEmbeddedCodeParam, {
-    name: "formatEmbeddedCode",
-  });
+  return pool!
+    .run({ options, code } satisfies FormatEmbeddedCodeParam, { name: "formatEmbeddedCode" })
+    .catch(rethrowAsError);
 }
 
 export async function formatFile(
   options: FormatFileParam["options"],
   code: string,
 ): Promise<string> {
-  return (
-    pool!
-      .run({ options, code } satisfies FormatFileParam, { name: "formatFile" })
-      // `tinypool` with `runtime: "child_process"` serializes Error as plain objects via IPC.
-      // (e.g. `{ name, message, stack, ... }`)
-      // And napi-rs converts unknown JS values to Rust Error by calling `String()` on them,
-      // which yields `"[object Object]"` for plain objects...
-      // So, this function reconstructs a proper `Error` instance so napi-rs can extract the message.
-      .catch((err) => {
-        if (err instanceof Error) throw err;
-        if (err !== null && typeof err === "object") {
-          const obj = err as { name: string; message: string };
-          const newErr = new Error(obj.message);
-          newErr.name = obj.name;
-          throw newErr;
-        }
-        throw new Error(String(err));
-      })
-  );
+  return pool!
+    .run({ options, code } satisfies FormatFileParam, { name: "formatFile" })
+    .catch(rethrowAsError);
 }
 
 export async function sortTailwindClasses(
   options: SortTailwindClassesArgs["options"],
   classes: string[],
 ): Promise<string[]> {
-  return pool!.run({ classes, options } satisfies SortTailwindClassesArgs, {
-    name: "sortTailwindClasses",
-  });
+  return pool!
+    .run({ classes, options } satisfies SortTailwindClassesArgs, { name: "sortTailwindClasses" })
+    .catch(rethrowAsError);
+}
+
+// ---
+
+// `tinypool` with `runtime: "child_process"` serializes Error as plain objects via IPC.
+// (e.g. `{ name, message, stack, ... }`)
+// And napi-rs converts unknown JS values to Rust Error by calling `String()` on them,
+// which yields `"[object Object]"` for plain objects...
+// So, this function reconstructs a proper `Error` instance so napi-rs can extract the message.
+function rethrowAsError(err: unknown): never {
+  if (err instanceof Error) throw err;
+  if (err !== null && typeof err === "object") {
+    const obj = err as { name: string; message: string };
+    const newErr = new Error(obj.message);
+    newErr.name = obj.name;
+    throw newErr;
+  }
+  throw new Error(String(err));
 }


### PR DESCRIPTION
Since everything is called via `child_process`, let's standardize it.
(Currently, even if the caller doesn't look at it at all.)