### PR TITLE
fix(linter): remove entire comment line when deleting unused disable directives

### DIFF
--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -10,6 +10,7 @@ use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_diagnostics::{OxcCode, Severity};
 use oxc_linter::{
     AllowWarnDeny, DisableDirectives, Fix, FixKind, Message, PossibleFixes, RuleCommentType,
+    full_comment_delete_span,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -276,7 +277,10 @@ pub fn create_unused_directives_report(
                     severity,
                     source_text,
                     rope,
-                    Some(&Fix::delete(span).with_message(fix_message)),
+                    Some(
+                        &Fix::delete(full_comment_delete_span(span, source_text))
+                            .with_message(fix_message),
+                    ),
                 ));
             }
             RuleCommentType::Single(rules) => {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -154,11 +154,11 @@ TextEdit: TextEdit {
     range: Range {
         start: Position {
             line: 0,
-            character: 2,
+            character: 0,
         },
         end: Position {
-            line: 0,
-            character: 56,
+            line: 1,
+            character: 0,
         },
     },
     new_text: "",
@@ -190,11 +190,11 @@ TextEdit: TextEdit {
     range: Range {
         start: Position {
             line: 8,
-            character: 2,
+            character: 0,
         },
         end: Position {
-            line: 8,
-            character: 52,
+            line: 9,
+            character: 0,
         },
     },
     new_text: "",
@@ -222,11 +222,11 @@ TextEdit: TextEdit {
     range: Range {
         start: Position {
             line: 0,
-            character: 2,
+            character: 0,
         },
         end: Position {
-            line: 0,
-            character: 56,
+            line: 1,
+            character: 0,
         },
     },
     new_text: "",
@@ -248,11 +248,11 @@ TextEdit: TextEdit {
     range: Range {
         start: Position {
             line: 8,
-            character: 2,
+            character: 0,
         },
         end: Position {
-            line: 8,
-            character: 52,
+            line: 9,
+            character: 0,
         },
     },
     new_text: "",

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -16,7 +16,9 @@ use oxc_span::{SourceType, Span};
 use crate::{
     AllowWarnDeny, FrameworkFlags,
     config::{LintConfig, LintPlugins, OxlintEnv, OxlintGlobals, OxlintSettings},
-    disable_directives::{DisableDirectives, DisableDirectivesBuilder, RuleCommentType},
+    disable_directives::{
+        DisableDirectives, DisableDirectivesBuilder, RuleCommentType, full_comment_delete_span,
+    },
     fixer::{Fix, FixKind, Message, PossibleFixes},
     frameworks::{self, FrameworkOptions},
     module_record::ModuleRecord,
@@ -332,7 +334,7 @@ impl<'a> ContextHost<'a> {
                             .with_label(span)
                             .with_severity(rule_severity),
                         PossibleFixes::Single(
-                            Fix::delete(span)
+                            Fix::delete(full_comment_delete_span(span, source_text))
                                 .with_kind(FixKind::Suggestion)
                                 .with_message(fix_message),
                         ),

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1098,6 +1098,7 @@ pub fn full_comment_delete_span(content_span: Span, source_text: &str) -> Span {
             (start - 2, (end + 2).min(src.len()))
         } else {
             // Shouldn't happen, but fall back to content span
+            debug_assert!(false, "content_span does not appear to be preceded by comment delimiters");
             (start, end)
         };
 
@@ -1135,7 +1136,7 @@ mod tests {
 
     use crate::disable_directives::{DisabledRule, RuleCommentRule, RuleCommentType};
 
-    use super::{DisableDirectives, DisableDirectivesBuilder};
+    use super::{DisableDirectives, DisableDirectivesBuilder, full_comment_delete_span};
 
     fn process_source<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
@@ -1440,144 +1441,138 @@ function test() {
         );
     }
 
-    mod full_comment_delete_span {
-        use oxc_span::Span;
+    #[test]
+    fn line_comment_own_line() {
+        let src = "let x = 1;\n// eslint-disable-next-line\nlet y = 2;\n";
+        // content_span covers " eslint-disable-next-line" (after "//")
+        let content = Span::new(13, 38);
+        assert_eq!(
+            &src[content.start as usize..content.end as usize],
+            " eslint-disable-next-line"
+        );
+        let result = full_comment_delete_span(content, src);
+        // Should delete entire line including trailing newline
+        assert_eq!(result, Span::new(11, 39));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "// eslint-disable-next-line\n"
+        );
+    }
 
-        use super::super::full_comment_delete_span;
+    #[test]
+    fn line_comment_after_code() {
+        let src = "let x = 1; // eslint-disable-line\n";
+        // content_span covers " eslint-disable-line" (after "//")
+        let content = Span::new(13, 33);
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-line");
+        let result = full_comment_delete_span(content, src);
+        // Should delete only comment (not the code before it)
+        assert_eq!(result, Span::new(11, 33));
+        assert_eq!(&src[result.start as usize..result.end as usize], "// eslint-disable-line");
+    }
 
-        #[test]
-        fn line_comment_own_line() {
-            let src = "let x = 1;\n// eslint-disable-next-line\nlet y = 2;\n";
-            // content_span covers " eslint-disable-next-line" (after "//")
-            let content = Span::new(13, 38);
-            assert_eq!(
-                &src[content.start as usize..content.end as usize],
-                " eslint-disable-next-line"
-            );
-            let result = full_comment_delete_span(content, src);
-            // Should delete entire line including trailing newline
-            assert_eq!(result, Span::new(11, 39));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "// eslint-disable-next-line\n"
-            );
-        }
+    #[test]
+    fn block_comment_own_line() {
+        let src = "let x = 1;\n/* eslint-disable */\nlet y = 2;\n";
+        // content_span covers " eslint-disable " (between "/*" and "*/")
+        let content = Span::new(13, 29);
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable ");
+        let result = full_comment_delete_span(content, src);
+        // Should delete entire line including trailing newline
+        assert_eq!(result, Span::new(11, 32));
+        assert_eq!(&src[result.start as usize..result.end as usize], "/* eslint-disable */\n");
+    }
 
-        #[test]
-        fn line_comment_after_code() {
-            let src = "let x = 1; // eslint-disable-line\n";
-            // content_span covers " eslint-disable-line" (after "//")
-            let content = Span::new(13, 33);
-            assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-line");
-            let result = full_comment_delete_span(content, src);
-            // Should delete only comment (not the code before it)
-            assert_eq!(result, Span::new(11, 33));
-            assert_eq!(&src[result.start as usize..result.end as usize], "// eslint-disable-line");
-        }
+    #[test]
+    fn block_comment_inline() {
+        let src = "let x = 1; /* eslint-disable */ let y = 2;\n";
+        let content = Span::new(13, 29);
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable ");
+        let result = full_comment_delete_span(content, src);
+        // Should delete only the comment (code on both sides)
+        assert_eq!(result, Span::new(11, 31));
+        assert_eq!(&src[result.start as usize..result.end as usize], "/* eslint-disable */");
+    }
 
-        #[test]
-        fn block_comment_own_line() {
-            let src = "let x = 1;\n/* eslint-disable */\nlet y = 2;\n";
-            // content_span covers " eslint-disable " (between "/*" and "*/")
-            let content = Span::new(13, 29);
-            assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable ");
-            let result = full_comment_delete_span(content, src);
-            // Should delete entire line including trailing newline
-            assert_eq!(result, Span::new(11, 32));
-            assert_eq!(&src[result.start as usize..result.end as usize], "/* eslint-disable */\n");
-        }
+    #[test]
+    fn comment_at_start_of_file() {
+        let src = "// eslint-disable-next-line\nlet x = 1;\n";
+        let content = Span::new(2, 27);
+        assert_eq!(
+            &src[content.start as usize..content.end as usize],
+            " eslint-disable-next-line"
+        );
+        let result = full_comment_delete_span(content, src);
+        assert_eq!(result, Span::new(0, 28));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "// eslint-disable-next-line\n"
+        );
+    }
 
-        #[test]
-        fn block_comment_inline() {
-            let src = "let x = 1; /* eslint-disable */ let y = 2;\n";
-            let content = Span::new(13, 29);
-            assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable ");
-            let result = full_comment_delete_span(content, src);
-            // Should delete only the comment (code on both sides)
-            assert_eq!(result, Span::new(11, 31));
-            assert_eq!(&src[result.start as usize..result.end as usize], "/* eslint-disable */");
-        }
+    #[test]
+    fn comment_at_end_of_file_no_trailing_newline() {
+        let src = "let x = 1;\n// eslint-disable-next-line";
+        let content = Span::new(13, 38);
+        assert_eq!(
+            &src[content.start as usize..content.end as usize],
+            " eslint-disable-next-line"
+        );
+        let result = full_comment_delete_span(content, src);
+        // Should delete from line start to EOF
+        assert_eq!(result, Span::new(11, 38));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "// eslint-disable-next-line"
+        );
+    }
 
-        #[test]
-        fn comment_at_start_of_file() {
-            let src = "// eslint-disable-next-line\nlet x = 1;\n";
-            let content = Span::new(2, 27);
-            assert_eq!(
-                &src[content.start as usize..content.end as usize],
-                " eslint-disable-next-line"
-            );
-            let result = full_comment_delete_span(content, src);
-            assert_eq!(result, Span::new(0, 28));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "// eslint-disable-next-line\n"
-            );
-        }
+    #[test]
+    fn crlf_line_endings() {
+        let src = "let x = 1;\r\n// eslint-disable-next-line\r\nlet y = 2;\r\n";
+        let content = Span::new(14, 39);
+        assert_eq!(
+            &src[content.start as usize..content.end as usize],
+            " eslint-disable-next-line"
+        );
+        let result = full_comment_delete_span(content, src);
+        // Should delete from after previous \n to after the \n of this line
+        assert_eq!(result, Span::new(12, 41));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "// eslint-disable-next-line\r\n"
+        );
+    }
 
-        #[test]
-        fn comment_at_end_of_file_no_trailing_newline() {
-            let src = "let x = 1;\n// eslint-disable-next-line";
-            let content = Span::new(13, 38);
-            assert_eq!(
-                &src[content.start as usize..content.end as usize],
-                " eslint-disable-next-line"
-            );
-            let result = full_comment_delete_span(content, src);
-            // Should delete from line start to EOF
-            assert_eq!(result, Span::new(11, 38));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "// eslint-disable-next-line"
-            );
-        }
+    #[test]
+    fn line_comment_with_leading_whitespace() {
+        let src = "let x = 1;\n    // eslint-disable-next-line\nlet y = 2;\n";
+        let content = Span::new(17, 42);
+        assert_eq!(
+            &src[content.start as usize..content.end as usize],
+            " eslint-disable-next-line"
+        );
+        let result = full_comment_delete_span(content, src);
+        // Should delete entire line including leading whitespace
+        assert_eq!(result, Span::new(11, 43));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "    // eslint-disable-next-line\n"
+        );
+    }
 
