### PR TITLE
fix(linter/consistent_type_imports): Add missing help and notes to diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -23,14 +23,22 @@ use crate::{
 };
 
 fn no_import_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("`import()` type annotations are forbidden.").with_label(span)
+    OxcDiagnostic::warn("`import()` type annotations are forbidden.")
+        .with_help("Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.")
+        .with_note("Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.")
+        .with_label(span)
 }
 
 fn avoid_import_type_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use an `import` instead of an `import type`.").with_label(span)
+    OxcDiagnostic::warn("Use an `import` instead of an `import type`.")
+        .with_help("Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.")
+        .with_note("When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern bundlers can still effectively tree-shake unused regular imports.")
+        .with_label(span)
 }
 fn type_over_value_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("All imports in the declaration are only used as types. Use `import type`.")
+        .with_help("Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.")
+        .with_note("Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, error::Error, fmt::Write, ops::Deref};
 
 use itertools::Itertools;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use oxc_ast::{
     AstKind,
     ast::{
@@ -12,8 +15,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{Reference, SymbolId};
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::{
     AstNode,
@@ -24,20 +25,18 @@ use crate::{
 
 fn no_import_type_annotations_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("`import()` type annotations are forbidden.")
-        .with_help("Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.")
-        .with_note("Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.")
+        .with_help("Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type`.")
         .with_label(span)
 }
 
 fn avoid_import_type_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Use an `import` instead of an `import type`.")
-        .with_help("Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.")
-        .with_note("When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern bundlers can still effectively tree-shake unused regular imports.")
+        .with_help("Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.")
         .with_label(span)
 }
 fn type_over_value_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("All imports in the declaration are only used as types. Use `import type`.")
-        .with_help("Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.")
+        .with_help("Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.")
         .with_note("Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.")
         .with_label(span)
 }

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
@@ -9,7 +9,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -18,7 +19,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -27,7 +29,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -36,7 +39,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -45,7 +49,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────
  3 │               let foo: a;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -54,7 +59,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = typeof Foo; // TSTypeQuery
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -63,7 +69,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = foo.Bar; // TSQualifiedName
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -72,7 +79,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Baz = (typeof foo.bar)['Baz']; // TSQualifiedName & TSTypeQuery
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -81,7 +89,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────
  3 │               let foo: A.Foo;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -90,7 +99,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -99,7 +109,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -234,7 +245,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────────────
  3 │               import Type from 'default_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -243,7 +255,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  4 │               import * as Types from 'namespace_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:4:15]
@@ -252,7 +265,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  5 │               import Default, { Named } from 'default_and_named_type';
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -261,7 +275,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────────────
  6 │               type T = Type1 | Type2 | Type | Types.A | Default | Named;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type1 are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -306,6 +321,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │               let bar: import('foo').Bar;
    ╰────
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
+  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:3:24]
@@ -314,6 +331,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────────
  4 │             
    ╰────
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
+  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:2:24]
@@ -322,6 +341,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │             
    ╰────
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
+  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -330,7 +351,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type Foo from 'foo';` with `import Foo from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -339,7 +362,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type { Foo } from 'foo';` with `import { Foo } from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -348,7 +373,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -357,7 +383,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -366,7 +393,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -375,7 +403,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type Type from 'foo';` with `import Type from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -384,7 +414,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type { Type } from 'foo';` with `import { Type } from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -393,7 +425,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type * as Type from 'foo';` with `import * as Type from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -402,7 +436,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────
  3 │               import type // comment
    ╰────
-  help: Replace `import type /*comment*/ * as AllType from 'foo';` with `import /*comment*/ * as AllType from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -411,9 +447,9 @@ source: crates/oxc_linter/src/tester.rs
  4 │ ╰─▶               DefType from 'foo';
  5 │                   import type /*comment*/ { Type } from 'foo';
    ╰────
-  help: Replace `import type // comment
-                      DefType from 'foo';` with `import // comment
-                      DefType from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -422,7 +458,9 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────
  6 │ 
    ╰────
-  help: Replace `import type /*comment*/ { Type } from 'foo';` with `import /*comment*/ { Type } from 'foo';`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Rest are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -449,7 +487,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Default are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -476,7 +515,9 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  3 │               type T = A;
    ╰────
-  help: Replace `type A` with `A`.
+  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
+  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
+           bundlers can still effectively tree-shake unused regular imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -494,7 +535,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Add type specifier to imported types
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -521,7 +563,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import { B } from 'foo';
    ╰────
-  help: Add type specifier to imported types
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -530,7 +573,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  4 │               type T = A;
    ╰────
-  help: Add type specifier to imported types
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -539,7 +583,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import B from 'foo';
    ╰────
-  help: Add type specifier to imported types
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -548,7 +593,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  4 │               type T = A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B and C are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -566,7 +612,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -575,7 +622,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Mark all type-only imports with the type specifier
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -620,7 +668,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -629,7 +678,8 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Add type specifier to imported types
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -638,7 +688,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -647,7 +698,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -656,7 +708,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -665,7 +718,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:17]
@@ -674,7 +728,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Add type specifier to this import declaration
+  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Foo are only used as type.
    ╭─[consistent_type_imports.tsx:3:15]

