### PR TITLE
feat(oxfmt): Support .svelte file

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -21,7 +21,9 @@
   },
   "dependencies": {
     "prettier": "3.8.1",
+    "prettier-plugin-svelte": "3.5.0",
     "prettier-plugin-tailwindcss": "0.0.0-insiders.3997fbd",
+    "svelte": "^5.53.6",
     "tinypool": "2.1.0"
   },
   "devDependencies": {

--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -29,7 +29,7 @@ export interface Oxfmtrc {
    */
   arrowParens?: ArrowParensConfig | null;
   /**
-   * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
+   * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
    * - Default: `false`
@@ -42,7 +42,7 @@ export interface Oxfmtrc {
    */
   bracketSpacing?: boolean | null;
   /**
-   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.
    *
    * NOTE: XXX-in-JS support is incomplete.
    *
@@ -59,7 +59,7 @@ export interface Oxfmtrc {
    */
   endOfLine?: EndOfLineConfig | null;
   /**
-   * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
+   * Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.
    *
    * - Default: `"css"`
    */
@@ -132,7 +132,7 @@ export interface Oxfmtrc {
    */
   semi?: boolean | null;
   /**
-   * Enforce single attribute per line in HTML, Vue, and JSX.
+   * Enforce single attribute per line in HTML, Vue, Svelte, and JSX.
    *
    * - Default: `false`
    */
@@ -174,6 +174,16 @@ export interface Oxfmtrc {
    * - Default: Disabled
    */
   sortTailwindcss?: SortTailwindcssConfig | null;
+  /**
+   * Svelte formatting options.
+   *
+   * These options are passed through to `prettier-plugin-svelte`.
+   * Option names omit the `svelte` prefix used in the original plugin.
+   * (e.g., `sortOrder` instead of `svelteSortOrder`)
+   *
+   * - Default: All plugin defaults
+   */
+  svelte?: FormatSvelteConfig | null;
   /**
    * Specify the number of spaces per indentation-level.
    *
@@ -228,7 +238,7 @@ export interface FormatConfig {
    */
   arrowParens?: ArrowParensConfig | null;
   /**
-   * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
+   * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
    * - Default: `false`
@@ -241,7 +251,7 @@ export interface FormatConfig {
    */
   bracketSpacing?: boolean | null;
   /**
-   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.
    *
    * NOTE: XXX-in-JS support is incomplete.
    *
@@ -258,7 +268,7 @@ export interface FormatConfig {
    */
   endOfLine?: EndOfLineConfig | null;
   /**
-   * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
+   * Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.
    *
    * - Default: `"css"`
    */
@@ -317,7 +327,7 @@ export interface FormatConfig {
    */
   semi?: boolean | null;
   /**
-   * Enforce single attribute per line in HTML, Vue, and JSX.
+   * Enforce single attribute per line in HTML, Vue, Svelte, and JSX.
    *
    * - Default: `false`
    */
@@ -359,6 +369,16 @@ export interface FormatConfig {
    * - Default: Disabled
    */
   sortTailwindcss?: SortTailwindcssConfig | null;
+  /**
+   * Svelte formatting options.
+   *
+   * These options are passed through to `prettier-plugin-svelte`.
+   * Option names omit the `svelte` prefix used in the original plugin.
+   * (e.g., `sortOrder` instead of `svelteSortOrder`)
+   *
+   * - Default: All plugin defaults
+   */
+  svelte?: FormatSvelteConfig | null;
   /**
    * Specify the number of spaces per indentation-level.
    *
@@ -615,5 +635,41 @@ export interface SortTailwindcssConfig {
    * - Default: Installed Tailwind CSS's `theme.css`
    */
   stylesheet?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * Configuration options for Svelte formatting.
+ *
+ * These options are passed through to `prettier-plugin-svelte`.
+ * Option names omit the `svelte` prefix used in the original plugin.
+ */
+export interface FormatSvelteConfig {
+  /**
+   * Allow attribute shorthand when attribute name and expression match.
+   *
+   * - Default: `true`
+   */
+  allowShorthand?: boolean | null;
+  /**
+   * Indent code inside `<script>` and `<style>` tags.
+   *
+   * - Default: `true`
+   */
+  indentScriptAndStyle?: boolean | null;
+  /**
+   * Sort order for Svelte component sections.
+   *
+   * Join the keywords:
+   * `options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`
+   *
+   * - Default: `"options-scripts-markup-styles"`
+   */
+  sortOrder?: string | null;
+  /**
+   * More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.
+   *
+   * - Default: `false`
+   */
+  strictMode?: boolean | null;
   [k: string]: unknown;
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -6,10 +6,6 @@ import {
   formatEmbeddedDoc,
   sortTailwindClasses,
 } from "./libs/apis";
-
-// napi-JS `oxfmt` API entry point
-// See also `format()` function in `./src/main_napi.rs`
-
 // Types are auto-generated from the JSON Schema.
 // See `config.generated.ts` for the full list of generated types.
 import type {
@@ -17,7 +13,11 @@ import type {
   SortImportsConfig,
   SortPackageJsonConfig,
   SortTailwindcssConfig,
+  FormatSvelteConfig,
 } from "./config.generated";
+
+// napi-JS `oxfmt` API entry point
+// See also `format()` function in `./src/main_napi.rs`
 
 /**
  * Configuration options for the `format()` API.
@@ -40,6 +40,7 @@ export type SortPackageJsonOptions = SortPackageJsonConfig;
 export type SortTailwindcssOptions = SortTailwindcssConfig;
 /** @deprecated Use `SortTailwindcssOptions` instead. */
 export type TailwindcssOptions = SortTailwindcssConfig;
+export type FormatSvelteOptions = FormatSvelteConfig;
 
 /**
  * Format the given source text according to the specified options.
@@ -62,6 +63,8 @@ export async function format(fileName: string, sourceText: string, options?: For
 
 /**
  * Format a JS/TS snippet for Prettier `textToDoc()` plugin flow.
+ *
+ * NOTE: This is an internal API
  */
 export async function jsTextToDoc(
   sourceExt: string,

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -57,10 +57,12 @@ export type FormatFileParam = {
 export async function formatFile({ code, options }: FormatFileParam): Promise<string> {
   const prettier = await loadPrettier();
 
-  // Enable Tailwind CSS plugin for non-JS files if needed
+  // NOTE: Since Prettier plugins are applied in order, the setup order is important:
+  // 1. Svelte plugin first (normal plugin: required for `.svelte`)
+  await setupSveltePlugin(options);
+  // 2. Tailwind plugin (transform plugin: wraps Svelte's parsers)
   await setupTailwindPlugin(options);
-  // Add oxfmt plugin for (j|t)-in-xxx files to use `oxc_formatter` instead of built-in formatter.
-  // NOTE: This must be last since Prettier plugins are applied in order
+  // 3. Oxfmt plugin last (transform plugin: overrides babel/typescript parsers)
   await setupOxfmtPlugin(options);
 
   return prettier.format(code, options);
@@ -149,6 +151,34 @@ export async function formatEmbeddedDoc({
       });
     }),
   );
+}
+
+// ---
+// Svelte support
+// ---
+
+let sveltePluginCache: typeof import("prettier-plugin-svelte");
+
+async function loadSveltePlugin(): Promise<typeof import("prettier-plugin-svelte")> {
+  if (sveltePluginCache) return sveltePluginCache;
+
+  sveltePluginCache = await import("prettier-plugin-svelte");
+  return sveltePluginCache;
+}
+
+/**
+ * Load Svelte plugin lazily when `options._useSveltePlugin` flag is set.
+ * The flag is added by Rust side only for `.svelte` files.
+ *
+ * Option mapping (svelte.xxx → svelteXxx) is also done in Rust side.
+ */
+async function setupSveltePlugin(options: Options): Promise<void> {
+  if ("_useSveltePlugin" in options === false) return;
+
+  const sveltePlugin = await loadSveltePlugin();
+
+  options.plugins ??= [];
+  options.plugins.push(sveltePlugin as Plugin);
 }
 
 // ---

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -49,6 +49,12 @@ function detectParentContext(parentParser: string, options: Record<string, unkno
     if ("__isEmbeddedTypescriptGenericParameters" in options) return "vue-script-generic";
     return "vue-script";
   }
-
+  if (parentParser === "svelte") {
+    if ("_svelte_asFunction" in options) {
+      if (options._svelte_asFunction) return "svelte-snippet";
+      return "svelte-expression";
+    }
+    return "svelte-script";
+  }
   return parentParser;
 }

--- a/apps/oxfmt/src/core/oxfmtrc/format_config.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/format_config.rs
@@ -122,7 +122,7 @@ pub struct FormatConfig {
     /// - Default: `true`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<bool>,
-    /// Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
+    /// Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,
     /// instead of being alone on the next line (does not apply to self closing elements).
     ///
     /// - Default: `false`
@@ -136,7 +136,7 @@ pub struct FormatConfig {
     /// - Default: `"preserve"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_wrap: Option<ObjectWrapConfig>,
-    /// Enforce single attribute per line in HTML, Vue, and JSX.
+    /// Enforce single attribute per line in HTML, Vue, Svelte, and JSX.
     ///
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -151,7 +151,7 @@ pub struct FormatConfig {
     #[schemars(skip)]
     pub experimental_ternaries: Option<bool>,
 
-    /// Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+    /// Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.
     ///
     /// NOTE: XXX-in-JS support is incomplete.
     ///
@@ -171,7 +171,7 @@ pub struct FormatConfig {
     /// - Default: `"preserve"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prose_wrap: Option<ProseWrapConfig>,
-    /// Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
+    /// Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.
     ///
     /// - Default: `"css"`
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,6 +223,16 @@ pub struct FormatConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalTailwindcss")]
     pub sort_tailwindcss: Option<SortTailwindcssConfig>,
+
+    /// Svelte formatting options.
+    ///
+    /// These options are passed through to `prettier-plugin-svelte`.
+    /// Option names omit the `svelte` prefix used in the original plugin.
+    /// (e.g., `sortOrder` instead of `svelteSortOrder`)
+    ///
+    /// - Default: All plugin defaults
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub svelte: Option<FormatSvelteConfig>,
 }
 
 impl FormatConfig {
@@ -612,6 +622,40 @@ pub struct SortTailwindcssConfig {
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preserve_duplicates: Option<bool>,
+}
+
+// ---
+
+/// Configuration options for Svelte formatting.
+///
+/// These options are passed through to `prettier-plugin-svelte`.
+/// Option names omit the `svelte` prefix used in the original plugin.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FormatSvelteConfig {
+    /// Sort order for Svelte component sections.
+    ///
+    /// Join the keywords:
+    /// `options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`
+    ///
+    /// - Default: `"options-scripts-markup-styles"`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_order: Option<String>,
+    /// More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.
+    ///
+    /// - Default: `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict_mode: Option<bool>,
+    /// Allow attribute shorthand when attribute name and expression match.
+    ///
+    /// - Default: `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_shorthand: Option<bool>,
+    /// Indent code inside `<script>` and `<style>` tags.
+    ///
+    /// - Default: `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indent_script_and_style: Option<bool>,
 }
 
 // ---

--- a/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_external_options.rs
@@ -63,6 +63,7 @@ static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     "css",
     "scss",
     "less",
+    "svelte",
 };
 
 /// Parsers(files) that can embed JS/TS code and benefit from oxfmt plugin.
@@ -72,6 +73,7 @@ static TAILWIND_PARSERS: phf::Set<&'static str> = phf::phf_set! {
 static OXFMT_PARSERS: phf::Set<&'static str> = phf::phf_set! {
     // "html",
     "vue",
+    "svelte",
     // "markdown",
     // "mdx",
 };
@@ -117,6 +119,27 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
             }
         }
         obj.insert("_useTailwindPlugin".to_string(), Value::Number(1.into()));
+    }
+
+    // Svelte plugin is required for `.svelte` files
+    #[cfg(feature = "napi")]
+    if matches!(
+        strategy,
+        FormatFileStrategy::ExternalFormatter { parser_name, .. } if *parser_name == "svelte"
+    ) {
+        if let Some(svelte) = obj.get("svelte").and_then(|v| v.as_object()).cloned() {
+            for (src, dst) in [
+                ("sortOrder", "svelteSortOrder"),
+                ("strictMode", "svelteStrictMode"),
+                ("allowShorthand", "svelteAllowShorthand"),
+                ("indentScriptAndStyle", "svelteIndentScriptAndStyle"),
+            ] {
+                if let Some(value) = svelte.get(src).cloned() {
+                    obj.insert(dst.to_string(), value);
+                }
+            }
+        }
+        obj.insert("_useSveltePlugin".to_string(), Value::Number(1.into()));
     }
 
     // Build oxfmt plugin options JSON for js-in-xxx parsers
@@ -167,6 +190,7 @@ pub fn finalize_external_options(config: &mut Value, strategy: &FormatFileStrate
         "sortImports",
         "sortTailwindcss",
         "sortPackageJson",
+        "svelte",
         "insertFinalNewline",
         "overrides",
         "ignorePatterns",

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -203,6 +203,9 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
     if extension == Some("vue") {
         return Some("vue");
     }
+    if extension == Some("svelte") {
+        return Some("svelte");
+    }
     if extension == Some("mjml") {
         return Some("mjml");
     }
@@ -399,6 +402,8 @@ mod tests {
             ("email.mjml", Some("mjml")),
             // Vue
             ("App.vue", Some("vue")),
+            // Svelte
+            ("App.svelte", Some("svelte")),
             // CSS
             ("styles.css", Some("css")),
             ("app.wxss", Some("css")),

--- a/apps/oxfmt/test/api/js-in-svelte.test.ts
+++ b/apps/oxfmt/test/api/js-in-svelte.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("Format js-in-svelte with prettier-plugin-oxfmt", () => {
+  it("should format .svelte w/ sort-imports", async () => {
+    const input = `
+<script>
+import z from "z";
+  import a from "a";
+    import m from "m";
+</script>
+
+<div>hello</div>
+`;
+    const result = await format("App.svelte", input, {
+      experimentalSortImports: {},
+    });
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "<script>
+        import a from "a";
+        import m from "m";
+        import z from "z";
+      </script>
+
+      <div>hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format .svelte w/ sort-tailwindcss", async () => {
+    const input = `
+<script>
+import clsx from "clsx";
+import z from "z";
+import a from "a";
+
+const cls = clsx("p-4 flex");
+</script>
+
+<div class="p-4 flex">hello</div>
+`;
+    const result = await format("App.svelte", input, {
+      experimentalSortImports: {},
+      sortTailwindcss: { functions: ["clsx"] },
+    });
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "<script>
+        import a from "a";
+        import clsx from "clsx";
+        import z from "z";
+
+        const cls = clsx("flex p-4");
+      </script>
+
+      <div class="flex p-4">hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+});

--- a/apps/oxfmt/test/api/svelte.test.ts
+++ b/apps/oxfmt/test/api/svelte.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("Svelte", () => {
+  it("should format a basic .svelte file", async () => {
+    const code = `
+<script>
+let   count=0;
+</script>
+
+<button on:click={()=>count++}>{count}</button>
+
+<style>button{color:red;}</style>
+`.trim();
+
+    const result = await format("App.svelte", code);
+    expect(result.code).toMatchInlineSnapshot(`
+      "<script>
+        let count = 0;
+      </script>
+
+      <button on:click={() => count++}>{count}</button>
+
+      <style>
+        button {
+          color: red;
+        }
+      </style>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should respect svelte options", async () => {
+    const code = `
+<style>div{color:red;}</style>
+
+<div>hello</div>
+
+<script>let x=1;</script>
+`.trim();
+
+    const result = await format("App.svelte", code, {
+      svelte: {
+        sortOrder: "options-styles-scripts-markup",
+        indentScriptAndStyle: false,
+      },
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "<style>
+      div {
+        color: red;
+      }
+      </style>
+
+      <script>
+      let x = 1;
+      </script>
+
+      <div>hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format script with lang=ts", async () => {
+    const code = `
+<script lang="ts">
+let   count:number=0;
+</script>
+
+<div>{count}</div>
+`.trim();
+
+    const result = await format("App.svelte", code);
+    expect(result.code).toMatchInlineSnapshot(`
+      "<script lang="ts">
+        let count: number = 0;
+      </script>
+
+      <div>{count}</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should format svelte:options", async () => {
+    const code = `
+<svelte:options   customElement="my-el" />
+
+<div>hello</div>
+`.trim();
+
+    const result = await format("App.svelte", code);
+    expect(result.code).toMatchInlineSnapshot(`
+      "<svelte:options customElement="my-el" />
+
+      <div>hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should respect svelte strictMode option", async () => {
+    const code = `<div foo={bar} />`;
+
+    const result = await format("App.svelte", code, {
+      svelte: { strictMode: true },
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "<div foo={bar}></div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should respect svelte allowShorthand option", async () => {
+    const code = `
+<script>
+let value = 1;
+</script>
+
+<div {value}>hello</div>
+`.trim();
+
+    const result = await format("App.svelte", code, {
+      svelte: { allowShorthand: false },
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "<script>
+        let value = 1;
+      </script>
+
+      <div value={value}>hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should work with Tailwind class sorting in markup", async () => {
+    const code = `<div class="py-2 px-4 flex mt-4 items-center">hello</div>`;
+
+    const result = await format("App.svelte", code, {
+      sortTailwindcss: {},
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "<div class="mt-4 flex items-center px-4 py-2">hello</div>
+      "
+    `);
+    expect(result.errors).toStrictEqual([]);
+  });
+});

--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from "tsdown";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
   // Build all entry points together to share Prettier chunks
@@ -12,10 +15,10 @@ export default defineConfig({
   outDir: "dist",
   shims: false,
   fixedExtension: false,
-  // Optional peer plugins that `prettier-plugin-tailwindcss` tries to dynamic import.
-  // They are not installed and not needed for us,
-  // mark as external to suppress "UNRESOLVED_IMPORT" warnings.
   external: [
+    // Optional peer plugins that `prettier-plugin-tailwindcss` tries to import.
+    // They are not installed and not needed for us,
+    // mark as external to suppress "UNRESOLVED_IMPORT" warnings.
     "@prettier/plugin-oxc",
     "@prettier/plugin-hermes",
     "@prettier/plugin-pug",
@@ -23,17 +26,23 @@ export default defineConfig({
     "@zackad/prettier-plugin-twig",
     "prettier-plugin-astro",
     "prettier-plugin-marko",
-    "prettier-plugin-svelte",
+    // From `prettier-plugin-svelte`
+    "svelte/compiler",
   ],
   noExternal: [
     // Bundle it to control version
     "prettier",
 
-    // We are using patched version, so we must bundle it
-    // Also, it internally loads plugins dynamically, so they also must be bundled
+    // Need to bundle plugins, since they depend on Prettier,
+    // and must be resolved to the same instance of Prettier at runtime.
     "prettier-plugin-tailwindcss",
     "prettier-plugin-tailwindcss/sorter",
+    // Also, it internally loads plugins dynamically, so they also must be bundled
     /^prettier\/plugins\//,
+
+    // Svelte plugin, `svelte/compiler` can be peer dependency in `npm/oxfmt/package.json`
+    "prettier-plugin-svelte",
+    // "svelte/compiler",
 
     // Cannot bundle: `cli-worker.js` runs in separate thread and can't resolve bundled chunks
     // Be sure to add it to "dependencies" in `npm/oxfmt/package.json`!
@@ -42,4 +51,28 @@ export default defineConfig({
   // tsdown warns about final bundled modules by `noExternal`.
   // But we know what we are doing, just suppress the warnings.
   inlineOnly: false,
+  // XXX: Workaround for rolldown code-splitting bug/limitation(?)
+  //
+  // `prettier-plugin-svelte` internally does CJS `require("prettier/plugins/babel")`,
+  // while Prettier itself uses ESM `import("prettier/plugins/babel")`.
+  // Both resolve to the same package, but rolldown treats the CJS and ESM entry points
+  // (`babel.js` vs `babel.mjs`) as separate module graph nodes.
+  //
+  // This itself is not a problem.
+  // It's common for packages to expose different code for ESM vs CJS,
+  // and rolldown not deduplicating them may be expected behavior (it increases bundle size tho).
+  //
+  // However, chunk splitting breaks: the duplicated nodes shift modules across chunks,
+  // producing broken `__esmMin` lazy-init wrappers at runtime
+  // (e.g., `TypeError: init_postcss is not a function`).
+  //
+  // As a workaround, we need to explicitly alias them to the same entry.
+  // Also, use the ESM entry to make deduplication work.
+  inputOptions: {
+    resolve: {
+      alias: {
+        "prettier/plugins/babel": require.resolve("prettier/plugins/babel").replace(".js", ".mjs"),
+      },
+    },
+  },
 });

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -17,12 +17,12 @@
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
       "type": [
         "boolean",
         "null"
       ],
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
     },
     "bracketSpacing": {
       "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
@@ -33,7 +33,7 @@
       "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
       "anyOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -42,7 +42,7 @@
           "type": "null"
         }
       ],
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
     },
     "endOfLine": {
       "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
@@ -57,7 +57,7 @@
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`",
       "anyOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
@@ -66,7 +66,7 @@
           "type": "null"
         }
       ],
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
@@ -161,12 +161,12 @@
       "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
     },
     "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "description": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`",
       "type": [
         "boolean",
         "null"
       ],
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`"
     },
     "singleQuote": {
       "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
@@ -211,6 +211,18 @@
         }
       ],
       "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "svelte": {
+      "description": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FormatSvelteConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
@@ -331,12 +343,12 @@
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
-          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
         },
         "bracketSpacing": {
           "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
@@ -347,7 +359,7 @@
           "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
-          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -356,7 +368,7 @@
               "type": "null"
             }
           ],
-          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
         },
         "endOfLine": {
           "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
@@ -371,7 +383,7 @@
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
-          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+          "description": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
@@ -380,7 +392,7 @@
               "type": "null"
             }
           ],
-          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
           "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
@@ -453,12 +465,12 @@
           "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
         },
         "singleAttributePerLine": {
-          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+          "description": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+          "markdownDescription": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`"
         },
         "singleQuote": {
           "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
@@ -504,6 +516,18 @@
           ],
           "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
+        "svelte": {
+          "description": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FormatSvelteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults"
+        },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
           "type": [
@@ -543,6 +567,45 @@
           "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
         }
       }
+    },
+    "FormatSvelteConfig": {
+      "description": "Configuration options for Svelte formatting.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.",
+      "type": "object",
+      "properties": {
+        "allowShorthand": {
+          "description": "Allow attribute shorthand when attribute name and expression match.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Allow attribute shorthand when attribute name and expression match.\n\n- Default: `true`"
+        },
+        "indentScriptAndStyle": {
+          "description": "Indent code inside `<script>` and `<style>` tags.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Indent code inside `<script>` and `<style>` tags.\n\n- Default: `true`"
+        },
+        "sortOrder": {
+          "description": "Sort order for Svelte component sections.\n\nJoin the keywords:\n`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`\n\n- Default: `\"options-scripts-markup-styles\"`",
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "Sort order for Svelte component sections.\n\nJoin the keywords:\n`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`\n\n- Default: `\"options-scripts-markup-styles\"`"
+        },
+        "strictMode": {
+          "description": "More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.\n\n- Default: `false`"
+        }
+      },
+      "markdownDescription": "Configuration options for Svelte formatting.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin."
     },
     "HtmlWhitespaceSensitivityConfig": {
       "type": "string",

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -37,6 +37,14 @@
   "dependencies": {
     "tinypool": "2.1.0"
   },
+  "peerDependencies": {
+    "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+  },
+  "peerDependenciesMeta": {
+    "svelte": {
+      "optional": true
+    }
+  },
   "napi": {
     "binaryName": "oxfmt",
     "packageName": "@oxfmt/binding",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,15 @@ importers:
       prettier:
         specifier: 3.8.1
         version: 3.8.1
+      prettier-plugin-svelte:
+        specifier: 3.5.0
+        version: 3.5.0(prettier@3.8.1)(svelte@5.53.6)
       prettier-plugin-tailwindcss:
         specifier: 0.0.0-insiders.3997fbd
-        version: 0.0.0-insiders.3997fbd(prettier@3.8.1)
+        version: 0.0.0-insiders.3997fbd(prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.53.6))(prettier@3.8.1)
+      svelte:
+        specifier: ^5.53.6
+        version: 5.53.6
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -274,6 +280,9 @@ importers:
 
   npm/oxfmt:
     dependencies:
+      svelte:
+        specifier: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+        version: 5.53.5
       tinypool:
         specifier: 2.1.0
         version: 2.1.0
@@ -2658,6 +2667,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@tokenizer/inflate@0.3.1':
     resolution: {integrity: sha512-4oeoZEBQdLdt5WmP/hx1KZ6D3/Oid/0cUb2nk4F0pTDAWy+KCH3/EnAkZF/bvckWo8I33EqBm01lIPgmgc8rCA==}
     engines: {node: '>=18'}
@@ -2715,6 +2729,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -2916,6 +2933,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
@@ -2932,6 +2953,10 @@ packages:
 
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3269,6 +3294,9 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  devalue@5.6.3:
+    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
@@ -3387,6 +3415,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3394,6 +3425,9 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.3:
+    resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -3677,6 +3711,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -3747,6 +3784,9 @@ packages:
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4036,6 +4076,12 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-svelte@3.5.0:
+    resolution: {integrity: sha512-2lLO/7EupnjO/95t+XZesXs8Bf3nYLIDfCo270h5QWbj/vjLqmrQ1LiRk9LPggxSDsnVYfehamZNf+rgQYApZg==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
   prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd:
     resolution: {integrity: sha512-H45ADK++Dyd7tMKCT7D6s+6uMxcVMZI841kyvSBXWaU8UOHJp273arY/5/5NqEBNxsquPGId7CatqUGbFbd0aQ==}
@@ -4360,6 +4406,14 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  svelte@5.53.5:
+    resolution: {integrity: sha512-YkqERnF05g8KLdDZwZrF8/i1eSbj6Eoat8Jjr2IfruZz9StLuBqo8sfCSzjosNKd+ZrQ8DkKZDjpO5y3ht1Pow==}
+    engines: {node: '>=18'}
+
+  svelte@5.53.6:
+    resolution: {integrity: sha512-lP5DGF3oDDI9fhHcSpaBiJEkFLuS16h92DhM1L5K1lFm0WjOmUh1i2sNkBBk8rkxJRpob0dBE75jRfUzGZUOGA==}
+    engines: {node: '>=18'}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -4716,6 +4770,9 @@ packages:
 
   yup@1.7.1:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
 
@@ -6673,6 +6730,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.15.0)':
+    dependencies:
+      acorn: 8.15.0
+
   '@tokenizer/inflate@0.3.1':
     dependencies:
       debug: 4.4.3
@@ -6737,6 +6798,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -7105,6 +7168,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.1: {}
+
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
@@ -7124,6 +7189,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -7450,6 +7517,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  devalue@5.6.3: {}
+
   dezalgo@1.0.4:
     dependencies:
       asap: 2.0.6
@@ -7594,6 +7663,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.15.0
@@ -7603,6 +7674,10 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   esrecurse@4.3.0:
     dependencies:
@@ -7885,6 +7960,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-stream@4.0.1: {}
 
   is-unicode-supported@2.1.0: {}
@@ -7942,6 +8021,8 @@ snapshots:
   lit@https://codeload.github.com/lit/dist/tar.gz/2d8c023d796e1884e53ad527d3c68214c866a9e1: {}
 
   load-esm@1.0.3: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -8237,9 +8318,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier@3.8.1):
+  prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.53.6):
     dependencies:
       prettier: 3.8.1
+      svelte: 5.53.6
+
+  prettier-plugin-tailwindcss@0.0.0-insiders.3997fbd(prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.53.6))(prettier@3.8.1):
+    dependencies:
+      prettier: 3.8.1
+    optionalDependencies:
+      prettier-plugin-svelte: 3.5.0(prettier@3.8.1)(svelte@5.53.6)
 
   prettier@3.8.1: {}
 
@@ -8573,6 +8661,44 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  svelte@5.53.5:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.15.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.6.3
+      esm-env: 1.2.2
+      esrap: 2.2.3
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+
+  svelte@5.53.6:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.15.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.6.3
+      esm-env: 1.2.2
+      esrap: 2.2.3
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+
   tagged-tag@1.0.0: {}
 
   terser@5.44.1:
@@ -8903,3 +9029,5 @@ snapshots:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
+
+  zimmerframe@1.1.4: {}

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -21,12 +21,12 @@ expression: json
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
       "type": [
         "boolean",
         "null"
       ],
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
     },
     "bracketSpacing": {
       "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
@@ -37,7 +37,7 @@ expression: json
       "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
       "anyOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -46,7 +46,7 @@ expression: json
           "type": "null"
         }
       ],
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
     },
     "endOfLine": {
       "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
@@ -61,7 +61,7 @@ expression: json
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`",
       "anyOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
@@ -70,7 +70,7 @@ expression: json
           "type": "null"
         }
       ],
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
@@ -165,12 +165,12 @@ expression: json
       "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
     },
     "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "description": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`",
       "type": [
         "boolean",
         "null"
       ],
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`"
     },
     "singleQuote": {
       "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
@@ -215,6 +215,18 @@ expression: json
         }
       ],
       "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
+    },
+    "svelte": {
+      "description": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FormatSvelteConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "markdownDescription": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
@@ -335,12 +347,12 @@ expression: json
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
-          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
         },
         "bracketSpacing": {
           "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
@@ -351,7 +363,7 @@ expression: json
           "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
-          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
@@ -360,7 +372,7 @@ expression: json
               "type": "null"
             }
           ],
-          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
         },
         "endOfLine": {
           "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
@@ -375,7 +387,7 @@ expression: json
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
-          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+          "description": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`",
           "anyOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
@@ -384,7 +396,7 @@ expression: json
               "type": "null"
             }
           ],
-          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.\n\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
           "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
@@ -457,12 +469,12 @@ expression: json
           "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
         },
         "singleAttributePerLine": {
-          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+          "description": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+          "markdownDescription": "Enforce single attribute per line in HTML, Vue, Svelte, and JSX.\n\n- Default: `false`"
         },
         "singleQuote": {
           "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
@@ -508,6 +520,18 @@ expression: json
           ],
           "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
+        "svelte": {
+          "description": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FormatSvelteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "markdownDescription": "Svelte formatting options.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.\n(e.g., `sortOrder` instead of `svelteSortOrder`)\n\n- Default: All plugin defaults"
+        },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
           "type": [
@@ -547,6 +571,45 @@ expression: json
           "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
         }
       }
+    },
+    "FormatSvelteConfig": {
+      "description": "Configuration options for Svelte formatting.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin.",
+      "type": "object",
+      "properties": {
+        "allowShorthand": {
+          "description": "Allow attribute shorthand when attribute name and expression match.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Allow attribute shorthand when attribute name and expression match.\n\n- Default: `true`"
+        },
+        "indentScriptAndStyle": {
+          "description": "Indent code inside `<script>` and `<style>` tags.\n\n- Default: `true`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "Indent code inside `<script>` and `<style>` tags.\n\n- Default: `true`"
+        },
+        "sortOrder": {
+          "description": "Sort order for Svelte component sections.\n\nJoin the keywords:\n`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`\n\n- Default: `\"options-scripts-markup-styles\"`",
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "Sort order for Svelte component sections.\n\nJoin the keywords:\n`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`\n\n- Default: `\"options-scripts-markup-styles\"`"
+        },
+        "strictMode": {
+          "description": "More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.\n\n- Default: `false`",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "markdownDescription": "More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.\n\n- Default: `false`"
+        }
+      },
+      "markdownDescription": "Configuration options for Svelte formatting.\n\nThese options are passed through to `prettier-plugin-svelte`.\nOption names omit the `svelte` prefix used in the original plugin."
     },
     "HtmlWhitespaceSensitivityConfig": {
       "type": "string",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -27,7 +27,7 @@ Include parentheses around a sole arrow function parameter.
 type: `boolean`
 
 
-Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
+Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,
 instead of being alone on the next line (does not apply to self closing elements).
 
 - Default: `false`
@@ -48,7 +48,7 @@ Print spaces between brackets in object literals.
 type: `"auto" | "off"`
 
 
-Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.
 
 NOTE: XXX-in-JS support is incomplete.
 
@@ -73,7 +73,7 @@ NOTE: `"auto"` is not supported.
 type: `"css" | "strict" | "ignore"`
 
 
-Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
+Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.
 
 - Default: `"css"`
 
@@ -182,7 +182,7 @@ Include parentheses around a sole arrow function parameter.
 type: `boolean`
 
 
-Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
+Put the `>` of a multi-line HTML (HTML, JSX, Vue, Svelte, Angular) element at the end of the last line,
 instead of being alone on the next line (does not apply to self closing elements).
 
 - Default: `false`
@@ -203,7 +203,7 @@ Print spaces between brackets in object literals.
 type: `"auto" | "off"`
 
 
-Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue/Svelte, etc.) in the file.
 
 NOTE: XXX-in-JS support is incomplete.
 
@@ -228,7 +228,7 @@ NOTE: `"auto"` is not supported.
 type: `"css" | "strict" | "ignore"`
 
 
-Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
+Specify the global whitespace sensitivity for HTML, Vue, Svelte, Angular, and Handlebars.
 
 - Default: `"css"`
 
@@ -319,7 +319,7 @@ Print semicolons at the ends of statements.
 type: `boolean`
 
 
-Enforce single attribute per line in HTML, Vue, and JSX.
+Enforce single attribute per line in HTML, Vue, Svelte, and JSX.
 
 - Default: `false`
 
@@ -684,6 +684,63 @@ NOTE: Paths are resolved relative to the Oxfmt configuration file.
 - Default: Installed Tailwind CSS's `theme.css`
 
 
+##### overrides[n].options.svelte
+
+type: `object`
+
+
+Svelte formatting options.
+
+These options are passed through to `prettier-plugin-svelte`.
+Option names omit the `svelte` prefix used in the original plugin.
+(e.g., `sortOrder` instead of `svelteSortOrder`)
+
+- Default: All plugin defaults
+
+
+###### overrides[n].options.svelte.allowShorthand
+
+type: `boolean`
+
+
+Allow attribute shorthand when attribute name and expression match.
+
+- Default: `true`
+
+
+###### overrides[n].options.svelte.indentScriptAndStyle
+
+type: `boolean`
+
+
+Indent code inside `<script>` and `<style>` tags.
+
+- Default: `true`
+
+
+###### overrides[n].options.svelte.sortOrder
+
+type: `string`
+
+
+Sort order for Svelte component sections.
+
+Join the keywords:
+`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`
+
+- Default: `"options-scripts-markup-styles"`
+
+
+###### overrides[n].options.svelte.strictMode
+
+type: `boolean`
+
+
+More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.
+
+- Default: `false`
+
+
 ##### overrides[n].options.tabWidth
 
 type: `integer`
@@ -780,7 +837,7 @@ Print semicolons at the ends of statements.
 type: `boolean`
 
 
-Enforce single attribute per line in HTML, Vue, and JSX.
+Enforce single attribute per line in HTML, Vue, Svelte, and JSX.
 
 - Default: `false`
 
@@ -1143,6 +1200,63 @@ Path to your Tailwind CSS stylesheet (v4).
 NOTE: Paths are resolved relative to the Oxfmt configuration file.
 
 - Default: Installed Tailwind CSS's `theme.css`
+
+
+## svelte
+
+type: `object`
+
+
+Svelte formatting options.
+
+These options are passed through to `prettier-plugin-svelte`.
+Option names omit the `svelte` prefix used in the original plugin.
+(e.g., `sortOrder` instead of `svelteSortOrder`)
+
+- Default: All plugin defaults
+
+
+### svelte.allowShorthand
+
+type: `boolean`
+
+
+Allow attribute shorthand when attribute name and expression match.
+
+- Default: `true`
+
+
+### svelte.indentScriptAndStyle
+
+type: `boolean`
+
+
+Indent code inside `<script>` and `<style>` tags.
+
+- Default: `true`
+
+
+### svelte.sortOrder
+
+type: `string`
+
+
+Sort order for Svelte component sections.
+
+Join the keywords:
+`options`, `scripts`, `markup`, `styles` with a `-` in the order you want; or `none`
+
+- Default: `"options-scripts-markup-styles"`
+
+
+### svelte.strictMode
+
+type: `boolean`
+
+
+More strict HTML syntax: Quotes in attributes, no self-closing DOM tags.
+
+- Default: `false`
 
 
 ## tabWidth


### PR DESCRIPTION
Part of #19715

### TODOs

- [x] Implementation
- [x] Self review and refactoring
- [x] Examining the implications of bundling `svelte@5`
  - Seems fine
  - Small difference related to `svelteStrictMode`, which will be always `true`
  - 👉🏻 Just leave it as `peerDeps`
- [x] https://github.com/rolldown/rolldown/issues/8522
  - 👉🏻 Found workaround, can be resolved by alias
- [x] https://github.com/rolldown/rolldown/issues/8492
  - 👉🏻 A duplicate is expected, can be solved by using esm only alias
- [x] Follow `main` branch (json-schema > TS type PR)
- [x] Test infra: #19952
- [x] migrate: #19953
- [x] LSP: #19954 
- [x] oxc-vscode: https://github.com/oxc-project/oxc-vscode/pull/111