### PR TITLE
perf(estree): use `CodeBuffer::print_strs_array` to reduce bounds checks

### DIFF
--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -223,9 +223,7 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
             }
             match *part {
                 TracePathPart::Key(key) => {
-                    self.fixes_buffer.print_ascii_byte(b'"');
-                    self.fixes_buffer.print_str(key);
-                    self.fixes_buffer.print_ascii_byte(b'"');
+                    self.fixes_buffer.print_strs_array(["\"", key, "\""]);
                 }
                 TracePathPart::Index(index) => {
                     let mut buffer = ItoaBuffer::new();

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -26,10 +26,7 @@ pub struct JsonSafeString<'s>(pub &'s str);
 impl ESTree for JsonSafeString<'_> {
     #[inline(always)]
     fn serialize<S: Serializer>(&self, mut serializer: S) {
-        let buffer = serializer.buffer_mut();
-        buffer.print_ascii_byte(b'"');
-        buffer.print_str(self.0);
-        buffer.print_ascii_byte(b'"');
+        serializer.buffer_mut().print_strs_array(["\"", self.0, "\""]);
     }
 }
 

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -98,9 +98,7 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
             formatter.before_later_element(buffer);
         }
 
-        buffer.print_ascii_byte(b'"');
-        buffer.print_str(key);
-        buffer.print_str("\":");
+        buffer.print_strs_array(["\"", key, "\":"]);
         formatter.before_field_value(buffer);
         value.serialize(&mut *self.serializer);
     }


### PR DESCRIPTION
Use `CodeBuffer::print_strs_array` (introduced in #19760) to optimize serializing to JSON in `ESTree` trait. When printing the start of an object property `"key":`, instead of printing `"`, then `key`, then `":`, print them all in one batch.

As this pushing strings into the serializer's buffer is the core of what JSON serialization involves, this simple optimization produces a sizeable speed-up - +10% on ESTree benchmark, +7% on ESTree tokens benchmark.