### PR TITLE
fix(linter/ban_types): Add missing help and note to diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -14,6 +14,8 @@ fn type_diagnostic(banned_type: &str, suggested_type: &str, span: Span) -> OxcDi
     OxcDiagnostic::warn(format!(
         "Do not use {banned_type:?} as a type. Use \"{suggested_type}\" instead"
     ))
+    .with_help(format!("Replace {banned_type:?} with the lowercase primitive type \"{suggested_type}\"."))
+    .with_note(format!("{banned_type} is a wrapper object type, while {suggested_type} is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value."))
     .with_label(span)
 }
 
@@ -31,6 +33,8 @@ fn function(span: Span) -> OxcDiagnostic {
 
 fn object(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("'The `Object` type actually means \"any non-nullish value\"")
+        .with_help("Replace `Object` with a more specific type. If you need a generic object, use `Record<string, unknown>` or define an interface/type with explicit properties. If you need any value, use `unknown` instead.")
+        .with_note("The `Object` type is confusing because it doesn't mean 'any object' - it means 'any non-nullish value', which includes primitives. This makes code harder to understand and can lead to unexpected behavior.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/typescript_ban_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_ban_types.snap
@@ -7,36 +7,48 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let a: String;
    ·        ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let b: Boolean;
    ·        ───────
    ╰────
+  help: Replace "Boolean" with the lowercase primitive type "boolean".
+  note: Boolean is a wrapper object type, while boolean is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Number" as a type. Use "number" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let c: Number;
    ·        ──────
    ╰────
+  help: Replace "Number" with the lowercase primitive type "number".
+  note: Number is a wrapper object type, while number is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Symbol" as a type. Use "symbol" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let d: Symbol;
    ·        ──────
    ╰────
+  help: Replace "Symbol" with the lowercase primitive type "symbol".
+  note: Symbol is a wrapper object type, while symbol is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "BigInt" as a type. Use "bigint" instead
    ╭─[ban_types.tsx:1:8]
  1 │ let e: BigInt;
    ·        ──────
    ╰────
+  help: Replace "BigInt" with the lowercase primitive type "bigint".
+  note: BigInt is a wrapper object type, while bigint is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:1:8]
  1 │ let f: Object;
    ·        ──────
    ╰────
+  help: Replace `Object` with a more specific type. If you need a generic object, use `Record<string, unknown>` or define an interface/type with explicit properties. If you need any value, use `unknown` instead.
+  note: The `Object` type is confusing because it doesn't mean 'any object' - it means 'any non-nullish value', which includes primitives. This makes code harder to understand and can lead to unexpected behavior.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:1:8]
@@ -57,24 +69,32 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let i: { b: String };
    ·             ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:13]
  1 │ let j: { c: String };
    ·             ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:20]
  1 │ function foo(arg0: String) {}
    ·                    ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:1:10]
  1 │ 'foo' as String;
    ·          ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:1:10]
@@ -88,18 +108,24 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let d: Symbol = Symbol('foo');
    ·        ──────
    ╰────
+  help: Replace "Symbol" with the lowercase primitive type "symbol".
+  note: Symbol is a wrapper object type, while symbol is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:20]
  1 │ let baz: [boolean, Boolean] = [true, false];
    ·                    ───────
    ╰────
+  help: Replace "Boolean" with the lowercase primitive type "boolean".
+  note: Boolean is a wrapper object type, while boolean is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:17]
  1 │ let z = true as Boolean;
    ·                 ───────
    ╰────
+  help: Replace "Boolean" with the lowercase primitive type "boolean".
+  note: Boolean is a wrapper object type, while boolean is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Prefer explicitly define the object shape
    ╭─[ban_types.tsx:1:14]
@@ -120,30 +146,40 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const str: String = 'foo';
    ·            ──────
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Boolean" as a type. Use "boolean" instead
    ╭─[ban_types.tsx:1:13]
  1 │ const bool: Boolean = true;
    ·             ───────
    ╰────
+  help: Replace "Boolean" with the lowercase primitive type "boolean".
+  note: Boolean is a wrapper object type, while boolean is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Number" as a type. Use "number" instead
    ╭─[ban_types.tsx:1:12]
  1 │ const num: Number = 1;
    ·            ──────
    ╰────
+  help: Replace "Number" with the lowercase primitive type "number".
+  note: Number is a wrapper object type, while number is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "Symbol" as a type. Use "symbol" instead
    ╭─[ban_types.tsx:1:13]
  1 │ const symb: Symbol = Symbol('foo');
    ·             ──────
    ╰────
+  help: Replace "Symbol" with the lowercase primitive type "symbol".
+  note: Symbol is a wrapper object type, while symbol is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "BigInt" as a type. Use "bigint" instead
    ╭─[ban_types.tsx:1:15]
  1 │ const bigInt: BigInt = 1n;
    ·               ──────
    ╰────
+  help: Replace "BigInt" with the lowercase primitive type "bigint".
+  note: BigInt is a wrapper object type, while bigint is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Prefer explicitly define the object shape
    ╭─[ban_types.tsx:1:17]
@@ -167,6 +203,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Replace "Boolean" with the lowercase primitive type "boolean".
+  note: Boolean is a wrapper object type, while boolean is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:2:45]
@@ -175,6 +213,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                             ──────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:2:68]
@@ -183,6 +223,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                                    ──────
  3 │           constructor(foo: String | Object | Function) {}
    ╰────
+  help: Replace `Object` with a more specific type. If you need a generic object, use `Record<string, unknown>` or define an interface/type with explicit properties. If you need any value, use `unknown` instead.
+  note: The `Object` type is confusing because it doesn't mean 'any object' - it means 'any non-nullish value', which includes primitives. This makes code harder to understand and can lead to unexpected behavior.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:3:28]
@@ -191,6 +233,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                            ──────
  4 │ 
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): 'The `Object` type actually means "any non-nullish value"
    ╭─[ban_types.tsx:3:37]
@@ -199,6 +243,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                     ──────
  4 │ 
    ╰────
+  help: Replace `Object` with a more specific type. If you need a generic object, use `Record<string, unknown>` or define an interface/type with explicit properties. If you need any value, use `unknown` instead.
+  note: The `Object` type is confusing because it doesn't mean 'any object' - it means 'any non-nullish value', which includes primitives. This makes code harder to understand and can lead to unexpected behavior.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:3:46]
@@ -216,6 +262,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  6 │             const foo: String = 1 as String;
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:6:24]
@@ -224,6 +272,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  7 │           }
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Do not use "String" as a type. Use "string" instead
    ╭─[ban_types.tsx:6:38]
@@ -232,6 +282,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ──────
  7 │           }
    ╰────
+  help: Replace "String" with the lowercase primitive type "string".
+  note: String is a wrapper object type, while string is the primitive type. Using the primitive type is more idiomatic and avoids confusion between the object wrapper and the primitive value.
 
   ⚠ typescript-eslint(ban-types): Don't use `Function` as a type
    ╭─[ban_types.tsx:3:12]


### PR DESCRIPTION
Added .with_help() and .with_note() to missing diagnostics in the typescript `ban_types.rs` file.

Part of #19121 