--- a/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_consistent_type_imports.snap
@@ -9,7 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -19,7 +19,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -29,7 +29,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -49,7 +49,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────────
  3 │               let foo: a;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -59,7 +59,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = typeof Foo; // TSTypeQuery
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -69,7 +69,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Bar = foo.Bar; // TSQualifiedName
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -79,7 +79,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────
  3 │               type Baz = (typeof foo.bar)['Baz']; // TSQualifiedName & TSTypeQuery
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -89,7 +89,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────
  3 │               let foo: A.Foo;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -99,7 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -109,7 +109,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
@@ -245,7 +245,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────────────
  3 │               import Type from 'default_type';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -255,7 +255,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  4 │               import * as Types from 'namespace_type';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -265,7 +265,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  5 │               import Default, { Named } from 'default_and_named_type';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -275,7 +275,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────────────
  6 │               type T = Type1 | Type2 | Type | Types.A | Default | Named;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Type1 are only used as type.
@@ -321,8 +321,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │               let bar: import('foo').Bar;
    ╰────
-  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
-  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type`.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:3:24]
@@ -331,8 +330,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────────
  4 │             
    ╰────
-  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
-  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type`.
 
   ⚠ typescript-eslint(consistent-type-imports): `import()` type annotations are forbidden.
    ╭─[consistent_type_imports.tsx:2:24]
@@ -341,8 +339,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ─────────────
  3 │             
    ╰────
-  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type` or use a regular import if the type is also used as a value.
-  note: Using `import()` in type annotations can make code harder to understand and maintain. Regular type imports are clearer and allow better tooling support.
+  help: Replace `import()` type annotations with a regular type import. For example, change `type T = import('module').Type` to `import type { Type } from 'module'; type T = Type`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -351,9 +348,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -362,9 +357,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────
  3 │               let foo: Foo;
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -373,7 +366,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────
  3 │ 
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -383,7 +376,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │ 
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -393,7 +386,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
@@ -403,9 +396,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -414,9 +405,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -425,9 +414,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ─────────────────────────────────
  3 │ 
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -436,9 +423,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────────
  3 │               import type // comment
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:3:15]
@@ -447,9 +432,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ ╰─▶               DefType from 'foo';
  5 │                   import type /*comment*/ { Type } from 'foo';
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Use an `import` instead of an `import type`.
    ╭─[consistent_type_imports.tsx:5:15]
@@ -458,9 +441,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────────
  6 │ 
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Rest are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -487,7 +468,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────────────────────
  3 │               const a: Default = '';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Default are only used as type.
@@ -515,9 +496,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ──────
  3 │               type T = A;
    ╰────
-  help: Replace `import type` with a regular `import`. For example, change `import type { Type } from 'module'` to `import { Type } from 'module'`.
-  note: When configured to prefer value imports, this rule ensures that imports are not unnecessarily marked as type-only. Regular imports allow flexibility if the import is later used as a value (e.g., with decorators that require runtime references), and can help avoid side-effect import issues that can occur when using inline type imports (see the `no-import-type-side-effects` rule). Modern
-           bundlers can still effectively tree-shake unused regular imports.
+  help: Replace the `import type` declaration with a regular `import` declaration. For example, `import type { Type } from 'module'` would become `import { Type } from 'module'`.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
    ╭─[consistent_type_imports.tsx:2:15]
@@ -535,7 +514,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────
  3 │               let foo: A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
@@ -563,7 +542,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import { B } from 'foo';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -573,7 +552,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  4 │               type T = A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -583,7 +562,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               import B from 'foo';
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -593,7 +572,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  4 │               type T = A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports B and C are only used as type.
@@ -612,7 +591,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -622,7 +601,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ───────────────────────────────────
  3 │               type T = B;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports A are only used as type.
@@ -668,7 +647,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -678,7 +657,7 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────────────────
  3 │               export = {} as A;
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -688,7 +667,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -698,7 +677,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -708,7 +687,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -718,7 +697,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): All imports in the declaration are only used as types. Use `import type`.
@@ -728,7 +707,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                 ──────────────────────
  3 │                 class A {
    ╰────
-  help: Replace the regular `import` with `import type`. For example, change `import { Type } from 'module'` to `import type { Type } from 'module'`. This makes it clear that these imports are only used for types and can be removed at compile time.
+  help: Replace the `import` declaration with `import type`. For example, change `import { Type } from 'module'` would become `import type { Type } from 'module'`.
   note: Using `import type` for type-only imports helps with tree-shaking, makes it clear that these imports don't affect runtime code, and can improve build performance by allowing bundlers to eliminate unused type imports.
 
   ⚠ typescript-eslint(consistent-type-imports): Imports Foo are only used as type.


### PR DESCRIPTION
Added .with_help() and .with_note() to missing diagnostics in the typescript consistent_type_imports.rs file.

Part of #19121 