### PR TITLE
refactor(estree/tokens): add `TokenType` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,7 @@ version = "0.115.0"
 dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_data_structures",
  "oxc_estree",
  "oxc_parser",
  "oxc_span",

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 [dependencies]
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
 oxc_estree = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true }
 oxc_span = { workspace = true, features = ["serialize"] }


### PR DESCRIPTION
Refactor. Add a `TokenType` type which represents the type of a token. It's purely a wrapper around a `&'static str`, except that it enforces a maximum length on the string.

This invariant is used in #19744 to avoid overflow checks when calling `CodeBuffer::print_strs_array`.