### PR TITLE
perf(estree/tokens): serialize tokens while visiting AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,6 @@ dependencies = [
 name = "oxc_estree_tokens"
 version = "0.115.0"
 dependencies = [
- "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_estree",

--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -220,7 +220,6 @@ unsafe fn parse_raw_impl(
                 original_source_text,
                 &span_converter,
                 EstreeTokenOptions::linter(),
-                &allocator,
             );
 
             span_converter.convert_program(program);

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_estree = { workspace = true, features = ["serialize"] }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -577,7 +577,6 @@ impl Linter {
                     original_source_text,
                     &span_converter,
                     EstreeTokenOptions::linter(),
-                    allocator,
                 );
                 let tokens_json = allocator.alloc_str(&tokens_json);
                 let tokens_offset = tokens_json.as_ptr() as u32;

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -146,7 +146,6 @@ fn bench_estree_tokens(criterion: &mut Criterion) {
                         program.source_text,
                         &span_converter,
                         EstreeTokenOptions::test262(),
-                        &allocator,
                     );
                     let tokens_json = black_box(tokens_json);
                     // Allocate tokens JSON into arena, same as linter and NAPI parser package do

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -855,7 +855,6 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
                 source_text,
                 &span_converter,
                 EstreeTokenOptions::test262(),
-                &allocator,
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -906,7 +905,6 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
                 source_text,
                 &span_converter,
                 EstreeTokenOptions::test262(),
-                &allocator,
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -1083,7 +1081,6 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
                     source_text,
                     &span_converter,
                     EstreeTokenOptions::typescript(),
-                    &allocator,
                 );
 
                 span_converter.convert_program_with_ascending_order_checks(&mut program);


### PR DESCRIPTION
Previously we used a 3-pass process for serializing tokens in ESTree format.

* Pass 1: Walk AST and produce a list of "overrides" - which tokens need their `Kind` changed.
* Pass 2: Loop through all tokens, apply any overrides, convert to `ESTreeToken`s, and save them in a `Vec`.
* Pass 3: Serialize the `Vec<ESTreeToken>` with `ESTree` trait (JSON serializer).

Compress this all to a single pass:

* Create an `ESTreeSequenceSerializer` which can have items sent to it to serialize one-by-one (streaming).
* Walk AST.
* When encounter a token which needs its `Kind` altered:
  * Flush all previous tokens, serializing each in turn, using its default `Kind`.
  * Serialize the current token with the amended `Kind`.
  * Continue walking.
* At the end, flush any remaining tokens to the serializer.

This avoids multiple passes, and also removes the `Vec<ESTreeToken>` which was just intermediate data, and grew very large.

+18% perf improvement on ESTree tokens benchmark.