### PR TITLE
fix(codegen): print `static` keyword for TSIndexSignature

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3675,6 +3675,9 @@ impl Gen for TSTypeParameterInstantiation<'_> {
 
 impl Gen for TSIndexSignature<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        if self.r#static {
+            p.print_str("static ");
+        }
         if self.readonly {
             p.print_str("readonly ");
         }

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -39,6 +39,7 @@ fn cases() {
     );
     test_same("class E {\n\tsubscribe!: string;\n}\n");
     test_same("class F {\n\taccessor value!: string;\n}\n");
+    test_same("class E {\n\tstatic [key: string]: string;\n}\n");
     test_same("export { type as as };\n");
     test_same("try {} catch (e: unknown) {} finally {}\n");
 }


### PR DESCRIPTION
The codegen was missing the `static` keyword when printing `TSIndexSignature`
nodes, causing `static [key: string]: string` index signatures to lose the
`static` modifier during code generation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>