### PR TITLE
perf(estree/tokens): serialize with `ESTree` not `serde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,10 +1910,9 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_estree",
  "oxc_parser",
  "oxc_span",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -23,7 +23,6 @@ doctest = false
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
+oxc_estree = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true }
-oxc_span = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+oxc_span = { workspace = true, features = ["serialize"] }


### PR DESCRIPTION
Serialize tokens using `ESTree` trait instead of `serde`. It's faster. +37% on ESTree tokens benchmark.