### PR TITLE
fix(parser): improve error recovery for private identifiers in property names

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -64,6 +64,12 @@ pub fn unexpected_token(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn private_identifier_in_property_name(name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Private identifier '#{name}' is not allowed in property names"))
+        .with_label(span)
+}
+
+#[cold]
 pub fn html_comment_in_module(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("HTML comments are not allowed in modules").with_label(span)
 }

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -175,6 +175,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 computed = true;
                 PropertyKey::from(self.parse_computed_property_name())
             }
+            Kind::PrivateIdentifier => {
+                let private_ident = self.parse_private_identifier();
+                self.error(diagnostics::private_identifier_in_property_name(
+                    &private_ident.name,
+                    private_ident.span,
+                ));
+                PropertyKey::PrivateIdentifier(self.alloc(private_ident))
+            }
             _ => {
                 let ident = self.parse_identifier_name();
                 PropertyKey::StaticIdentifier(self.alloc(ident))

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -7919,7 +7919,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-method/input.js:2:11]
  1 │ class C {
  2 │   #p = ({ #x() {} });
@@ -7927,7 +7927,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-property/input.js:2:11]
  1 │ class C {
  2 │   #p = ({ #x: 42 });
@@ -7935,7 +7935,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  3 │ }
    ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-object-property-with-assignment/input.js:4:5]
  3 │   m = {
  4 │     #x: x,
@@ -7943,7 +7943,15 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  5 │     y: y = m
    ╰────
 
-  × Unexpected token
+  × Private identifier '#p' is not allowed in property names
+   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-ts-type-literal/input.js:2:3]
+ 1 │ interface I {
+ 2 │   #p: string
+   ·   ──
+ 3 │ }
+   ╰────
+
+  × Private identifier '#p' is not allowed outside class bodies
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/invalid-ts-type-literal/input.js:2:3]
  1 │ interface I {
  2 │   #p: string

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -12946,7 +12946,7 @@ Negative Passed: 4588/4588 (100.00%)
  38 │ {
     ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
     ╭─[test262/test/language/expressions/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js:31:13]
  30 │   destructureX() {
  31 │     const { #x: x } = this;
@@ -19635,7 +19635,7 @@ Negative Passed: 4588/4588 (100.00%)
  18 │ });
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-fn-inside-class.js:25:11]
  24 │   field = {
  25 │     async #m() {}
@@ -19643,7 +19643,7 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-fn.js:24:9]
  23 │ var o = {
  24 │   async #m() {}
@@ -19651,7 +19651,15 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ };
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-fn.js:24:9]
+ 23 │ var o = {
+ 24 │   async #m() {}
+    ·         ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-gen-inside-class.js:25:13]
  24 │   field = {
  25 │     async * #m() {}
@@ -19659,7 +19667,7 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-gen.js:24:11]
  23 │ var o = {
  24 │   async * #m() {}
@@ -19667,7 +19675,15 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ };
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-async-gen.js:24:11]
+ 23 │ var o = {
+ 24 │   async * #m() {}
+    ·           ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-gen-inside-class.js:25:7]
  24 │   field = {
  25 │     * #m() {}
@@ -19675,7 +19691,7 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-gen.js:24:5]
  23 │ var o = {
  24 │   * #m() {}
@@ -19683,7 +19699,15 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ };
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-gen.js:24:5]
+ 23 │ var o = {
+ 24 │   * #m() {}
+    ·     ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-get-method-inside-class.js:25:9]
  24 │   field = {
  25 │     get #m() {}
@@ -19691,7 +19715,7 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-get-method.js:24:7]
  23 │ var o = {
  24 │   get #m() {}
@@ -19699,7 +19723,15 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ };
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-get-method.js:24:7]
+ 23 │ var o = {
+ 24 │   get #m() {}
+    ·       ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-method-inside-class.js:25:5]
  24 │   field = {
  25 │     #m() {}
@@ -19707,7 +19739,7 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-method.js:24:3]
  23 │ var o = {
  24 │   #m() {}
@@ -19715,7 +19747,15 @@ Negative Passed: 4588/4588 (100.00%)
  25 │ };
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-method.js:24:3]
+ 23 │ var o = {
+ 24 │   #m() {}
+    ·   ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-set-method-inside-class.js:25:9]
  24 │   field = {
  25 │     set #m(x) {}
@@ -19723,7 +19763,15 @@ Negative Passed: 4588/4588 (100.00%)
  26 │   }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#m' is not allowed in property names
