### PR TITLE
feat(oxlint/lsp)!: show/fix safe suggestions by default

### DIFF
--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -38,8 +38,8 @@ pub struct LintOptions {
 #[derive(Debug, Default, Serialize, PartialEq, Eq, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum LintFixKindFlag {
-    #[default]
     SafeFix,
+    #[default]
     SafeFixOrSuggestion,
     DangerousFix,
     DangerousFixOrSuggestion,
@@ -173,7 +173,7 @@ mod test {
         assert_eq!(options.unused_disable_directives, None);
         assert_eq!(options.type_aware, None);
         assert!(!options.disable_nested_config);
-        assert_eq!(options.fix_kind, super::LintFixKindFlag::SafeFix);
+        assert_eq!(options.fix_kind, super::LintFixKindFlag::SafeFixOrSuggestion);
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_deny_no_console@hello_world.js.snap
@@ -20,6 +20,24 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
+Title: Delete this code.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 29,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
 Title: Disable no-console for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -56,4 +74,19 @@ TextEdit: TextEdit {
 
 
 ########### Fix All Action
-None
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 29,
+        },
+    },
+    new_text: "",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_issue_9958@issue.ts.snap
@@ -45,6 +45,24 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
+Title: Replace `!!x` with `x`.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 3,
+            character: 14,
+        },
+        end: Position {
+            line: 3,
+            character: 17,
+        },
+    },
+    new_text: "x",
+}
+
+
+CodeAction: 
 Title: Disable no-extra-boolean-cast for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -77,6 +95,24 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable no-extra-boolean-cast\n",
+}
+
+
+CodeAction: 
+Title: Delete this code.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 11,
+            character: 21,
+        },
+        end: Position {
+            line: 11,
+            character: 22,
+        },
+    },
+    new_text: "",
 }
 
 
@@ -117,4 +153,32 @@ TextEdit: TextEdit {
 
 
 ########### Fix All Action
-None
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 3,
+            character: 14,
+        },
+        end: Position {
+            line: 3,
+            character: 17,
+        },
+    },
+    new_text: "x",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 11,
+            character: 21,
+        },
+        end: Position {
+            line: 11,
+            character: 22,
+        },
+    },
+    new_text: "",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_type_aware_config@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_type_aware_config@test.ts.snap
@@ -67,6 +67,42 @@ TextEdit: TextEdit {
 
 
 CodeAction: 
+Title: Add void operator to ignore.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+
+
+CodeAction: 
+Title: Add await operator.
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 0,
+        },
+    },
+    new_text: "await ",
+}
+
+
+CodeAction: 
 Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -103,4 +139,19 @@ TextEdit: TextEdit {
 
 
 ########### Fix All Action
-None
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint_unused_disabled_directives@test.ts.snap
@@ -31,6 +31,42 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
+Title: Add void operator to ignore.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 18,
+            character: 0,
+        },
+        end: Position {
+            line: 18,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+
+
+CodeAction: 
+Title: Add await operator.
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 18,
+            character: 0,
+        },
+        end: Position {
+            line: 18,
+            character: 0,
+        },
+    },
+    new_text: "await ",
+}
+
+
+CodeAction: 
 Title: Disable typescript/no-floating-promises for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -63,6 +99,42 @@ TextEdit: TextEdit {
         },
     },
     new_text: "// oxlint-disable typescript/no-floating-promises\n",
+}
+
+
+CodeAction: 
+Title: Add void operator to ignore.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 38,
+            character: 0,
+        },
+        end: Position {
+            line: 38,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+
+
+CodeAction: 
+Title: Add await operator.
+Is Preferred: Some(false)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 38,
+            character: 0,
+        },
+        end: Position {
+            line: 38,
+            character: 0,
+        },
+    },
+    new_text: "await ",
 }
 
 
@@ -103,4 +175,32 @@ TextEdit: TextEdit {
 
 
 ########### Fix All Action
-None
+CodeAction: 
+Title: fix all safe fixable oxlint issues
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 18,
+            character: 0,
+        },
+        end: Position {
+            line: 18,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 38,
+            character: 0,
+        },
+        end: Position {
+            line: 38,
+            character: 0,
+        },
+    },
+    new_text: "void ",
+}

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -58,6 +58,24 @@ tags: None
 
 ########### Code Actions/Commands
 CodeAction: 
+Title: Delete this code.
+Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 9,
+            character: 0,
+        },
+        end: Position {
+            line: 9,
+            character: 29,
+        },
+    },
+    new_text: "",
+}
+
+
+CodeAction: 
 Title: Disable no-console for this line
 Is Preferred: Some(false)
 TextEdit: TextEdit {
@@ -205,6 +223,19 @@ TextEdit: TextEdit {
 CodeAction: 
 Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
+TextEdit: TextEdit {
+    range: Range {
+        start: Position {
+            line: 9,
+            character: 0,
+        },
+        end: Position {
+            line: 9,
+            character: 29,
+        },
+    },
+    new_text: "",
+}
 TextEdit: TextEdit {
     range: Range {
         start: Position {

--- a/apps/oxlint/test/lsp/code_action/code_action.test.ts
+++ b/apps/oxlint/test/lsp/code_action/code_action.test.ts
@@ -12,11 +12,7 @@ describe("LSP code actions", () => {
       ["js-plugin-fix/test.js", "javascript"],
       ["js-plugin-suggestion/test.js", "javascript"],
     ])("should handle %s", async (path, languageId) => {
-      expect(
-        await fixFixture(FIXTURES_DIR, path, languageId, {
-          fixKind: "safe_fix_or_suggestion",
-        }),
-      ).toMatchSnapshot();
+      expect(await fixFixture(FIXTURES_DIR, path, languageId)).toMatchSnapshot();
     });
   });
 
@@ -25,9 +21,13 @@ describe("LSP code actions", () => {
       ["suggestion/test.ts", "typescript"],
       ["js-plugin-suggestion/test.js", "javascript"],
     ])("should handle %s", async (path, languageId) => {
-      // because fixKind is default `safe_fix`, we do not expect any fix as code actions
+      // because these rules are only suggestions, they should be hidden when `fixKind` is set to `safe_fix`. In that case,
       // the only code action valid for this test should be "ignore for this line" and "ignore for this file".
-      expect(await fixFixture(FIXTURES_DIR, path, languageId)).toMatchSnapshot();
+      expect(
+        await fixFixture(FIXTURES_DIR, path, languageId, {
+          fixKind: "safe_fix",
+        }),
+      ).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
ESLint shows by default suggestions in the editor. We did not have the right architecture to difference between safe or dangerous fix / suggestions. With https://github.com/oxc-project/oxc/pull/19113 we know now what kind of fix this is. 
This allows us now to align more with the ESLint editor experience. The last found tech dep was https://github.com/oxc-project/oxc/pull/19795. 
This will not apply for editors which manage its own configurations like VS Code editor and IntelliJ Plugin (cc @nrayburn-tech). These editors need their own default value changed.

When using auto save `source.fixAll.oxc` or `source.fixAll` code action, or the `oxc.fixAll` command, the suggestions will be applied too. Because this is always in a context of one file only, I guess this is safe. Or we can change the line for this: https://github.com/oxc-project/oxc/blob/a45b9f4f808e4761ee615c31ea32bccfad322602/apps/oxlint/src/lsp/code_actions.rs#L96-L100
