### PR TITLE
fix(linter): support jsx-a11y attributes setting in anchor-is-valid rule

### DIFF
--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/extends_config
    :           ^
  3 | }
    `----
-  help: Provide an `href` for the `a` element.
+  help: Provide a `href` for the `a` element.
 
 Found 1 warning and 3 errors.
 Finished in <variable>ms on 2 files with 93 rules using 1 threads.

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 use oxc_ast::{
     AstKind,
@@ -149,13 +150,15 @@ impl Rule for AnchorIsValid {
             // Don't eagerly get `span` here, to avoid that work unless rule fails
             let get_span = || jsx_el.opening_element.name.span();
             // Check href or any configured alternative attribute names (e.g. `to` for router Link components)
-            let href_names: Vec<CompactStr> = ctx
+            static DEFAULT_HREF_NAMES: LazyLock<Vec<CompactStr>> =
+                LazyLock::new(|| vec![CompactStr::from("href")]);
+            let href_names: &[CompactStr] = ctx
                 .settings()
                 .jsx_a11y
                 .attributes
                 .get("href")
-                .cloned()
-                .unwrap_or_else(|| vec![CompactStr::from("href")]);
+                .map(Vec::as_slice)
+                .unwrap_or(&DEFAULT_HREF_NAMES);
             let href_attr = href_names
                 .iter()
                 .find_map(|n| has_jsx_prop_ignore_case(&jsx_el.opening_element, n.as_str()));

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_anchor_is_valid.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_anchor_is_valid.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <a />
    ·  ─
    ╰────
-  help: Provide an `href` for the `a` element.
+  help: Provide a `href` for the `a` element.
 
   ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Use of incorrect `href` for the 'a' element.
    ╭─[anchor_is_valid.tsx:1:2]
@@ -70,7 +70,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ <a onClick={() => void 0} />
    ·  ─
    ╰────
-  help: Provide an `href` for the `a` element.
+  help: Provide a `href` for the `a` element.
 
   ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): The `a` element has `href` and `onClick`.
    ╭─[anchor_is_valid.tsx:1:2]
@@ -99,3 +99,17 @@ source: crates/oxc_linter/src/tester.rs
    ·  ────
    ╰────
   help: Use a `button` element instead of an `a` element.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Missing `href` attribute for the `a` element.
+   ╭─[anchor_is_valid.tsx:1:2]
+ 1 │ <Link />
+   ·  ────
+   ╰────
+  help: Provide one of `href`, `to` for the `a` element.
+
+  ⚠ eslint-plugin-jsx-a11y(anchor-is-valid): Use of incorrect `href` for the 'a' element.
+   ╭─[anchor_is_valid.tsx:1:2]
+ 1 │ <Link to='#' />
+   ·  ────
+   ╰────
+  help: Provide a correct `href` for the `a` element.


### PR DESCRIPTION
## Summary

The `anchor-is-valid` rule was not reading the `attributes` setting from `jsx-a11y` plugin settings, even though the setting is already supported and documented for other rules.

This meant users who configured alternative `href` attribute names (e.g. `to` for React Router's `Link` component) would still get false positives:

```js
// oxlint.config.js
defineConfig({
  settings: {
    "jsx-a11y": {
      components: { Link: "a" },
      attributes: { href: ["href", "to"] }, // was ignored by anchor-is-valid
    },
  },
});
```

```jsx
// false positive before this fix
<Link to="https://example.com">click</Link>
//  ⚠ anchor-is-valid: Missing `href` attribute for the `a` element.
```

## Changes

- Read `settings["jsx-a11y"].attributes.href` in `anchor-is-valid` to determine valid href attribute names
- Error message now reflects the configured attribute names (e.g. Provide one of `href`, `to` for the `a` element.)
- Added test cases for both `pass` (valid `to` prop) and `fail` (`Link` without any href-equivalent)