+    ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-set-method.js:24:7]
+ 23 │ var o = {
+ 24 │   set #m(x) {}
+    ·       ──
+ 25 │ };
+    ╰────
+
+  × Private identifier '#m' is not allowed outside class bodies
     ╭─[test262/test/language/expressions/object/method-definition/private-name-early-error-set-method.js:24:7]
  23 │ var o = {
  24 │   set #m(x) {}
@@ -32151,7 +32199,7 @@ Negative Passed: 4588/4588 (100.00%)
  38 │ {
     ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
     ╭─[test262/test/language/statements/class/elements/syntax/early-errors/grammar-private-field-on-object-destructuring.js:31:13]
  30 │   destructureX() {
  31 │     const { #x: x } = this;

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -14196,13 +14196,147 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Did you mean '#foo'?
 
-  × Unexpected token
+  × Private identifier '#foo' is not allowed in property names
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:2:5]
  1 │ type A = {
  2 │     #foo: string;
    ·     ────
  3 │     #bar(): string;
    ╰────
+
+  × Private identifier '#bar' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:3:5]
+ 2 │     #foo: string;
+ 3 │     #bar(): string;
+   ·     ────
+ 4 │ }
+   ╰────
+
+  × Private identifier '#foo' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:7:5]
+ 6 │ interface B {
+ 7 │     #foo: string;
+   ·     ────
+ 8 │     #bar(): string;
+   ╰────
+
+  × Private identifier '#bar' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:8:5]
+ 7 │     #foo: string;
+ 8 │     #bar(): string;
+   ·     ────
+ 9 │ }
+   ╰────
+
+  × Private identifier '#foo' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:12:5]
+ 11 │ declare const x: {
+ 12 │     #foo: number;
+    ·     ────
+ 13 │     bar: {
+    ╰────
+
+  × Private identifier '#baz' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:14:9]
+ 13 │     bar: {
+ 14 │         #baz: string;
+    ·         ────
+ 15 │         #taz(): string;
+    ╰────
+
+  × Private identifier '#taz' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:15:9]
+ 14 │         #baz: string;
+ 15 │         #taz(): string;
+    ·         ────
+ 16 │     }
+    ╰────
+
+  × Private identifier '#baz' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:17:5]
+ 16 │     }
+ 17 │     #baz(): string;
+    ·     ────
+ 18 │ };
+    ╰────
+
+  × Private identifier '#quux' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:20:28]
+ 19 │ 
+ 20 │ declare const y: [{ qux: { #quux: 3 } }];
+    ·                            ─────
+    ╰────
+
+  × Private identifier '#foo' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:2:5]
+ 1 │ type A = {
+ 2 │     #foo: string;
+   ·     ────
+ 3 │     #bar(): string;
+   ╰────
+
+  × Private identifier '#bar' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:3:5]
+ 2 │     #foo: string;
+ 3 │     #bar(): string;
+   ·     ────
+ 4 │ }
+   ╰────
+
+  × Private identifier '#foo' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:7:5]
+ 6 │ interface B {
+ 7 │     #foo: string;
+   ·     ────
+ 8 │     #bar(): string;
+   ╰────
+
+  × Private identifier '#bar' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:8:5]
+ 7 │     #foo: string;
+ 8 │     #bar(): string;
+   ·     ────
+ 9 │ }
+   ╰────
+
+  × Private identifier '#foo' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:12:5]
+ 11 │ declare const x: {
+ 12 │     #foo: number;
+    ·     ────
+ 13 │     bar: {
+    ╰────
+
+  × Private identifier '#baz' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:14:9]
+ 13 │     bar: {
+ 14 │         #baz: string;
+    ·         ────
+ 15 │         #taz(): string;
+    ╰────
+
+  × Private identifier '#taz' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:15:9]
+ 14 │         #baz: string;
+ 15 │         #taz(): string;
+    ·         ────
+ 16 │     }
+    ╰────
+
+  × Private identifier '#baz' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:17:5]
+ 16 │     }
+ 17 │     #baz(): string;
+    ·     ────
+ 18 │ };
+    ╰────
+
+  × Private identifier '#quux' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts:20:28]
+ 19 │ 
+ 20 │ declare const y: [{ qux: { #quux: 3 } }];
+    ·                            ─────
+    ╰────
 
   × Private identifier '#nope' is not allowed outside class bodies
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadAssignment.ts:1:9]
@@ -14235,13 +14369,109 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  13 │     }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:3:3]
  2 │ A.prototype = {
  3 │   #x: 1,         // Error
    ·   ──
  4 │   #m() {},       // Error
    ╰────
+
+  × Private identifier '#m' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:4:3]
+ 3 │   #x: 1,         // Error
+ 4 │   #m() {},       // Error
+   ·   ──
+ 5 │   get #p() { return "" } // Error
+   ╰────
+
+  × Private identifier '#p' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:5:7]
+ 4 │   #m() {},       // Error
+ 5 │   get #p() { return "" } // Error
+   ·       ──
+ 6 │ }
+   ╰────
+
+  × Private identifier '#y' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:9:3]
+  8 │ B.prototype = {
+  9 │   #y: 2,         // Error
+    ·   ──
+ 10 │   #m() {},       // Error
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:10:3]
+  9 │   #y: 2,         // Error
+ 10 │   #m() {},       // Error
+    ·   ──
+ 11 │   get #p() { return "" } // Error
+    ╰────
+
+  × Private identifier '#p' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:11:7]
+ 10 │   #m() {},       // Error
+ 11 │   get #p() { return "" } // Error
+    ·       ──
+ 12 │ }
+    ╰────
+
+  × Private identifier '#x' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:3:3]
+ 2 │ A.prototype = {
+ 3 │   #x: 1,         // Error
+   ·   ──
+ 4 │   #m() {},       // Error
+   ╰────
+
+  × Private identifier '#m' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:4:3]
+ 3 │   #x: 1,         // Error
+ 4 │   #m() {},       // Error
+   ·   ──
+ 5 │   get #p() { return "" } // Error
+   ╰────
+
+  × Private identifier '#p' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:5:7]
+ 4 │   #m() {},       // Error
+ 5 │   get #p() { return "" } // Error
+   ·       ──
+ 6 │ }
+   ╰────
+
+  × Private identifier '#y' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:9:3]
+  8 │ B.prototype = {
+  9 │   #y: 2,         // Error
+    ·   ──
+ 10 │   #m() {},       // Error
+    ╰────
+
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:10:3]
+  9 │   #y: 2,         // Error
+ 10 │   #m() {},       // Error
+    ·   ──
+ 11 │   get #p() { return "" } // Error
+    ╰────
+
+  × Private identifier '#p' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:11:7]
+ 10 │   #m() {},       // Error
+ 11 │   get #p() { return "" } // Error
+    ·       ──
+ 12 │ }
+    ╰────
+
+  × Private field '#z' must be declared in an enclosing class
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts:15:10]
+ 14 │   constructor() {
+ 15 │     this.#z = 3;
+    ·          ──
+ 16 │   }
+    ╰────
 
   × Classes can't have an element named '#constructor'
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorReserved.ts:2:5]
@@ -15021,7 +15251,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  21 │ 
     ╰────
 
