### PR TITLE
perf(estree/tokens): use strings from AST for identifier tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
 name = "oxc_estree_tokens"
 version = "0.115.0"
 dependencies = [
+ "itoa",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_data_structures",

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -26,3 +26,4 @@ oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
 oxc_estree = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true, features = ["serialize"] }
+itoa = { workspace = true }

--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -1,5 +1,7 @@
 use std::slice::Iter;
 
+use itoa::Buffer as ItoaBuffer;
+
 use oxc_ast::ast::*;
 use oxc_ast_visit::{
     Visit,
@@ -75,6 +77,57 @@ impl ESTree for EstreeRegExpToken<'_> {
     }
 }
 
+/// Token type for identifiers (and keywords which are used as identifiers).
+///
+/// Despite the name, this type is also used for tokens with `"Keyword"` or `"PrivateIdentifier"`
+/// type — it covers any token whose value is guaranteed JSON-safe.
+///
+/// This is a separate type from `EstreeToken` for two reasons:
+/// 1. It has no `regex` field (identifiers never have regex data).
+/// 2. Value is wrapped in `JsonSafeString` during serialization, skipping escape-checking.
+///    Identifier names are guaranteed JSON-safe (no quotes, backslashes, or control characters).
+struct EstreeIdentToken<'a> {
+    token_type: TokenType,
+    value: &'a str,
+    span: Span,
+}
+
+impl ESTree for EstreeIdentToken<'_> {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        // Assemble the JSON string manually using `print_strs_array`.
+        // This reduces bounds checks to only 1 per token.
+        static TYPE_PREFIX: &str = "{\"type\":\"";
+        static VALUE_PREFIX: &str = "\",\"value\":\"";
+        static START_PREFIX: &str = "\",\"start\":";
+        static END_PREFIX: &str = ",\"end\":";
+        static POSTFIX: &str = "}";
+
+        static TYPE_PREFIX_PRETTY: &str = "{\n    \"type\": \"";
+        static VALUE_PREFIX_PRETTY: &str = "\",\n    \"value\": \"";
+        static START_PREFIX_PRETTY: &str = "\",\n    \"start\": ";
+        static END_PREFIX_PRETTY: &str = ",\n    \"end\": ";
+        static POSTFIX_PRETTY: &str = "\n  }";
+
+        let mut start_buffer = U32String::new();
+        let start = start_buffer.format(self.span.start);
+
+        let mut end_buffer = U32String::new();
+        let end = end_buffer.format(self.span.end);
+
+        serializer.buffer_mut().print_strs_array([
+            if S::IS_COMPACT { TYPE_PREFIX } else { TYPE_PREFIX_PRETTY },
+            self.token_type.as_str(),
+            if S::IS_COMPACT { VALUE_PREFIX } else { VALUE_PREFIX_PRETTY },
+            self.value,
+            if S::IS_COMPACT { START_PREFIX } else { START_PREFIX_PRETTY },
+            start,
+            if S::IS_COMPACT { END_PREFIX } else { END_PREFIX_PRETTY },
+            end,
+            if S::IS_COMPACT { POSTFIX } else { POSTFIX_PRETTY },
+        ]);
+    }
+}
+
 /// Token type.
 /// Wrapped in a module to ensure `TokenType` can only be constructed via `TokenType::new`.
 mod token_type {
@@ -110,6 +163,37 @@ mod token_type {
     }
 }
 use token_type::TokenType;
