### PR TITLE
fix(linter): expose linkAttribute and formAttribute in ReactPluginSettings schema

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -83,6 +83,26 @@ export type CustomComponent =
       attributes: string[];
       name: string;
       [k: string]: unknown;
+    }
+  | {
+      linkAttribute: string;
+      name: string;
+      [k: string]: unknown;
+    }
+  | {
+      linkAttribute: string[];
+      name: string;
+      [k: string]: unknown;
+    }
+  | {
+      formAttribute: string;
+      name: string;
+      [k: string]: unknown;
+    }
+  | {
+      formAttribute: string[];
+      name: string;
+      [k: string]: unknown;
     };
 
 /**

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -139,23 +139,23 @@ enum CustomComponent {
     // they exist so the generated TypeScript types accept the documented forms.
     ObjectWithLinkAttr {
         name: CompactStr,
-        #[serde(rename = "linkAttribute")]
+        #[serde(rename = "linkAttribute", alias = "attribute")]
         link_attribute: CompactStr,
     },
     ObjectWithLinkAttrs {
         name: CompactStr,
-        #[serde(rename = "linkAttribute")]
+        #[serde(rename = "linkAttribute", alias = "attributes")]
         link_attributes: Vec<CompactStr>,
     },
     // Schema-visible variants for `formAttribute`.
     ObjectWithFormAttr {
         name: CompactStr,
-        #[serde(rename = "formAttribute")]
+        #[serde(rename = "formAttribute", alias = "attribute")]
         form_attribute: CompactStr,
     },
     ObjectWithFormAttrs {
         name: CompactStr,
-        #[serde(rename = "formAttribute")]
+        #[serde(rename = "formAttribute", alias = "attributes")]
         form_attributes: Vec<CompactStr>,
     },
 }

--- a/crates/oxc_linter/src/config/settings/react.rs
+++ b/crates/oxc_linter/src/config/settings/react.rs
@@ -121,6 +121,9 @@ impl ReactPluginSettings {
 #[serde(untagged)]
 enum CustomComponent {
     NameOnly(CompactStr),
+    // Canonical form: `attribute` / `attributes` (also accepts `linkAttribute` /
+    // `formAttribute` as serde aliases at runtime, but those aliases are invisible
+    // to JsonSchema, so the variants below exist solely to expose them in the schema).
     ObjectWithOneAttr {
         name: CompactStr,
         #[serde(alias = "formAttribute", alias = "linkAttribute")]
@@ -130,6 +133,30 @@ enum CustomComponent {
         name: CompactStr,
         #[serde(alias = "formAttribute", alias = "linkAttribute")]
         attributes: Vec<CompactStr>,
+    },
+    // Schema-visible variants for `linkAttribute`.
+    // At runtime these are unreachable because the aliases above match first;
+    // they exist so the generated TypeScript types accept the documented forms.
+    ObjectWithLinkAttr {
+        name: CompactStr,
+        #[serde(rename = "linkAttribute")]
+        link_attribute: CompactStr,
+    },
+    ObjectWithLinkAttrs {
+        name: CompactStr,
+        #[serde(rename = "linkAttribute")]
+        link_attributes: Vec<CompactStr>,
+    },
+    // Schema-visible variants for `formAttribute`.
+    ObjectWithFormAttr {
+        name: CompactStr,
+        #[serde(rename = "formAttribute")]
+        form_attribute: CompactStr,
+    },
+    ObjectWithFormAttrs {
+        name: CompactStr,
+        #[serde(rename = "formAttribute")]
+        form_attributes: Vec<CompactStr>,
     },
 }
 
@@ -151,6 +178,26 @@ fn get_component_attrs_by_name<'c>(
                 if comp_name == name =>
             {
                 return Some(Cow::Borrowed(attributes));
+            }
+            CustomComponent::ObjectWithLinkAttr { name: comp_name, link_attribute }
+                if comp_name == name =>
+            {
+                return Some(Cow::Owned(vec![link_attribute.clone()]));
+            }
+            CustomComponent::ObjectWithLinkAttrs { name: comp_name, link_attributes }
+                if comp_name == name =>
+            {
+                return Some(Cow::Borrowed(link_attributes));
+            }
+            CustomComponent::ObjectWithFormAttr { name: comp_name, form_attribute }
+                if comp_name == name =>
+            {
+                return Some(Cow::Owned(vec![form_attribute.clone()]));
+            }
+            CustomComponent::ObjectWithFormAttrs { name: comp_name, form_attributes }
+                if comp_name == name =>
+            {
+                return Some(Cow::Borrowed(form_attributes));
             }
             _ => {}
         }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1,770 +1,836 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Oxlintrc",
-  "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json --import-plugin`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```",
-  "type": "object",
-  "properties": {
-    "$schema": {
-      "description": "Schema URI for editor tooling.",
-      "type": [
-        "string",
-        "null"
-      ],
-      "markdownDescription": "Schema URI for editor tooling."
-    },
-    "categories": {
-      "default": {},
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintCategories"
-        }
-      ]
-    },
-    "env": {
-      "description": "Environments enable and disable collections of global variables.",
-      "default": {
-        "builtin": true
+   "$schema": "http://json-schema.org/draft-07/schema#",
+   "title": "Oxlintrc",
+   "description": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json --import-plugin`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```",
+   "type": "object",
+   "properties": {
+      "$schema": {
+         "description": "Schema URI for editor tooling.",
+         "type": [
+            "string",
+            "null"
+         ],
+         "markdownDescription": "Schema URI for editor tooling."
       },
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintEnv"
-        }
-      ],
-      "markdownDescription": "Environments enable and disable collections of global variables."
-    },
-    "extends": {
-      "description": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "markdownDescription": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones."
-    },
-    "globals": {
-      "description": "Enabled or disabled specific global variables.",
-      "default": {},
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintGlobals"
-        }
-      ],
-      "markdownDescription": "Enabled or disabled specific global variables."
-    },
-    "ignorePatterns": {
-      "description": "Globs to ignore during linting. These are resolved from the configuration file path.",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "markdownDescription": "Globs to ignore during linting. These are resolved from the configuration file path."
-    },
-    "jsPlugins": {
-      "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
-      "anyOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ExternalPluginEntry"
-          },
-          "uniqueItems": true
-        }
-      ],
-      "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
-    },
-    "options": {
-      "description": "Oxlint config options.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintOptions"
-        }
-      ],
-      "markdownDescription": "Oxlint config options."
-    },
-    "overrides": {
-      "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintOverrides"
-        }
-      ],
-      "markdownDescription": "Add, remove, or otherwise reconfigure rules for specific files or groups of files."
-    },
-    "plugins": {
-      "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
-      "default": null,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/LintPlugins"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "markdownDescription": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use."
-    },
-    "rules": {
-      "description": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules.",
-      "default": {},
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintRules"
-        }
-      ],
-      "markdownDescription": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules."
-    },
-    "settings": {
-      "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
-      "default": {
-        "jsx-a11y": {
-          "polymorphicPropName": null,
-          "components": {},
-          "attributes": {}
-        },
-        "next": {
-          "rootDir": []
-        },
-        "react": {
-          "formComponents": [],
-          "linkComponents": [],
-          "version": null,
-          "componentWrapperFunctions": []
-        },
-        "jsdoc": {
-          "ignorePrivate": false,
-          "ignoreInternal": false,
-          "ignoreReplacesDocs": true,
-          "overrideReplacesDocs": true,
-          "augmentsExtendsReplacesDocs": false,
-          "implementsReplacesDocs": false,
-          "exemptDestructuredRootsFromChecks": false,
-          "tagNamePreference": {}
-        },
-        "vitest": {
-          "typecheck": false
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/OxlintSettings"
-        }
-      ],
-      "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
-    }
-  },
-  "additionalProperties": false,
-  "allowComments": true,
-  "allowTrailingCommas": true,
-  "definitions": {
-    "AllowWarnDeny": {
-      "oneOf": [
-        {
-          "description": "Oxlint rule.\n- \"allow\" or \"off\": Turn off the rule.\n- \"warn\": Turn the rule on as a warning (doesn't affect exit code).\n- \"error\" or \"deny\": Turn the rule on as an error (will exit with a failure code).",
-          "type": "string",
-          "enum": [
-            "allow",
-            "off",
-            "warn",
-            "error",
-            "deny"
-          ],
-          "markdownDescription": "Oxlint rule.\n- \"allow\" or \"off\": Turn off the rule.\n- \"warn\": Turn the rule on as a warning (doesn't affect exit code).\n- \"error\" or \"deny\": Turn the rule on as an error (will exit with a failure code)."
-        },
-        {
-          "description": "Oxlint rule.\n    \n- 0: Turn off the rule.\n- 1: Turn the rule on as a warning (doesn't affect exit code).\n- 2: Turn the rule on as an error (will exit with a failure code).",
-          "type": "integer",
-          "format": "uint32",
-          "maximum": 2.0,
-          "minimum": 0.0,
-          "markdownDescription": "Oxlint rule.\n    \n- 0: Turn off the rule.\n- 1: Turn the rule on as a warning (doesn't affect exit code).\n- 2: Turn the rule on as an error (will exit with a failure code)."
-        }
-      ]
-    },
-    "CustomComponent": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "required": [
-            "attribute",
-            "name"
-          ],
-          "properties": {
-            "attribute": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
+      "categories": {
+         "default": {},
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintCategories"
             }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "attributes",
-            "name"
-          ],
-          "properties": {
+         ]
+      },
+      "env": {
+         "description": "Environments enable and disable collections of global variables.",
+         "default": {
+            "builtin": true
+         },
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintEnv"
+            }
+         ],
+         "markdownDescription": "Environments enable and disable collections of global variables."
+      },
+      "extends": {
+         "description": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones.",
+         "type": "array",
+         "items": {
+            "type": "string"
+         },
+         "markdownDescription": "Paths of configuration files that this configuration file extends (inherits from). The files\nare resolved relative to the location of the configuration file that contains the `extends`\nproperty. The configuration files are merged from the first to the last, with the last file\noverriding the previous ones."
+      },
+      "globals": {
+         "description": "Enabled or disabled specific global variables.",
+         "default": {},
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintGlobals"
+            }
+         ],
+         "markdownDescription": "Enabled or disabled specific global variables."
+      },
+      "ignorePatterns": {
+         "description": "Globs to ignore during linting. These are resolved from the configuration file path.",
+         "default": [],
+         "type": "array",
+         "items": {
+            "type": "string"
+         },
+         "markdownDescription": "Globs to ignore during linting. These are resolved from the configuration file path."
+      },
+      "jsPlugins": {
+         "description": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```",
+         "anyOf": [
+            {
+               "type": "null"
+            },
+            {
+               "type": "array",
+               "items": {
+                  "$ref": "#/definitions/ExternalPluginEntry"
+               },
+               "uniqueItems": true
+            }
+         ],
+         "markdownDescription": "JS plugins, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.\n\nExamples:\n\nBasic usage with a local plugin path.\n\n```json\n{\n\"jsPlugins\": [\"./custom-plugin.js\"],\n\"rules\": {\n\"custom/rule-name\": \"warn\"\n}\n}\n```\n\nUsing a built-in Rust plugin alongside a JS plugin with the same name\nby giving the JS plugin an alias.\n\n```json\n{\n\"plugins\": [\"import\"],\n\"jsPlugins\": [\n{ \"name\": \"import-js\", \"specifier\": \"eslint-plugin-import\" }\n],\n\"rules\": {\n\"import/no-cycle\": \"error\",\n\"import-js/no-unresolved\": \"warn\"\n}\n}\n```"
+      },
+      "options": {
+         "description": "Oxlint config options.",
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintOptions"
+            }
+         ],
+         "markdownDescription": "Oxlint config options."
+      },
+      "overrides": {
+         "description": "Add, remove, or otherwise reconfigure rules for specific files or groups of files.",
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintOverrides"
+            }
+         ],
+         "markdownDescription": "Add, remove, or otherwise reconfigure rules for specific files or groups of files."
+      },
+      "plugins": {
+         "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
+         "default": null,
+         "anyOf": [
+            {
+               "$ref": "#/definitions/LintPlugins"
+            },
+            {
+               "type": "null"
+            }
+         ],
+         "markdownDescription": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use."
+      },
+      "rules": {
+         "description": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules.",
+         "default": {},
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintRules"
+            }
+         ],
+         "markdownDescription": "Example\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"prefer-const\": [\"error\", { \"ignoreReadBeforeAssign\": true }]\n}\n}\n```\n\nSee [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html) for the list of\nrules."
+      },
+      "settings": {
+         "description": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`.",
+         "default": {
+            "jsx-a11y": {
+               "polymorphicPropName": null,
+               "components": {},
+               "attributes": {}
+            },
+            "next": {
+               "rootDir": []
+            },
+            "react": {
+               "formComponents": [],
+               "linkComponents": [],
+               "version": null,
+               "componentWrapperFunctions": []
+            },
+            "jsdoc": {
+               "ignorePrivate": false,
+               "ignoreInternal": false,
+               "ignoreReplacesDocs": true,
+               "overrideReplacesDocs": true,
+               "augmentsExtendsReplacesDocs": false,
+               "implementsReplacesDocs": false,
+               "exemptDestructuredRootsFromChecks": false,
+               "tagNamePreference": {}
+            },
+            "vitest": {
+               "typecheck": false
+            }
+         },
+         "allOf": [
+            {
+               "$ref": "#/definitions/OxlintSettings"
+            }
+         ],
+         "markdownDescription": "Plugin-specific configuration for both built-in and custom plugins.\nThis includes settings for built-in plugins such as `react` and `jsdoc`\nas well as configuring settings for JS custom plugins loaded via `jsPlugins`."
+      }
+   },
+   "additionalProperties": false,
+   "allowComments": true,
+   "allowTrailingCommas": true,
+   "definitions": {
+      "AllowWarnDeny": {
+         "oneOf": [
+            {
+               "description": "Oxlint rule.\n- \"allow\" or \"off\": Turn off the rule.\n- \"warn\": Turn the rule on as a warning (doesn't affect exit code).\n- \"error\" or \"deny\": Turn the rule on as an error (will exit with a failure code).",
+               "type": "string",
+               "enum": [
+                  "allow",
+                  "off",
+                  "warn",
+                  "error",
+                  "deny"
+               ],
+               "markdownDescription": "Oxlint rule.\n- \"allow\" or \"off\": Turn off the rule.\n- \"warn\": Turn the rule on as a warning (doesn't affect exit code).\n- \"error\" or \"deny\": Turn the rule on as an error (will exit with a failure code)."
+            },
+            {
+               "description": "Oxlint rule.\n    \n- 0: Turn off the rule.\n- 1: Turn the rule on as a warning (doesn't affect exit code).\n- 2: Turn the rule on as an error (will exit with a failure code).",
+               "type": "integer",
+               "format": "uint32",
+               "maximum": 2.0,
+               "minimum": 0.0,
+               "markdownDescription": "Oxlint rule.\n    \n- 0: Turn off the rule.\n- 1: Turn the rule on as a warning (doesn't affect exit code).\n- 2: Turn the rule on as an error (will exit with a failure code)."
+            }
+         ]
+      },
+      "CustomComponent": {
+         "anyOf": [
+            {
+               "type": "string"
+            },
+            {
+               "type": "object",
+               "required": [
+                  "attribute",
+                  "name"
+               ],
+               "properties": {
+                  "attribute": {
+                     "type": "string"
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "attributes",
+                  "name"
+               ],
+               "properties": {
+                  "attributes": {
+                     "type": "array",
+                     "items": {
+                        "type": "string"
+                     }
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "linkAttribute",
+                  "name"
+               ],
+               "properties": {
+                  "linkAttribute": {
+                     "type": "string"
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "linkAttribute",
+                  "name"
+               ],
+               "properties": {
+                  "linkAttribute": {
+                     "type": "array",
+                     "items": {
+                        "type": "string"
+                     }
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "formAttribute",
+                  "name"
+               ],
+               "properties": {
+                  "formAttribute": {
+                     "type": "string"
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "formAttribute",
+                  "name"
+               ],
+               "properties": {
+                  "formAttribute": {
+                     "type": "array",
+                     "items": {
+                        "type": "string"
+                     }
+                  },
+                  "name": {
+                     "type": "string"
+                  }
+               }
+            }
+         ]
+      },
+      "DummyRule": {
+         "anyOf": [
+            {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+               "type": "array",
+               "items": true
+            }
+         ]
+      },
+      "DummyRuleMap": {
+         "description": "See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)",
+         "type": "object",
+         "additionalProperties": {
+            "$ref": "#/definitions/DummyRule"
+         },
+         "markdownDescription": "See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)"
+      },
+      "ExternalPluginEntry": {
+         "anyOf": [
+            {
+               "description": "Path or package name of the plugin",
+               "type": "string",
+               "markdownDescription": "Path or package name of the plugin"
+            },
+            {
+               "description": "Plugin with custom name/alias",
+               "type": "object",
+               "required": [
+                  "name",
+                  "specifier"
+               ],
+               "properties": {
+                  "name": {
+                     "description": "Custom name/alias for the plugin.\n\nNote: The following plugin names are reserved because they are implemented natively in Rust within oxlint and cannot be used for JS plugins:\n- react (includes react-hooks)\n- unicorn\n- typescript (includes @typescript-eslint)\n- oxc\n- import (includes import-x)\n- jsdoc\n- jest\n- vitest\n- jsx-a11y\n- nextjs\n- react-perf\n- promise\n- node\n- vue\n- eslint\n\nIf you need to use the JavaScript version of any of these plugins, provide a custom alias to avoid conflicts.",
+                     "type": "string",
+                     "markdownDescription": "Custom name/alias for the plugin.\n\nNote: The following plugin names are reserved because they are implemented natively in Rust within oxlint and cannot be used for JS plugins:\n- react (includes react-hooks)\n- unicorn\n- typescript (includes @typescript-eslint)\n- oxc\n- import (includes import-x)\n- jsdoc\n- jest\n- vitest\n- jsx-a11y\n- nextjs\n- react-perf\n- promise\n- node\n- vue\n- eslint\n\nIf you need to use the JavaScript version of any of these plugins, provide a custom alias to avoid conflicts."
+                  },
+                  "specifier": {
+                     "description": "Path or package name of the plugin",
+                     "type": "string",
+                     "markdownDescription": "Path or package name of the plugin"
+                  }
+               },
+               "additionalProperties": false,
+               "markdownDescription": "Plugin with custom name/alias"
+            }
+         ]
+      },
+      "GlobSet": {
+         "description": "A set of glob patterns.",
+         "type": "array",
+         "items": {
+            "type": "string"
+         },
+         "markdownDescription": "A set of glob patterns."
+      },
+      "GlobalValue": {
+         "type": "string",
+         "enum": [
+            "readonly",
+            "writable",
+            "off"
+         ]
+      },
+      "JSDocPluginSettings": {
+         "type": "object",
+         "properties": {
+            "augmentsExtendsReplacesDocs": {
+               "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
+            },
+            "exemptDestructuredRootsFromChecks": {
+               "description": "Only for `require-param-type` and `require-param-description` rule",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "Only for `require-param-type` and `require-param-description` rule"
+            },
+            "ignoreInternal": {
+               "description": "For all rules but NOT apply to `empty-tags` rule",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "For all rules but NOT apply to `empty-tags` rule"
+            },
+            "ignorePrivate": {
+               "description": "For all rules but NOT apply to `check-access` and `empty-tags` rule",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "For all rules but NOT apply to `check-access` and `empty-tags` rule"
+            },
+            "ignoreReplacesDocs": {
+               "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
+               "default": true,
+               "type": "boolean",
+               "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
+            },
+            "implementsReplacesDocs": {
+               "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
+            },
+            "overrideReplacesDocs": {
+               "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
+               "default": true,
+               "type": "boolean",
+               "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
+            },
+            "tagNamePreference": {
+               "default": {},
+               "type": "object",
+               "additionalProperties": {
+                  "$ref": "#/definitions/TagNamePreference"
+               }
+            }
+         }
+      },
+      "JSXA11yPluginSettings": {
+         "description": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference.",
+         "type": "object",
+         "properties": {
             "attributes": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+               "description": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```",
+               "default": {},
+               "type": "object",
+               "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                     "type": "string"
+                  }
+               },
+               "markdownDescription": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```"
             },
-            "name": {
-              "type": "string"
-            }
-          }
-        }
-      ]
-    },
-    "DummyRule": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        {
-          "type": "array",
-          "items": true
-        }
-      ]
-    },
-    "DummyRuleMap": {
-      "description": "See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/DummyRule"
-      },
-      "markdownDescription": "See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)"
-    },
-    "ExternalPluginEntry": {
-      "anyOf": [
-        {
-          "description": "Path or package name of the plugin",
-          "type": "string",
-          "markdownDescription": "Path or package name of the plugin"
-        },
-        {
-          "description": "Plugin with custom name/alias",
-          "type": "object",
-          "required": [
-            "name",
-            "specifier"
-          ],
-          "properties": {
-            "name": {
-              "description": "Custom name/alias for the plugin.\n\nNote: The following plugin names are reserved because they are implemented natively in Rust within oxlint and cannot be used for JS plugins:\n- react (includes react-hooks)\n- unicorn\n- typescript (includes @typescript-eslint)\n- oxc\n- import (includes import-x)\n- jsdoc\n- jest\n- vitest\n- jsx-a11y\n- nextjs\n- react-perf\n- promise\n- node\n- vue\n- eslint\n\nIf you need to use the JavaScript version of any of these plugins, provide a custom alias to avoid conflicts.",
-              "type": "string",
-              "markdownDescription": "Custom name/alias for the plugin.\n\nNote: The following plugin names are reserved because they are implemented natively in Rust within oxlint and cannot be used for JS plugins:\n- react (includes react-hooks)\n- unicorn\n- typescript (includes @typescript-eslint)\n- oxc\n- import (includes import-x)\n- jsdoc\n- jest\n- vitest\n- jsx-a11y\n- nextjs\n- react-perf\n- promise\n- node\n- vue\n- eslint\n\nIf you need to use the JavaScript version of any of these plugins, provide a custom alias to avoid conflicts."
+            "components": {
+               "description": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```",
+               "default": {},
+               "type": "object",
+               "additionalProperties": {
+                  "type": "string"
+               },
+               "markdownDescription": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```"
             },
-            "specifier": {
-              "description": "Path or package name of the plugin",
-              "type": "string",
-              "markdownDescription": "Path or package name of the plugin"
+            "polymorphicPropName": {
+               "description": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`.",
+               "type": [
+                  "string",
+                  "null"
+               ],
+               "markdownDescription": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`."
             }
-          },
-          "additionalProperties": false,
-          "markdownDescription": "Plugin with custom name/alias"
-        }
-      ]
-    },
-    "GlobSet": {
-      "description": "A set of glob patterns.",
-      "type": "array",
-      "items": {
-        "type": "string"
+         },
+         "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
       },
-      "markdownDescription": "A set of glob patterns."
-    },
-    "GlobalValue": {
-      "type": "string",
-      "enum": [
-        "readonly",
-        "writable",
-        "off"
-      ]
-    },
-    "JSDocPluginSettings": {
-      "type": "object",
-      "properties": {
-        "augmentsExtendsReplacesDocs": {
-          "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
-        },
-        "exemptDestructuredRootsFromChecks": {
-          "description": "Only for `require-param-type` and `require-param-description` rule",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "Only for `require-param-type` and `require-param-description` rule"
-        },
-        "ignoreInternal": {
-          "description": "For all rules but NOT apply to `empty-tags` rule",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "For all rules but NOT apply to `empty-tags` rule"
-        },
-        "ignorePrivate": {
-          "description": "For all rules but NOT apply to `check-access` and `empty-tags` rule",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "For all rules but NOT apply to `check-access` and `empty-tags` rule"
-        },
-        "ignoreReplacesDocs": {
-          "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
-          "default": true,
-          "type": "boolean",
-          "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
-        },
-        "implementsReplacesDocs": {
-          "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
-        },
-        "overrideReplacesDocs": {
-          "description": "Only for `require-(yields|returns|description|example|param|throws)` rule",
-          "default": true,
-          "type": "boolean",
-          "markdownDescription": "Only for `require-(yields|returns|description|example|param|throws)` rule"
-        },
-        "tagNamePreference": {
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/TagNamePreference"
-          }
-        }
+      "LintPluginOptionsSchema": {
+         "type": "string",
+         "enum": [
+            "eslint",
+            "react",
+            "unicorn",
+            "typescript",
+            "oxc",
+            "import",
+            "jsdoc",
+            "jest",
+            "vitest",
+            "jsx-a11y",
+            "nextjs",
+            "react-perf",
+            "promise",
+            "node",
+            "vue"
+         ]
+      },
+      "LintPlugins": {
+         "type": "array",
+         "items": {
+            "anyOf": [
+               {
+                  "$ref": "#/definitions/LintPluginOptionsSchema"
+               }
+            ]
+         }
+      },
+      "NextPluginSettings": {
+         "description": "Configure Next.js plugin rules.",
+         "type": "object",
+         "properties": {
+            "rootDir": {
+               "description": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```",
+               "default": [],
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/OneOrMany_for_String"
+                  }
+               ],
+               "markdownDescription": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```"
+            }
+         },
+         "markdownDescription": "Configure Next.js plugin rules."
+      },
+      "OneOrMany_for_String": {
+         "anyOf": [
+            {
+               "type": "string"
+            },
+            {
+               "type": "array",
+               "items": {
+                  "type": "string"
+               }
+            }
+         ]
+      },
+      "OxlintCategories": {
+         "title": "Rule Categories",
+         "description": "Configure an entire category of rules all at once.\n\nRules enabled or disabled this way will be overwritten by individual rules in the `rules` field.\n\nExample\n```json\n{\n    \"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n    \"categories\": {\n        \"correctness\": \"warn\"\n    },\n    \"rules\": {\n        \"eslint/no-unused-vars\": \"error\"\n    }\n}\n```",
+         "examples": [
+            {
+               "correctness": "warn"
+            }
+         ],
+         "type": "object",
+         "properties": {
+            "correctness": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "nursery": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "pedantic": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "perf": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "restriction": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "style": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            },
+            "suspicious": {
+               "$ref": "#/definitions/AllowWarnDeny"
+            }
+         },
+         "additionalProperties": false,
+         "markdownDescription": "Configure an entire category of rules all at once.\n\nRules enabled or disabled this way will be overwritten by individual rules in the `rules` field.\n\nExample\n```json\n{\n    \"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n    \"categories\": {\n        \"correctness\": \"warn\"\n    },\n    \"rules\": {\n        \"eslint/no-unused-vars\": \"error\"\n    }\n}\n```"
+      },
+      "OxlintEnv": {
+         "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
+         "type": "object",
+         "additionalProperties": {
+            "type": "boolean"
+         },
+         "markdownDescription": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides."
+      },
+      "OxlintGlobals": {
+         "description": "Add or remove global variables.\n\nFor each global variable, set the corresponding value equal to `\"writable\"`\nto allow the variable to be overwritten or `\"readonly\"` to disallow overwriting.\n\nGlobals can be disabled by setting their value to `\"off\"`. For example, in\nan environment where most Es2015 globals are available but `Promise` is unavailable,\nyou might use this config:\n\n```json\n\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"env\": {\n\"es6\": true\n},\n\"globals\": {\n\"Promise\": \"off\"\n}\n}\n\n```\n\nYou may also use `\"readable\"` or `false` to represent `\"readonly\"`, and\n`\"writeable\"` or `true` to represent `\"writable\"`.",
+         "type": "object",
+         "additionalProperties": {
+            "$ref": "#/definitions/GlobalValue"
+         },
+         "markdownDescription": "Add or remove global variables.\n\nFor each global variable, set the corresponding value equal to `\"writable\"`\nto allow the variable to be overwritten or `\"readonly\"` to disallow overwriting.\n\nGlobals can be disabled by setting their value to `\"off\"`. For example, in\nan environment where most Es2015 globals are available but `Promise` is unavailable,\nyou might use this config:\n\n```json\n\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"env\": {\n\"es6\": true\n},\n\"globals\": {\n\"Promise\": \"off\"\n}\n}\n\n```\n\nYou may also use `\"readable\"` or `false` to represent `\"readonly\"`, and\n`\"writeable\"` or `true` to represent `\"writable\"`."
+      },
+      "OxlintOptions": {
+         "description": "Options for the linter.",
+         "type": "object",
+         "properties": {
+            "typeAware": {
+               "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.",
+               "type": [
+                  "boolean",
+                  "null"
+               ],
+               "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI."
+            },
+            "typeCheck": {
+               "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.",
+               "type": [
+                  "boolean",
+                  "null"
+               ],
+               "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI."
+            }
+         },
+         "additionalProperties": false,
+         "markdownDescription": "Options for the linter."
+      },
+      "OxlintOverride": {
+         "type": "object",
+         "required": [
+            "files"
+         ],
+         "properties": {
+            "env": {
+               "description": "Environments enable and disable collections of global variables.",
+               "anyOf": [
+                  {
+                     "$ref": "#/definitions/OxlintEnv"
+                  },
+                  {
+                     "type": "null"
+                  }
+               ],
+               "markdownDescription": "Environments enable and disable collections of global variables."
+            },
+            "files": {
+               "description": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`",
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/GlobSet"
+                  }
+               ],
+               "markdownDescription": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`"
+            },
+            "globals": {
+               "description": "Enabled or disabled specific global variables.",
+               "anyOf": [
+                  {
+                     "$ref": "#/definitions/OxlintGlobals"
+                  },
+                  {
+                     "type": "null"
+                  }
+               ],
+               "markdownDescription": "Enabled or disabled specific global variables."
+            },
+            "jsPlugins": {
+               "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.",
+               "anyOf": [
+                  {
+                     "type": "null"
+                  },
+                  {
+                     "type": "array",
+                     "items": {
+                        "$ref": "#/definitions/ExternalPluginEntry"
+                     },
+                     "uniqueItems": true
+                  }
+               ],
+               "markdownDescription": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver."
+            },
+            "plugins": {
+               "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",
+               "default": null,
+               "anyOf": [
+                  {
+                     "$ref": "#/definitions/LintPlugins"
+                  },
+                  {
+                     "type": "null"
+                  }
+               ],
+               "markdownDescription": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used."
+            },
+            "rules": {
+               "default": {},
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/OxlintRules"
+                  }
+               ]
+            }
+         },
+         "additionalProperties": false
+      },
+      "OxlintOverrides": {
+         "type": "array",
+         "items": {
+            "$ref": "#/definitions/OxlintOverride"
+         }
+      },
+      "OxlintRules": {
+         "$ref": "#/definitions/DummyRuleMap"
+      },
+      "OxlintSettings": {
+         "title": "Oxlint Plugin Settings",
+         "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
+         "type": "object",
+         "properties": {
+            "jsdoc": {
+               "default": {
+                  "ignorePrivate": false,
+                  "ignoreInternal": false,
+                  "ignoreReplacesDocs": true,
+                  "overrideReplacesDocs": true,
+                  "augmentsExtendsReplacesDocs": false,
+                  "implementsReplacesDocs": false,
+                  "exemptDestructuredRootsFromChecks": false,
+                  "tagNamePreference": {}
+               },
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/JSDocPluginSettings"
+                  }
+               ]
+            },
+            "jsx-a11y": {
+               "default": {
+                  "polymorphicPropName": null,
+                  "components": {},
+                  "attributes": {}
+               },
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/JSXA11yPluginSettings"
+                  }
+               ]
+            },
+            "next": {
+               "default": {
+                  "rootDir": []
+               },
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/NextPluginSettings"
+                  }
+               ]
+            },
+            "react": {
+               "default": {
+                  "formComponents": [],
+                  "linkComponents": [],
+                  "version": null,
+                  "componentWrapperFunctions": []
+               },
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/ReactPluginSettings"
+                  }
+               ]
+            },
+            "vitest": {
+               "default": {
+                  "typecheck": false
+               },
+               "allOf": [
+                  {
+                     "$ref": "#/definitions/VitestPluginSettings"
+                  }
+               ]
+            }
+         },
+         "markdownDescription": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```"
+      },
+      "ReactPluginSettings": {
+         "description": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)",
+         "type": "object",
+         "properties": {
+            "componentWrapperFunctions": {
+               "description": "Functions that wrap React components and should be treated as HOCs.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"componentWrapperFunctions\": [\"observer\", \"withRouter\"]\n}\n}\n}\n```",
+               "default": [],
+               "type": "array",
+               "items": {
+                  "type": "string"
+               },
+               "markdownDescription": "Functions that wrap React components and should be treated as HOCs.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"componentWrapperFunctions\": [\"observer\", \"withRouter\"]\n}\n}\n}\n```"
+            },
+            "formComponents": {
+               "description": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```",
+               "default": [],
+               "type": "array",
+               "items": {
+                  "$ref": "#/definitions/CustomComponent"
+               },
+               "markdownDescription": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```"
+            },
+            "linkComponents": {
+               "description": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```",
+               "default": [],
+               "type": "array",
+               "items": {
+                  "$ref": "#/definitions/CustomComponent"
+               },
+               "markdownDescription": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```"
+            },
+            "version": {
+               "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
+               "default": null,
+               "type": [
+                  "string",
+                  "null"
+               ],
+               "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
+               "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
+            }
+         },
+         "markdownDescription": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)"
+      },
+      "TagNamePreference": {
+         "anyOf": [
+            {
+               "type": "string"
+            },
+            {
+               "type": "object",
+               "required": [
+                  "message",
+                  "replacement"
+               ],
+               "properties": {
+                  "message": {
+                     "type": "string"
+                  },
+                  "replacement": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "object",
+               "required": [
+                  "message"
+               ],
+               "properties": {
+                  "message": {
+                     "type": "string"
+                  }
+               }
+            },
+            {
+               "type": "boolean"
+            }
+         ]
+      },
+      "VitestPluginSettings": {
+         "description": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference.",
+         "type": "object",
+         "properties": {
+            "typecheck": {
+               "description": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios.",
+               "default": false,
+               "type": "boolean",
+               "markdownDescription": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios."
+            }
+         },
+         "markdownDescription": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference."
       }
-    },
-    "JSXA11yPluginSettings": {
-      "description": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference.",
-      "type": "object",
-      "properties": {
-        "attributes": {
-          "description": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "markdownDescription": "Map of attribute names to their DOM equivalents.\nThis is useful for non-React frameworks that use different attribute names.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"attributes\": {\n\"for\": [\"htmlFor\", \"for\"]\n}\n}\n}\n}\n```"
-        },
-        "components": {
-          "description": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "markdownDescription": "To have your custom components be checked as DOM elements, you can\nprovide a mapping of your component names to the DOM element name.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"IconButton\": \"button\"\n}\n}\n}\n}\n```"
-        },
-        "polymorphicPropName": {
-          "description": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "markdownDescription": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`."
-        }
-      },
-      "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
-    },
-    "LintPluginOptionsSchema": {
-      "type": "string",
-      "enum": [
-        "eslint",
-        "react",
-        "unicorn",
-        "typescript",
-        "oxc",
-        "import",
-        "jsdoc",
-        "jest",
-        "vitest",
-        "jsx-a11y",
-        "nextjs",
-        "react-perf",
-        "promise",
-        "node",
-        "vue"
-      ]
-    },
-    "LintPlugins": {
-      "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/LintPluginOptionsSchema"
-          }
-        ]
-      }
-    },
-    "NextPluginSettings": {
-      "description": "Configure Next.js plugin rules.",
-      "type": "object",
-      "properties": {
-        "rootDir": {
-          "description": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```",
-          "default": [],
-          "allOf": [
-            {
-              "$ref": "#/definitions/OneOrMany_for_String"
-            }
-          ],
-          "markdownDescription": "The root directory of the Next.js project.\n\nThis is particularly useful when you have a monorepo and your Next.js\nproject is in a subfolder.\n\nExample:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n}\n}\n}\n```"
-        }
-      },
-      "markdownDescription": "Configure Next.js plugin rules."
-    },
-    "OneOrMany_for_String": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "OxlintCategories": {
-      "title": "Rule Categories",
-      "description": "Configure an entire category of rules all at once.\n\nRules enabled or disabled this way will be overwritten by individual rules in the `rules` field.\n\nExample\n```json\n{\n    \"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n    \"categories\": {\n        \"correctness\": \"warn\"\n    },\n    \"rules\": {\n        \"eslint/no-unused-vars\": \"error\"\n    }\n}\n```",
-      "examples": [
-        {
-          "correctness": "warn"
-        }
-      ],
-      "type": "object",
-      "properties": {
-        "correctness": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "nursery": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "pedantic": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "perf": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "restriction": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "style": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        },
-        "suspicious": {
-          "$ref": "#/definitions/AllowWarnDeny"
-        }
-      },
-      "additionalProperties": false,
-      "markdownDescription": "Configure an entire category of rules all at once.\n\nRules enabled or disabled this way will be overwritten by individual rules in the `rules` field.\n\nExample\n```json\n{\n    \"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n    \"categories\": {\n        \"correctness\": \"warn\"\n    },\n    \"rules\": {\n        \"eslint/no-unused-vars\": \"error\"\n    }\n}\n```"
-    },
-    "OxlintEnv": {
-      "description": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides.",
-      "type": "object",
-      "additionalProperties": {
-        "type": "boolean"
-      },
-      "markdownDescription": "Predefine global variables.\n\nEnvironments specify what global variables are predefined.\nSee [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)\nfor what environments are available and what each one provides."
-    },
-    "OxlintGlobals": {
-      "description": "Add or remove global variables.\n\nFor each global variable, set the corresponding value equal to `\"writable\"`\nto allow the variable to be overwritten or `\"readonly\"` to disallow overwriting.\n\nGlobals can be disabled by setting their value to `\"off\"`. For example, in\nan environment where most Es2015 globals are available but `Promise` is unavailable,\nyou might use this config:\n\n```json\n\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"env\": {\n\"es6\": true\n},\n\"globals\": {\n\"Promise\": \"off\"\n}\n}\n\n```\n\nYou may also use `\"readable\"` or `false` to represent `\"readonly\"`, and\n`\"writeable\"` or `true` to represent `\"writable\"`.",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/GlobalValue"
-      },
-      "markdownDescription": "Add or remove global variables.\n\nFor each global variable, set the corresponding value equal to `\"writable\"`\nto allow the variable to be overwritten or `\"readonly\"` to disallow overwriting.\n\nGlobals can be disabled by setting their value to `\"off\"`. For example, in\nan environment where most Es2015 globals are available but `Promise` is unavailable,\nyou might use this config:\n\n```json\n\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"env\": {\n\"es6\": true\n},\n\"globals\": {\n\"Promise\": \"off\"\n}\n}\n\n```\n\nYou may also use `\"readable\"` or `false` to represent `\"readonly\"`, and\n`\"writeable\"` or `true` to represent `\"writable\"`."
-    },
-    "OxlintOptions": {
-      "description": "Options for the linter.",
-      "type": "object",
-      "properties": {
-        "typeAware": {
-          "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.",
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI."
-        },
-        "typeCheck": {
-          "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.",
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI."
-        }
-      },
-      "additionalProperties": false,
-      "markdownDescription": "Options for the linter."
-    },
-    "OxlintOverride": {
-      "type": "object",
-      "required": [
-        "files"
-      ],
-      "properties": {
-        "env": {
-          "description": "Environments enable and disable collections of global variables.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OxlintEnv"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Environments enable and disable collections of global variables."
-        },
-        "files": {
-          "description": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`",
-          "allOf": [
-            {
-              "$ref": "#/definitions/GlobSet"
-            }
-          ],
-          "markdownDescription": "A list of glob patterns to override.\n\n## Example\n`[ \"*.test.ts\", \"*.spec.ts\" ]`"
-        },
-        "globals": {
-          "description": "Enabled or disabled specific global variables.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OxlintGlobals"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Enabled or disabled specific global variables."
-        },
-        "jsPlugins": {
-          "description": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver.",
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ExternalPluginEntry"
-              },
-              "uniqueItems": true
-            }
-          ],
-          "markdownDescription": "JS plugins for this override, allows usage of ESLint plugins with Oxlint.\n\nRead more about JS plugins in\n[the docs](https://oxc.rs/docs/guide/usage/linter/js-plugins.html).\n\nNote: JS plugins are experimental and not subject to semver."
-        },
-        "plugins": {
-          "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",
-          "default": null,
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LintPlugins"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "markdownDescription": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used."
-        },
-        "rules": {
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/OxlintRules"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "OxlintOverrides": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/OxlintOverride"
-      }
-    },
-    "OxlintRules": {
-      "$ref": "#/definitions/DummyRuleMap"
-    },
-    "OxlintSettings": {
-      "title": "Oxlint Plugin Settings",
-      "description": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```",
-      "type": "object",
-      "properties": {
-        "jsdoc": {
-          "default": {
-            "ignorePrivate": false,
-            "ignoreInternal": false,
-            "ignoreReplacesDocs": true,
-            "overrideReplacesDocs": true,
-            "augmentsExtendsReplacesDocs": false,
-            "implementsReplacesDocs": false,
-            "exemptDestructuredRootsFromChecks": false,
-            "tagNamePreference": {}
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/JSDocPluginSettings"
-            }
-          ]
-        },
-        "jsx-a11y": {
-          "default": {
-            "polymorphicPropName": null,
-            "components": {},
-            "attributes": {}
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/JSXA11yPluginSettings"
-            }
-          ]
-        },
-        "next": {
-          "default": {
-            "rootDir": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/NextPluginSettings"
-            }
-          ]
-        },
-        "react": {
-          "default": {
-            "formComponents": [],
-            "linkComponents": [],
-            "version": null,
-            "componentWrapperFunctions": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/ReactPluginSettings"
-            }
-          ]
-        },
-        "vitest": {
-          "default": {
-            "typecheck": false
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/VitestPluginSettings"
-            }
-          ]
-        }
-      },
-      "markdownDescription": "Configure the behavior of linter plugins.\n\nHere's an example if you're using Next.js in a monorepo:\n\n```json\n{\n\"settings\": {\n\"next\": {\n\"rootDir\": \"apps/dashboard/\"\n},\n\"react\": {\n\"linkComponents\": [\n{ \"name\": \"Link\", \"linkAttribute\": \"to\" }\n]\n},\n\"jsx-a11y\": {\n\"components\": {\n\"Link\": \"a\",\n\"Button\": \"button\"\n}\n}\n}\n}\n```"
-    },
-    "ReactPluginSettings": {
-      "description": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)",
-      "type": "object",
-      "properties": {
-        "componentWrapperFunctions": {
-          "description": "Functions that wrap React components and should be treated as HOCs.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"componentWrapperFunctions\": [\"observer\", \"withRouter\"]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Functions that wrap React components and should be treated as HOCs.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"componentWrapperFunctions\": [\"observer\", \"withRouter\"]\n}\n}\n}\n```"
-        },
-        "formComponents": {
-          "description": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CustomComponent"
-          },
-          "markdownDescription": "Components used as alternatives to `<form>` for forms, such as `<Formik>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"formComponents\": [\n\"CustomForm\",\n// OtherForm is considered a form component and has an endpoint attribute\n{ \"name\": \"OtherForm\", \"formAttribute\": \"endpoint\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Form\", \"formAttribute\": [\"registerEndpoint\", \"loginEndpoint\"] }\n]\n}\n}\n}\n```"
-        },
-        "linkComponents": {
-          "description": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```",
-          "default": [],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CustomComponent"
-          },
-          "markdownDescription": "Components used as alternatives to `<a>` for linking, such as `<Link>`.\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"linkComponents\": [\n\"HyperLink\",\n// Use `linkAttribute` for components that use a different prop name\n// than `href`.\n{ \"name\": \"MyLink\", \"linkAttribute\": \"to\" },\n// allows specifying multiple properties if necessary\n{ \"name\": \"Link\", \"linkAttribute\": [\"to\", \"href\"] }\n]\n}\n}\n}\n```"
-        },
-        "version": {
-          "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ],
-          "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
-          "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
-        }
-      },
-      "markdownDescription": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)"
-    },
-    "TagNamePreference": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "required": [
-            "message",
-            "replacement"
-          ],
-          "properties": {
-            "message": {
-              "type": "string"
-            },
-            "replacement": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "required": [
-            "message"
-          ],
-          "properties": {
-            "message": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "boolean"
-        }
-      ]
-    },
-    "VitestPluginSettings": {
-      "description": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference.",
-      "type": "object",
-      "properties": {
-        "typecheck": {
-          "description": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios.",
-          "default": false,
-          "type": "boolean",
-          "markdownDescription": "Whether to enable typecheck mode for Vitest rules.\nWhen enabled, some rules will skip certain checks for describe blocks\nto accommodate TypeScript type checking scenarios."
-        }
-      },
-      "markdownDescription": "Configure Vitest plugin rules.\n\nSee [eslint-plugin-vitest](https://github.com/vitest-dev/eslint-plugin-vitest)'s\nconfiguration for a full reference."
-    }
-  },
-  "markdownDescription": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json --import-plugin`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```"
+   },
+   "markdownDescription": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json --import-plugin`\n\n::: danger NOTE\n\nOnly the `.json` format is supported. You can use comments in configuration files.\n\n:::\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```"
 }


### PR DESCRIPTION
## Summary

`CustomComponent` type in `ReactPluginSettings` was missing `linkAttribute` and `formAttribute` variants in the generated TypeScript types and JSON schema, even though the documentation shows these as the expected API:

```json
{ "name": "MyLink", "linkAttribute": "to" }
{ "name": "Link", "linkAttribute": ["to", "href"] }
{ "name": "Form", "formAttribute": ["registerEndpoint", "loginEndpoint"] }
```

These worked at runtime (via serde aliases), but caused TypeScript errors:

```
Type '{ name: string; linkAttribute: string[]; }' is not assignable to type 'CustomComponent'.
  Property 'attributes' is missing in type '{ name: string; linkAttribute: string[]; }'
  but required in type '{ [k: string]: unknown; attributes: string[]; name: string; }'.
```

## Changes

- Added explicit `linkAttribute` / `formAttribute` enum variants to `CustomComponent` so the `JsonSchema` derive includes them in the generated schema
- Regenerated `npm/oxlint/configuration_schema.json`
- Regenerated `apps/oxlint/src-js/package/config.generated.ts`