-  × Unexpected token
+  × Private identifier '#foo' is not allowed in property names
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-1.ts:2:5]
  1 │ const obj = {
  2 │     #foo: 1
@@ -15029,7 +15259,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ };
    ╰────
 
-  × Unexpected token
+  × Private identifier '#foo' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-1.ts:2:5]
+ 1 │ const obj = {
+ 2 │     #foo: 1
+   ·     ────
+ 3 │ };
+   ╰────
+
+  × Private identifier '#foo' is not allowed in property names
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-2.ts:2:5]
  1 │ const obj = {
  2 │     #foo() {
@@ -15037,7 +15275,23 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  3 │ 
    ╰────
 
-  × Unexpected token
+  × Private identifier '#foo' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-2.ts:2:5]
+ 1 │ const obj = {
+ 2 │     #foo() {
+   ·     ────
+ 3 │ 
+   ╰────
+
+  × Private identifier '#foo' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-3.ts:2:9]
+ 1 │ const obj = {
+ 2 │     get #foo() {
+   ·         ────
+ 3 │         return ""
+   ╰────
+
+  × Private identifier '#foo' is not allowed outside class bodies
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-3.ts:2:9]
  1 │ const obj = {
  2 │     get #foo() {
@@ -15076,13 +15330,109 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  12 │     }
     ╰────
 
