### PR TITLE
fix(npm): add `preferUnplugged` for Yarn PnP compatibility

### DIFF
--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -62,6 +62,7 @@
       "x86_64-unknown-linux-musl"
     ]
   },
+  "preferUnplugged": true,
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/npm/oxfmt/package.json
+++ b/npm/oxfmt/package.json
@@ -62,8 +62,8 @@
       "x86_64-unknown-linux-musl"
     ]
   },
-  "preferUnplugged": true,
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
-  }
+  },
+  "preferUnplugged": true
 }

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -77,6 +77,7 @@
       "x86_64-unknown-linux-musl"
     ]
   },
+  "preferUnplugged": true,
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -77,8 +77,8 @@
       "x86_64-unknown-linux-musl"
     ]
   },
-  "preferUnplugged": true,
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
-  }
+  },
+  "preferUnplugged": true
 }


### PR DESCRIPTION
## Summary

- Add `"preferUnplugged": true` to `oxlint` and `oxfmt` `package.json` files so Yarn PnP always extracts them to disk instead of keeping them in zip archives
- This fixes `EBADF: bad file descriptor` errors when running oxlint/oxfmt in Yarn PnP projects, since native binaries cannot execute from within zip archives

Closes #19163

🤖 Generated with [Claude Code](https://claude.com/claude-code)