### PR TITLE
fix(linter/explicit-module-boundary-types): add help messages to missing diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -24,15 +24,23 @@ use crate::{
 };
 
 fn func_missing_return_type(fn_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing return type on function").with_label(fn_span)
+    OxcDiagnostic::warn("Missing return type on function")
+        .with_help("Define an explicit return type for the function.")
+        .with_label(fn_span)
 }
 
 fn func_missing_argument_type(param_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing argument type on function").with_label(param_span)
+    OxcDiagnostic::warn("Missing argument type on function")
+        .with_help("Define an explicit argument type for each argument.")
+        .with_label(param_span)
 }
 
 fn func_argument_is_explicitly_any(param_span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Argument is explicitly typed as `any`").with_label(param_span)
+    OxcDiagnostic::warn("Argument is explicitly typed as `any`")
+        .with_help(
+            "Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.",
+        )
+        .with_label(param_span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -7,28 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export function test(a: number, b: number) { return; }
    ·                 ────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function test() { return; }
    ·                 ────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var fn = function () { return 1; };
    ·            ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:19]
@@ -37,7 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────
  5 │                 return 1;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:7:24]
@@ -46,7 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────
  8 │               method() {
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -55,7 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:11:23]
@@ -64,7 +64,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                       ───
  12 │               private method() {
     ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:11:15]
@@ -73,7 +73,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ─────
  12 │               private method() {
     ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:15:28]
@@ -82,7 +82,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                            ───
  16 │             }
     ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -91,7 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  4 │               public b = function () {};
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:22]
@@ -100,7 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  5 │               public c = function test() {};
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:35]
@@ -109,7 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────
  6 │ 
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:22]
@@ -118,7 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  8 │               static e = function () {};
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:22]
@@ -127,7 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  9 │             }
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:25]
@@ -136,7 +136,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────
  4 │                 return one;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:6:25]
@@ -145,28 +145,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────
  7 │             }
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:16]
  1 │ export default () => (true ? () => {} : (): void => {});
    ·                ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var funcExpr = function () { return 'test'; };
    ·            ────────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:15]
@@ -175,28 +175,28 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───
  5 │             };
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => () => {};
    ·                      ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => function () {};
    ·                      ────────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:31]
  1 │ export default () => { return () => {}; };
    ·                               ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -205,21 +205,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────
  4 │             };
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return () => {}; }
    ·                 ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return function () {}; }
    ·                 ──
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:33]
@@ -228,7 +228,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ────────────────────────────────────────────
  5 │                   return () => {
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -237,7 +237,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──
  4 │                 return;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -246,7 +246,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:26]
@@ -255,7 +255,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  4 │             
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -264,7 +264,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  3 │             
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:26]
@@ -273,7 +273,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  8 │               ({ type: 'X', value }) as const satisfies R;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -282,7 +282,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:12:15]
@@ -291,7 +291,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ───
  13 │             }
     ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   × Unexpected token
    ╭─[explicit_module_boundary_types.tsx:5:25]
@@ -308,7 +308,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => value;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:32]
@@ -317,14 +317,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────
  3 │               return '123';
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:33]
  1 │ export const fn = (one: number, two): string => '123';
    ·                                 ───
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -333,7 +333,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner) {};
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -342,7 +342,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -351,14 +351,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ───
  3 │               return function (inner) {};
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export const baz = arg => arg as const;
    ·                    ───
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -367,7 +367,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default foo;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -376,7 +376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default foo;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -385,7 +385,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export = foo;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -394,7 +394,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export = foo;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -403,7 +403,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default [foo];
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -412,7 +412,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default [foo];
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -421,7 +421,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default { foo };
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -430,7 +430,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default { foo };
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -439,7 +439,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -448,7 +448,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -457,7 +457,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -466,7 +466,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -475,7 +475,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -484,7 +484,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:38]
@@ -493,7 +493,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ───
  3 │               return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:34]
@@ -502,7 +502,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ───
  3 │               return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:20]