-  × Unexpected token
+  × Private identifier '#x' is not allowed in property names
    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:3:3]
  2 │ A.prototype = {
  3 │   #x: 1,         // Error
    ·   ──
  4 │   #m() {},       // Error
    ╰────
+
+  × Private identifier '#m' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:4:3]
+ 3 │   #x: 1,         // Error
+ 4 │   #m() {},       // Error
+   ·   ──
+ 5 │   get #p() { return "" } // Error
+   ╰────
+
+  × Private identifier '#p' is not allowed in property names
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:5:7]
+ 4 │   #m() {},       // Error
+ 5 │   get #p() { return "" } // Error
+   ·       ──
+ 6 │ }
+   ╰────
+
+  × Private identifier '#y' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:9:3]
+  8 │ B.prototype = {
+  9 │   #y: 2,         // Error
+    ·   ──
+ 10 │   #m() {},       // Error
+    ╰────
+
+  × Private identifier '#m' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:10:3]
+  9 │   #y: 2,         // Error
+ 10 │   #m() {},       // Error
+    ·   ──
+ 11 │   get #p() { return "" } // Error
+    ╰────
+
+  × Private identifier '#p' is not allowed in property names
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:11:7]
+ 10 │   #m() {},       // Error
+ 11 │   get #p() { return "" } // Error
+    ·       ──
+ 12 │ }
+    ╰────
+
+  × Private identifier '#x' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:3:3]
+ 2 │ A.prototype = {
+ 3 │   #x: 1,         // Error
+   ·   ──
+ 4 │   #m() {},       // Error
+   ╰────
+
+  × Private identifier '#m' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:4:3]
+ 3 │   #x: 1,         // Error
+ 4 │   #m() {},       // Error
+   ·   ──
+ 5 │   get #p() { return "" } // Error
+   ╰────
+
+  × Private identifier '#p' is not allowed outside class bodies
+   ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:5:7]
+ 4 │   #m() {},       // Error
+ 5 │   get #p() { return "" } // Error
+   ·       ──
+ 6 │ }
+   ╰────
+
+  × Private identifier '#y' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:9:3]
+  8 │ B.prototype = {
+  9 │   #y: 2,         // Error
+    ·   ──
+ 10 │   #m() {},       // Error
+    ╰────
+
+  × Private identifier '#m' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:10:3]
+  9 │   #y: 2,         // Error
+ 10 │   #m() {},       // Error
+    ·   ──
+ 11 │   get #p() { return "" } // Error
+    ╰────
+
+  × Private identifier '#p' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:11:7]
+ 10 │   #m() {},       // Error
+ 11 │   get #p() { return "" } // Error
+    ·       ──
+ 12 │ }
+    ╰────
+
+  × Private field '#z' must be declared in an enclosing class
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts:15:10]
+ 14 │   constructor() {
+ 15 │     this.#z = 3;
+    ·          ──
+ 16 │   }
+    ╰────
 
   × Private identifier '#method' is not allowed outside class bodies
     ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAccess.ts:12:10]
@@ -19992,7 +20342,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
     ╰────
   help: Wrap either expression by parentheses
 
-  × Unexpected token
+  × Private identifier '#z' is not allowed in property names
     ╭─[typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralErrors.ts:50:5]
  49 │     y = 2,
  50 │     #z: 3
@@ -20017,6 +20367,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  49 │     y = 2,
     ╰────
   help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
+
+  × Private identifier '#z' is not allowed outside class bodies
+    ╭─[typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralErrors.ts:50:5]
+ 49 │     y = 2,
+ 50 │     #z: 3
+    ·     ──
+ 51 │ }
+    ╰────
 
   × Cannot assign to this expression
    ╭─[typescript/tests/cases/conformance/expressions/operators/incrementAndDecrement.ts:8:1]


### PR DESCRIPTION
## Summary

- When `#ident` appears as a property key in invalid positions (object literals `{#x: 1}`, destructuring `const {#x} = y`, TS interface members), the parser previously fell into `parse_identifier_name()` producing an unhelpful "Unexpected token" error
- Added a `Kind::PrivateIdentifier` arm in `parse_property_name()` that creates a proper `PropertyKey::PrivateIdentifier` AST node and emits "Private identifier '#x' is not allowed in property names"
- This works correctly both inside and outside class bodies, with no conformance regressions

closes #19669

🤖 Generated with [Claude Code](https://claude.com/claude-code)