### PR TITLE
fix(lsp): shorten write lock in handle_tool_changes to unblock concurrent requests

### DIFF
--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -330,34 +330,47 @@ impl WorkspaceWorker {
         let mut unregistrations = vec![];
         let mut diagnostics: Option<Vec<(Uri, Vec<Diagnostic>)>> = None;
 
-        let mut tools = self.tools.write().await;
-        debug_assert_eq!(
-            tools.len(),
-            self.builders.len(),
-            "tools and builders must have the same length"
-        );
-        for (tool, builder) in tools.iter_mut().zip(self.builders.iter()) {
-            let builder: &dyn ToolBuilder = builder.as_ref();
-            let change = change_handler(tool, builder);
+        // Phase 1: acquire write lock, apply replacements, record which indices changed.
+        let replaced_indices: Vec<usize> = {
+            let mut tools = self.tools.write().await;
+            debug_assert_eq!(
+                tools.len(),
+                self.builders.len(),
+                "tools and builders must have the same length"
+            );
+            let mut replaced = vec![];
+            for (idx, (tool, builder)) in tools.iter_mut().zip(self.builders.iter()).enumerate() {
+                let builder: &dyn ToolBuilder = builder.as_ref();
+                let change = change_handler(tool, builder);
 
-            if let Some(patterns) = change.watch_patterns {
-                unregistrations.push(unregistration_tool_watcher_id(tool.name(), &self.root_uri));
-                if !patterns.is_empty() {
-                    registrations.push(registration_tool_watcher_id(
-                        tool.name(),
-                        &self.root_uri,
-                        patterns,
-                    ));
+                if let Some(patterns) = change.watch_patterns {
+                    unregistrations
+                        .push(unregistration_tool_watcher_id(tool.name(), &self.root_uri));
+                    if !patterns.is_empty() {
+                        registrations.push(registration_tool_watcher_id(
+                            tool.name(),
+                            &self.root_uri,
+                            patterns,
+                        ));
+                    }
+                }
+                if let Some(replaced_tool) = change.tool {
+                    *tool = replaced_tool;
+                    *needs_diagnostic_refresh = true;
+                    replaced.push(idx);
                 }
             }
-            if let Some(replaced_tool) = change.tool {
-                *tool = replaced_tool;
-                *needs_diagnostic_refresh = true;
+            replaced
+            // write lock dropped here
+        };
 
-                let Some(file_system) = file_system else {
-                    continue;
-                };
-
+        // Phase 2: re-run diagnostics under a read lock (only for replaced tools).
+        if let Some(file_system) = file_system
+            && !replaced_indices.is_empty()
+        {
+            let tools = self.tools.read().await;
+            for &idx in &replaced_indices {
+                let tool = &tools[idx];
                 for uri in file_system.keys() {
                     let document = file_system.get_document(&uri);
                     let Ok(mut reports) = tool.run_diagnostic(&document) else {


### PR DESCRIPTION
## Summary

- `handle_tool_changes` previously held `tools.write()` for the full duration including the per-URI diagnostic loop, blocking concurrent `codeAction` and `shutdown` requests for 2-3s in large workspaces
- Split into two phases: write lock covers only tool replacement (recording replaced indices), then diagnostics are re-run under a read lock
- Eliminates the stall that caused vscode-languageclient's 2-second `shutdown` timeout to fire during server restarts when a config file change was in flight

## Test plan

- [x] `cargo test -p oxc_language_server` — all 57 tests pass
- [ ] Manual: trigger "Restart Server" while a config change is in flight; confirm restart completes without "Stopping server timed out" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)