### PR TITLE
fix(parser): use TS8037 for satisfies expression in JS files diagnostic

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1092,7 +1092,7 @@ pub fn as_in_ts(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn satisfies_in_ts(span: Span) -> OxcDiagnostic {
-    ts_error("8016", "Type satisfaction expressions can only be used in TypeScript files.")
+    ts_error("8037", "Type satisfaction expressions can only be used in TypeScript files.")
         .with_label(span)
 }
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -20631,7 +20631,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
    ╰────
   help: Try inserting a semicolon here
 
-  × TS(8016): Type satisfaction expressions can only be used in TypeScript files.
+  × TS(8037): Type satisfaction expressions can only be used in TypeScript files.
    ╭─[typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_js.ts:1:9]
  1 │ var v = undefined satisfies 1;
    ·         ─────────────────────


### PR DESCRIPTION
https://github.com/microsoft/typescript/blob/0208948c95817bd7491111b40d6cf05013b21c4a/src/compiler/diagnosticMessages.json#L7082-L7085