### PR TITLE
refactor(estree/tokens): rename types

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
-use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
 use oxc_linter::RawTransferMetadata2 as RawTransferMetadata;
 use oxc_napi::get_source_type;
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
@@ -219,7 +219,7 @@ unsafe fn parse_raw_impl(
                 program,
                 original_source_text,
                 &span_converter,
-                EstreeTokenOptions::linter(),
+                ESTreeTokenOptions::linter(),
             );
 
             span_converter.convert_program(program);

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -20,7 +20,7 @@ use oxc_ast_macros::ast;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_data_structures::box_macros::boxed_array;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
 use oxc_semantic::AstNode;
 use oxc_span::Span;
 
@@ -576,7 +576,7 @@ impl Linter {
                     program,
                     original_source_text,
                     &span_converter,
-                    EstreeTokenOptions::linter(),
+                    ESTreeTokenOptions::linter(),
                 );
                 let tokens_json = allocator.alloc_str(&tokens_json);
                 let tokens_offset = tokens_json.as_ptr() as u32;

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_benchmark::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
 use oxc_tasks_common::TestFiles;
 
@@ -145,7 +145,7 @@ fn bench_estree_tokens(criterion: &mut Criterion) {
                         &program,
                         program.source_text,
                         &span_converter,
-                        EstreeTokenOptions::test262(),
+                        ESTreeTokenOptions::test262(),
                     );
                     let tokens_json = black_box(tokens_json);
                     // Allocate tokens JSON into arena, same as linter and NAPI parser package do

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -11,7 +11,7 @@ use oxc::{
     span::{ModuleKind, SourceType, Span},
     transformer::{JsxOptions, JsxRuntime, TransformOptions},
 };
-use oxc_estree_tokens::{EstreeTokenOptions, to_estree_tokens_pretty_json};
+use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_pretty_json};
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, Expand, FormatOptions,
     Formatter, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteProperties, QuoteStyle,
@@ -854,7 +854,7 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
                 &program,
                 source_text,
                 &span_converter,
-                EstreeTokenOptions::test262(),
+                ESTreeTokenOptions::test262(),
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -904,7 +904,7 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
                 &program,
                 source_text,
                 &span_converter,
-                EstreeTokenOptions::test262(),
+                ESTreeTokenOptions::test262(),
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -1080,7 +1080,7 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
                     &program,
                     source_text,
                     &span_converter,
-                    EstreeTokenOptions::typescript(),
+                    ESTreeTokenOptions::typescript(),
                 );
 
                 span_converter.convert_program_with_ascending_order_checks(&mut program);


### PR DESCRIPTION
Pure refactor. Rename types. Correct capitalization in `ESTreeSafeToken` etc.