### PR TITLE
feat(estree): expose buffer and formatter of serializers

### DIFF
--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -1,6 +1,4 @@
-use super::{
-    Config, ESTree, ESTreeSerializer, Formatter, Serializer, SerializerPrivate, TracePathPart,
-};
+use super::{Config, ESTree, ESTreeSerializer, Formatter, Serializer, TracePathPart};
 
 /// Trait for sequence serializers.
 pub trait SequenceSerializer {

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -2,7 +2,7 @@ use oxc_data_structures::code_buffer::CodeBuffer;
 
 use super::{
     Config, ESTree, ESTreeSequenceSerializer, ESTreeSerializer, Formatter, Serializer,
-    SerializerPrivate, TracePathPart,
+    TracePathPart,
 };
 
 /// Trait for struct serializers.
@@ -222,6 +222,7 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
     /// `true` if output should contain TS fields
     const INCLUDE_TS_FIELDS: bool = P::Config::INCLUDE_TS_FIELDS;
 
+    type Formatter = P::Formatter;
     type StructSerializer = Self;
     type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Config, P::Formatter>;
 
@@ -247,10 +248,6 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
     fn ranges(&self) -> bool {
         self.0.ranges()
     }
-}
-
-impl<P: StructSerializer> SerializerPrivate for FlatStructSerializer<'_, P> {
-    type Formatter = P::Formatter;
 
     fn buffer_mut(&mut self) -> &mut CodeBuffer {
         const {


### PR DESCRIPTION
In `ESTree` trait, expose the buffer and formatter to callers. Usually callers use the standard APIs for serialization (`serializer.serialize_struct()` etc), exposing the underlying primitives allows callers to manually construct the JSON themselves where it's useful to do that for perf.

This is used in #19744 to net a +9% perf gain in ESTree token serialization.