-        #[test]
-        fn crlf_line_endings() {
-            let src = "let x = 1;\r\n// eslint-disable-next-line\r\nlet y = 2;\r\n";
-            let content = Span::new(14, 39);
-            assert_eq!(
-                &src[content.start as usize..content.end as usize],
-                " eslint-disable-next-line"
-            );
-            let result = full_comment_delete_span(content, src);
-            // Should delete from after previous \n to after the \n of this line
-            assert_eq!(result, Span::new(12, 41));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "// eslint-disable-next-line\r\n"
-            );
-        }
-
-        #[test]
-        fn line_comment_with_leading_whitespace() {
-            let src = "let x = 1;\n    // eslint-disable-next-line\nlet y = 2;\n";
-            let content = Span::new(17, 42);
-            assert_eq!(
-                &src[content.start as usize..content.end as usize],
-                " eslint-disable-next-line"
-            );
-            let result = full_comment_delete_span(content, src);
-            // Should delete entire line including leading whitespace
-            assert_eq!(result, Span::new(11, 43));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "    // eslint-disable-next-line\n"
-            );
-        }
-
-        #[test]
-        fn multiline_block_comment_own_lines() {
-            let src = "let x = 1;\n/*\neslint-disable\n*/\nlet y = 2;\n";
-            // content_span: between /* and */ -> "\neslint-disable\n"
-            let content = Span::new(13, 29);
-            assert_eq!(&src[content.start as usize..content.end as usize], "\neslint-disable\n");
-            let result = full_comment_delete_span(content, src);
-            // Should delete from start of `/*` line through end of `*/` line
-            assert_eq!(result, Span::new(11, 32));
-            assert_eq!(
-                &src[result.start as usize..result.end as usize],
-                "/*\neslint-disable\n*/\n"
-            );
-        }
+    #[test]
+    fn multiline_block_comment_own_lines() {
+        let src = "let x = 1;\n/*\neslint-disable\n*/\nlet y = 2;\n";
+        // content_span: between /* and */ -> "\neslint-disable\n"
+        let content = Span::new(13, 29);
+        assert_eq!(&src[content.start as usize..content.end as usize], "\neslint-disable\n");
+        let result = full_comment_delete_span(content, src);
+        // Should delete from start of `/*` line through end of `*/` line
+        assert_eq!(result, Span::new(11, 32));
+        assert_eq!(
+            &src[result.start as usize..result.end as usize],
+            "/*\neslint-disable\n*/\n"
+        );
     }
 }

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1564,5 +1564,20 @@ function test() {
                 "    // eslint-disable-next-line\n"
             );
         }