+
+mod u32_string {
+    use super::*;
+
+    /// Maximum length of a decimal string representation of a `u32`.
+    const MAX_U32_LEN: usize = "4294967295".len(); // `u32::MAX` (10 bytes string)
+
+    /// Wrapper around [`ItoaBuffer`] which asserts that the formatted string is not longer than 10 bytes.
+    ///
+    /// Purpose of this type is to inform the compiler that the `&str` has a short length,
+    /// which allows it to remove bounds checks when concatenating multiple strings.
+    #[repr(transparent)]
+    pub struct U32String(ItoaBuffer);
+
+    #[expect(clippy::inline_always)]
+    impl U32String {
+        #[inline(always)]
+        pub fn new() -> Self {
+            Self(ItoaBuffer::new())
+        }
+
+        #[inline(always)]
+        pub fn format(&mut self, n: u32) -> &str {
+            let s = self.0.format(n);
+            // SAFETY: A `u32` converted to decimal string cannot have more than 10 digits
+            unsafe { assert_unchecked!(s.len() <= MAX_U32_LEN) };
+            s
+        }
+    }
+}
+use u32_string::U32String;
 
 #[derive(Debug, Clone, Copy)]
 pub struct EstreeTokenOptions {
@@ -259,7 +343,13 @@ impl<'b, S: SequenceSerializer> EstreeTokenContext<'b, S> {
 
     /// Emit the token at `start` as `"Identifier"`, unless it's a legacy keyword
     /// and `exclude_legacy_keyword_identifiers` is set (in which case it gets its default type).
-    fn emit_identifier(&mut self, start: u32) {
+    ///
+    /// `name` is the decoded identifier name from the AST node.
+    /// When the token has no escapes, `name` points into the source text, same as slicing it.
+    /// When the token has escapes and `decode_identifier_escapes` is enabled, `name` provides
+    /// the decoded value. Only when escapes are present but decoding is disabled do we need to
+    /// fall back to slicing the raw source text (preserving the escape sequences in the output).
+    fn emit_identifier(&mut self, start: u32, name: &str) {
         let token = self.advance_to(start);
         let token_type = if self.options.exclude_legacy_keyword_identifiers
             && matches!(token.kind(), Kind::Yield | Kind::Let | Kind::Static)
@@ -268,7 +358,24 @@ impl<'b, S: SequenceSerializer> EstreeTokenContext<'b, S> {
         } else {
             TokenType::new("Identifier")
         };
-        self.emit_token(token, token_type);
+
+        // Use `name` from AST node in most cases — it's JSON-safe so can skip escape checking.
+        // Only fall back to raw source text when the token contains escapes and decoding is disabled,
+        // since raw escape sequences contain `\` which needs JSON escaping.
+        if self.options.decode_identifier_escapes || !token.escaped() {
+            self.serialize_ident_token(token, token_type, name);
+        } else {
+            #[cold]
+            #[inline(never)]
+            fn emit<S: SequenceSerializer>(
+                ctx: &mut EstreeTokenContext<'_, S>,
+                token: &Token,
+                token_type: TokenType,
+            ) {
+                ctx.emit_token(token, token_type);
+            }
+            emit(self, token, token_type);
+        }
     }
 
     /// Consume all tokens before `start` (emitting them with default types),
@@ -292,38 +399,42 @@ impl<'b, S: SequenceSerializer> EstreeTokenContext<'b, S> {
 
     /// Serialize a single token.
     fn emit_token(&mut self, token: &Token, token_type: TokenType) {
-        let kind = token.kind();
-        let start = token.start();
-        let end = token.end();
-        let value = &self.source_text[start as usize..end as usize];
-        let value = if kind == Kind::PrivateIdentifier { &value[1..] } else { value };
-
-        let decoded;
-        let value = if self.options.decode_identifier_escapes
-            && token.escaped()
-            && (kind.is_identifier_name() || kind == Kind::PrivateIdentifier)
-            && value.contains("\\u")
-        {
-            decoded = decode_js_unicode_escapes(value);
-            decoded.as_str()
-        } else {
-            value
-        };
-
-        let regex = if kind == Kind::RegExp {
+        let value = &self.source_text[token.start() as usize..token.end() as usize];
+        let regex = if token.kind() == Kind::RegExp {
             regex_parts(value).map(|(pattern, flags)| EstreeRegExpToken { pattern, flags })
         } else {
             None
         };
+        self.serialize_token(token, token_type, value, regex);
+    }
 
+    /// Convert span to UTF-16 and serialize token.
+    fn serialize_token(
+        &mut self,
+        token: &Token,
+        token_type: TokenType,
+        value: &str,
+        regex: Option<EstreeRegExpToken<'_>>,
+    ) {
         // Convert offsets to UTF-16
-        let mut span = Span::new(start, end);
+        let mut span = Span::new(token.start(), token.end());
         if let Some(converter) = self.span_converter.as_mut() {
             converter.convert_span(&mut span);
         }
 
         let estree_token = EstreeToken { token_type, value, regex, span };
         self.seq.serialize_element(&estree_token);
+    }
+
+    /// Serialize a token whose value is guaranteed JSON-safe, skipping escape-checking.
+    fn serialize_ident_token(&mut self, token: &Token, token_type: TokenType, value: &str) {
+        // Convert offsets to UTF-16
+        let mut span = Span::new(token.start(), token.end());
+        if let Some(converter) = self.span_converter.as_mut() {
+            converter.convert_span(&mut span);
+        }
+
+        self.seq.serialize_element(&EstreeIdentToken { token_type, value, span });
     }
 
     /// Serialize all remaining tokens and close the sequence.
@@ -408,7 +519,7 @@ impl<'a, S: SequenceSerializer> Visit<'a> for EstreeTokenContext<'_, S> {
         {
             self.emit_token_at(identifier.span.start, TokenType::new("JSXIdentifier"));
         } else {
-            self.emit_identifier(identifier.span.start);
+            self.emit_identifier(identifier.span.start, &identifier.name);
         }
     }
 
@@ -420,16 +531,40 @@ impl<'a, S: SequenceSerializer> Visit<'a> for EstreeTokenContext<'_, S> {
         {
             self.emit_token_at(identifier.span.start, TokenType::new("JSXIdentifier"));
         } else {
-            self.emit_identifier(identifier.span.start);
+            self.emit_identifier(identifier.span.start, &identifier.name);
         }
     }
 
     fn visit_binding_identifier(&mut self, identifier: &BindingIdentifier<'a>) {
-        self.emit_identifier(identifier.span.start);
+        self.emit_identifier(identifier.span.start, &identifier.name);
     }
 
     fn visit_label_identifier(&mut self, identifier: &LabelIdentifier<'a>) {
-        self.emit_identifier(identifier.span.start);
+        self.emit_identifier(identifier.span.start, &identifier.name);
+    }
+
+    fn visit_private_identifier(&mut self, identifier: &PrivateIdentifier<'a>) {
+        let token = self.advance_to(identifier.span.start);
+
+        // `identifier.name` has `#` stripped and escapes decoded by the parser, and is JSON-safe.
+        // Only fall back to slicing raw source text when the token contains escapes and decoding
+        // is disabled, since raw escape sequences contain `\` which needs JSON escaping.
+        if self.options.decode_identifier_escapes || !token.escaped() {
+            self.serialize_ident_token(
+                token,
+                TokenType::new("PrivateIdentifier"),
+                &identifier.name,
+            );
+        } else {
+            #[cold]
+            #[inline(never)]
+            fn emit<S: SequenceSerializer>(ctx: &mut EstreeTokenContext<'_, S>, token: &Token) {
+                // Strip leading `#`
+                let value = &ctx.source_text[token.start() as usize + 1..token.end() as usize];
+                ctx.serialize_token(token, TokenType::new("PrivateIdentifier"), value, None);
+            }
+            emit(self, token);
+        }
     }
 
     fn visit_ts_this_parameter(&mut self, parameter: &TSThisParameter<'a>) {
@@ -598,47 +733,4 @@ fn regex_parts(raw: &str) -> Option<(&str, &str)> {
     }
 
     None
-}
-
-fn decode_js_unicode_escapes(raw: &str) -> String {
-    debug_assert!(raw.contains("\\u"));
-
-    let bytes = raw.as_bytes();
-    let mut output = String::with_capacity(raw.len());
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b'u' {
-            // `\u{...}`
-            if i + 2 < bytes.len() && bytes[i + 2] == b'{' {
-                let mut j = i + 3;
-                while j < bytes.len() && bytes[j] != b'}' {
-                    j += 1;
-                }
-                if j < bytes.len()
-                    && j > i + 3
-                    && let Ok(codepoint) = u32::from_str_radix(&raw[i + 3..j], 16)
-                    && let Some(ch) = char::from_u32(codepoint)
-                {
-                    output.push(ch);
-                    i = j + 1;
-                    continue;
-                }
-            // `\uXXXX`
-            } else if i + 6 <= bytes.len()
-                && let Ok(codepoint) = u32::from_str_radix(&raw[i + 2..i + 6], 16)
-                && let Some(ch) = char::from_u32(codepoint)
-            {
-                output.push(ch);
-                i += 6;
-                continue;
-            }
-        }
-
-        let ch = raw[i..].chars().next().unwrap();
-        output.push(ch);
-        i += ch.len_utf8();
-    }
-
-    output
 }


### PR DESCRIPTION
Previously we would create `Identifier` tokens' `value` by slice the source text `start..end`. If the identifier has `escaped` flag set, it would decode the unescaped `value` from that source slice if `options.decode_identifier_escapes` is enabled.

The identifier AST node already contains the unescaped identifier name, so just use that instead in almost all cases. This avoids the string slice (4 checks). We can use that cheap path if either:

1. `options.decode_identifier_escapes` is enabled (which it is by default in JS files, to match Espree).
2. Token's `escaped` flag is not set.

Additionally, identifier name is guaranteed already JSON-safe (can't contain backslashes, control characters etc), so all the parts of the JSON for an identifier token are JSON-safe. This makes it easy to manually assemble the JSON and write it all with only a single bounds check, using `CodeBuffer::print_strs_array` (added in #19766).

It's the latter change which is having the positive perf impact - +9% on ESTree tokens benchmark.