### PR TITLE
fix(linter/no-dynamic-delete): add help messages to missing diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -41,6 +41,9 @@ declare_oxc_lint!(
 fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
         .with_help("Use a static property key, or use a Map/Set for dynamic keys.")
+        .with_note(
+            "Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.",
+        )
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_dynamic_delete.rs
@@ -39,7 +39,9 @@ declare_oxc_lint!(
 );
 
 fn no_dynamic_delete_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not delete dynamically computed property keys.").with_label(span)
+    OxcDiagnostic::warn("Do not delete dynamically computed property keys.")
+        .with_help("Use a static property key, or use a Map/Set for dynamic keys.")
+        .with_label(span)
 }
 
 impl Rule for NoDynamicDelete {

--- a/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────
  5 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ───────────────────────────
  5 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────────
  5 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -81,3 +90,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ──────────────────────────
  4 │                   
    ╰────
+  help: Use a static property key, or use a Map/Set for dynamic keys.

--- a/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_dynamic_delete.snap
@@ -10,6 +10,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -19,6 +20,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -28,6 +30,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -37,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -46,6 +50,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -55,6 +60,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -64,6 +70,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:4:13]
@@ -73,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
  5 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -82,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.
 
   ⚠ typescript-eslint(no-dynamic-delete): Do not delete dynamically computed property keys.
    ╭─[no_dynamic_delete.tsx:3:13]
@@ -91,3 +100,4 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Use a static property key, or use a Map/Set for dynamic keys.
+  note: Frequent property deletions can move objects to slower dictionary-mode properties and hurt inline-cache optimizations. See: https://v8.dev/blog/fast-properties.


### PR DESCRIPTION
Added `.with_help()` to missing diagnostics in the typescript `no_dynamic_delete.rs` file.

Part of #19121

(Used cursor to split up my PR into smaller PRs per module)