### PR TITLE
fix(codegen): print `override` keyword for method and property definitions

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2666,6 +2666,11 @@ impl Gen for MethodDefinition<'_> {
             p.print_str("static");
             p.print_soft_space();
         }
+        if self.r#override {
+            p.print_space_before_identifier();
+            p.print_str("override");
+            p.print_soft_space();
+        }
         match &self.kind {
             MethodDefinitionKind::Constructor | MethodDefinitionKind::Method => {}
             MethodDefinitionKind::Get => {
@@ -2746,6 +2751,11 @@ impl Gen for PropertyDefinition<'_> {
         if self.r#static {
             p.print_space_before_identifier();
             p.print_str("static");
+            p.print_soft_space();
+        }
+        if self.r#override {
+            p.print_space_before_identifier();
+            p.print_str("override");
             p.print_soft_space();
         }
         if self.readonly {

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -15,6 +15,8 @@ fn cases() {
         "class Foo {\n\t#name: string;\n\tf() {\n\t\t#name in other && this.#name === other.#name;\n\t}\n}\n",
     );
     test_same("class B {\n\tconstructor(override readonly a: number) {}\n}\n");
+    test_same("class C extends B {\n\toverride show(): void;\n\toverride hide(): void;\n}\n");
+    test_same("class D extends B {\n\toverride readonly x: number;\n}\n");
     test_same("export { type as as };\n");
 }
 


### PR DESCRIPTION
## Summary
- Add `override` keyword printing for `MethodDefinition` and `PropertyDefinition` in codegen
- Previously, class members with the `override` modifier would silently drop the keyword during code generation

## Test plan
- [x] Added `test_same` cases for `override` on methods and properties
- [x] Passes `cargo clippy` and existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)