### PR TITLE
refactor(examples/semantic): simplify symbol span retrieval in semantic analysis

### DIFF
--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -91,9 +91,7 @@ fn main() -> std::io::Result<()> {
 
         for sym in semantic.semantic.scoping().symbol_ids() {
             let symbol_name = semantic.semantic.scoping().symbol_name(sym);
-            let declaration_node_id = semantic.semantic.scoping().symbol_declaration(sym);
-            let declaration_span =
-                semantic.semantic.nodes().get_node(declaration_node_id).kind().span();
+            let declaration_span = semantic.semantic.scoping().symbol_span(sym);
 
             let reference_spans = semantic.semantic.symbol_references(sym).map(|reference| {
                 (


### PR DESCRIPTION
This makes it clear exactly where the declaration is, instead of it being ambiguous.

It also reduces the changes of spans being overlapping ect.

Before:


![Screenshot 2026-02-26 at 12.12.14.png](https://app.graphite.com/user-attachments/assets/cfe5fce1-c488-4d70-9f4e-d3270f651cba.png)

After:

![Screenshot 2026-02-26 at 12.12.03.png](https://app.graphite.com/user-attachments/assets/fc7181b1-24ab-44d4-8753-01e4a7974245.png)

