### PR TITLE
feat(oxfmt): Support `graphql()` variant for gql-in-js

### DIFF
--- a/apps/oxfmt/cmp.js
+++ b/apps/oxfmt/cmp.js
@@ -13,21 +13,22 @@ const FIXTURES_DIR = join(
 const EXCLUDE = new Set([
   "format.test.js",
   "comment-tag.js", // /* GraphQL */ comment tag (not yet supported)
-  "expressions.js", // graphql() function call pattern (not yet supported)
-  "graphql.js", // graphql() function call pattern (not yet supported)
 ]);
 
 const files = (await readdir(FIXTURES_DIR))
   .filter((f) => f.endsWith(".js") && !EXCLUDE.has(f))
+  .map((f) => join(FIXTURES_DIR, f))
   .sort();
+
+files.push("./test/cli/embedded_languages/fixtures/graphql.js");
 
 let matchCount = 0;
 let mismatchCount = 0;
 let errorCount = 0;
 
-for (const file of files) {
-  const filePath = join(FIXTURES_DIR, file);
+for (const filePath of files) {
   const source = await readFile(filePath, "utf8");
+  const file = filePath.split("/").slice(-2).join("/");
 
   const prettierOutput = await prettier.format(source, {
     parser: "babel",

--- a/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
@@ -424,6 +424,21 @@ const query = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 
 const mutation = graphql\`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}\`;
 
+// graphql() function call - single argument (hugging layout)
+const schema = graphql(\`query{users{name email}}\`);
+
+// graphql() function call - multiple arguments
+graphql(schema, \`mutation MarkReadNotificationMutation($input:MarkReadNotificationData!){markReadNotification(data:$input){notification{seenState}}}\`)
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
+
 --- AFTER ----------
 // Tagged template literals with gql and graphql tags
 const query = gql\`
@@ -443,6 +458,40 @@ const mutation = graphql\`
     }
   }
 \`;
+
+// graphql() function call - single argument (hugging layout)
+const schema =
+  graphql(\`
+    query {
+      users {
+        name
+        email
+      }
+    }
+  \`);
+
+// graphql() function call - multiple arguments
+graphql(
+  schema,
+  \`
+    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+      markReadNotification(data: $input) {
+        notification {
+          seenState
+        }
+      }
+    }
+  \`,
+);
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
 
 --------------------"
 `;
@@ -615,6 +664,21 @@ const query = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 
 const mutation = graphql\`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}\`;
 
+// graphql() function call - single argument (hugging layout)
+const schema = graphql(\`query{users{name email}}\`);
+
+// graphql() function call - multiple arguments
+graphql(schema, \`mutation MarkReadNotificationMutation($input:MarkReadNotificationData!){markReadNotification(data:$input){notification{seenState}}}\`)
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
+
 --- AFTER ----------
 // Tagged template literals with gql and graphql tags
 const query = gql\`
@@ -634,6 +698,40 @@ const mutation = graphql\`
     }
   }
 \`;
+
+// graphql() function call - single argument (hugging layout)
+const schema =
+  graphql(\`
+    query {
+      users {
+        name
+        email
+      }
+    }
+  \`);
+
+// graphql() function call - multiple arguments
+graphql(
+  schema,
+  \`
+    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+      markReadNotification(data: $input) {
+        notification {
+          seenState
+        }
+      }
+    }
+  \`,
+);
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
 
 --------------------
 
@@ -869,11 +967,44 @@ const query = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 
 const mutation = graphql\`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}\`;
 
+// graphql() function call - single argument (hugging layout)
+const schema = graphql(\`query{users{name email}}\`);
+
+// graphql() function call - multiple arguments
+graphql(schema, \`mutation MarkReadNotificationMutation($input:MarkReadNotificationData!){markReadNotification(data:$input){notification{seenState}}}\`)
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
+
 --- AFTER ----------
 // Tagged template literals with gql and graphql tags
 const query = gql\`query GetUser($id:ID!){user(id:$id){name email}}\`;
 
 const mutation = graphql\`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}\`;
+
+// graphql() function call - single argument (hugging layout)
+const schema = graphql(\`query{users{name email}}\`);
+
+// graphql() function call - multiple arguments
+graphql(
+  schema,
+  \`mutation MarkReadNotificationMutation($input:MarkReadNotificationData!){markReadNotification(data:$input){notification{seenState}}}\`,
+);
+
+// graphql() function call - empty
+graphql(\`\`);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(\`query{users{name}}\`);
+
+// Non-target: other function names
+someFunction(\`query{users{name}}\`);
 
 --------------------
 

--- a/apps/oxfmt/test/cli/embedded_languages/fixtures/graphql.js
+++ b/apps/oxfmt/test/cli/embedded_languages/fixtures/graphql.js
@@ -2,3 +2,18 @@
 const query = gql`query GetUser($id:ID!){user(id:$id){name email}}`;
 
 const mutation = graphql`mutation CreatePost($input:PostInput!){createPost(input:$input){id title}}`;
+
+// graphql() function call - single argument (hugging layout)
+const schema = graphql(`query{users{name email}}`);
+
+// graphql() function call - multiple arguments
+graphql(schema, `mutation MarkReadNotificationMutation($input:MarkReadNotificationData!){markReadNotification(data:$input){notification{seenState}}}`)
+
+// graphql() function call - empty
+graphql(``);
+
+// Non-target: gql() is NOT recognized as a function call pattern
+gql(`query{users{name}}`);
+
+// Non-target: other function names
+someFunction(`query{users{name}}`);

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -45,6 +45,24 @@ fn get_tag_name<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
     }
 }
 
+/// Try to format a template literal inside a `graphql()` function call.
+/// Returns `true` if formatting was performed, `false` if not applicable.
+///
+/// NOTE: when this fires for a single-argument call,
+/// `arguments.rs` also applies a "hugging" layout (`graphql(`…`)` with no trailing comma).
+/// See `is_graphql_call_with_single_template_arg()` in `arguments.rs`.
+pub(super) fn try_format_graphql_call<'a>(
+    template: &AstNode<'a, TemplateLiteral<'a>>,
+    f: &mut Formatter<'_, 'a>,
+) -> bool {
+    let AstNodes::CallExpression(call) = template.parent() else { return false };
+    let Expression::Identifier(ident) = &call.callee else { return false };
+    if ident.name.as_str() != "graphql" {
+        return false;
+    }
+    graphql::format_graphql_doc(template, f)
+}
+
 /// Try to format a template literal inside css prop or styled-jsx with the embedded formatter.
 /// Returns `true` if formatting was attempted, `false` if not applicable.
 pub(super) fn try_format_css_template<'a>(

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -39,6 +39,10 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TemplateLiteral<'a>> {
         if embed::try_format_css_template(self, f) {
             return;
         }
+        // graphql(`...`) function call
+        if embed::try_format_graphql_call(self, f) {
+            return;
+        }
         let template = TemplateLike::TemplateLiteral(self);
         write!(f, template);
     }


### PR DESCRIPTION
Part of #15180 

Now we can support all gql-in-js variants. ✌🏻 