### PR TITLE
refactor(estree/tokens): convert tokens spans before AST spans

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -214,9 +214,6 @@ unsafe fn parse_raw_impl(
                 Utf8ToUtf16::new(source_text)
             };
 
-            span_converter.convert_program(program);
-            span_converter.convert_comments(&mut program.comments);
-
             let tokens_json = to_estree_tokens_json(
                 &tokens,
                 program,
@@ -225,6 +222,10 @@ unsafe fn parse_raw_impl(
                 EstreeTokenOptions::linter(),
                 &allocator,
             );
+
+            span_converter.convert_program(program);
+            span_converter.convert_comments(&mut program.comments);
+
             let tokens_json = allocator.alloc_str(&tokens_json);
             let tokens_offset = tokens_json.as_ptr() as u32;
             #[expect(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -569,9 +569,6 @@ impl Linter {
             Utf8ToUtf16::new(source_text)
         };
 
-        span_converter.convert_program(program);
-        span_converter.convert_comments(&mut program.comments);
-
         let (tokens_offset, tokens_len) =
             if let Some(tokens) = ctx_host.current_sub_host().parser_tokens() {
                 let tokens_json = to_estree_tokens_json(
@@ -590,6 +587,9 @@ impl Linter {
             } else {
                 (0, 0)
             };
+
+        span_converter.convert_program(program);
+        span_converter.convert_comments(&mut program.comments);
 
         // Get offset of `Program` within buffer (bottom 32 bits of pointer)
         let program_offset = ptr::from_ref(program) as u32;

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -133,11 +133,11 @@ fn bench_estree_tokens(criterion: &mut Criterion) {
                     })
                     .with_config(config)
                     .parse();
-                let ParserReturn { mut program, tokens, .. } = ret;
+                let ParserReturn { program, tokens, .. } = ret;
 
-                // Span conversion of AST is not performed in measured section, as we only want to measure tokens
+                // Creating span converter is not performed in measured section, as we only want to measure tokens.
+                // Span converter needs to be created anyway for serializing AST.
                 let span_converter = Utf8ToUtf16::new(program.source_text);
-                span_converter.convert_program(&mut program);
 
                 runner.run(|| {
                     let tokens_json = to_estree_tokens_json(

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -848,7 +848,6 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
 
             let ParserReturn { mut program, tokens, .. } = ret;
             let span_converter = Utf8ToUtf16::new(source_text);
-            span_converter.convert_program_with_ascending_order_checks(&mut program);
 
             let oxc_tokens_json = to_estree_tokens_pretty_json(
                 &tokens,
@@ -858,6 +857,8 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
                 EstreeTokenOptions::test262(),
                 &allocator,
             );
+
+            span_converter.convert_program_with_ascending_order_checks(&mut program);
 
             let token_path = workspace_root()
                 .join("estree-conformance/tests/test262-tokens")
@@ -898,7 +899,6 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
 
             let ParserReturn { mut program, tokens, .. } = ret;
             let span_converter = Utf8ToUtf16::new(source_text);
-            span_converter.convert_program_with_ascending_order_checks(&mut program);
 
             let oxc_tokens_json = to_estree_tokens_pretty_json(
                 &tokens,
@@ -908,6 +908,8 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
                 EstreeTokenOptions::test262(),
                 &allocator,
             );
+
+            span_converter.convert_program_with_ascending_order_checks(&mut program);
 
             let token_path = workspace_root().join(f.path.with_extension("tokens.json"));
             let expected_tokens_json = fs::read_to_string(&token_path).unwrap_or_default();
@@ -1074,7 +1076,6 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
 
                 let ParserReturn { mut program, tokens, .. } = ret;
                 let span_converter = Utf8ToUtf16::new(source_text);
-                span_converter.convert_program_with_ascending_order_checks(&mut program);
 
                 let oxc_tokens_json = to_estree_tokens_pretty_json(
                     &tokens,
@@ -1084,6 +1085,8 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
                     EstreeTokenOptions::typescript(),
                     &allocator,
                 );
+
+                span_converter.convert_program_with_ascending_order_checks(&mut program);
 
                 if oxc_tokens_json != *expected_tokens {
                     return CoverageResult {


### PR DESCRIPTION
Refactor.

Previously we converted spans from UTF-8 to UTF-16 in AST first, then serialized tokens. This meant that when serializing tokens, we had to convert spans to UTF-16 before comparing offsets of overrides to the token's start offset (because the override offsets are taken from the AST nodes during the AST walk pass).

Instead, convert token spans first, *then* the AST. This removes span conversion from the critical path. On a CPU with instruction-level parallelism, other work can start without being blocked on waiting for the result of span conversion, and the two can happen in parallel.

This should be a slight perf improvement, though it likely won't show up on CodSpeed benchmarks as CodSpeed's CPU simulation to basic to emulate instruction-level parallelism.

But mainly, the motivation is that this makes the process simpler and easier to reason about.