+
+        #[test]
+        fn multiline_block_comment_own_lines() {
+            let src = "let x = 1;\n/*\neslint-disable\n*/\nlet y = 2;\n";
+            // content_span: between /* and */ -> "\neslint-disable\n"
+            let content = Span::new(13, 29);
+            assert_eq!(&src[content.start as usize..content.end as usize], "\neslint-disable\n");
+            let result = full_comment_delete_span(content, src);
+            // Should delete from start of `/*` line through end of `*/` line
+            assert_eq!(result, Span::new(11, 32));
+            assert_eq!(
+                &src[result.start as usize..result.end as usize],
+                "/*\neslint-disable\n*/\n"
+            );
+        }
     }
 }

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1089,18 +1089,20 @@ pub fn full_comment_delete_span(content_span: Span, source_text: &str) -> Span {
     let end = content_span.end as usize;
 
     // Expand to include delimiters
-    let (comment_start, comment_end) =
-        if start >= 2 && src[start - 2] == b'/' && src[start - 1] == b'/' {
-            // Line comment: `// ...`
-            (start - 2, end)
-        } else if start >= 2 && src[start - 2] == b'/' && src[start - 1] == b'*' {
-            // Block comment: `/* ... */`
-            (start - 2, (end + 2).min(src.len()))
-        } else {
-            // Shouldn't happen, but fall back to content span
-            debug_assert!(false, "content_span does not appear to be preceded by comment delimiters");
-            (start, end)
-        };
+    let (comment_start, comment_end) = if start >= 2
+        && src[start - 2] == b'/'
+        && src[start - 1] == b'/'
+    {
+        // Line comment: `// ...`
+        (start - 2, end)
+    } else if start >= 2 && src[start - 2] == b'/' && src[start - 1] == b'*' {
+        // Block comment: `/* ... */`
+        (start - 2, (end + 2).min(src.len()))
+    } else {
+        // Shouldn't happen, but fall back to content span
+        debug_assert!(false, "content_span does not appear to be preceded by comment delimiters");
+        (start, end)
+    };
 
     // Find line boundaries
     let line_start =
@@ -1446,10 +1448,7 @@ function test() {
         let src = "let x = 1;\n// eslint-disable-next-line\nlet y = 2;\n";
         // content_span covers " eslint-disable-next-line" (after "//")
         let content = Span::new(13, 38);
-        assert_eq!(
-            &src[content.start as usize..content.end as usize],
-            " eslint-disable-next-line"
-        );
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-next-line");
         let result = full_comment_delete_span(content, src);
         // Should delete entire line including trailing newline
         assert_eq!(result, Span::new(11, 39));
@@ -1498,10 +1497,7 @@ function test() {
     fn comment_at_start_of_file() {
         let src = "// eslint-disable-next-line\nlet x = 1;\n";
         let content = Span::new(2, 27);
-        assert_eq!(
-            &src[content.start as usize..content.end as usize],
-            " eslint-disable-next-line"
-        );
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-next-line");
         let result = full_comment_delete_span(content, src);
         assert_eq!(result, Span::new(0, 28));
         assert_eq!(
@@ -1514,27 +1510,18 @@ function test() {
     fn comment_at_end_of_file_no_trailing_newline() {
         let src = "let x = 1;\n// eslint-disable-next-line";
         let content = Span::new(13, 38);
-        assert_eq!(
-            &src[content.start as usize..content.end as usize],
-            " eslint-disable-next-line"
-        );
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-next-line");
         let result = full_comment_delete_span(content, src);
         // Should delete from line start to EOF
         assert_eq!(result, Span::new(11, 38));
-        assert_eq!(
-            &src[result.start as usize..result.end as usize],
-            "// eslint-disable-next-line"
-        );
+        assert_eq!(&src[result.start as usize..result.end as usize], "// eslint-disable-next-line");
     }
 
     #[test]
     fn crlf_line_endings() {
         let src = "let x = 1;\r\n// eslint-disable-next-line\r\nlet y = 2;\r\n";
         let content = Span::new(14, 39);
-        assert_eq!(
-            &src[content.start as usize..content.end as usize],
-            " eslint-disable-next-line"
-        );
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-next-line");
         let result = full_comment_delete_span(content, src);
         // Should delete from after previous \n to after the \n of this line
         assert_eq!(result, Span::new(12, 41));
@@ -1548,10 +1535,7 @@ function test() {
     fn line_comment_with_leading_whitespace() {
         let src = "let x = 1;\n    // eslint-disable-next-line\nlet y = 2;\n";
         let content = Span::new(17, 42);
-        assert_eq!(
-            &src[content.start as usize..content.end as usize],
-            " eslint-disable-next-line"
-        );
+        assert_eq!(&src[content.start as usize..content.end as usize], " eslint-disable-next-line");
         let result = full_comment_delete_span(content, src);
         // Should delete entire line including leading whitespace
         assert_eq!(result, Span::new(11, 43));
@@ -1570,9 +1554,6 @@ function test() {
         let result = full_comment_delete_span(content, src);
         // Should delete from start of `/*` line through end of `*/` line
         assert_eq!(result, Span::new(11, 32));
-        assert_eq!(
-            &src[result.start as usize..result.end as usize],
-            "/*\neslint-disable\n*/\n"
-        );
+        assert_eq!(&src[result.start as usize..result.end as usize], "/*\neslint-disable\n*/\n");
     }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -60,7 +60,7 @@ mod lint_runner;
 pub use crate::config::plugins::normalize_plugin_name;
 pub use crate::disable_directives::{
     DisableDirectives, DisableRuleComment, RuleCommentRule, RuleCommentType,
-    create_unused_directives_diagnostics,
+    create_unused_directives_diagnostics, full_comment_delete_span,
 };
 pub use crate::{
     config::{


### PR DESCRIPTION
## Summary

- When removing unused `eslint-disable`/`oxlint-disable` comments, the auto-fix previously only deleted the comment content (via `Comment::content_span()`), leaving behind empty `//` or `/* */` delimiters
- Adds `full_comment_delete_span()` helper that expands the deletion span to include comment delimiters and, when the comment is the sole content on its line, the entire line
- Applied in both the CLI `--fix` path and the LSP code action path

## Test plan

- [x] 8 new unit tests for `full_comment_delete_span` covering line/block comments, inline vs own-line, start/end of file, CRLF, leading whitespace
- [x] `cargo test -p oxc_linter` (981 tests pass)
- [x] `cargo test -p oxlint` (254 tests pass, snapshot updated)
- [x] `cargo clippy -p oxc_linter -p oxlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)