### PR TITLE
fix(linter/consistent_type_assertions): Add missing with_help and with_note to diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
@@ -21,14 +21,11 @@ use crate::{
 fn use_angle_bracket_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `<{cast}>` instead of `as {cast}`."))
         .with_help(format!("Replace `as {cast}` with `<{cast}>`. For example, change `value as {cast}` to `<{cast}>value`."))
-        .with_note("This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.")
         .with_label(span)
 }
 
 fn use_as_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `as {cast}` instead of `<{cast}>`."))
-        .with_note("This rule enforces consistent type assertion syntax across the codebase.")
-        .with_label(span)
+    OxcDiagnostic::warn(format!("Use `as {cast}` instead of `<{cast}>`.")).with_label(span)
 }
 
 fn never_diagnostic(span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
@@ -27,7 +27,6 @@ fn use_angle_bracket_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
 
 fn use_as_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use `as {cast}` instead of `<{cast}>`."))
-        .with_help(format!("Replace `<{cast}>` with `as {cast}`. For example, change `<{cast}>value` to `value as {cast}`. Note: you may need to add parentheses around the expression if it's used in certain contexts."))
         .with_note("This rule enforces consistent type assertion syntax across the codebase.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_assertions.rs
@@ -19,23 +19,38 @@ use crate::{
 };
 
 fn use_angle_bracket_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `<{cast}>` instead of `as {cast}`.")).with_label(span)
+    OxcDiagnostic::warn(format!("Use `<{cast}>` instead of `as {cast}`."))
+        .with_help(format!("Replace `as {cast}` with `<{cast}>`. For example, change `value as {cast}` to `<{cast}>value`."))
+        .with_note("This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.")
+        .with_label(span)
 }
 
 fn use_as_diagnostic(cast: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Use `as {cast}` instead of `<{cast}>`.")).with_label(span)
+    OxcDiagnostic::warn(format!("Use `as {cast}` instead of `<{cast}>`."))
+        .with_help(format!("Replace `<{cast}>` with `as {cast}`. For example, change `<{cast}>value` to `value as {cast}`. Note: you may need to add parentheses around the expression if it's used in certain contexts."))
+        .with_note("This rule enforces consistent type assertion syntax across the codebase.")
+        .with_label(span)
 }
 
 fn never_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use any type assertions.").with_label(span)
+    OxcDiagnostic::warn("Do not use any type assertions.")
+        .with_help("Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.")
+        .with_note("Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.")
+        .with_label(span)
 }
 
 fn unexpected_object_type_assertion_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Always prefer `const x: T = { ... }`.").with_label(span)
+    OxcDiagnostic::warn("Always prefer `const x: T = { ... }`.")
+        .with_help("Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.")
+        .with_note("Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.")
+        .with_label(span)
 }
 
 fn unexpected_array_type_assertion_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Always prefer `const x: T[] = [ ... ]`.").with_label(span)
