### PR TITLE
perf(estree/tokens): replace hash map with `Vec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,6 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
- "rustc-hash",
  "serde",
  "serde_json",
 ]

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -25,7 +25,5 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
-
-rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
AST walk happens in source code order, so we don't need a hashmap for storing token kind overrides. We can instead use a `Vec`. The `Vec` gets filled in ascending order of span start, and then is consumed in the 2nd pass in ascending order as well.

Iterating over a `Vec` in first-to-last order is much cheaper than a series of hashmap lookups which have a scattered read pattern.