### PR TITLE
refactor(formatter,oxfmt): Remove `EmbeddedIR` and use `FormatElement` directly

### DIFF
--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -276,7 +276,7 @@ impl ExternalFormatter {
         let embedded_doc_callback: Option<EmbeddedDocFormatterCallback> = if needs_embedded {
             let format_embedded_doc = Arc::clone(&self.format_embedded_doc);
             let options_for_doc = options.clone();
-            Some(Arc::new(move |language: &str, texts: &[&str]| {
+            Some(Arc::new(move |allocator, group_id_builder, language: &str, texts: &[&str]| {
                 let Some(parser_name) = language_to_prettier_parser(language) else {
                     return Err(format!("Unsupported language: {language}"));
                 };
@@ -302,7 +302,7 @@ impl ExternalFormatter {
                                     serde_json::from_str(&doc_json_str).map_err(|err| {
                                         format!("Failed to parse Doc JSON: {err}")
                                     })?;
-                                from_prettier_doc::doc_json_to_embedded_ir(&doc_json)
+                                from_prettier_doc::to_format_elements_for_template(&doc_json, allocator, group_id_builder)
                             })
                             .collect()
                     })

--- a/crates/oxc_formatter/src/formatter/format_element/tag.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/tag.rs
@@ -158,11 +158,13 @@ impl Group {
         Self { id: None, mode: Cell::new(GroupMode::Flat) }
     }
 
+    #[must_use]
     pub fn with_id(mut self, id: Option<GroupId>) -> Self {
         self.id = id;
         self
     }
 
+    #[must_use]
     pub fn with_mode(mut self, mode: GroupMode) -> Self {
         self.mode = Cell::new(mode);
         self
@@ -208,6 +210,7 @@ impl Condition {
         Self { mode, group_id: None }
     }
 
+    #[must_use]
     pub fn with_group_id(mut self, id: Option<GroupId>) -> Self {
         self.group_id = id;
         self
@@ -226,6 +229,10 @@ impl Condition {
 pub struct Align(pub(crate) NonZeroU8);
 
 impl Align {
+    pub fn new(count: NonZeroU8) -> Self {
+        Self(count)
+    }
+
     pub fn count(&self) -> NonZeroU8 {
         self.0
     }

--- a/crates/oxc_formatter/src/formatter/formatter.rs
+++ b/crates/oxc_formatter/src/formatter/formatter.rs
@@ -67,6 +67,12 @@ impl<'buf, 'ast> Formatter<'buf, 'ast> {
         self.state().group_id(debug_name)
     }
 
+    /// Returns a reference to the unique group id builder for this document.
+    #[inline]
+    pub fn group_id_builder(&self) -> &super::UniqueGroupIdBuilder {
+        self.state().group_id_builder()
+    }
+
     /// Joins multiple [Format] together without any separator
     ///
     /// ## Examples

--- a/crates/oxc_formatter/src/formatter/group_id.rs
+++ b/crates/oxc_formatter/src/formatter/group_id.rs
@@ -66,7 +66,7 @@ impl From<GroupId> for u32 {
 }
 
 /// Builder to construct unique group ids that are unique if created with the same builder.
-pub(super) struct UniqueGroupIdBuilder {
+pub struct UniqueGroupIdBuilder {
     next_id: AtomicU32,
 }
 

--- a/crates/oxc_formatter/src/formatter/mod.rs
+++ b/crates/oxc_formatter/src/formatter/mod.rs
@@ -41,7 +41,7 @@ use std::fmt::Debug;
 
 pub use buffer::{Buffer, BufferExtensions, VecBuffer};
 pub use format_element::FormatElement;
-pub use group_id::GroupId;
+pub use group_id::{GroupId, UniqueGroupIdBuilder};
 
 pub use self::comments::Comments;
 use self::printer::Printer;
@@ -54,7 +54,7 @@ pub use self::{
     state::FormatState,
     text_range::TextRange,
 };
-use self::{format_element::document::Document, group_id::UniqueGroupIdBuilder, prelude::TagKind};
+use self::{format_element::document::Document, prelude::TagKind};
 
 #[derive(Debug)]
 pub struct Formatted<'a> {

--- a/crates/oxc_formatter/src/formatter/state.rs
+++ b/crates/oxc_formatter/src/formatter/state.rs
@@ -52,6 +52,11 @@ impl<'ast> FormatState<'ast> {
         self.group_id_builder.group_id(debug_name)
     }
 
+    /// Returns a reference to the unique group id builder.
+    pub fn group_id_builder(&self) -> &UniqueGroupIdBuilder {
+        &self.group_id_builder
+    }
+
     #[expect(clippy::mutable_key_type)]
     pub fn printed_interned_elements(&mut self) -> &mut FxHashMap<Interned<'ast>, usize> {
         &mut self.printed_interned_elements

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -19,15 +19,16 @@ use oxc_span::SourceType;
 
 pub use crate::ast_nodes::{AstNode, AstNodes};
 pub use crate::external_formatter::{
-    EmbeddedDocFormatterCallback, EmbeddedFormatterCallback, EmbeddedIR, ExternalCallbacks,
-    TailwindCallback,
+    EmbeddedDocFormatterCallback, EmbeddedFormatterCallback, ExternalCallbacks, TailwindCallback,
 };
-pub use crate::formatter::GroupId;
-pub use crate::formatter::format_element::tag::{DedentMode, Tag};
+pub use crate::formatter::format_element::tag::{
+    Align, Condition, DedentMode, Group, GroupMode, Tag,
+};
 pub use crate::formatter::format_element::{
-    BestFittingElement, FormatElement, LineMode, PrintMode,
+    BestFittingElement, FormatElement, LineMode, PrintMode, TextWidth,
 };
 pub use crate::formatter::{Format, Formatted};
+pub use crate::formatter::{GroupId, UniqueGroupIdBuilder};
 pub use crate::ir_transform::options::*;
 pub use crate::options::*;
 pub use crate::print::{FormatVueBindingParams, FormatVueScriptGeneric};


### PR DESCRIPTION
Follow up on https://github.com/oxc-project/oxc/pull/19670#issuecomment-3970150536

It seems it was achievable without requiring such major changes.
Thank you for your suggestion! 🙏🏻 