+    OxcDiagnostic::warn("Always prefer `const x: T[] = [ ... ]`.")
+        .with_help("Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.")
+        .with_note("Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
@@ -111,7 +111,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <Foo>new Generic<int>();
    ·           ───────────────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>new Generic<int>()` with `new Generic<int>() as Foo`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
@@ -119,7 +119,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <A>b;
    ·           ────
    ╰────
-  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<A>b` with `b as A`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as readonly number[]` instead of `<readonly number[]>`.
@@ -127,7 +127,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <readonly number[]>[1];
    ·           ──────────────────────
    ╰────
-  help: Replace `<readonly number[]>` with `as readonly number[]`. For example, change `<readonly number[]>value` to `value as readonly number[]`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<readonly number[]>[1]` with `[1] as readonly number[]`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as a | b` instead of `<a | b>`.
@@ -135,7 +135,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <a | b>'string';
    ·           ───────────────
    ╰────
-  help: Replace `<a | b>` with `as a | b`. For example, change `<a | b>value` to `value as a | b`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<a | b>'string'` with `'string' as a | b`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
@@ -143,7 +143,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <A>!'string';
    ·           ────────────
    ╰────
-  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<A>!'string'` with `!'string' as A`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
@@ -151,7 +151,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <A>a + b;
    ·           ────
    ╰────
-  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<A>a` with `(a as A)`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -159,7 +159,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <Foo>new Generic<string>();
    ·           ──────────────────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>new Generic<string>()` with `new Generic<string>() as Foo`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -167,7 +167,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = new (<Foo>Generic<string>)();
    ·                ────────────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -175,7 +175,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = new (<Foo>Generic<string>)('string');
    ·                ────────────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -183,7 +183,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = () => <Foo>{ bar: 5 };
    ·                 ───────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>{ bar: 5 }` with `({ bar: 5 } as Foo)`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -191,7 +191,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = () => <Foo>bar;
    ·                 ────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>bar` with `(bar as Foo)`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
@@ -199,7 +199,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <Foo>bar<string>`${'baz'}`;
    ·           ──────────────────────────
    ╰────
-  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<Foo>bar<string>`${'baz'}`` with `bar<string>`${'baz'}` as Foo`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as const` instead of `<const>`.
@@ -207,7 +207,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <const>{ key: 'value' };
    ·           ───────────────────────
    ╰────
-  help: Replace `<const>` with `as const`. For example, change `<const>value` to `value as const`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<const>{ key: 'value' }` with `{ key: 'value' } as const`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
@@ -619,7 +619,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const a = <any>(b, c);
    ·           ───────────
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(b, c)` with `(b, c) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -627,7 +627,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const f = <any>(() => {});
    ·           ───────────────
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(() => {})` with `(() => {}) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -635,7 +635,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const f = <any>function () {};
    ·           ───────────────────
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>function () {}` with `function () {} as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -643,7 +643,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const f = <any>(async () => {});
    ·           ─────────────────────
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(async () => {})` with `(async () => {}) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -653,7 +653,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────────
  4 │             }
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(yield a)` with `(yield a) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -663,7 +663,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────────────
  4 │                   
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(x <<= y)` with `(x <<= y) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
@@ -671,7 +671,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const ternary = <any>(true ? x : y);
    ·                 ───────────────────
    ╰────
-  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<any>(true ? x : y)` with `(true ? x : y) as any`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
@@ -703,7 +703,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
-  help: Replace `<string[]>` with `as string[]`. For example, change `<string[]>value` to `value as string[]`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  help: Replace `<string[]>[]` with `[] as string[]`.
   note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
@@ -8,7 +8,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ─────────────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -16,7 +15,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────
    ╰────
   help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<readonly number[]>` instead of `as readonly number[]`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -24,7 +22,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────────────────
    ╰────
   help: Replace `as readonly number[]` with `<readonly number[]>`. For example, change `value as readonly number[]` to `<readonly number[]>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<a | b>` instead of `as a | b`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -32,7 +29,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ─────────────────
    ╰────
   help: Replace `as a | b` with `<a | b>`. For example, change `value as a | b` to `<a | b>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -40,7 +36,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────
    ╰────
   help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:12]
@@ -48,7 +43,6 @@ source: crates/oxc_linter/src/tester.rs
    ·            ──────
    ╰────
   help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -56,7 +50,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:16]
@@ -64,7 +57,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──────────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:16]
@@ -72,7 +64,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                ──────────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:17]
@@ -80,7 +71,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:17]
@@ -88,7 +78,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -96,7 +85,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────────────────────
    ╰────
   help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<const>` instead of `as const`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -104,7 +92,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ─────────────────────────
    ╰────
   help: Replace `as const` with `<const>`. For example, change `value as const` to `<const>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -112,7 +99,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────────────────
    ╰────
   help: Replace `<Foo>new Generic<int>()` with `new Generic<int>() as Foo`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -120,7 +106,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────
    ╰────
   help: Replace `<A>b` with `b as A`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as readonly number[]` instead of `<readonly number[]>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -128,7 +113,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────────────
    ╰────
   help: Replace `<readonly number[]>[1]` with `[1] as readonly number[]`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as a | b` instead of `<a | b>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -136,7 +120,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────────
    ╰────
   help: Replace `<a | b>'string'` with `'string' as a | b`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -144,7 +127,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────
    ╰────
   help: Replace `<A>!'string'` with `!'string' as A`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -152,7 +134,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────
    ╰────
   help: Replace `<A>a` with `(a as A)`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -160,7 +141,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────────────────
    ╰────
   help: Replace `<Foo>new Generic<string>()` with `new Generic<string>() as Foo`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:16]
@@ -168,7 +148,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                ────────────────────
    ╰────
   help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:16]
@@ -176,7 +155,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                ────────────────────
    ╰────
   help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:17]
@@ -184,7 +162,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────
    ╰────
   help: Replace `<Foo>{ bar: 5 }` with `({ bar: 5 } as Foo)`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:17]
@@ -192,7 +169,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ────────
    ╰────
   help: Replace `<Foo>bar` with `(bar as Foo)`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -200,7 +176,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────────────────
    ╰────
   help: Replace `<Foo>bar<string>`${'baz'}`` with `bar<string>`${'baz'}` as Foo`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as const` instead of `<const>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -208,7 +183,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────────────────
    ╰────
   help: Replace `<const>{ key: 'value' }` with `{ key: 'value' } as const`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -620,7 +594,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────
    ╰────
   help: Replace `<any>(b, c)` with `(b, c) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -628,7 +601,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────────
    ╰────
   help: Replace `<any>(() => {})` with `(() => {}) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -636,7 +608,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ───────────────────
    ╰────
   help: Replace `<any>function () {}` with `function () {} as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -644,7 +615,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ─────────────────────
    ╰────
   help: Replace `<any>(async () => {})` with `(async () => {}) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:3:25]
@@ -654,7 +624,6 @@ source: crates/oxc_linter/src/tester.rs
  4 │             }
    ╰────
   help: Replace `<any>(yield a)` with `(yield a) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:3:24]
