### PR TITLE
fix(linter/plugins): decode escapes in identifier tokens

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -219,7 +219,7 @@ unsafe fn parse_raw_impl(
                 program,
                 original_source_text,
                 &span_converter,
-                ESTreeTokenOptions::linter(),
+                ESTreeTokenOptions::test262(),
             );
 
             span_converter.convert_program(program);

--- a/apps/oxlint/test/fixtures/tokens/files/escaped_idents.js
+++ b/apps/oxlint/test/fixtures/tokens/files/escaped_idents.js
@@ -1,0 +1,45 @@
+// abc
+var \u{61}b\u0063;
+
+// let
+var \u{6C}e\u0074;
+
+// static
+var st\u{61}\u{074}\u{0069}\u0063;
+
+// yield
+var y\u{69}e\u{006C}d;
+
+const obj = {
+  // abc
+  \u{61}b\u0063,
+  // let
+  \u{6C}e\u0074,
+  // static
+  st\u{61}\u{074}\u{0069}\u0063,
+  // yield
+  y\u{69}e\u{006C}d,
+};
+
+const obj2 = {
+  // abc: abc
+  \u{61}b\u0063: \u{61}b\u0063,
+  // let: let
+  \u{6C}e\u0074: \u{6C}e\u0074,
+  // static: static
+  st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+  // yield: yield
+  y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+};
+
+// abc
+\u{61}b\u0063: break \u{61}b\u0063;
+
+// let
+\u{6C}e\u0074: break \u{6C}e\u0074;
+
+// static
+st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+
+// yield
+y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -47,6 +47,922 @@
    :      ^
    `----
 
+  x tokens-plugin(tokens): Line (" abc")
+   ,-[files/escaped_idents.js:1:1]
+ 1 | // abc
+   : ^^^^^^
+ 2 | var \u{61}b\u0063;
+   `----
+
+  x tokens-plugin(tokens): Tokens and comments:
+  | Line              loc= 1:0 - 1:6    range= 0-6     " abc"
+  | Keyword           loc= 2:0 - 2:3    range= 7-10    "var"
+  | Identifier        loc= 2:4 - 2:17   range= 11-24   "abc"
+  | Punctuator        loc= 2:17 - 2:18  range= 24-25   ";"
+  | Line              loc= 4:0 - 4:6    range= 27-33   " let"
+  | Keyword           loc= 5:0 - 5:3    range= 34-37   "var"
+  | Keyword           loc= 5:4 - 5:17   range= 38-51   "let"
+  | Punctuator        loc= 5:17 - 5:18  range= 51-52   ";"
+  | Line              loc= 7:0 - 7:9    range= 54-63   " static"
+  | Keyword           loc= 8:0 - 8:3    range= 64-67   "var"
+  | Keyword           loc= 8:4 - 8:33   range= 68-97   "static"
+  | Punctuator        loc= 8:33 - 8:34  range= 97-98   ";"
+  | Line              loc= 10:0 - 10:8  range= 100-108 " yield"
+  | Keyword           loc= 11:0 - 11:3  range= 109-112 "var"
+  | Keyword           loc= 11:4 - 11:21 range= 113-130 "yield"
+  | Punctuator        loc= 11:21 - 11:22 range= 130-131 ";"
+  | Keyword           loc= 13:0 - 13:5  range= 133-138 "const"
+  | Identifier        loc= 13:6 - 13:9  range= 139-142 "obj"
+  | Punctuator        loc= 13:10 - 13:11 range= 143-144 "="
+  | Punctuator        loc= 13:12 - 13:13 range= 145-146 "{"
+  | Line              loc= 14:2 - 14:8  range= 149-155 " abc"
+  | Identifier        loc= 15:2 - 15:15 range= 158-171 "abc"
+  | Punctuator        loc= 15:15 - 15:16 range= 171-172 ","
+  | Line              loc= 16:2 - 16:8  range= 175-181 " let"
+  | Keyword           loc= 17:2 - 17:15 range= 184-197 "let"
+  | Punctuator        loc= 17:15 - 17:16 range= 197-198 ","
+  | Line              loc= 18:2 - 18:11 range= 201-210 " static"
+  | Keyword           loc= 19:2 - 19:31 range= 213-242 "static"
+  | Punctuator        loc= 19:31 - 19:32 range= 242-243 ","
+  | Line              loc= 20:2 - 20:10 range= 246-254 " yield"
+  | Keyword           loc= 21:2 - 21:19 range= 257-274 "yield"
+  | Punctuator        loc= 21:19 - 21:20 range= 274-275 ","
+  | Punctuator        loc= 22:0 - 22:1  range= 276-277 "}"
+  | Punctuator        loc= 22:1 - 22:2  range= 277-278 ";"
+  | Keyword           loc= 24:0 - 24:5  range= 280-285 "const"
+  | Identifier        loc= 24:6 - 24:10 range= 286-290 "obj2"
+  | Punctuator        loc= 24:11 - 24:12 range= 291-292 "="
+  | Punctuator        loc= 24:13 - 24:14 range= 293-294 "{"
+  | Line              loc= 25:2 - 25:13 range= 297-308 " abc: abc"
+  | Identifier        loc= 26:2 - 26:15 range= 311-324 "abc"
+  | Punctuator        loc= 26:15 - 26:16 range= 324-325 ":"
+  | Identifier        loc= 26:17 - 26:30 range= 326-339 "abc"
+  | Punctuator        loc= 26:30 - 26:31 range= 339-340 ","
+  | Line              loc= 27:2 - 27:13 range= 343-354 " let: let"
+  | Keyword           loc= 28:2 - 28:15 range= 357-370 "let"
+  | Punctuator        loc= 28:15 - 28:16 range= 370-371 ":"
+  | Keyword           loc= 28:17 - 28:30 range= 372-385 "let"
+  | Punctuator        loc= 28:30 - 28:31 range= 385-386 ","
+  | Line              loc= 29:2 - 29:19 range= 389-406 " static: static"
+  | Keyword           loc= 30:2 - 30:31 range= 409-438 "static"
+  | Punctuator        loc= 30:31 - 30:32 range= 438-439 ":"
+  | Keyword           loc= 30:33 - 30:62 range= 440-469 "static"
+  | Punctuator        loc= 30:62 - 30:63 range= 469-470 ","
+  | Line              loc= 31:2 - 31:17 range= 473-488 " yield: yield"
+  | Keyword           loc= 32:2 - 32:19 range= 491-508 "yield"
+  | Punctuator        loc= 32:19 - 32:20 range= 508-509 ":"
+  | Keyword           loc= 32:21 - 32:38 range= 510-527 "yield"
+  | Punctuator        loc= 32:38 - 32:39 range= 527-528 ","
+  | Punctuator        loc= 33:0 - 33:1  range= 529-530 "}"
+  | Punctuator        loc= 33:1 - 33:2  range= 530-531 ";"
+  | Line              loc= 35:0 - 35:6  range= 533-539 " abc"
+  | Identifier        loc= 36:0 - 36:13 range= 540-553 "abc"
+  | Punctuator        loc= 36:13 - 36:14 range= 553-554 ":"
+  | Keyword           loc= 36:15 - 36:20 range= 555-560 "break"
+  | Identifier        loc= 36:21 - 36:34 range= 561-574 "abc"
+  | Punctuator        loc= 36:34 - 36:35 range= 574-575 ";"
+  | Line              loc= 38:0 - 38:6  range= 577-583 " let"
+  | Keyword           loc= 39:0 - 39:13 range= 584-597 "let"
+  | Punctuator        loc= 39:13 - 39:14 range= 597-598 ":"
+  | Keyword           loc= 39:15 - 39:20 range= 599-604 "break"
+  | Keyword           loc= 39:21 - 39:34 range= 605-618 "let"
+  | Punctuator        loc= 39:34 - 39:35 range= 618-619 ";"
+  | Line              loc= 41:0 - 41:9  range= 621-630 " static"
+  | Keyword           loc= 42:0 - 42:29 range= 631-660 "static"
+  | Punctuator        loc= 42:29 - 42:30 range= 660-661 ":"
+  | Keyword           loc= 42:31 - 42:36 range= 662-667 "break"
+  | Keyword           loc= 42:37 - 42:66 range= 668-697 "static"
+  | Punctuator        loc= 42:66 - 42:67 range= 697-698 ";"
+  | Line              loc= 44:0 - 44:8  range= 700-708 " yield"
+  | Keyword           loc= 45:0 - 45:17 range= 709-726 "yield"
+  | Punctuator        loc= 45:17 - 45:18 range= 726-727 ":"
+  | Keyword           loc= 45:19 - 45:24 range= 728-733 "break"
+  | Keyword           loc= 45:25 - 45:42 range= 734-751 "yield"
+  | Punctuator        loc= 45:42 - 45:43 range= 751-752 ";"
+    ,-[files/escaped_idents.js:1:1]
+  1 | ,-> // abc
+  2 | |   var \u{61}b\u0063;
+  3 | |   
+  4 | |   // let
+  5 | |   var \u{6C}e\u0074;
+  6 | |   
+  7 | |   // static
+  8 | |   var st\u{61}\u{074}\u{0069}\u0063;
+  9 | |   
+ 10 | |   // yield
+ 11 | |   var y\u{69}e\u{006C}d;
+ 12 | |   
+ 13 | |   const obj = {
+ 14 | |     // abc
+ 15 | |     \u{61}b\u0063,
+ 16 | |     // let
+ 17 | |     \u{6C}e\u0074,
+ 18 | |     // static
+ 19 | |     st\u{61}\u{074}\u{0069}\u0063,
+ 20 | |     // yield
+ 21 | |     y\u{69}e\u{006C}d,
+ 22 | |   };
+ 23 | |   
+ 24 | |   const obj2 = {
+ 25 | |     // abc: abc
+ 26 | |     \u{61}b\u0063: \u{61}b\u0063,
+ 27 | |     // let: let
+ 28 | |     \u{6C}e\u0074: \u{6C}e\u0074,
+ 29 | |     // static: static
+ 30 | |     st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+ 31 | |     // yield: yield
+ 32 | |     y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+ 33 | |   };
+ 34 | |   
+ 35 | |   // abc
+ 36 | |   \u{61}b\u0063: break \u{61}b\u0063;
+ 37 | |   
+ 38 | |   // let
+ 39 | |   \u{6C}e\u0074: break \u{6C}e\u0074;
+ 40 | |   
+ 41 | |   // static
+ 42 | |   st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+ 43 | |   
+ 44 | |   // yield
+ 45 | `-> y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    `----
+
+  x tokens-plugin(tokens): Tokens:
+  | Keyword           loc= 2:0 - 2:3    range= 7-10    "var"
+  | Identifier        loc= 2:4 - 2:17   range= 11-24   "abc"
+  | Punctuator        loc= 2:17 - 2:18  range= 24-25   ";"
+  | Keyword           loc= 5:0 - 5:3    range= 34-37   "var"
+  | Keyword           loc= 5:4 - 5:17   range= 38-51   "let"
+  | Punctuator        loc= 5:17 - 5:18  range= 51-52   ";"
+  | Keyword           loc= 8:0 - 8:3    range= 64-67   "var"
+  | Keyword           loc= 8:4 - 8:33   range= 68-97   "static"
+  | Punctuator        loc= 8:33 - 8:34  range= 97-98   ";"
+  | Keyword           loc= 11:0 - 11:3  range= 109-112 "var"
+  | Keyword           loc= 11:4 - 11:21 range= 113-130 "yield"
+  | Punctuator        loc= 11:21 - 11:22 range= 130-131 ";"
+  | Keyword           loc= 13:0 - 13:5  range= 133-138 "const"
+  | Identifier        loc= 13:6 - 13:9  range= 139-142 "obj"
+  | Punctuator        loc= 13:10 - 13:11 range= 143-144 "="
+  | Punctuator        loc= 13:12 - 13:13 range= 145-146 "{"
+  | Identifier        loc= 15:2 - 15:15 range= 158-171 "abc"
+  | Punctuator        loc= 15:15 - 15:16 range= 171-172 ","
+  | Keyword           loc= 17:2 - 17:15 range= 184-197 "let"
+  | Punctuator        loc= 17:15 - 17:16 range= 197-198 ","
+  | Keyword           loc= 19:2 - 19:31 range= 213-242 "static"
+  | Punctuator        loc= 19:31 - 19:32 range= 242-243 ","
+  | Keyword           loc= 21:2 - 21:19 range= 257-274 "yield"
+  | Punctuator        loc= 21:19 - 21:20 range= 274-275 ","
+  | Punctuator        loc= 22:0 - 22:1  range= 276-277 "}"
+  | Punctuator        loc= 22:1 - 22:2  range= 277-278 ";"
+  | Keyword           loc= 24:0 - 24:5  range= 280-285 "const"
+  | Identifier        loc= 24:6 - 24:10 range= 286-290 "obj2"
+  | Punctuator        loc= 24:11 - 24:12 range= 291-292 "="
+  | Punctuator        loc= 24:13 - 24:14 range= 293-294 "{"
+  | Identifier        loc= 26:2 - 26:15 range= 311-324 "abc"
+  | Punctuator        loc= 26:15 - 26:16 range= 324-325 ":"
+  | Identifier        loc= 26:17 - 26:30 range= 326-339 "abc"
+  | Punctuator        loc= 26:30 - 26:31 range= 339-340 ","
+  | Keyword           loc= 28:2 - 28:15 range= 357-370 "let"
+  | Punctuator        loc= 28:15 - 28:16 range= 370-371 ":"
+  | Keyword           loc= 28:17 - 28:30 range= 372-385 "let"
+  | Punctuator        loc= 28:30 - 28:31 range= 385-386 ","
+  | Keyword           loc= 30:2 - 30:31 range= 409-438 "static"
+  | Punctuator        loc= 30:31 - 30:32 range= 438-439 ":"
+  | Keyword           loc= 30:33 - 30:62 range= 440-469 "static"
+  | Punctuator        loc= 30:62 - 30:63 range= 469-470 ","
+  | Keyword           loc= 32:2 - 32:19 range= 491-508 "yield"
+  | Punctuator        loc= 32:19 - 32:20 range= 508-509 ":"
+  | Keyword           loc= 32:21 - 32:38 range= 510-527 "yield"
+  | Punctuator        loc= 32:38 - 32:39 range= 527-528 ","
+  | Punctuator        loc= 33:0 - 33:1  range= 529-530 "}"
+  | Punctuator        loc= 33:1 - 33:2  range= 530-531 ";"
+  | Identifier        loc= 36:0 - 36:13 range= 540-553 "abc"
+  | Punctuator        loc= 36:13 - 36:14 range= 553-554 ":"
+  | Keyword           loc= 36:15 - 36:20 range= 555-560 "break"
+  | Identifier        loc= 36:21 - 36:34 range= 561-574 "abc"
+  | Punctuator        loc= 36:34 - 36:35 range= 574-575 ";"
+  | Keyword           loc= 39:0 - 39:13 range= 584-597 "let"
+  | Punctuator        loc= 39:13 - 39:14 range= 597-598 ":"
+  | Keyword           loc= 39:15 - 39:20 range= 599-604 "break"
+  | Keyword           loc= 39:21 - 39:34 range= 605-618 "let"
+  | Punctuator        loc= 39:34 - 39:35 range= 618-619 ";"
+  | Keyword           loc= 42:0 - 42:29 range= 631-660 "static"
+  | Punctuator        loc= 42:29 - 42:30 range= 660-661 ":"
+  | Keyword           loc= 42:31 - 42:36 range= 662-667 "break"
+  | Keyword           loc= 42:37 - 42:66 range= 668-697 "static"
+  | Punctuator        loc= 42:66 - 42:67 range= 697-698 ";"
+  | Keyword           loc= 45:0 - 45:17 range= 709-726 "yield"
+  | Punctuator        loc= 45:17 - 45:18 range= 726-727 ":"
+  | Keyword           loc= 45:19 - 45:24 range= 728-733 "break"
+  | Keyword           loc= 45:25 - 45:42 range= 734-751 "yield"
+  | Punctuator        loc= 45:42 - 45:43 range= 751-752 ";"
+    ,-[files/escaped_idents.js:1:1]
+  1 | ,-> // abc
+  2 | |   var \u{61}b\u0063;
+  3 | |   
+  4 | |   // let
+  5 | |   var \u{6C}e\u0074;
+  6 | |   
+  7 | |   // static
+  8 | |   var st\u{61}\u{074}\u{0069}\u0063;
+  9 | |   
+ 10 | |   // yield
+ 11 | |   var y\u{69}e\u{006C}d;
+ 12 | |   
+ 13 | |   const obj = {
+ 14 | |     // abc
+ 15 | |     \u{61}b\u0063,
+ 16 | |     // let
+ 17 | |     \u{6C}e\u0074,
+ 18 | |     // static
+ 19 | |     st\u{61}\u{074}\u{0069}\u0063,
+ 20 | |     // yield
+ 21 | |     y\u{69}e\u{006C}d,
+ 22 | |   };
+ 23 | |   
+ 24 | |   const obj2 = {
+ 25 | |     // abc: abc
+ 26 | |     \u{61}b\u0063: \u{61}b\u0063,
+ 27 | |     // let: let
+ 28 | |     \u{6C}e\u0074: \u{6C}e\u0074,
+ 29 | |     // static: static
+ 30 | |     st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+ 31 | |     // yield: yield
+ 32 | |     y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+ 33 | |   };
+ 34 | |   
+ 35 | |   // abc
+ 36 | |   \u{61}b\u0063: break \u{61}b\u0063;
+ 37 | |   
+ 38 | |   // let
+ 39 | |   \u{6C}e\u0074: break \u{6C}e\u0074;
+ 40 | |   
+ 41 | |   // static
+ 42 | |   st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+ 43 | |   
+ 44 | |   // yield
+ 45 | `-> y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    `----
+
+  x tokens-plugin(tokens): Keyword ("var")
+   ,-[files/escaped_idents.js:2:1]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   : ^^^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+   ,-[files/escaped_idents.js:2:5]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   :     ^^^^^^^^^^^^^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+   ,-[files/escaped_idents.js:2:18]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   :                  ^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Line (" let")
+   ,-[files/escaped_idents.js:4:1]
+ 3 | 
+ 4 | // let
+   : ^^^^^^
+ 5 | var \u{6C}e\u0074;
+   `----
+
+  x tokens-plugin(tokens): Keyword ("var")
+   ,-[files/escaped_idents.js:5:1]
+ 4 | // let
+ 5 | var \u{6C}e\u0074;
+   : ^^^
+ 6 | 
+   `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+   ,-[files/escaped_idents.js:5:5]
+ 4 | // let
+ 5 | var \u{6C}e\u0074;
+   :     ^^^^^^^^^^^^^
+ 6 | 
+   `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+   ,-[files/escaped_idents.js:5:18]
+ 4 | // let
+ 5 | var \u{6C}e\u0074;
+   :                  ^
+ 6 | 
+   `----
+
+  x tokens-plugin(tokens): Line (" static")
+   ,-[files/escaped_idents.js:7:1]
+ 6 | 
+ 7 | // static
+   : ^^^^^^^^^
+ 8 | var st\u{61}\u{074}\u{0069}\u0063;
+   `----
+
+  x tokens-plugin(tokens): Keyword ("var")
+   ,-[files/escaped_idents.js:8:1]
+ 7 | // static
+ 8 | var st\u{61}\u{074}\u{0069}\u0063;
+   : ^^^
+ 9 | 
+   `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+   ,-[files/escaped_idents.js:8:5]
+ 7 | // static
+ 8 | var st\u{61}\u{074}\u{0069}\u0063;
+   :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 9 | 
+   `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+   ,-[files/escaped_idents.js:8:34]
+ 7 | // static
+ 8 | var st\u{61}\u{074}\u{0069}\u0063;
+   :                                  ^
+ 9 | 
+   `----
+
+  x tokens-plugin(tokens): Line (" yield")
+    ,-[files/escaped_idents.js:10:1]
+  9 | 
+ 10 | // yield
+    : ^^^^^^^^
+ 11 | var y\u{69}e\u{006C}d;
+    `----
+
+  x tokens-plugin(tokens): Keyword ("var")
+    ,-[files/escaped_idents.js:11:1]
+ 10 | // yield
+ 11 | var y\u{69}e\u{006C}d;
+    : ^^^
+ 12 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:11:5]
+ 10 | // yield
+ 11 | var y\u{69}e\u{006C}d;
+    :     ^^^^^^^^^^^^^^^^^
+ 12 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:11:22]
+ 10 | // yield
+ 11 | var y\u{69}e\u{006C}d;
+    :                      ^
+ 12 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("const")
+    ,-[files/escaped_idents.js:13:1]
+ 12 | 
+ 13 | const obj = {
+    : ^^^^^
+ 14 |   // abc
+    `----
+
+  x tokens-plugin(tokens): Identifier ("obj")
+    ,-[files/escaped_idents.js:13:7]
+ 12 | 
+ 13 | const obj = {
+    :       ^^^
+ 14 |   // abc
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("=")
+    ,-[files/escaped_idents.js:13:11]
+ 12 | 
+ 13 | const obj = {
+    :           ^
+ 14 |   // abc
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("{")
+    ,-[files/escaped_idents.js:13:13]
+ 12 | 
+ 13 | const obj = {
+    :             ^
+ 14 |   // abc
+    `----
+
+  x tokens-plugin(tokens): Line (" abc")
+    ,-[files/escaped_idents.js:14:3]
+ 13 | const obj = {
+ 14 |   // abc
+    :   ^^^^^^
+ 15 |   \u{61}b\u0063,
+    `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+    ,-[files/escaped_idents.js:15:3]
+ 14 |   // abc
+ 15 |   \u{61}b\u0063,
+    :   ^^^^^^^^^^^^^
+ 16 |   // let
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:15:16]
+ 14 |   // abc
+ 15 |   \u{61}b\u0063,
+    :                ^
+ 16 |   // let
+    `----
+
+  x tokens-plugin(tokens): Line (" let")
+    ,-[files/escaped_idents.js:16:3]
+ 15 |   \u{61}b\u0063,
+ 16 |   // let
+    :   ^^^^^^
+ 17 |   \u{6C}e\u0074,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+    ,-[files/escaped_idents.js:17:3]
+ 16 |   // let
+ 17 |   \u{6C}e\u0074,
+    :   ^^^^^^^^^^^^^
+ 18 |   // static
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:17:16]
+ 16 |   // let
+ 17 |   \u{6C}e\u0074,
+    :                ^
+ 18 |   // static
+    `----
+
+  x tokens-plugin(tokens): Line (" static")
+    ,-[files/escaped_idents.js:18:3]
+ 17 |   \u{6C}e\u0074,
+ 18 |   // static
+    :   ^^^^^^^^^
+ 19 |   st\u{61}\u{074}\u{0069}\u0063,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+    ,-[files/escaped_idents.js:19:3]
+ 18 |   // static
+ 19 |   st\u{61}\u{074}\u{0069}\u0063,
+    :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 20 |   // yield
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:19:32]
+ 18 |   // static
+ 19 |   st\u{61}\u{074}\u{0069}\u0063,
+    :                                ^
+ 20 |   // yield
+    `----
+
+  x tokens-plugin(tokens): Line (" yield")
+    ,-[files/escaped_idents.js:20:3]
+ 19 |   st\u{61}\u{074}\u{0069}\u0063,
+ 20 |   // yield
+    :   ^^^^^^^^
+ 21 |   y\u{69}e\u{006C}d,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:21:3]
+ 20 |   // yield
+ 21 |   y\u{69}e\u{006C}d,
+    :   ^^^^^^^^^^^^^^^^^
+ 22 | };
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:21:20]
+ 20 |   // yield
+ 21 |   y\u{69}e\u{006C}d,
+    :                    ^
+ 22 | };
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("}")
+    ,-[files/escaped_idents.js:22:1]
+ 21 |   y\u{69}e\u{006C}d,
+ 22 | };
+    : ^
+ 23 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:22:2]
+ 21 |   y\u{69}e\u{006C}d,
+ 22 | };
+    :  ^
+ 23 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("const")
+    ,-[files/escaped_idents.js:24:1]
+ 23 | 
+ 24 | const obj2 = {
+    : ^^^^^
+ 25 |   // abc: abc
+    `----
+
+  x tokens-plugin(tokens): Identifier ("obj2")
+    ,-[files/escaped_idents.js:24:7]
+ 23 | 
+ 24 | const obj2 = {
+    :       ^^^^
+ 25 |   // abc: abc
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("=")
+    ,-[files/escaped_idents.js:24:12]
+ 23 | 
+ 24 | const obj2 = {
+    :            ^
+ 25 |   // abc: abc
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("{")
+    ,-[files/escaped_idents.js:24:14]
+ 23 | 
+ 24 | const obj2 = {
+    :              ^
+ 25 |   // abc: abc
+    `----
+
+  x tokens-plugin(tokens): Line (" abc: abc")
+    ,-[files/escaped_idents.js:25:3]
+ 24 | const obj2 = {
+ 25 |   // abc: abc
+    :   ^^^^^^^^^^^
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+    `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+    ,-[files/escaped_idents.js:26:3]
+ 25 |   // abc: abc
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+    :   ^^^^^^^^^^^^^
+ 27 |   // let: let
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:26:16]
+ 25 |   // abc: abc
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+    :                ^
+ 27 |   // let: let
+    `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+    ,-[files/escaped_idents.js:26:18]
+ 25 |   // abc: abc
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+    :                  ^^^^^^^^^^^^^
+ 27 |   // let: let
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:26:31]
+ 25 |   // abc: abc
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+    :                               ^
+ 27 |   // let: let
+    `----
+
+  x tokens-plugin(tokens): Line (" let: let")
+    ,-[files/escaped_idents.js:27:3]
+ 26 |   \u{61}b\u0063: \u{61}b\u0063,
+ 27 |   // let: let
+    :   ^^^^^^^^^^^
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+    ,-[files/escaped_idents.js:28:3]
+ 27 |   // let: let
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+    :   ^^^^^^^^^^^^^
+ 29 |   // static: static
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:28:16]
+ 27 |   // let: let
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+    :                ^
+ 29 |   // static: static
+    `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+    ,-[files/escaped_idents.js:28:18]
+ 27 |   // let: let
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+    :                  ^^^^^^^^^^^^^
+ 29 |   // static: static
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:28:31]
+ 27 |   // let: let
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+    :                               ^
+ 29 |   // static: static
+    `----
+
+  x tokens-plugin(tokens): Line (" static: static")
+    ,-[files/escaped_idents.js:29:3]
+ 28 |   \u{6C}e\u0074: \u{6C}e\u0074,
+ 29 |   // static: static
+    :   ^^^^^^^^^^^^^^^^^
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+    ,-[files/escaped_idents.js:30:3]
+ 29 |   // static: static
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+    :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 31 |   // yield: yield
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:30:32]
+ 29 |   // static: static
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+    :                                ^
+ 31 |   // yield: yield
+    `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+    ,-[files/escaped_idents.js:30:34]
+ 29 |   // static: static
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+    :                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 31 |   // yield: yield
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:30:63]
+ 29 |   // static: static
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+    :                                                               ^
+ 31 |   // yield: yield
+    `----
+
+  x tokens-plugin(tokens): Line (" yield: yield")
+    ,-[files/escaped_idents.js:31:3]
+ 30 |   st\u{61}\u{074}\u{0069}\u0063: st\u{61}\u{074}\u{0069}\u0063,
+ 31 |   // yield: yield
+    :   ^^^^^^^^^^^^^^^
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:32:3]
+ 31 |   // yield: yield
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+    :   ^^^^^^^^^^^^^^^^^
+ 33 | };
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:32:20]
+ 31 |   // yield: yield
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+    :                    ^
+ 33 | };
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:32:22]
+ 31 |   // yield: yield
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+    :                      ^^^^^^^^^^^^^^^^^
+ 33 | };
+    `----
+
+  x tokens-plugin(tokens): Punctuator (",")
+    ,-[files/escaped_idents.js:32:39]
+ 31 |   // yield: yield
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+    :                                       ^
+ 33 | };
+    `----
+
+  x tokens-plugin(tokens): Punctuator ("}")
+    ,-[files/escaped_idents.js:33:1]
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+ 33 | };
+    : ^
+ 34 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:33:2]
+ 32 |   y\u{69}e\u{006C}d: y\u{69}e\u{006C}d,
+ 33 | };
+    :  ^
+ 34 | 
+    `----
+
+  x tokens-plugin(tokens): Line (" abc")
+    ,-[files/escaped_idents.js:35:1]
+ 34 | 
+ 35 | // abc
+    : ^^^^^^
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+    ,-[files/escaped_idents.js:36:1]
+ 35 | // abc
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    : ^^^^^^^^^^^^^
+ 37 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:36:14]
+ 35 | // abc
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    :              ^
+ 37 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("break")
+    ,-[files/escaped_idents.js:36:16]
+ 35 | // abc
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    :                ^^^^^
+ 37 | 
+    `----
+
+  x tokens-plugin(tokens): Identifier ("abc")
+    ,-[files/escaped_idents.js:36:22]
+ 35 | // abc
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    :                      ^^^^^^^^^^^^^
+ 37 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:36:35]
+ 35 | // abc
+ 36 | \u{61}b\u0063: break \u{61}b\u0063;
+    :                                   ^
+ 37 | 
+    `----
+
+  x tokens-plugin(tokens): Line (" let")
+    ,-[files/escaped_idents.js:38:1]
+ 37 | 
+ 38 | // let
+    : ^^^^^^
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+    ,-[files/escaped_idents.js:39:1]
+ 38 | // let
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    : ^^^^^^^^^^^^^
+ 40 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:39:14]
+ 38 | // let
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    :              ^
+ 40 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("break")
+    ,-[files/escaped_idents.js:39:16]
+ 38 | // let
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    :                ^^^^^
+ 40 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("let")
+    ,-[files/escaped_idents.js:39:22]
+ 38 | // let
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    :                      ^^^^^^^^^^^^^
+ 40 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:39:35]
+ 38 | // let
+ 39 | \u{6C}e\u0074: break \u{6C}e\u0074;
+    :                                   ^
+ 40 | 
+    `----
+
+  x tokens-plugin(tokens): Line (" static")
+    ,-[files/escaped_idents.js:41:1]
+ 40 | 
+ 41 | // static
+    : ^^^^^^^^^
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+    ,-[files/escaped_idents.js:42:1]
+ 41 | // static
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 43 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:42:30]
+ 41 | // static
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    :                              ^
+ 43 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("break")
+    ,-[files/escaped_idents.js:42:32]
+ 41 | // static
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    :                                ^^^^^
+ 43 | 
+    `----
+
+  x tokens-plugin(tokens): Keyword ("static")
+    ,-[files/escaped_idents.js:42:38]
+ 41 | // static
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    :                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 43 | 
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:42:67]
+ 41 | // static
+ 42 | st\u{61}\u{074}\u{0069}\u0063: break st\u{61}\u{074}\u{0069}\u0063;
+    :                                                                   ^
+ 43 | 
+    `----
+
+  x tokens-plugin(tokens): Line (" yield")
+    ,-[files/escaped_idents.js:44:1]
+ 43 | 
+ 44 | // yield
+    : ^^^^^^^^
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:45:1]
+ 44 | // yield
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    : ^^^^^^^^^^^^^^^^^
+    `----
+
+  x tokens-plugin(tokens): Punctuator (":")
+    ,-[files/escaped_idents.js:45:18]
+ 44 | // yield
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    :                  ^
+    `----
+
+  x tokens-plugin(tokens): Keyword ("break")
+    ,-[files/escaped_idents.js:45:20]
+ 44 | // yield
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    :                    ^^^^^
+    `----
+
+  x tokens-plugin(tokens): Keyword ("yield")
+    ,-[files/escaped_idents.js:45:26]
+ 44 | // yield
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    :                          ^^^^^^^^^^^^^^^^^
+    `----
+
+  x tokens-plugin(tokens): Punctuator (";")
+    ,-[files/escaped_idents.js:45:43]
+ 44 | // yield
+ 45 | y\u{69}e\u{006C}d: break y\u{69}e\u{006C}d;
+    :                                           ^
+    `----
+
   x tokens-plugin(tokens): Keyword ("const")
    ,-[files/generic_arrow.ts:1:1]
  1 | const obj = {
@@ -1514,8 +2430,8 @@
    :  ^
    `----
 
-Found 0 warnings and 157 errors.
-Finished in Xms on 7 files with 1 rules using X threads.
+Found 0 warnings and 243 errors.
+Finished in Xms on 8 files with 1 rules using X threads.
 ```
 
 # stderr

--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -59,15 +59,6 @@ impl ESTreeTokenOptions {
             member_expr_in_jsx_expression_jsx_identifiers: true,
         }
     }
-
-    pub const fn linter() -> Self {
-        Self {
-            exclude_legacy_keyword_identifiers: true,
-            decode_identifier_escapes: false,
-            jsx_namespace_jsx_identifiers: true,
-            member_expr_in_jsx_expression_jsx_identifiers: false,
-        }
-    }
 }
 
 /// Serialize tokens to JSON.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -576,7 +576,7 @@ impl Linter {
                     program,
                     original_source_text,
                     &span_converter,
-                    ESTreeTokenOptions::linter(),
+                    ESTreeTokenOptions::test262(),
                 );
                 let tokens_json = allocator.alloc_str(&tokens_json);
                 let tokens_offset = tokens_json.as_ptr() as u32;


### PR DESCRIPTION
Fix tokens in linter. Use options for tokens which match ESLint's tokens style, instead of matching TS-ESLint's.