### PR TITLE
feat(oxfmt): support `experimentalOperatorPosition` option with default "start"

### DIFF
--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -55,7 +55,7 @@ pub struct FormatOptions {
     /// Whether to expand object and array literals to multiple lines. Defaults to "auto".
     pub expand: Expand,
 
-    /// Controls the position of operators in binary expressions. [**NOT SUPPORTED YET**]
+    /// Controls the position of operators in binary expressions.
     ///
     /// Accepted values are:
     /// - `"start"`: Places the operator at the beginning of the next line.
@@ -954,9 +954,9 @@ impl fmt::Display for Expand {
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum OperatorPosition {
     /// When binary expressions wrap lines, print operators at the start of new lines.
+    #[default]
     Start,
     // Default behavior; when binary expressions wrap lines, print operators at the end of previous lines.
-    #[default]
     End,
 }
 

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -953,10 +953,10 @@ impl fmt::Display for Expand {
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum OperatorPosition {
-    /// When binary expressions wrap lines, print operators at the start of new lines.
+    /// Default behavior; when binary expressions wrap lines, print operators at the start of new lines.
     #[default]
     Start,
-    // Default behavior; when binary expressions wrap lines, print operators at the end of previous lines.
+    /// When binary expressions wrap lines, print operators at the end of previous lines.
     End,
 }
 

--- a/crates/oxc_formatter/src/print/intersection_type.rs
+++ b/crates/oxc_formatter/src/print/intersection_type.rs
@@ -3,10 +3,11 @@ use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use crate::{
-    ast_nodes::AstNode,
+    ast_nodes::{AstNode, AstNodes},
     formatter::{Formatter, prelude::*},
     parentheses::NeedsParentheses,
     print::FormatWrite,
+    utils::format_node_without_trailing_comments::FormatNodeWithoutTrailingComments,
     utils::typescript::is_object_like_type,
     write,
 };
@@ -23,16 +24,55 @@ fn format_intersection_types<'a>(
     node: &AstNode<'a, Vec<'a, TSType<'a>>>,
     f: &mut Formatter<'_, 'a>,
 ) {
-    let last_index = node.len().saturating_sub(1);
+    let len = node.len();
+    let last_index = len.saturating_sub(1);
     let mut is_prev_object_like = false;
     let mut is_chain_indented = false;
+    let is_operator_start = f.options().experimental_operator_position.is_start();
 
     for (index, item) in node.iter().enumerate() {
         let is_object_like = is_object_like_type(item.as_ref());
 
+        // Compute inter-item comment info (used for both suppression and separator spacing).
+        // Only relevant in operator-start mode when there is a following item.
+        let (has_inline_line_comment_between, has_own_line_comment_between) =
+            if is_operator_start && index < last_index {
+                let next = &node[index + 1];
+                let comments_between =
+                    f.comments().comments_in_range(item.span().end, next.span().start);
+                (
+                    comments_between
+                        .iter()
+                        .any(|comment| comment.is_line() && !comment.preceded_by_newline()),
+                    comments_between
+                        .iter()
+                        .any(|comment| comment.is_line() && comment.preceded_by_newline()),
+                )
+            } else {
+                (false, false)
+            };
+
+        // Case covered by Prettier conformance fixture:
+        // `typescript/intersection/mutiple-comments/17192.ts` with
+        // `{ experimentalOperatorPosition: "start" }`.
+        //
+        // When comments between `item` and `next` are mixed (inline + own-line),
+        // suppress default trailing-comment emission for `item` and re-emit with exact spacing later.
+        let suppress_item_trailing_comments =
+            has_inline_line_comment_between && has_own_line_comment_between;
+
+        // Formats item, suppressing trailing comments when needed for controlled re-emission.
+        let write_item = format_with(|f| {
+            if suppress_item_trailing_comments {
+                write!(f, FormatNodeWithoutTrailingComments(item));
+            } else {
+                write!(f, item);
+            }
+        });
+
         // always inline first element
         if index == 0 {
-            write!(f, item);
+            write!(f, write_item);
         } else {
             // If no object is involved, go to the next line if it breaks
             if !(is_prev_object_like || is_object_like)
@@ -42,9 +82,19 @@ fn format_intersection_types<'a>(
                     if item.needs_parentheses(f) {
                         write!(f, format_leading_comments(item.span()));
                     }
-                    write!(f, item);
+                    write!(f, write_item);
                 });
-                write!(f, soft_line_indent_or_space(&content));
+
+                if is_operator_start {
+                    write!(
+                        f,
+                        [indent(&format_with(|f| {
+                            write!(f, [soft_line_break_or_space(), "&", space(), &content]);
+                        }))]
+                    );
+                } else {
+                    write!(f, soft_line_indent_or_space(&content));
+                }
             } else {
                 write!(f, space());
 
@@ -54,16 +104,50 @@ fn format_intersection_types<'a>(
                 }
 
                 if is_chain_indented {
-                    write!(f, [indent(&item)]);
+                    write!(f, [indent(&write_item)]);
                 } else {
-                    write!(f, item);
+                    write!(f, write_item);
                 }
             }
         }
 
         // Add separator if not the last element
         if index < last_index {
-            write!(f, [space(), "&"]);
+            let should_print_at_end = if !is_operator_start {
+                true
+            } else {
+                let next = &node[index + 1];
+                let next_is_object_like = is_object_like_type(next);
+                let next_is_non_object_branch = !(is_object_like || next_is_object_like)
+                    || f.comments().has_leading_own_line_comment(next.span().start);
+                !next_is_non_object_branch
+            };
+
+            if should_print_at_end {
+                write!(f, [space(), "&"]);
+            } else if is_operator_start {
+                let next = &node[index + 1];
+                if suppress_item_trailing_comments {
+                    // Companion branch for `typescript/intersection/mutiple-comments/17192.ts`.
+                    // Re-emit the suppressed trailing comments with controlled spacing before
+                    // moving `&` to the start of the next line.
+                    write!(f, [space(), space()]);
+                    match item.as_ast_nodes() {
+                        AstNodes::TSTypeReference(r) => r.format_trailing_comments(f),
+                        AstNodes::TSLiteralType(l) => l.format_trailing_comments(f),
+                        AstNodes::TSIntersectionType(i) => i.format_trailing_comments(f),
+                        AstNodes::TSUnionType(u) => u.format_trailing_comments(f),
+                        _ => {}
+                    }
+                }
+                if f.comments().has_comment_in_range(item.span().end, next.span().start) {
+                    // Same fixture as above (`17192.ts`): add one extra space for the
+                    // inline-line-comment transition to preserve Prettier's exact spacing.
+                    let add_extra_space_before_inline_comment = has_inline_line_comment_between
+                        && f.comments().has_leading_own_line_comment(next.span().start);
+                    write!(f, [space(), add_extra_space_before_inline_comment.then_some(space())]);
+                }
+            }
         }
 
         is_prev_object_like = is_object_like;

