### PR TITLE
fix(oxfmt): Support tailwind sort for CSS/LESS/SCSS

### DIFF
--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -975,19 +975,21 @@ pub fn sync_external_options(options: &FormatOptions, config: &mut Value) {
     // Other options defined independently by plugins are also left as they are.
 }
 
-/// Parsers that can embed JS/TS code and benefit from Tailwind plugin
+/// Parsers(files) that benefit from Tailwind plugin
 #[cfg(feature = "napi")]
 static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     "html",
     "vue",
     "angular",
     "glimmer",
+    "css",
+    "scss",
+    "less",
 };
 
-/// Parsers that can embed JS/TS code and benefit from oxfmt plugin.
+/// Parsers(files) that can embed JS/TS code and benefit from oxfmt plugin.
 /// For now, expressions are not supported.
-/// - e.g. `__vue_expression` in `vue`
-/// - e.g. `__ng_directive` in `angular`
+/// - e.g. `__vue_expression` in `vue`, `__ng_directive` in `angular`
 #[cfg(feature = "napi")]
 static OXFMT_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     // "html",

--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -1209,3 +1209,16 @@ describe("Tailwind CSS Sorting in Embedded HTML (Tagged Template Literals)", () 
     expect(result.errors).toStrictEqual([]);
   });
 });
+
+describe("Tailwind CSS Sorting in CSS (@apply)", () => {
+  it("should sort @apply classes in CSS files", async () => {
+    const input = `.btn { @apply p-4 flex; }`;
+
+    const result = await format("test.css", input, {
+      sortTailwindcss: {},
+    });
+
+    expect(result.code).toContain("@apply flex p-4;");
+    expect(result.errors).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #19801

Since this is a clear fix, I'll merge it without review.