@@ -664,7 +633,6 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Replace `<any>(x <<= y)` with `(x <<= y) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:17]
@@ -672,7 +640,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ───────────────────
    ╰────
   help: Replace `<any>(true ? x : y)` with `(true ? x : y) as any`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -696,7 +663,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ──────────────
    ╰────
   help: Replace `as string[]` with `<string[]>`. For example, change `value as string[]` to `<string[]>value`.
-  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as string[]` instead of `<string[]>`.
    ╭─[consistent_type_assertions.ts:1:11]
@@ -704,7 +670,6 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────
    ╰────
   help: Replace `<string[]>[]` with `[] as string[]`.
-  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_assertions.snap
@@ -7,379 +7,488 @@ source: crates/oxc_linter/src/tester.rs
  1 │ const x = new Generic<int>() as Foo;
    ·           ─────────────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = b as A;
    ·           ──────
    ╰────
+  help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<readonly number[]>` instead of `as readonly number[]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [1] as readonly number[];
    ·           ────────────────────────
    ╰────
+  help: Replace `as readonly number[]` with `<readonly number[]>`. For example, change `value as readonly number[]` to `<readonly number[]>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<a | b>` instead of `as a | b`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = 'string' as a | b;
    ·           ─────────────────
    ╰────
+  help: Replace `as a | b` with `<a | b>`. For example, change `value as a | b` to `<a | b>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = !'string' as A;
    ·           ──────────────
    ╰────
+  help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<A>` instead of `as A`.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = (a as A) + b;
    ·            ──────
    ╰────
+  help: Replace `as A` with `<A>`. For example, change `value as A` to `<A>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = new Generic<string>() as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)();
    ·                ──────────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)('string');
    ·                ──────────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => ({ bar: 5 }) as Foo;
    ·                 ───────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => bar as Foo;
    ·                 ──────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<Foo>` instead of `as Foo`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = bar<string>`${'baz'}` as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Replace `as Foo` with `<Foo>`. For example, change `value as Foo` to `<Foo>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<const>` instead of `as const`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = { key: 'value' } as const;
    ·           ─────────────────────────
    ╰────
