### PR TITLE
feat(estree): add `IS_COMPACT` const to `Formatter` trait

### DIFF
--- a/crates/oxc_estree/src/serialize/formatter.rs
+++ b/crates/oxc_estree/src/serialize/formatter.rs
@@ -2,6 +2,9 @@ use oxc_data_structures::code_buffer::CodeBuffer;
 
 /// Formatter trait.
 pub trait Formatter {
+    /// `true` if formatter produces compact JSON (not pretty-printed JSON).
+    const IS_COMPACT: bool;
+
     /// Create new [`Formatter`].
     fn new() -> Self;
 
@@ -30,6 +33,8 @@ pub trait Formatter {
 pub struct CompactFormatter;
 
 impl Formatter for CompactFormatter {
+    const IS_COMPACT: bool = true;
+
     #[inline(always)]
     fn new() -> Self {
         Self
@@ -71,6 +76,8 @@ pub struct PrettyFormatter {
 }
 
 impl Formatter for PrettyFormatter {
+    const IS_COMPACT: bool = false;
+
     #[inline(always)]
     fn new() -> Self {
         Self { indent: 0 }

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -35,8 +35,11 @@ pub trait ESTree {
 
 /// Trait for serializers.
 pub trait Serializer {
-    /// `true` if output should contain TS fields
+    /// `true` if output should contain TS fields.
     const INCLUDE_TS_FIELDS: bool;
+
+    /// `true` if serializer's formatter produces compact JSON (not pretty-printed JSON).
+    const IS_COMPACT: bool = Self::Formatter::IS_COMPACT;
 
     /// Type of `Formatter` this serializer uses.
     type Formatter: Formatter;


### PR DESCRIPTION
Add `IS_COMPACT` const to `Formatter` and `Serializer` traits. In conjunction with #19773, callers can manually construct JSON themselves in the correct format for the serializer (compact or pretty-printed).

This is used in #19744 to net a +9% perf gain in ESTree token serialization.