### PR TITLE
perf(estree): use `CodeBuffer::print_indent`

### DIFF
--- a/crates/oxc_estree/src/serialize/formatter.rs
+++ b/crates/oxc_estree/src/serialize/formatter.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use oxc_data_structures::code_buffer::CodeBuffer;
 
 /// Formatter trait.
@@ -79,7 +77,7 @@ impl Formatter for PrettyFormatter {
     }
 
     fn before_first_element(&mut self, buffer: &mut CodeBuffer) {
-        self.indent += 2;
+        self.indent += 1;
         self.push_new_line_and_indent(buffer);
     }
 
@@ -92,7 +90,7 @@ impl Formatter for PrettyFormatter {
     }
 
     fn after_last_element(&mut self, buffer: &mut CodeBuffer) {
-        self.indent -= 2;
+        self.indent -= 1;
         self.push_new_line_and_indent(buffer);
     }
 }
@@ -100,7 +98,6 @@ impl Formatter for PrettyFormatter {
 impl PrettyFormatter {
     fn push_new_line_and_indent(&self, buffer: &mut CodeBuffer) {
         buffer.print_ascii_byte(b'\n');
-        // SAFETY: Spaces are ASCII
-        unsafe { buffer.print_bytes_iter_unchecked(iter::repeat_n(b' ', self.indent)) };
+        buffer.print_indent(self.indent);
     }
 }

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -5,7 +5,10 @@ use std::mem;
 
 use itoa::Buffer as ItoaBuffer;
 
-use oxc_data_structures::{code_buffer::CodeBuffer, stack::NonEmptyStack};
+use oxc_data_structures::{
+    code_buffer::{CodeBuffer, IndentChar},
+    stack::NonEmptyStack,
+};
 
 mod blanket;
 mod concat;
@@ -110,7 +113,7 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
     /// Create new [`ESTreeSerializer`].
     pub fn new(ranges: bool) -> Self {
         Self {
-            buffer: CodeBuffer::new(),
+            buffer: CodeBuffer::with_indent(IndentChar::Space, 2),
             formatter: F::new(),
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),
@@ -121,7 +124,7 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
     /// Create new [`ESTreeSerializer`] with specified buffer capacity.
     pub fn with_capacity(capacity: usize, ranges: bool) -> Self {
         Self {
-            buffer: CodeBuffer::with_capacity(capacity),
+            buffer: CodeBuffer::with_capacity_and_indent(capacity, IndentChar::Space, 2),
             formatter: F::new(),
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),


### PR DESCRIPTION
`ESTree::serialize` use `CodeBuffer::indent` to print indentation, instead of using unsafe method `CodeBuffer::print_bytes_iter_unchecked`. `indent` method is more optimized, and this removes some `unsafe`.

This only applies to pretty-printing JSON, as indentation is not used in compact JSON. Therefore it doesn't affect our production code, but it should speed up conformance tests a bit.