--- a/crates/oxc_formatter/tests/README.md
+++ b/crates/oxc_formatter/tests/README.md
@@ -99,6 +99,7 @@ The following format options are supported in `options.json`:
 - `bracketSpacing`: `true` | `false` - Object literal spacing
 - `bracketSameLine`: `true` | `false` - JSX bracket on same line
 - `jsxBracketSameLine`: `true` | `false` - (alias for bracketSameLine)
+- `experimentalOperatorPosition`: `"start"` | `"end"` - Binary/intersection operator line position
 
 ## Running Tests
 

--- a/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/assignments.js.snap
@@ -38,9 +38,8 @@ const jestPackageJson =
 
 {
   sourcemap =
-    /** @type {'inline' | 'hidden' | 'sourcemap'} */ (
-      process.env.WORKER_MODE
-    ) || sourcemap;
+    /** @type {'inline' | 'hidden' | 'sourcemap'} */ (process.env.WORKER_MODE)
+    || sourcemap;
 }
 
 class A {

--- a/crates/oxc_formatter/tests/fixtures/js/comments/computed-member.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/computed-member.js.snap
@@ -21,8 +21,8 @@ prop[
 ] = shouldCast;
 
 let handler =
-  props[(handlerName = toHandlerKey(event))] || // also try camelCase event handler (#2249)
-  props[(handlerName = toHandlerKey(camelize(event)))];
+  props[(handlerName = toHandlerKey(event))] // also try camelCase event handler (#2249)
+  || props[(handlerName = toHandlerKey(camelize(event)))];
 
 -------------------
 { printWidth: 100 }
@@ -33,7 +33,7 @@ prop[
 ] = shouldCast;
 
 let handler =
-  props[(handlerName = toHandlerKey(event))] || // also try camelCase event handler (#2249)
-  props[(handlerName = toHandlerKey(camelize(event)))];
+  props[(handlerName = toHandlerKey(event))] // also try camelCase event handler (#2249)
+  || props[(handlerName = toHandlerKey(camelize(event)))];
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/comment.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/comment.js
@@ -1,0 +1,68 @@
+a =
+  // Comment 1
+  Math.random() * (yRange * (1 - minVerticalFraction)) +
+  minVerticalFraction * yRange -
+  offset;
+
+a +
+  a +
+  a + // comment
+  a +
+  a;
+
+a &&
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong && // comment
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong;
+
+a ||
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong || // comment
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong;
+
+var a = x(
+  abifornCringerMoshedPerplexSawder +
+    kochabCooieGameOnOboleUnweave + // f
+    glimseGlyphsHazardNoopsTieTie +
+    bifornCringerMoshedPerplexSawder,
+);
+
+foo[
+  a +
+    a + // comment
+    a +
+    bar[
+      b +
+        b +
+        b + // comment
+        b +
+        b
+    ]
+];
+
+!(
+  a +
+  a + // comment
+  a +
+  !(
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */ &&
+  /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  // line comment
+  cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a +
+  /**/
+  a.a().a();

--- a/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/comment.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/comment.js.snap
@@ -1,0 +1,360 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+a = (
+  // Comment 1
+  (Math.random() * (yRange * (1 - minVerticalFraction)))
+  + (minVerticalFraction * yRange)
+) - offset;
+
+a +
+ a +
+ a + // comment
+ a +
+ a;
+
+a &&
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong &&  // comment
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong
+
+a ||
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong ||  // comment
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong
+
+var a = x(abifornCringerMoshedPerplexSawder
++ kochabCooieGameOnOboleUnweave // f
++ glimseGlyphsHazardNoopsTieTie+bifornCringerMoshedPerplexSawder);
+
+foo[
+  a +
+  a + // comment
+  a +
+  bar[
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  ]
+];
+
+!(
+  a +
+  a + // comment
+  a +
+  !(
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */ &&
+  /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  // line comment
+  cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a +
+  /**/
+  a.a().a();
+
+==================== Output ====================
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+a =
+  // Comment 1
+  Math.random() * (yRange * (1 - minVerticalFraction)) +
+  minVerticalFraction * yRange -
+  offset;
+
+a +
+  a +
+  a + // comment
+  a +
+  a;
+
+a &&
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong && // comment
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong;
+
+a ||
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong || // comment
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong;
+
+var a = x(
+  abifornCringerMoshedPerplexSawder +
+    kochabCooieGameOnOboleUnweave + // f
+    glimseGlyphsHazardNoopsTieTie +
+    bifornCringerMoshedPerplexSawder,
+);
+
+foo[
+  a +
+    a + // comment
+    a +
+    bar[
+      b +
+        b +
+        b + // comment
+        b +
+        b
+    ]
+];
+
+!(
+  a +
+  a + // comment
+  a +
+  !(
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */ &&
+  /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  // line comment
+  cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a +
+  /**/
+  a.a().a();
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+a =
+  // Comment 1
+  Math.random() * (yRange * (1 - minVerticalFraction)) +
+  minVerticalFraction * yRange -
+  offset;
+
+a +
+  a +
+  a + // comment
+  a +
+  a;
+
+a &&
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong && // comment
+  longLongLongLongLongLongLongLongLong &&
+  longLongLongLongLongLongLongLongLong;
+
+a ||
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong || // comment
+  longLongLongLongLongLongLongLongLong ||
+  longLongLongLongLongLongLongLongLong;
+
+var a = x(
+  abifornCringerMoshedPerplexSawder +
+    kochabCooieGameOnOboleUnweave + // f
+    glimseGlyphsHazardNoopsTieTie +
+    bifornCringerMoshedPerplexSawder,
+);
+
+foo[
+  a +
+    a + // comment
+    a +
+    bar[
+      b +
+        b +
+        b + // comment
+        b +
+        b
+    ]
+];
+
+!(
+  a +
+  a + // comment
+  a +
+  !(
+    b +
+    b +
+    b + // comment
+    b +
+    b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */ &&
+  /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb &&
+  // line comment
+  cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a +
+  /**/
+  a.a().a();
+
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+a =
+  // Comment 1
+  Math.random() * (yRange * (1 - minVerticalFraction))
+  + minVerticalFraction * yRange
+  - offset;
+
+a
+  + a
+  + a // comment
+  + a
+  + a;
+
+a
+  && longLongLongLongLongLongLongLongLong
+  && longLongLongLongLongLongLongLongLong // comment
+  && longLongLongLongLongLongLongLongLong
+  && longLongLongLongLongLongLongLongLong;
+
+a
+  || longLongLongLongLongLongLongLongLong
+  || longLongLongLongLongLongLongLongLong // comment
+  || longLongLongLongLongLongLongLongLong
+  || longLongLongLongLongLongLongLongLong;
+
+var a = x(
+  abifornCringerMoshedPerplexSawder
+    + kochabCooieGameOnOboleUnweave // f
+    + glimseGlyphsHazardNoopsTieTie
+    + bifornCringerMoshedPerplexSawder,
+);
+
+foo[
+  a
+    + a // comment
+    + a
+    + bar[
+      b
+        + b
+        + b // comment
+        + b
+        + b
+    ]
+];
+
+!(
+  a
+  + a // comment
+  + a
+  + !(
+    b
+    + b
+    + b // comment
+    + b
+    + b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */
+  && /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  // line comment
+  && cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a
+  /**/
+  + a.a().a();
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+a =
+  // Comment 1
+  Math.random() * (yRange * (1 - minVerticalFraction))
+  + minVerticalFraction * yRange
+  - offset;
+
+a
+  + a
+  + a // comment
+  + a
+  + a;
+
+a
+  && longLongLongLongLongLongLongLongLong
+  && longLongLongLongLongLongLongLongLong // comment
+  && longLongLongLongLongLongLongLongLong
+  && longLongLongLongLongLongLongLongLong;
+
+a
+  || longLongLongLongLongLongLongLongLong
+  || longLongLongLongLongLongLongLongLong // comment
+  || longLongLongLongLongLongLongLongLong
+  || longLongLongLongLongLongLongLongLong;
+
+var a = x(
+  abifornCringerMoshedPerplexSawder
+    + kochabCooieGameOnOboleUnweave // f
+    + glimseGlyphsHazardNoopsTieTie
+    + bifornCringerMoshedPerplexSawder,
+);
+
+foo[
+  a
+    + a // comment
+    + a
+    + bar[
+      b
+        + b
+        + b // comment
+        + b
+        + b
+    ]
+];
+
+!(
+  a
+  + a // comment
+  + a
+  + !(
+    b
+    + b
+    + b // comment
+    + b
+    + b
+  )
+);
+
+const logical_expression =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /* trailing comment */
+  && /* leading comment */ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  // line comment
+  && cccccccccccccccccccccccc;
+
+const bc = a /* internal before */ || /* internal after */ b;
+
+a
+  /**/
+  + a.a().a();
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/options.json
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/operator-position/options.json
@@ -1,0 +1,8 @@
+[
+  {
+    "experimentalOperatorPosition": "end"
+  },
+  {
+    "experimentalOperatorPosition": "start"
+  }
+]

--- a/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-node.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/type-cast-node.js.snap
@@ -19,16 +19,16 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 ------------------
 { printWidth: 80 }
 ------------------
-!left &&
-  /** @type {boolean} */
+!left
+  && /** @type {boolean} */
   (
     /** @type {Identifier} */
-    (a) === "call" ||
-      /** @type {Identifier} */
+    (a) === "call"
+      || /** @type {Identifier} */
       (b) === "bind"
     //  ^^^^^^^^^^^^^^ No need to wrap with parentheses here because the type cast node is already wrapped with parentheses.
-  ) &&
-  right;
+  )
+  && right;
 
 /** @type {Number} */ (a + b)();
 //                    ^^^^^^^ No need to wrap with parentheses here because the type cast node is already wrapped with parentheses.
@@ -36,16 +36,16 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
 -------------------
 { printWidth: 100 }
 -------------------
-!left &&
-  /** @type {boolean} */
+!left
+  && /** @type {boolean} */
   (
     /** @type {Identifier} */
-    (a) === "call" ||
-      /** @type {Identifier} */
+    (a) === "call"
+      || /** @type {Identifier} */
       (b) === "bind"
     //  ^^^^^^^^^^^^^^ No need to wrap with parentheses here because the type cast node is already wrapped with parentheses.
-  ) &&
-  right;
+  )
+  && right;
 
 /** @type {Number} */ (a + b)();
 //                    ^^^^^^^ No need to wrap with parentheses here because the type cast node is already wrapped with parentheses.

--- a/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/logicals/indent.js.snap
@@ -19,8 +19,8 @@ source: crates/oxc_formatter/tests/fixtures/mod.rs
   RESOLUTION_CACHE = new ExpiringCache(
     options.singleRun
       ? "Infinity"
-      : (options.cacheLifetime?.glob ??
-          DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
+      : (options.cacheLifetime?.glob
+          ?? DEFAULT_TSCONFIG_CACHE_DURATION_SECONDS),
   );
 }
 

--- a/crates/oxc_formatter/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter/tests/fixtures/mod.rs
@@ -3,8 +3,8 @@ use std::{env::current_dir, fs, path::Path};
 use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, BracketSameLine, BracketSpacing, FormatOptions, Formatter, IndentStyle,
-    IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
-    get_parse_options,
+    IndentWidth, LineEnding, LineWidth, OperatorPosition, QuoteProperties, QuoteStyle, Semicolons,
+    TrailingCommas, get_parse_options,
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -126,6 +126,15 @@ fn parse_format_options(json: &OptionSet) -> FormatOptions {
                         "preserve" => QuoteProperties::Preserve,
                         "consistent" => QuoteProperties::Consistent,
                         _ => QuoteProperties::default(),
+                    };
+                }
+            }
+            "experimentalOperatorPosition" => {
+                if let Some(s) = value.as_str() {
+                    options.experimental_operator_position = match s {
+                        "start" => OperatorPosition::Start,
+                        "end" => OperatorPosition::End,
+                        _ => options.experimental_operator_position,
                     };
                 }
             }

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/assignments.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/assignments.ts.snap
@@ -38,9 +38,8 @@ const jestPackageJson =
 
 {
   sourcemap =
-    /** @type {'inline' | 'hidden' | 'sourcemap'} */ (
-      process.env.WORKER_MODE
-    ) || sourcemap;
+    /** @type {'inline' | 'hidden' | 'sourcemap'} */ (process.env.WORKER_MODE)
+    || sourcemap;
 }
 
 class A {

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/intersection-parens.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/intersection-parens.ts
@@ -1,0 +1,94 @@
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): string & number {}
+
+var x: string & number;
+var y: string & number;
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z;
+  j: Partial<X & Y>;
+}
+
+type State = {
+  sharedProperty: any;
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ";
+  baz: any;
+});
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string &
+  undefined)[];
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD)[] = [];
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+const foo4: foo &
+  (AAAAAAAAAAAAAAAAAAAAAA &
+    BBBBBBBBBBBBBBBBBBBBBB &
+    CCCCCCCCCCCCCCCCCCCCCC &
+    DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+let a1: C;
+let a2: C;
+let a3: C;
+let a4: C;
+let a5: C;
+let a6: /*1*/ C;
+let a7: /*1*/ C;
+let a8: /*1*/ C;
+let a9: /*1*/ C;
+let a10: /*1*/ /*2*/ C;
+let a11: /*1*/ /*2*/ C;
+
+let aa1: /*1*/ /*2*/ C & D;
+let aa2: /*1*/ /*2*/ C & /*3*/ D;
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type A1 = C;
+type A2 = C;
+type A3 = C;
+type A4 = C;
+type A5 = C;
+type A6 /*1*/ = C;
+type A7 /*1*/ = C;
+type A8 /*1*/ = C;
+type A9 /*1*/ = C;
+type A10 /*1*/ = /*2*/ C;
+type A11 /*1*/ = /*2*/ C;
+type A12 /*1*/ = C;
+type A13 = /*1*/ C;
+
+type Aa1 = /*1*/ /*2*/ C & D;
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type C1 /*1*/ = a & b;
+type C2 /*1*/ = a & b;
+type C3 /*1*/ = a & b;
+type C4 /*1*/ = a & b;
+type C5 /*1*/ = a & b;
+type C6 /*0*/ /*1*/ = a & b;
+
+type Ctor = (new () => X) & Y;

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/intersection-parens.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/intersection-parens.ts.snap
@@ -1,0 +1,703 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+
+export type A = (
+  & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type B = (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type C =
+  & aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): (string & number) {}
+
+var x: (string & number);
+var y: ((string & number));
+
+class Foo<T extends (string & number)> {}
+
+interface Interface {
+    i: (X & Y) | Z;
+    j: Partial<(X & Y)>;
+}
+
+type State = {
+  sharedProperty: any;
+} & (
+  & { discriminant: "FOO"; foo: any }
+  & { discriminant: "BAR"; bar: any }
+  & { discriminant: "BAZ"; baz: any }
+);
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  & string
+  & undefined
+)[];
+
+const foo2: (
+  & AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD
+)[] = [];
+
+const foo3: keyof (
+  & AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD
+) = bar;
+
+const foo4:
+  & foo
+  & (
+      & AAAAAAAAAAAAAAAAAAAAAA
+      & BBBBBBBBBBBBBBBBBBBBBB
+      & CCCCCCCCCCCCCCCCCCCCCC
+      & DDDDDDDDDDDDDDDDDDDDDD
+    ) = bar;
+
+let a1 : C;
+let a2 : & C;
+let a3 : (& C);
+let a4 : & (C);
+let a5 : (& (C));
+let a6 : /*1*/ & C;
+let a7 : /*1*/ & (C);
+let a8 : /*1*/ (& C);
+let a9 : (/*1*/ & C);
+let a10: /*1*/ & /*2*/ C;
+let a11: /*1*/ (& /*2*/ C);
+
+let aa1: /*1*/ & /*2*/ C & D;
+let aa2: /*1*/ & /*2*/ C & /*3*/ D;
+let aa3: /*1*/ & /*2*/ C & /*3*/ D /*4*/;
+
+type A1  = C;
+type A2  = & C;
+type A3  = (& C);
+type A4  = & (C);
+type A5  = (& (C));
+type A6  = /*1*/ & C;
+type A7  = /*1*/ & (C);
+type A8  = /*1*/ (& C);
+type A9  = (/*1*/ & C);
+type A10 = /*1*/ & /*2*/ C;
+type A11 = /*1*/ (& /*2*/ C);
+type A12 = /*1*/ & ( (C));
+type A13 = /*1*/ ( (C));
+
+type Aa1 = /*1*/ & /*2*/ C & D;
+type Aa2 = /*1*/ & /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ & /*2*/ C & /*3*/ D /*4*/;
+
+type C1 = /*1*/ | a & b;
+type C2 = /*1*/ | a & (b);
+type C3 = /*1*/ | a & (| b);
+type C4 = /*1*/ | (a & b);
+type C5 = /*1*/ (| a & b);
+type C6 /*0*/ = /*1*/ (| a & b);
+
+type Ctor = (new () => X) & Y;
+
+==================== Output ====================
+-------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80 }
+-------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): string & number {}
+
+var x: string & number;
+var y: string & number;
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z;
+  j: Partial<X & Y>;
+}
+
+type State = {
+  sharedProperty: any;
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ";
+  baz: any;
+});
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string &
+  undefined)[];
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD)[] = [];
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+const foo4: foo &
+  (AAAAAAAAAAAAAAAAAAAAAA &
+    BBBBBBBBBBBBBBBBBBBBBB &
+    CCCCCCCCCCCCCCCCCCCCCC &
+    DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+let a1: C;
+let a2: C;
+let a3: C;
+let a4: C;
+let a5: C;
+let a6: /*1*/ C;
+let a7: /*1*/ C;
+let a8: /*1*/ C;
+let a9: /*1*/ C;
+let a10: /*1*/ /*2*/ C;
+let a11: /*1*/ /*2*/ C;
+
+let aa1: /*1*/ /*2*/ C & D;
+let aa2: /*1*/ /*2*/ C & /*3*/ D;
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type A1 = C;
+type A2 = C;
+type A3 = C;
+type A4 = C;
+type A5 = C;
+type A6 /*1*/ = C;
+type A7 /*1*/ = C;
+type A8 /*1*/ = C;
+type A9 /*1*/ = C;
+type A10 /*1*/ = /*2*/ C;
+type A11 /*1*/ = /*2*/ C;
+type A12 /*1*/ = C;
+type A13 = /*1*/ C;
+
+type Aa1 = /*1*/ /*2*/ C & D;
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type C1 /*1*/ = a & b;
+type C2 /*1*/ = a & b;
+type C3 /*1*/ = a & b;
+type C4 /*1*/ = a & b;
+type C5 /*1*/ = a & b;
+type C6 /*0*/ /*1*/ = a & b;
+
+type Ctor = (new () => X) & Y;
+
+--------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100 }
+--------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): string & number {}
+
+var x: string & number;
+var y: string & number;
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z;
+  j: Partial<X & Y>;
+}
+
+type State = {
+  sharedProperty: any;
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ";
+  baz: any;
+});
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string & undefined)[];
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD)[] = [];
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+const foo4: foo &
+  (AAAAAAAAAAAAAAAAAAAAAA &
+    BBBBBBBBBBBBBBBBBBBBBB &
+    CCCCCCCCCCCCCCCCCCCCCC &
+    DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+let a1: C;
+let a2: C;
+let a3: C;
+let a4: C;
+let a5: C;
+let a6: /*1*/ C;
+let a7: /*1*/ C;
+let a8: /*1*/ C;
+let a9: /*1*/ C;
+let a10: /*1*/ /*2*/ C;
+let a11: /*1*/ /*2*/ C;
+
+let aa1: /*1*/ /*2*/ C & D;
+let aa2: /*1*/ /*2*/ C & /*3*/ D;
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type A1 = C;
+type A2 = C;
+type A3 = C;
+type A4 = C;
+type A5 = C;
+type A6 /*1*/ = C;
+type A7 /*1*/ = C;
+type A8 /*1*/ = C;
+type A9 /*1*/ = C;
+type A10 /*1*/ = /*2*/ C;
+type A11 /*1*/ = /*2*/ C;
+type A12 /*1*/ = C;
+type A13 = /*1*/ C;
+
+type Aa1 = /*1*/ /*2*/ C & D;
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type C1 /*1*/ = a & b;
+type C2 /*1*/ = a & b;
+type C3 /*1*/ = a & b;
+type C4 /*1*/ = a & b;
+type C5 /*1*/ = a & b;
+type C6 /*0*/ /*1*/ = a & b;
+
+type Ctor = (new () => X) & Y;
+
+--------------------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 80, semi: false }
+--------------------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type Multi = (string & number)[]
+
+function f(): string & number {}
+
+var x: string & number
+var y: string & number
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z
+  j: Partial<X & Y>
+}
+
+type State = {
+  sharedProperty: any
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ"
+  baz: any
+})
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string &
+  undefined)[]
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD)[] = []
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD) = bar
+
+const foo4: foo &
+  (AAAAAAAAAAAAAAAAAAAAAA &
+    BBBBBBBBBBBBBBBBBBBBBB &
+    CCCCCCCCCCCCCCCCCCCCCC &
+    DDDDDDDDDDDDDDDDDDDDDD) = bar
+
+let a1: C
+let a2: C
+let a3: C
+let a4: C
+let a5: C
+let a6: /*1*/ C
+let a7: /*1*/ C
+let a8: /*1*/ C
+let a9: /*1*/ C
+let a10: /*1*/ /*2*/ C
+let a11: /*1*/ /*2*/ C
+
+let aa1: /*1*/ /*2*/ C & D
+let aa2: /*1*/ /*2*/ C & /*3*/ D
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/
+
+type A1 = C
+type A2 = C
+type A3 = C
+type A4 = C
+type A5 = C
+type A6 /*1*/ = C
+type A7 /*1*/ = C
+type A8 /*1*/ = C
+type A9 /*1*/ = C
+type A10 /*1*/ = /*2*/ C
+type A11 /*1*/ = /*2*/ C
+type A12 /*1*/ = C
+type A13 = /*1*/ C
+
+type Aa1 = /*1*/ /*2*/ C & D
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/
+
+type C1 /*1*/ = a & b
+type C2 /*1*/ = a & b
+type C3 /*1*/ = a & b
+type C4 /*1*/ = a & b
+type C5 /*1*/ = a & b
+type C6 /*0*/ /*1*/ = a & b
+
+type Ctor = (new () => X) & Y
+
+---------------------------------------------------------------------
+{ experimentalOperatorPosition: "end", printWidth: 100, semi: false }
+---------------------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+export type Multi = (string & number)[]
+
+function f(): string & number {}
+
+var x: string & number
+var y: string & number
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z
+  j: Partial<X & Y>
+}
+
+type State = {
+  sharedProperty: any
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ"
+  baz: any
+})
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string & undefined)[]
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD)[] = []
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA &
+  BBBBBBBBBBBBBBBBBBBBBB &
+  CCCCCCCCCCCCCCCCCCCCCC &
+  DDDDDDDDDDDDDDDDDDDDDD) = bar
+
+const foo4: foo &
+  (AAAAAAAAAAAAAAAAAAAAAA &
+    BBBBBBBBBBBBBBBBBBBBBB &
+    CCCCCCCCCCCCCCCCCCCCCC &
+    DDDDDDDDDDDDDDDDDDDDDD) = bar
+
+let a1: C
+let a2: C
+let a3: C
+let a4: C
+let a5: C
+let a6: /*1*/ C
+let a7: /*1*/ C
+let a8: /*1*/ C
+let a9: /*1*/ C
+let a10: /*1*/ /*2*/ C
+let a11: /*1*/ /*2*/ C
+
+let aa1: /*1*/ /*2*/ C & D
+let aa2: /*1*/ /*2*/ C & /*3*/ D
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/
+
+type A1 = C
+type A2 = C
+type A3 = C
+type A4 = C
+type A5 = C
+type A6 /*1*/ = C
+type A7 /*1*/ = C
+type A8 /*1*/ = C
+type A9 /*1*/ = C
+type A10 /*1*/ = /*2*/ C
+type A11 /*1*/ = /*2*/ C
+type A12 /*1*/ = C
+type A13 = /*1*/ C
+
+type Aa1 = /*1*/ /*2*/ C & D
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/
+
+type C1 /*1*/ = a & b
+type C2 /*1*/ = a & b
+type C3 /*1*/ = a & b
+type C4 /*1*/ = a & b
+type C5 /*1*/ = a & b
+type C6 /*0*/ /*1*/ = a & b
+
+type Ctor = (new () => X) & Y
+
+---------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 80 }
+---------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): string & number {}
+
+var x: string & number;
+var y: string & number;
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z;
+  j: Partial<X & Y>;
+}
+
+type State = {
+  sharedProperty: any;
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ";
+  baz: any;
+});
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string
+  & undefined)[];
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD)[] = [];
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+const foo4: foo
+  & (AAAAAAAAAAAAAAAAAAAAAA
+    & BBBBBBBBBBBBBBBBBBBBBB
+    & CCCCCCCCCCCCCCCCCCCCCC
+    & DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+let a1: C;
+let a2: C;
+let a3: C;
+let a4: C;
+let a5: C;
+let a6: /*1*/ C;
+let a7: /*1*/ C;
+let a8: /*1*/ C;
+let a9: /*1*/ C;
+let a10: /*1*/ /*2*/ C;
+let a11: /*1*/ /*2*/ C;
+
+let aa1: /*1*/ /*2*/ C & D;
+let aa2: /*1*/ /*2*/ C & /*3*/ D;
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type A1 = C;
+type A2 = C;
+type A3 = C;
+type A4 = C;
+type A5 = C;
+type A6 /*1*/ = C;
+type A7 /*1*/ = C;
+type A8 /*1*/ = C;
+type A9 /*1*/ = C;
+type A10 /*1*/ = /*2*/ C;
+type A11 /*1*/ = /*2*/ C;
+type A12 /*1*/ = C;
+type A13 = /*1*/ C;
+
+type Aa1 = /*1*/ /*2*/ C & D;
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type C1 /*1*/ = a & b;
+type C2 /*1*/ = a & b;
+type C3 /*1*/ = a & b;
+type C4 /*1*/ = a & b;
+type C5 /*1*/ = a & b;
+type C6 /*0*/ /*1*/ = a & b;
+
+type Ctor = (new () => X) & Y;
+
+----------------------------------------------------------
+{ experimentalOperatorPosition: "start", printWidth: 100 }
+----------------------------------------------------------
+export type A = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  & bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string & number)[];
+
+function f(): string & number {}
+
+var x: string & number;
+var y: string & number;
+
+class Foo<T extends string & number> {}
+
+interface Interface {
+  i: (X & Y) | Z;
+  j: Partial<X & Y>;
+}
+
+type State = {
+  sharedProperty: any;
+} & ({ discriminant: "FOO"; foo: any } & { discriminant: "BAR"; bar: any } & {
+  discriminant: "BAZ";
+  baz: any;
+});
+
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string & undefined)[];
+
+const foo2: (AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD)[] = [];
+
+const foo3: keyof (AAAAAAAAAAAAAAAAAAAAAA
+  & BBBBBBBBBBBBBBBBBBBBBB
+  & CCCCCCCCCCCCCCCCCCCCCC
+  & DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+const foo4: foo
+  & (AAAAAAAAAAAAAAAAAAAAAA
+    & BBBBBBBBBBBBBBBBBBBBBB
+    & CCCCCCCCCCCCCCCCCCCCCC
+    & DDDDDDDDDDDDDDDDDDDDDD) = bar;
+
+let a1: C;
+let a2: C;
+let a3: C;
+let a4: C;
+let a5: C;
+let a6: /*1*/ C;
+let a7: /*1*/ C;
+let a8: /*1*/ C;
+let a9: /*1*/ C;
+let a10: /*1*/ /*2*/ C;
+let a11: /*1*/ /*2*/ C;
+
+let aa1: /*1*/ /*2*/ C & D;
+let aa2: /*1*/ /*2*/ C & /*3*/ D;
+let aa3: /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type A1 = C;
+type A2 = C;
+type A3 = C;
+type A4 = C;
+type A5 = C;
+type A6 /*1*/ = C;
+type A7 /*1*/ = C;
+type A8 /*1*/ = C;
+type A9 /*1*/ = C;
+type A10 /*1*/ = /*2*/ C;
+type A11 /*1*/ = /*2*/ C;
+type A12 /*1*/ = C;
+type A13 = /*1*/ C;
+
+type Aa1 = /*1*/ /*2*/ C & D;
+type Aa2 = /*1*/ /*2*/ C & /*3*/ D;
+type Aa3 = /*1*/ /*2*/ C & /*3*/ D /*4*/;
+
+type C1 /*1*/ = a & b;
+type C2 /*1*/ = a & b;
+type C3 /*1*/ = a & b;
+type C4 /*1*/ = a & b;
+type C5 /*1*/ = a & b;
+type C6 /*0*/ /*1*/ = a & b;
+
+type Ctor = (new () => X) & Y;
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/options.json
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/operator-position/options.json
@@ -1,0 +1,12 @@
+[
+  {
+    "experimentalOperatorPosition": "end"
+  },
+  {
+    "semi": false,
+    "experimentalOperatorPosition": "end"
+  },
+  {
+    "experimentalOperatorPosition": "start"
+  }
+]

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -213,8 +213,7 @@ impl TestRunner {
             .filter(|call| {
                 let options = &call.0;
                 // Skip all options that are not supported yet
-                !options.experimental_operator_position.is_start()
-                    && !options.experimental_ternaries
+                !options.experimental_ternaries
             })
             .collect::<Vec<_>>();
 

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -86,6 +86,8 @@ impl VisitMut<'_> for SpecParser {
         let mut options = FormatOptions {
             // Use Prettier's default printWidth(80) instead of our default(100)
             line_width: LineWidth::try_from(80).unwrap(),
+            // Keep Prettier's default operator position for conformance snapshots.
+            experimental_operator_position: OperatorPosition::End,
             ..Default::default()
         };
 
@@ -214,9 +216,10 @@ impl VisitMut<'_> for SpecParser {
                                     .unwrap_or_default();
                                 }
                                 "experimentalOperatorPosition" => {
-                                    // TODO: change `unwrap_or_default` to `unwrap`
+                                    // Keep Prettier's default (`end`) for conformance if parsing fails.
                                     options.experimental_operator_position =
-                                        OperatorPosition::from_str(s).unwrap_or_default();
+                                        OperatorPosition::from_str(s)
+                                            .unwrap_or(OperatorPosition::End);
                                 }
                                 _ => {}
                             }


### PR DESCRIPTION
This PR implements support for the `experimentalOperatorPosition` option and sets it to `"start"` by default as mentioned in https://github.com/oxc-project/oxc/issues/16366.
It also updates the fixtures to include the ones from prettier/prettier#7111 to make sure we conform with them.

fixes: https://github.com/oxc-project/oxc/issues/16366

Disclaimer: This changeset was created with the help of AI. I manually verified the output and snapshot changes, but I'm not super familiar with this codebase.