### PR TITLE
feat(oxfmt): add Astro file formatting support

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "prettier": "3.8.1",
+    "prettier-plugin-astro": "0.14.1",
     "prettier-plugin-tailwindcss": "0.0.0-insiders.3997fbd",
     "tinypool": "2.1.0"
   },

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -103,6 +103,10 @@ export type FormatOptions = Pick<
   sortTailwindcss?: SortTailwindcssOptions;
   /** @deprecated Use `sortTailwindcss` instead. */
   experimentalTailwindcss?: SortTailwindcssOptions;
+  /** Enable/disable attribute shorthand if attribute name and expression are the same in Astro. (Default: `false`) */
+  astroAllowShorthand?: boolean;
+  /** Skip formatting of the frontmatter in Astro files. (Default: `false`) */
+  astroSkipFrontmatter?: boolean;
 } & Record<string, unknown>; // Also allow additional options for we don't have typed yet.
 
 /**

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -203,6 +203,9 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     if extension == Some("vue") {
         return Some("vue");
     }
+    if extension == Some("astro") {
+        return Some("astro");
+    }
     if extension == Some("mjml") {
         return Some("mjml");
     }
@@ -399,6 +402,8 @@ mod tests {
             ("email.mjml", Some("mjml")),
             // Vue
             ("App.vue", Some("vue")),
+            // Astro
+            ("Layout.astro", Some("astro")),
             // CSS
             ("styles.css", Some("css")),
             ("app.wxss", Some("css")),

--- a/apps/oxfmt/test/api/__snapshots__/js-in-astro.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/js-in-astro.test.ts.snap
@@ -1,0 +1,147 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro <script> blocks 1`] = `
+"---
+const title = "Hello";
+---
+
+<html>
+  <body>
+    <h1>{title}</h1>
+    <script>
+      import a from "a";
+      import z from "z";
+      const y = 2;
+    </script>
+  </body>
+</html>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro frontmatter w/ sort-imports 1`] = `
+"---
+import a from "a";
+import m from "m";
+import z from "z";
+
+const x = 1;
+---
+
+<div>{x}</div>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro frontmatter-only (no template) 1`] = `
+"---
+import a from "a";
+import z from "z";
+export const prerender = true;
+---
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro w/ Tailwind class sorting 1`] = `
+"---
+const title = "Hello";
+---
+
+<div class="flex p-4">text</div>
+<div class="flex p-4">text</div>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro with multiple <script> blocks 1`] = `
+"---
+const title = "Hello";
+---
+
+<html>
+  <body>
+    <h1>{title}</h1>
+    <script>
+      const a = 1;
+    </script>
+    <script>
+      const b = 2;
+    </script>
+  </body>
+</html>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should format .astro without frontmatter 1`] = `
+"<div class="p-4 flex">
+  <p>Hello</p>
+</div>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle .astro with TypeScript in frontmatter 1`] = `
+"---
+interface Props {
+  title: string;
+  count: number;
+}
+
+const { title, count } = Astro.props;
+---
+
+<h1>{title} ({count})</h1>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle .astro with class:list directive 1`] = `
+"---
+const isActive = true;
+---
+
+<div class:list={["base", { active: isActive }]}>text</div>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle .astro with client:load directives 1`] = `
+"---
+import Counter from "../components/Counter";
+---
+
+<Counter client:load />
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle .astro with set:html directive 1`] = `
+"---
+const rawHtml = "<em>Hello</em>";
+---
+
+<div set:html={rawHtml} />
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle <script is:inline> 1`] = `
+"---
+const title = "Hello";
+---
+
+<script is:inline>
+  const x = 1;
+</script>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should handle empty frontmatter 1`] = `
+"---
+
+---
+
+<div>hello</div>
+"
+`;
+
+exports[`Format js-in-astro with prettier-plugin-oxfmt > should pass astroAllowShorthand option 1`] = `
+"---
+const title = "Hello";
+---
+
+<Component {title} />
+"
+`;

--- a/apps/oxfmt/test/api/js-in-astro.test.ts
+++ b/apps/oxfmt/test/api/js-in-astro.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("Format js-in-astro with prettier-plugin-oxfmt", () => {
+  it("should format .astro frontmatter w/ sort-imports", async () => {
+    const input = `---
+import z from "z";
+  import a from "a";
+    import m from "m";
+
+const   x  =    1;
+---
+<div>{x}</div>
+`;
+    const result = await format("Layout.astro", input, {
+      experimentalSortImports: {},
+    });
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .astro <script> blocks", async () => {
+    const input = `---
+const title = "Hello";
+---
+<html>
+  <body>
+    <h1>{title}</h1>
+    <script>
+import z from "z";
+  import a from "a";
+    const   y  =   2;
+    </script>
+  </body>
+</html>
+`;
+    const result = await format("Page.astro", input, {
+      experimentalSortImports: {},
+    });
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .astro w/ Tailwind class sorting", async () => {
+    const input = `---
+const title = "Hello";
+---
+<div class="flex p-4">text</div>
+<div class="p-4 flex">text</div>
+`;
+    const result = await format("Component.astro", input, {
+      experimentalTailwindcss: {},
+    });
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .astro frontmatter-only (no template)", async () => {
+    const input = `---
+import z from "z";
+import a from "a";
+export const prerender   =   true;
+---
+`;
+    const result = await format("Config.astro", input, {
+      experimentalSortImports: {},
+    });
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .astro without frontmatter", async () => {
+    const input = `<div class="p-4 flex">
+  <p>Hello</p>
+</div>
+`;
+    const result = await format("NoFrontmatter.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .astro with multiple <script> blocks", async () => {
+    const input = `---
+const title = "Hello";
+---
+<html>
+  <body>
+    <h1>{title}</h1>
+    <script>
+      const   a  =   1;
+    </script>
+    <script>
+      const   b  =   2;
+    </script>
+  </body>
+</html>
+`;
+    const result = await format("MultiScript.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle .astro with client:load directives", async () => {
+    const input = `---
+import Counter from "../components/Counter";
+---
+<Counter   client:load  />
+`;
+    const result = await format("ClientDirective.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle .astro with TypeScript in frontmatter", async () => {
+    const input = `---
+interface Props {
+  title:   string;
+  count:number;
+}
+
+const { title,    count } = Astro.props;
+---
+<h1>{title} ({count})</h1>
+`;
+    const result = await format("TypedComponent.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle .astro with class:list directive", async () => {
+    const input = `---
+const isActive = true;
+---
+<div class:list={["base",   {active:isActive}]}>text</div>
+`;
+    const result = await format("ClassList.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle .astro with set:html directive", async () => {
+    const input = `---
+const   rawHtml   =   "<em>Hello</em>";
+---
+<div set:html={rawHtml} />
+`;
+    const result = await format("SetHtml.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should pass astroAllowShorthand option", async () => {
+    const input = `---
+const title = "Hello";
+---
+<Component {title} />
+`;
+    const result = await format("Shorthand.astro", input, {
+      astroAllowShorthand: true,
+    });
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should pass astroSkipFrontmatter option", async () => {
+    const input = `---
+import z from "z";
+  import a from "a";
+    const   x  =    1;
+---
+<div>{x}</div>
+`;
+    const withSkip = await format("Skip.astro", input, {
+      astroSkipFrontmatter: true,
+    });
+    const withoutSkip = await format("NoSkip.astro", input, {
+      astroSkipFrontmatter: false,
+    });
+    // With skip: frontmatter should be preserved as-is
+    expect(withSkip.code).toContain("import z from \"z\";\n  import a from \"a\"");
+    // Without skip: frontmatter should be formatted
+    expect(withoutSkip.code).not.toContain("  import a");
+    expect(withSkip.errors).toStrictEqual([]);
+    expect(withoutSkip.errors).toStrictEqual([]);
+  });
+
+  it("should handle empty .astro file", async () => {
+    const result = await format("Empty.astro", "", {});
+    expect(result.code).toBe("");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle empty frontmatter", async () => {
+    const input = `---
+---
+<div>hello</div>
+`;
+    const result = await format("EmptyFrontmatter.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should pass formatting options through to Prettier", async () => {
+    const input = `---
+const x = "hello";
+---
+<div>{x}</div>
+`;
+    const result = await format("Options.astro", input, {
+      printWidth: 40,
+      singleQuote: true,
+    });
+    expect(result.code).toContain("'hello'");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should handle <script is:inline>", async () => {
+    const input = `---
+const title = "Hello";
+---
+<script is:inline>
+  const   x  =   1;
+</script>
+`;
+    const result = await format("Inline.astro", input, {});
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+  });
+});

--- a/apps/oxfmt/test/api/js-in-xxx-conformance.test.ts
+++ b/apps/oxfmt/test/api/js-in-xxx-conformance.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
+import type { Plugin } from "prettier";
 import prettier from "prettier";
+import * as astroPlugin from "prettier-plugin-astro";
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
@@ -55,6 +57,81 @@ const value = 1
   });
 });
 
+describe("Prettier conformance for .astro files", () => {
+  const astroFixtures = collectFixtures(".astro", []);
+  astroFixtures.push(
+    {
+      name: "edge/astro-frontmatter-and-script.astro",
+      content: `---
+import { foo } from "bar";
+const x = 1;
+---
+<html>
+  <body>
+    <h1>{x}</h1>
+    <script>
+      const y = 2;
+    </script>
+  </body>
+</html>
+`,
+    },
+    {
+      name: "edge/astro-typescript-frontmatter.astro",
+      content: `---
+interface Props {
+  title: string;
+  count: number;
+}
+
+const { title, count } = Astro.props;
+---
+<h1>{title} ({count})</h1>
+`,
+    },
+    {
+      name: "edge/astro-no-frontmatter.astro",
+      content: `<div>
+  <p>Hello</p>
+</div>
+`,
+    },
+    {
+      name: "edge/astro-empty-frontmatter.astro",
+      content: `---
+---
+<div>hello</div>
+`,
+    },
+    {
+      name: "edge/astro-client-directives.astro",
+      content: `---
+import Counter from "../components/Counter";
+import Toggle from "../components/Toggle";
+---
+<Counter client:load />
+<Toggle client:visible />
+`,
+    },
+  );
+
+  describe.concurrent.each(astroFixtures)("$name", ({ name, content }) => {
+    it.each([
+      { printWidth: 80 },
+      { printWidth: 100, singleQuote: true },
+    ])("%j", async (options) => {
+      const [oxfmtRes, prettierRes] = await compareWithPrettier(
+        name,
+        content,
+        "astro",
+        options,
+        [astroPlugin as Plugin],
+      );
+      expect(oxfmtRes).toBe(prettierRes);
+    });
+  });
+});
+
 // ---
 
 type TestCase = { name: string; content: string };
@@ -82,13 +159,15 @@ async function compareWithPrettier(
   fileName: string,
   content: string,
   parser: string,
-  options = {},
+  options: Record<string, unknown> = {},
+  plugins: Plugin[] = [],
 ) {
   let prettierResult;
   try {
     prettierResult = await prettier.format(content, {
       parser,
       filepath: fileName,
+      plugins,
       ...options,
     });
   } catch {

--- a/apps/oxfmt/test/cli/external_formatter_with_config/__snapshots__/external_formatter_with_config.test.ts.snap
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/__snapshots__/external_formatter_with_config.test.ts.snap
@@ -1,6 +1,32 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`external_formatter_with_config > should pass config options to prettier 1`] = `
+exports[`external_formatter_with_config > should pass config options to prettier for astro 1`] = `
+"--- FILE -----------
+test.astro
+--- BEFORE ---------
+---
+import {foo} from "bar";
+const title="Hello World with a long title that exceeds print width";
+---
+<div>
+        <span>{title}</span>
+</div>
+
+--- AFTER ----------
+---
+import { foo } from 'bar';
+const title =
+	'Hello World with a long title that exceeds print width';
+---
+
+<div>
+	<span>{title}</span>
+</div>
+
+--------------------"
+`;
+
+exports[`external_formatter_with_config > should pass config options to prettier for vue 1`] = `
 "--- FILE -----------
 test.vue
 --- BEFORE ---------

--- a/apps/oxfmt/test/cli/external_formatter_with_config/external_formatter_with_config.test.ts
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/external_formatter_with_config.test.ts
@@ -5,8 +5,13 @@ import { runWriteModeAndSnapshot } from "../utils";
 const fixturesDir = join(import.meta.dirname, "fixtures");
 
 describe("external_formatter_with_config", () => {
-  it("should pass config options to prettier", async () => {
+  it("should pass config options to prettier for vue", async () => {
     const snapshot = await runWriteModeAndSnapshot(fixturesDir, ["test.vue"]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it("should pass config options to prettier for astro", async () => {
+    const snapshot = await runWriteModeAndSnapshot(fixturesDir, ["test.astro"]);
     expect(snapshot).toMatchSnapshot();
   });
 });

--- a/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/.oxfmtrc.json
@@ -3,5 +3,6 @@
   "useTabs": true,
   "singleQuote": true,
   "embeddedLanguageFormatting": "auto",
-  "vueIndentScriptAndStyle": true
+  "vueIndentScriptAndStyle": true,
+  "astroAllowShorthand": true
 }

--- a/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/test.astro
+++ b/apps/oxfmt/test/cli/external_formatter_with_config/fixtures/test.astro
@@ -1,0 +1,7 @@
+---
+import {foo} from "bar";
+const title="Hello World with a long title that exceeds print width";
+---
+<div>
+        <span>{title}</span>
+</div>

--- a/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
+++ b/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
@@ -270,5 +270,50 @@ const count = ref(0);
   <div>{{ count }}</div>
 </template>
 
+--------------------
+
+--- FILE -----------
+app.astro
+--- BEFORE ---------
+---
+import z from "z";
+  import a from "a";
+    import m from "m";
+
+const count = 0;
+---
+<html>
+  <body>
+    <div class="p-4 flex m-0">{count}</div>
+    <button class="m-2 p-1 flex">Click</button>
+    <script>
+      import z from "z";
+      import a from "a";
+      const   y  =   2;
+    </script>
+  </body>
+</html>
+
+--- AFTER ----------
+---
+import a from "a";
+import m from "m";
+import z from "z";
+
+const count = 0;
+---
+
+<html>
+  <body>
+    <div class="m-0 flex p-4">{count}</div>
+    <button class="m-2 flex p-1">Click</button>
+    <script>
+      import a from "a";
+      import z from "z";
+      const y = 2;
+    </script>
+  </body>
+</html>
+
 --------------------"
 `;

--- a/apps/oxfmt/test/cli/js_in_xxx/fixtures/app.astro
+++ b/apps/oxfmt/test/cli/js_in_xxx/fixtures/app.astro
@@ -1,0 +1,18 @@
+---
+import z from "z";
+  import a from "a";
+    import m from "m";
+
+const count = 0;
+---
+<html>
+  <body>
+    <div class="p-4 flex m-0">{count}</div>
+    <button class="m-2 p-1 flex">Click</button>
+    <script>
+      import z from "z";
+      import a from "a";
+      const   y  =   2;
+    </script>
+  </body>
+</html>

--- a/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
+++ b/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
@@ -14,6 +14,8 @@ describe("js-in-xxx", () => {
         // NOTE: For now, Vue files are still handled by Prettier
         "app.vue",
         "multi-script.vue",
+        // NOTE: For now, Astro files are still handled by Prettier
+        "app.astro",
       ],
       ["--config", "oxfmtrc-full.json"],
     );

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/__snapshots__/oxfmtrc_overrides.test.ts.snap
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/__snapshots__/oxfmtrc_overrides.test.ts.snap
@@ -9,7 +9,7 @@ exit code: 0
 Checking formatting...
 
 All matched files use the correct format.
-Finished in <variable>ms on 5 files using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 --- STDERR ---------
 
 --------------------"

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/.oxfmtrc.json
@@ -1,6 +1,7 @@
 {
   "experimentalSortPackageJson": false,
   "vueIndentScriptAndStyle": false,
+  "astroSkipFrontmatter": false,
   "overrides": [
     {
       "files": ["sorted/package.json"],
@@ -12,6 +13,12 @@
       "files": ["indented.vue"],
       "options": {
         "vueIndentScriptAndStyle": true
+      }
+    },
+    {
+      "files": ["skipped.astro"],
+      "options": {
+        "astroSkipFrontmatter": true
       }
     }
   ]

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/not-skipped.astro
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/not-skipped.astro
@@ -1,0 +1,7 @@
+---
+import z from "z";
+import a from "a";
+const x = 1;
+---
+
+<div>{x}</div>

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/skipped.astro
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/fixtures/prettier_overrides/skipped.astro
@@ -1,0 +1,7 @@
+---
+import z from "z";
+  import a from "a";
+    const   x  =    1;
+---
+
+<div>{x}</div>

--- a/apps/oxfmt/test/cli/oxfmtrc_overrides/oxfmtrc_overrides.test.ts
+++ b/apps/oxfmt/test/cli/oxfmtrc_overrides/oxfmtrc_overrides.test.ts
@@ -88,9 +88,11 @@ describe("oxfmtrc overrides", () => {
   // .oxfmtrc.json:
   //   experimentalSortPackageJson: false
   //   vueIndentScriptAndStyle: false
+  //   astroSkipFrontmatter: false
   //   overrides: [
   //     { files: ["sorted/package.json"], options: { experimentalSortPackageJson: true } },
-  //     { files: ["indented.vue"], options: { vueIndentScriptAndStyle: true } }
+  //     { files: ["indented.vue"], options: { vueIndentScriptAndStyle: true } },
+  //     { files: ["skipped.astro"], options: { astroSkipFrontmatter: true } }
   //   ]
   //
   // Expected:
@@ -98,6 +100,8 @@ describe("oxfmtrc overrides", () => {
   // - unsorted/package.json: keys NOT sorted (original order preserved)
   // - indented.vue: script/style content indented
   // - not-indented.vue: script/style content NOT indented
+  // - skipped.astro: frontmatter NOT formatted (skip enabled)
+  // - not-skipped.astro: frontmatter formatted (skip disabled, base config)
   //
   // This test verifies overrides work for external formatter path (Prettier)
   it("Prettier options override - only enabled for specific files", async () => {

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "@prettier/plugin-pug",
     "@shopify/prettier-plugin-liquid",
     "@zackad/prettier-plugin-twig",
+    // Cannot bundle: @astrojs/compiler loads astro.wasm at runtime via file path
     "prettier-plugin-astro",
     "prettier-plugin-marko",
     "prettier-plugin-svelte",

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -16,6 +16,22 @@
       ],
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
+    "astroAllowShorthand": {
+      "description": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`"
+    },
+    "astroSkipFrontmatter": {
+      "description": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`"
+    },
     "bracketSameLine": {
       "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
       "type": [
@@ -329,6 +345,22 @@
             }
           ],
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+        },
+        "astroAllowShorthand": {
+          "description": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`"
+        },
+        "astroSkipFrontmatter": {
+          "description": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`"
         },
         "bracketSameLine": {
           "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -35,6 +35,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
+    "prettier-plugin-astro": "0.14.1",
     "tinypool": "2.1.0"
   },
   "napi": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,12 @@ importers:
       prettier:
         specifier: 3.8.1
         version: 3.8.1
+      prettier-plugin-astro:
+        specifier: 0.14.1
+        version: 0.14.1
       prettier-plugin-tailwindcss:
         specifier: 0.0.0-insiders.3997fbd
-        version: 0.0.0-insiders.3997fbd(prettier@3.8.1)
+        version: 0.0.0-insiders.3997fbd(prettier-plugin-astro@0.14.1)(prettier@3.8.1)
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -512,6 +515,9 @@ packages:
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
+
+  '@astrojs/compiler@2.13.1':
+    resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -3994,6 +4000,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-plugin-astro@0.14.1:
+    resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
+    engines: {node: ^14.15.0 || >=16.0.0}
+
   prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd:
     resolution: {integrity: sha512-H45ADK++Dyd7tMKCT7D6s+6uMxcVMZI841kyvSBXWaU8UOHJp273arY/5/5NqEBNxsquPGId7CatqUGbFbd0aQ==}
     engines: {node: '>=20.19'}
@@ -4168,6 +4178,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  s.color@0.0.15:
+    resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -4177,6 +4190,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass-formatter@0.7.9:
+    resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4305,6 +4321,9 @@ packages:
 
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
+  suf-log@2.5.3:
+    resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
   superagent@10.2.3:
     resolution: {integrity: sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==}
@@ -4740,6 +4759,8 @@ snapshots:
       semver: 7.7.4
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
+
+  '@astrojs/compiler@2.13.1': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -8146,9 +8167,17 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier@3.8.1):
+  prettier-plugin-astro@0.14.1:
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      prettier: 3.8.1
+      sass-formatter: 0.7.9
+
+  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier-plugin-astro@0.14.1)(prettier@3.8.1):
     dependencies:
       prettier: 3.8.1
+    optionalDependencies:
+      prettier-plugin-astro: 0.14.1
 
   prettier@3.8.1: {}
 
@@ -8313,6 +8342,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  s.color@0.0.15: {}
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -8320,6 +8351,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sass-formatter@0.7.9:
+    dependencies:
+      suf-log: 2.5.3
 
   scheduler@0.27.0: {}
 
@@ -8456,6 +8491,10 @@ snapshots:
       '@tokenizer/token': 0.3.0
 
   stylis@4.3.6: {}
+
+  suf-log@2.5.3:
+    dependencies:
+      s.color: 0.0.15
 
   superagent@10.2.3:
     dependencies:

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -20,6 +20,22 @@ expression: json
       ],
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
+    "astroAllowShorthand": {
+      "description": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`"
+    },
+    "astroSkipFrontmatter": {
+      "description": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "markdownDescription": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`"
+    },
     "bracketSameLine": {
       "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
       "type": [
@@ -333,6 +349,22 @@ expression: json
             }
           ],
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+        },
+        "astroAllowShorthand": {
+          "description": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Enable/disable attribute shorthand if attribute name and expression are the same in Astro.\n\n- Default: `false`"
+        },
+        "astroSkipFrontmatter": {
+          "description": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Skip formatting of the frontmatter in Astro files.\n\n- Default: `false`"
         },
         "bracketSameLine": {
           "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -22,6 +22,26 @@ Include parentheses around a sole arrow function parameter.
 - Default: `"always"`
 
 
+## astroAllowShorthand
+
+type: `boolean`
+
+
+Enable/disable attribute shorthand if attribute name and expression are the same in Astro.
+
+- Default: `false`
+
+
+## astroSkipFrontmatter
+
+type: `boolean`
+
+
+Skip formatting of the frontmatter in Astro files.
+
+- Default: `false`
+
+
 ## bracketSameLine
 
 type: `boolean`
@@ -175,6 +195,26 @@ type: `"always" | "avoid"`
 Include parentheses around a sole arrow function parameter.
 
 - Default: `"always"`
+
+
+##### overrides[n].options.astroAllowShorthand
+
+type: `boolean`
+
+
+Enable/disable attribute shorthand if attribute name and expression are the same in Astro.
+
+- Default: `false`
+
+
+##### overrides[n].options.astroSkipFrontmatter
+
+type: `boolean`
+
+
+Skip formatting of the frontmatter in Astro files.
+
+- Default: `false`
 
 
 ##### overrides[n].options.bracketSameLine


### PR DESCRIPTION
## Summary

Add `.astro` file formatting support to oxfmt via `prettier-plugin-astro`, following the existing Vue formatting pattern.

- Map `.astro` extension → `ExternalFormatter { parser_name: "astro" }` (same flow as Vue)
- Register `prettier-plugin-astro` with lazy loading, ordered before Tailwind and oxfmt plugins
- Add `astroAllowShorthand` and `astroSkipFrontmatter` config options (pass-through to `prettier-plugin-astro`)
- Keep `prettier-plugin-astro` as external dependency (cannot bundle — `@astrojs/compiler` loads `astro.wasm` at runtime via file path)

Related #19715 (Astro portion only; Svelte is not included in this PR)

## Design decisions for maintainer review

1. **`prettier-plugin-astro` is external, not bundled** — Unlike `prettier-plugin-tailwindcss` (bundled via `noExternal`), `prettier-plugin-astro` must stay in the `external` array because `@astrojs/compiler` loads `astro.wasm` at runtime via file path. Is this acceptable, or would you prefer a different approach?

2. **Plugin ordering: Astro → Tailwind → oxfmt** — `prettier-plugin-tailwindcss` needs to wrap framework plugin printers, so it must come after Astro. oxfmt must be last. This matches the order recommended by the Tailwind docs. Does this align with your expectations?

3. **Expression formatting limitation** — Astro `{expression}` uses `astroExpressionParser` (not overridable), same as Vue's `__vue_expression`. Only frontmatter and `<script>` blocks are formatted by oxfmt. Is this the expected scope?

4. **`prettier-plugin-astro@0.14.1`** — This is the latest stable release. The plugin's maintenance status is moderate (last release Oct 2024). Should we pin this version or use a range?

## Test plan

- [x] 16 API tests (frontmatter, script blocks, Tailwind, directives, boundary cases, option pass-through)
- [x] 10 Prettier conformance tests (5 edge cases × 2 option variants, comparing oxfmt vs vanilla Prettier output)
- [x] CLI `js_in_xxx` test with Astro fixture (sort-imports + Tailwind via CLI)
- [x] CLI `external_formatter_with_config` test (config pass-through for Astro)
- [x] CLI `oxfmtrc_overrides` test (per-file `astroSkipFrontmatter` override)
- [x] Rust unit test for `finalize_external_options` with `parser_name: "astro"`
- [x] All 256 JS tests pass, all 33 Rust tests pass

## AI Disclosure

This PR was developed with AI assistance (Claude). All code has been reviewed, tested, and understood by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)