### PR TITLE
perf(estree/tokens): speed up JSON stringifying with raw writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
 name = "oxc_estree_tokens"
 version = "0.115.0"
 dependencies = [
+ "itoa",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_estree",

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -147,6 +147,15 @@ impl CodeBuffer {
         self.buf.len()
     }
 
+    /// Obtain the underlying buffer.
+    ///
+    /// # SAFETY
+    /// Caller must ensure that any mutations to the buffer leave it containing a valid UTF-8 string.
+    #[inline]
+    pub unsafe fn inner_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buf
+    }
+
     /// Returns the capacity of the buffer in bytes.
     ///
     /// This is *not* the same as capacity in characters,

--- a/crates/oxc_estree/src/serialize/formatter.rs
+++ b/crates/oxc_estree/src/serialize/formatter.rs
@@ -2,6 +2,8 @@ use oxc_data_structures::code_buffer::CodeBuffer;
 
 /// Formatter trait.
 pub trait Formatter {
+    const IS_COMPACT: bool;
+
     /// Create new [`Formatter`].
     fn new() -> Self;
 
@@ -30,6 +32,8 @@ pub trait Formatter {
 pub struct CompactFormatter;
 
 impl Formatter for CompactFormatter {
+    const IS_COMPACT: bool = true;
+
     #[inline(always)]
     fn new() -> Self {
         Self
@@ -71,6 +75,8 @@ pub struct PrettyFormatter {
 }
 
 impl Formatter for PrettyFormatter {
+    const IS_COMPACT: bool = false;
+
     #[inline(always)]
     fn new() -> Self {
         Self { indent: 0 }

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -37,10 +37,12 @@ pub trait ESTree {
 //
 // This trait contains public methods.
 // Internal methods we don't want to expose outside this crate are in [`SerializerPrivate`] trait.
-#[expect(private_bounds)]
-pub trait Serializer: SerializerPrivate {
+pub trait Serializer {
     /// `true` if output should contain TS fields
     const INCLUDE_TS_FIELDS: bool;
+
+    /// Formatter type
+    type Formatter: Formatter;
 
     /// Type of struct serializer this serializer uses.
     type StructSerializer: StructSerializer;
@@ -62,12 +64,6 @@ pub trait Serializer: SerializerPrivate {
     /// These nodes cannot be serialized to JSON, because JSON doesn't support `BigInt`s or `RegExp`s.
     /// "Fix paths" can be used on JS side to locate these nodes and set their `value` fields correctly.
     fn record_fix_path(&mut self);
-}
-
-/// Trait containing internal methods of [`Serializer`]s that we don't want to expose outside this crate.
-trait SerializerPrivate: Sized {
-    /// Formatter type
-    type Formatter: Formatter;
 
     /// Get mutable reference to buffer.
     fn buffer_mut(&mut self) -> &mut CodeBuffer;
@@ -181,6 +177,8 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
     /// `true` if output should contain TS fields
     const INCLUDE_TS_FIELDS: bool = C::INCLUDE_TS_FIELDS;
 
+    type Formatter = F;
+
     type StructSerializer = ESTreeStructSerializer<'s, C, F>;
     type SequenceSerializer = ESTreeSequenceSerializer<'s, C, F>;
 
@@ -235,10 +233,6 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
 
         self.fixes_buffer.print_ascii_byte(b']');
     }
-}
-
-impl<C: Config, F: Formatter> SerializerPrivate for &mut ESTreeSerializer<C, F> {
-    type Formatter = F;
 
     /// Get mutable reference to buffer.
     #[inline(always)]

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -1,6 +1,4 @@
-use super::{
-    Config, ESTree, ESTreeSerializer, Formatter, Serializer, SerializerPrivate, TracePathPart,
-};
+use super::{Config, ESTree, ESTreeSerializer, Formatter, Serializer, TracePathPart};
 
 /// Trait for sequence serializers.
 pub trait SequenceSerializer {

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -2,7 +2,7 @@ use oxc_data_structures::code_buffer::CodeBuffer;
 
 use super::{
     Config, ESTree, ESTreeSequenceSerializer, ESTreeSerializer, Formatter, Serializer,
-    SerializerPrivate, TracePathPart,
+    TracePathPart,
 };
 
 /// Trait for struct serializers.
@@ -222,6 +222,8 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
     /// `true` if output should contain TS fields
     const INCLUDE_TS_FIELDS: bool = P::Config::INCLUDE_TS_FIELDS;
 
+    type Formatter = P::Formatter;
+
     type StructSerializer = Self;
     type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Config, P::Formatter>;
 
@@ -247,10 +249,6 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
     fn ranges(&self) -> bool {
         self.0.ranges()
     }
-}
-
-impl<P: StructSerializer> SerializerPrivate for FlatStructSerializer<'_, P> {
-    type Formatter = P::Formatter;
 
     fn buffer_mut(&mut self) -> &mut CodeBuffer {
         const {

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -25,3 +25,4 @@ oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_estree = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true, features = ["serialize"] }
+itoa = { workspace = true }


### PR DESCRIPTION
WIP. This optimization is (mostly) sound, but it's pretty nasty. Would be better to implement in `ESTree` trait methods directly, so there's no unsafe at call sites. Made this PR mostly to see what CodSpeed says (it says 🚀).