+  help: Replace `as const` with `<const>`. For example, change `value as const` to `<const>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<int>();
    ·           ───────────────────────
    ╰────
-  help: Replace `<Foo>new Generic<int>()` with `new Generic<int>() as Foo`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>b;
    ·           ────
    ╰────
-  help: Replace `<A>b` with `b as A`.
+  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as readonly number[]` instead of `<readonly number[]>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <readonly number[]>[1];
    ·           ──────────────────────
    ╰────
-  help: Replace `<readonly number[]>[1]` with `[1] as readonly number[]`.
+  help: Replace `<readonly number[]>` with `as readonly number[]`. For example, change `<readonly number[]>value` to `value as readonly number[]`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as a | b` instead of `<a | b>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>'string';
    ·           ───────────────
    ╰────
-  help: Replace `<a | b>'string'` with `'string' as a | b`.
+  help: Replace `<a | b>` with `as a | b`. For example, change `<a | b>value` to `value as a | b`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>!'string';
    ·           ────────────
    ╰────
-  help: Replace `<A>!'string'` with `!'string' as A`.
+  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as A` instead of `<A>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>a + b;
    ·           ────
    ╰────
-  help: Replace `<A>a` with `(a as A)`.
+  help: Replace `<A>` with `as A`. For example, change `<A>value` to `value as A`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<string>();
    ·           ──────────────────────────
    ╰────
-  help: Replace `<Foo>new Generic<string>()` with `new Generic<string>() as Foo`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)();
    ·                ────────────────────
    ╰────
-  help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)('string');
    ·                ────────────────────
    ╰────
-  help: Replace `<Foo>Generic<string>` with `(Generic<string>) as Foo`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>{ bar: 5 };
    ·                 ───────────────
    ╰────
-  help: Replace `<Foo>{ bar: 5 }` with `({ bar: 5 } as Foo)`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>bar;
    ·                 ────────
    ╰────
-  help: Replace `<Foo>bar` with `(bar as Foo)`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as Foo` instead of `<Foo>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>bar<string>`${'baz'}`;
    ·           ──────────────────────────
    ╰────
-  help: Replace `<Foo>bar<string>`${'baz'}`` with `bar<string>`${'baz'}` as Foo`.
+  help: Replace `<Foo>` with `as Foo`. For example, change `<Foo>value` to `value as Foo`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as const` instead of `<const>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <const>{ key: 'value' };
    ·           ───────────────────────
    ╰────
-  help: Replace `<const>{ key: 'value' }` with `{ key: 'value' } as const`.
+  help: Replace `<const>` with `as const`. For example, change `<const>value` to `value as const`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = new Generic<int>() as Foo;
    ·           ─────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = b as A;
    ·           ──────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [1] as readonly number[];
    ·           ────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = 'string' as a | b;
    ·           ─────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = !'string' as A;
    ·           ──────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = (a as A) + b;
    ·            ──────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = new Generic<string>() as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)();
    ·                ──────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (Generic<string> as Foo)('string');
    ·                ──────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => ({ bar: 5 }) as Foo;
    ·                 ───────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => bar as Foo;
    ·                 ──────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = bar<string>`${'baz'}` as Foo;
    ·           ────────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<int>();
    ·           ───────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>b;
    ·           ────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <readonly number[]>[1];
    ·           ──────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>'string';
    ·           ───────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>!'string';
    ·           ────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>a + b;
    ·           ────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>new Generic<string>();
    ·           ──────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)();
    ·                ────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ const x = new (<Foo>Generic<string>)('string');
    ·                ────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>{ bar: 5 };
    ·                 ───────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const x = () => <Foo>bar;
    ·                 ────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo>bar<string>`${'baz'}`;
    ·           ──────────────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as Foo<int>;
    ·           ──────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as a | b;
    ·           ───────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = ({} as A) + b;
    ·            ───────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo<int>>{};
    ·           ────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>{};
    ·           ─────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>{} + b;
    ·           ─────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as Foo<int>;
    ·           ──────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = {} as a | b;
    ·           ───────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:12]
  1 │ const x = ({} as A) + b;
    ·            ───────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print({ bar: 5 } as Foo);
    ·       ─────────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print({ bar: 5 } as Foo);
    ·           ─────────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -388,66 +497,88 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ─────────────────
  4 │             }
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = {} as Foo.Bar) {}
    ·                ─────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function c(x = {} as Foo) {}
    ·                ─────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print?.({ bar: 5 } as Foo);
    ·         ─────────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ print?.call({ bar: 5 } as Foo);
    ·             ─────────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${{ bar: 5 } as Foo}`;
    ·         ─────────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <Foo<int>>{};
    ·           ────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <a | b>{};
    ·           ─────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <A>{} + b;
    ·           ─────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print(<Foo>{ bar: 5 });
    ·       ───────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print(<Foo>{ bar: 5 });
    ·           ───────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -456,52 +587,64 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ───────────────
  4 │             }
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print?.(<Foo>{ bar: 5 });
    ·         ───────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ print?.call(<Foo>{ bar: 5 });
    ·             ───────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T = { ... }`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${<Foo>{ bar: 5 }}`;
    ·         ───────────────
    ╰────
+  help: Replace the object literal type assertion with a type annotation. For example, change `const x = { a: 1 } as Type` to `const x: Type = { a: 1 }`. Alternatively, use `const x = { a: 1 } satisfies Type` if you want TypeScript to infer the exact shape.
+  note: Type assertions on object literals can hide errors where the object doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the object matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const a = <any>(b, c);
    ·           ───────────
    ╰────