@@ -511,7 +511,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -520,7 +520,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -529,7 +529,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -538,7 +538,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -547,7 +547,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -556,7 +556,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:31]
@@ -565,7 +565,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -574,7 +574,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:41]
@@ -583,7 +583,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                         ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -592,7 +592,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -601,7 +601,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -610,7 +610,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -619,7 +619,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -628,7 +628,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -637,7 +637,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -646,7 +646,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -655,14 +655,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               () =>
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => () => {};
    ·            ───────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -671,7 +671,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──
  3 │               return function () {};
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -680,7 +680,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner): void {};
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -689,7 +689,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:6:32]
@@ -698,35 +698,35 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  7 │             }
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo({ foo }): void {}
    ·                     ───────
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo([bar]): void {}
    ·                     ─────
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...bar): void {}
    ·                    ────────
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...[a]): void {}
    ·                    ────────
    ╰────
-  help: Define an explicit argument type for each function parameter.
+  help: Define an explicit argument type for each argument.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
@@ -770,7 +770,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────
  3 │               return 0;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:6:15]
@@ -779,7 +779,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────
  7 │                 return 0;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:29]
@@ -788,7 +788,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────
  5 │               return a;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:37]
@@ -797,7 +797,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ────
  5 │               return a;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:28]
@@ -806,7 +806,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────
  5 │               return a;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:15]
@@ -815,21 +815,21 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  6 │                 return a;
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:58]
  1 │ function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };
    ·                                                          ─────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:10]
  1 │ function App() { return 42; } export default App
    ·          ───
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:2:28]
@@ -845,11 +845,11 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶             }) => {
  11 │                     return `${a} ${b} ${c}`;
     ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export default (function() { return 'test'; });
    ·                 ────────
    ╰────
-  help: Require explicit return types on functions and class methods.
+  help: Define an explicit return type for the function.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_module_boundary_types.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export function test(a: number, b: number) { return; }
    ·                 ────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function test() { return; }
    ·                 ────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var fn = function () { return 1; };
    ·            ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:19]
@@ -33,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────
  5 │                 return 1;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:7:24]
@@ -41,6 +46,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────
  8 │               method() {
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -49,6 +55,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:11:23]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                       ───
  12 │               private method() {
     ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:11:15]
@@ -65,6 +73,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ─────
  12 │               private method() {
     ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
     ╭─[explicit_module_boundary_types.tsx:15:28]
@@ -73,6 +82,7 @@ source: crates/oxc_linter/src/tester.rs
     ·                            ───
  16 │             }
     ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -81,6 +91,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  4 │               public b = function () {};
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:22]
@@ -89,6 +100,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  5 │               public c = function test() {};
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:35]
@@ -97,6 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────
  6 │ 
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:22]
@@ -105,6 +118,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  8 │               static e = function () {};
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:22]
@@ -113,6 +127,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  9 │             }
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:25]
@@ -121,6 +136,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────
  4 │                 return one;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:6:25]
@@ -129,24 +145,28 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ─────
  7 │             }
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:16]
  1 │ export default () => (true ? () => {} : (): void => {});
    ·                ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => 'test';
    ·            ───────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var funcExpr = function () { return 'test'; };
    ·            ────────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:15]
@@ -155,24 +175,28 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───
  5 │             };
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => () => {};
    ·                      ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:22]
  1 │ export default () => function () {};
    ·                      ────────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:31]
  1 │ export default () => { return () => {}; };
    ·                               ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -181,18 +205,21 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────
  4 │             };
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return () => {}; }
    ·                 ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export function fn() { return function () {}; }
    ·                 ──
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:33]
@@ -201,6 +228,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ────────────────────────────────────────────
  5 │                   return () => {
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -209,6 +237,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ──
  4 │                 return;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -217,6 +246,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:26]
@@ -225,6 +255,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  4 │             
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -233,6 +264,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  3 │             
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:7:26]
@@ -241,6 +273,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ────
  8 │               ({ type: 'X', value }) as const satisfies R;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:8:15]
@@ -249,6 +282,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────
  9 │                 return;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:12:15]
@@ -257,6 +291,7 @@ source: crates/oxc_linter/src/tester.rs
     ·               ───
  13 │             }
     ╰────
+  help: Require explicit return types on functions and class methods.
 
   × Unexpected token
    ╭─[explicit_module_boundary_types.tsx:5:25]
@@ -273,6 +308,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─────
  3 │             export const func2 = (value: number) => value;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:32]
