### PR TITLE
fix(linter/no-use-before-define): honor `ignoreTypeReferences` when value and type name collisions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_use_before_define.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_use_before_define.rs
@@ -132,6 +132,9 @@ impl Rule for NoUseBeforeDefine {
         }
 
         let Some(symbol_id) = reference.symbol_id() else {
+            if self.0.ignore_type_references && is_type_reference(reference, node, ctx) {
+                return;
+            }
             if let Some(declaration_span) =
                 unresolved_initializer_reference_declaration_span(identifier, node, ctx)
             {
@@ -2507,6 +2510,19 @@ fn test_typescript_eslint() {
             const baz = '';
                   ",
             Some(serde_json::json!([{ "ignoreTypeReferences": true }])),
+        ),
+        (
+            "
+            declare global {
+              type foo = string;
+            }
+
+            export function fn(x: unknown) {
+              const foo = x as foo;
+              return foo;
+            }
+                  ",
+            Some(serde_json::json!([{ "ignoreTypeReferences": true, "variables": true }])),
         ),
         (
             "


### PR DESCRIPTION
Prevent no-use-before-define from reporting unresolved references in initializers when ignoreTypeReferences is enabled, so type assertions like `x as foo` are not treated as value self-references.

Made-with: Cursor

fixes #19743

# fix(linter): honor `ignoreTypeReferences` when value and type names collide

## Summary

- Fixes a `no-use-before-define` false positive in TypeScript when `ignoreTypeReferences: true`.
- Prevents unresolved **type-only** initializer references from being treated as value self-references.
- Adds a regression test for a global type `foo` and local variable `foo` with `x as foo`.
- Fixed by GPT-5.3 Codex in Cursor.

## Bug Repro

Config:

```json
{
  "rules": {
    "no-use-before-define": ["error", { "ignoreTypeReferences": true, "variables": true }]
  }
}
```

Input:

```ts
declare global {
  type foo = string
}

export function fn(x: unknown) {
  const foo = x as foo
  return foo
}
```

Expected: no lint error (`as foo` is type-only).  
Actual before fix: `'foo' was used before it was defined.`

## Root Cause

In the unresolved-reference branch of `no-use-before-define`, the initializer self-reference fallback path ran without first honoring `ignoreTypeReferences`.  
That allowed unresolved type-only references (like `as foo`) to be interpreted like value self-references (`let foo = foo`).

## Fix

- In unresolved-symbol handling, return early when:
  - `ignoreTypeReferences` is enabled, and
  - the reference is type-only (`is_type_reference(...)`).
- Keep existing initializer self-reference behavior for value references unchanged.
- Add a regression case to the TypeScript ESLint test set.

## Files Changed

- `crates/oxc_linter/src/rules/eslint/no_use_before_define.rs`

## Validation

- Confirmed regression behavior: test fails without the fix and passes with the fix restored.
- `cargo test -p oxc_linter no_use_before_define::test_typescript_eslint`
- `cargo lint -- --deny warnings`

## Prerequisites Checklist

- [x] Branch created from `origin/main`
- [x] Change is scoped to one rule and includes regression test
- [x] Root cause identified and fixed (no workaround)
- [x] No unrelated files included in this change
- [x] Full lint suite passed (`cargo lint -- --deny warnings`)
- [x] Targeted rule tests passed

## Test Plan

- [x] Run `cargo test -p oxc_linter no_use_before_define::test_typescript_eslint`
- [x] Verify new test case passes with fix
- [x] Verify same case fails when guard is temporarily removed (done locally)
- [x] Run full lint (`cargo lint -- --deny warnings`)

## Notes for Reviewers

- Behavior change is intentionally narrow: unresolved **type-only** references are ignored only when `ignoreTypeReferences` is true.
- Value-reference ordering checks and initializer self-reference detection remain unchanged.
