### PR TITLE
fix(codegen): remove double indentation for enum inside namespace

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3825,7 +3825,6 @@ impl Gen for TSInterfaceHeritage<'_> {
 
 impl Gen for TSEnumDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
-        p.print_indent();
         if self.declare {
             p.print_str("declare ");
         }

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -33,6 +33,9 @@ fn cases() {
     test_same("class B {\n\tconstructor(override readonly a: number) {}\n}\n");
     test_same("class C extends B {\n\toverride show(): void;\n\toverride hide(): void;\n}\n");
     test_same("class D extends B {\n\toverride readonly x: number;\n}\n");
+    test_same(
+        "declare namespace ns {\n\tclass Foo {}\n\tenum Bar {}\n\ttype Baz = undefined;\n}\n",
+    );
     test_same("class E {\n\tsubscribe!: string;\n}\n");
     test_same("class F {\n\taccessor value!: string;\n}\n");
     test_same("export { type as as };\n");


### PR DESCRIPTION
## Summary

- `TSEnumDeclaration::gen()` called `p.print_indent()`, but the `Statement` handler already calls `print_indent()` before dispatching — causing enums inside namespaces to get double indentation (e.g. 4 spaces instead of 2).
- No other declaration type (`Class`, `TSModuleDeclaration`, `TSInterfaceDeclaration`, `TSTypeAliasDeclaration`) has this issue.

**Before:**
```ts
declare namespace ns {
  class Foo {}
    enum Bar {}
  type Baz = undefined;
}
```

**After:**
```ts
declare namespace ns {
  class Foo {}
  enum Bar {}
  type Baz = undefined;
}
```

## Test plan

- [x] Added `test_same` case for `declare namespace` with class, enum, and type alias
- [x] Verified test fails without the fix, passes with it
- [x] All 92 `oxc_codegen` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)