@@ -281,12 +317,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ────
  3 │               return '123';
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:33]
  1 │ export const fn = (one: number, two): string => '123';
    ·                                 ───
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -295,6 +333,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner) {};
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -303,6 +342,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -311,12 +351,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ───
  3 │               return function (inner) {};
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export const baz = arg => arg as const;
    ·                    ───
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -325,6 +367,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default foo;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -333,6 +376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default foo;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -341,6 +385,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export = foo;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -349,6 +394,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export = foo;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -357,6 +403,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default [foo];
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -365,6 +412,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default [foo];
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:25]
@@ -373,6 +421,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ───
  3 │             export default { foo };
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:19]
@@ -381,6 +430,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ───
  3 │             export default { foo };
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -389,6 +439,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -397,6 +448,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -405,6 +457,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -413,6 +466,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -421,6 +475,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:22]
@@ -429,6 +484,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  3 │               return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:38]
@@ -437,6 +493,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ───
  3 │               return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:34]
@@ -445,6 +502,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                  ───
  3 │               return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:20]
@@ -453,6 +511,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -461,6 +520,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:22]
@@ -469,6 +529,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -477,6 +538,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -485,6 +547,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -493,6 +556,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:31]
@@ -501,6 +565,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -509,6 +574,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:41]
@@ -517,6 +583,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                         ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:24]
@@ -525,6 +592,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -533,6 +601,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
  4 │                 return arg;
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:3:15]
@@ -541,6 +610,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  4 │                 return arg;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -549,6 +619,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -557,6 +628,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:24]
@@ -565,6 +637,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───
  3 │             test = (): void => {
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:17]
@@ -573,6 +646,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────
  3 │             test = (): void => {
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:26]
@@ -581,12 +655,14 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ───
  3 │               () =>
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:12]
  1 │ export var arrowFn = () => () => {};
    ·            ───────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -595,6 +671,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ──
  3 │               return function () {};
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:2:33]
@@ -603,6 +680,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ─────
  3 │               return function (inner): void {};
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:3:32]
@@ -611,6 +689,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  4 │             }
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:6:32]
@@ -619,60 +698,70 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ─────
  7 │             }
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo({ foo }): void {}
    ·                     ───────
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo([bar]): void {}
    ·                     ─────
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...bar): void {}
    ·                    ────────
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing argument type on function
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...[a]): void {}
    ·                    ────────
    ╰────
+  help: Define an explicit argument type for each function parameter.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo(foo: any): void {}
    ·                     ────────
    ╰────
+  help: Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo({ foo }: any): void {}
    ·                     ────────────
    ╰────
+  help: Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:21]
  1 │ export function foo([bar]: any): void {}
    ·                     ──────────
    ╰────
+  help: Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...bar: any): void {}
    ·                    ─────────────
    ╰────
+  help: Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Argument is explicitly typed as `any`
    ╭─[explicit_module_boundary_types.tsx:1:20]
  1 │ export function foo(...[a]: any): void {}
    ·                    ─────────────
    ╰────
+  help: Avoid explicit `any` at module boundaries; prefer `unknown` and narrow before use.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:2:29]
@@ -681,6 +770,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ─────
  3 │               return 0;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:6:15]
@@ -689,6 +779,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────
  7 │                 return 0;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:29]
@@ -697,6 +788,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ────
  5 │               return a;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:37]
@@ -705,6 +797,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ────
  5 │               return a;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:4:28]
@@ -713,6 +806,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ────────
  5 │               return a;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:5:15]
@@ -721,18 +815,21 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────
  6 │                 return a;
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:58]
  1 │ function Test(): void { const _x = () => { }; } function Test2() { return () => { }; } export { Test2 };
    ·                                                          ─────
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:10]
  1 │ function App() { return 42; } export default App
    ·          ───
    ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
     ╭─[explicit_module_boundary_types.tsx:2:28]
@@ -748,9 +845,11 @@ source: crates/oxc_linter/src/tester.rs
  10 │ ╰─▶             }) => {
  11 │                     return `${a} ${b} ${c}`;
     ╰────
+  help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-module-boundary-types): Missing return type on function
    ╭─[explicit_module_boundary_types.tsx:1:17]
  1 │ export default (function() { return 'test'; });
    ·                 ────────
    ╰────
+  help: Require explicit return types on functions and class methods.


### PR DESCRIPTION
Added `.with_help` to the following lint rules at in the typescript `explicit-module-boundary-types.rs` file:
- `func_missing_return_type`
- `func_missing_argument_type`
- `func_argument_is_explicitly_any`

Part of #19121 