-  help: Replace `<any>(b, c)` with `(b, c) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const f = <any>(() => {});
    ·           ───────────────
    ╰────
-  help: Replace `<any>(() => {})` with `(() => {}) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const f = <any>function () {};
    ·           ───────────────────
    ╰────
-  help: Replace `<any>function () {}` with `function () {} as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const f = <any>(async () => {});
    ·           ─────────────────────
    ╰────
-  help: Replace `<any>(async () => {})` with `(async () => {}) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:3:25]
@@ -510,7 +653,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ──────────────
  4 │             }
    ╰────
-  help: Replace `<any>(yield a)` with `(yield a) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:3:24]
@@ -519,69 +663,88 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────────────
  4 │                   
    ╰────
-  help: Replace `<any>(x <<= y)` with `(x <<= y) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as any` instead of `<any>`.
    ╭─[consistent_type_assertions.ts:1:17]
  1 │ const ternary = <any>(true ? x : y);
    ·                 ───────────────────
    ╰────
-  help: Replace `<any>(true ? x : y)` with `(true ? x : y) as any`.
+  help: Replace `<any>` with `as any`. For example, change `<any>value` to `value as any`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [] as string[];
    ·           ──────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `<string[]>` instead of `as string[]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [] as string[];
    ·           ──────────────
    ╰────
+  help: Replace `as string[]` with `<string[]>`. For example, change `value as string[]` to `<string[]>value`.
+  note: This rule enforces consistent type assertion syntax across the codebase. Angle-bracket syntax (`<Type>value`) is preferred when this rule is configured to use it.
 
   ⚠ typescript-eslint(consistent-type-assertions): Use `as string[]` instead of `<string[]>`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
-  help: Replace `<string[]>[]` with `[] as string[]`.
+  help: Replace `<string[]>` with `as string[]`. For example, change `<string[]>value` to `value as string[]`. Note: you may need to add parentheses around the expression if it's used in certain contexts.
+  note: This rule enforces consistent type assertion syntax across the codebase.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = [] as string[];
    ·           ──────────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ const x = <string[]>[];
    ·           ────────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:7]
  1 │ print([5] as Foo);
    ·       ──────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print([5] as Foo);
    ·           ──────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = [5] as Foo.Bar) {}
    ·                ──────────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -590,30 +753,40 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────
  4 │             }
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${[5] as Foo}`;
    ·         ──────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:19]
  1 │ const foo = () => [5] as Foo;
    ·                   ──────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:11]
  1 │ new print(<Foo>[5]);
    ·           ────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:16]
  1 │ function b(x = <Foo.Bar>[5]) {}
    ·                ────────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:3:21]
@@ -622,21 +795,29 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ────────
  4 │             }
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:9]
  1 │ print`${<Foo>[5]}`;
    ·         ────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Always prefer `const x: T[] = [ ... ]`.
    ╭─[consistent_type_assertions.ts:1:13]
  1 │ const foo = <Foo>[5];
    ·             ────────
    ╰────
+  help: Replace the array literal type assertion with a type annotation. For example, change `const x = [1, 2] as Type[]` to `const x: Type[] = [1, 2]`. Alternatively, use `const x = [1, 2] satisfies Type[]` if you want TypeScript to infer the exact array type.
+  note: Type assertions on array literals can hide errors where the array doesn't actually match the asserted type. Using type annotations or `satisfies` ensures TypeScript verifies that the array matches the expected type.
 
   ⚠ typescript-eslint(consistent-type-assertions): Do not use any type assertions.
    ╭─[consistent_type_assertions.ts:1:25]
  1 │ const foo = <Foo style={{ bar: 5 } as Bar} />;
    ·                         ─────────────────
    ╰────
+  help: Remove the type assertion and use a type annotation instead. For example, change `const x = value as Type` to `const x: Type = value`. Alternatively, use the `satisfies` operator: `const x = value satisfies Type`.
+  note: Type assertions bypass TypeScript's type checking and can hide type errors. Using type annotations or the `satisfies` operator provides better type safety while still allowing TypeScript to infer types where appropriate.


### PR DESCRIPTION
Added .with_help() and .with_note() to missing diagnostics in the typescript consistent_type_assertions.rs file.

Part of #19121 