### PR TITLE
fix(oxfmt): avoid embedded TSFN crash by returning errors as data

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -34,7 +34,7 @@ export declare const enum Severity {
  * # Panics
  * Panics if the current working directory cannot be determined.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -49,7 +49,7 @@ export interface FormatResult {
  * This API is specialized for JS/TS snippets embedded in non-JS files.
  * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<string | null>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -66,4 +66,4 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[]>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -55,13 +55,4 @@ void (async () => {
   // `process.exit()` kills the process immediately and `stdout` may not be flushed before process dies.
   // https://nodejs.org/api/process.html#processexitcode
   process.exitCode = exitCode!;
-
-  // Node.js < 25.4.0 has a race condition with ThreadsafeFunction cleanup that causes
-  // crashes on large codebases. Add a small delay to allow pending NAPI operations
-  // to complete before exit. Fixed in Node.js 25.4.0+.
-  // See: https://github.com/nodejs/node/issues/55706
-  const [major, minor] = process.versions.node.split(".").map(Number);
-  if (major < 25 || (major === 25 && minor < 4)) {
-    setTimeout(() => process.exit(), 50);
-  }
 })();

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,5 +1,10 @@
 import { format as napiFormat, jsTextToDoc as napiJsTextToDoc } from "./bindings";
-import { resolvePlugins, formatEmbeddedCode, formatFile, sortTailwindClasses } from "./libs/apis";
+import {
+  resolvePlugins,
+  formatEmbeddedCodeSafe,
+  formatFile,
+  sortTailwindClasses,
+} from "./libs/apis";
 import type { Options } from "prettier";
 
 // napi-JS `oxfmt` API entry point
@@ -17,7 +22,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     sourceText,
     options ?? {},
     resolvePlugins,
-    (options, code) => formatEmbeddedCode({ options, code }),
+    (options, code) => formatEmbeddedCodeSafe({ options, code }),
     (options, code) => formatFile({ options, code }),
     (options, classes) => sortTailwindClasses({ options, classes }),
   );
@@ -38,7 +43,7 @@ export async function jsTextToDoc(
     oxfmtPluginOptionsJson,
     parentContext,
     resolvePlugins,
-    (options, code) => formatEmbeddedCode({ options, code }),
+    (options, code) => formatEmbeddedCodeSafe({ options, code }),
     (_options, _code) => Promise.reject(/* Unreachable */),
     (options, classes) => sortTailwindClasses({ options, classes }),
   );

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -49,9 +49,7 @@ export type FormatEmbeddedCodeParam = {
   options: Options;
 };
 
-export type FormatEmbeddedCodeResult =
-  | { ok: true; code: string }
-  | { ok: false; error: string };
+export type FormatEmbeddedCodeResult = { ok: true; code: string } | { ok: false; error: string };
 
 /**
  * Format xxx-in-js code snippets

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -36,7 +36,9 @@ pub async fn run_cli(
     args: Vec<String>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
@@ -140,7 +142,9 @@ pub async fn format(
     options: Option<Value>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,
@@ -176,7 +180,9 @@ pub async fn js_text_to_doc(
     parent_context: String,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
     format_file_cb: JsFormatFileCb,


### PR DESCRIPTION
## Summary

This fixes a crash in `oxfmt` NAPI CLI when formatting large repos with embedded formatting enabled.

Root cause: embedded formatter errors were propagated as rejected JS promises, which become `napi::Error` values in Rust TSFN await paths. In heavily concurrent runs, dropping those error values could reach `napi_reference_unref` during teardown and trigger V8 fatal checks.

Fix:
- Change embedded callback contract from `Promise<string>` to `Promise<{ ok: boolean; code?: string; error?: string }>`.
- Add `formatEmbeddedCodeSafe()` in JS that never rejects and encodes errors as data.
- Parse the wrapped embedded result in Rust (`parse_embedded_callback_result`) and keep existing fallback behavior.
- Wire CLI worker-proxy and JS API to use the safe embedded callback path.
- Remove the temporary `waitForImmediate` workaround in CLI exit path.

## Details

- `JsFormatEmbeddedCb` now returns `Promise<Value>`.
- Embedded callback result parser accepts:
  - `{ ok: true, code: string }`
  - `{ ok: false, error: string }`
  - legacy plain `string` (backward-compatible fallback)
- NAPI TS arg types and generated `bindings.d.ts` updated accordingly.

## Validation

Executed locally on Node `v24.12.0`:

- `pnpm -C apps/oxfmt run build-dev`
- Repro loop in `/Users/boshen/github/linear-app`:
  - `node /Users/boshen/oxc/oxc4/apps/oxfmt/dist/cli.js --check` => `PASS 80/80`
  - same command => `PASS 200/200`
  - `node /Users/boshen/oxc/oxc4/apps/oxfmt/dist/cli.js --check --ignore-path /tmp/oxfmt-js-only.ignore` => `PASS 40/40`

## AI Usage Disclosure

This PR was prepared with AI assistance (Codex) for investigation, implementation, and stress-test scripting. Changes were reviewed and validated in local runs before submission.

Fixes #19713
