### PR TITLE
perf(estree/tokens): introduce `ESTreeTokenConfig` trait

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
-use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptionsJS, to_estree_tokens_json};
 use oxc_linter::RawTransferMetadata2 as RawTransferMetadata;
 use oxc_napi::get_source_type;
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
@@ -219,7 +219,7 @@ unsafe fn parse_raw_impl(
                 program,
                 original_source_text,
                 &span_converter,
-                ESTreeTokenOptions::test262(),
+                ESTreeTokenOptionsJS,
             );
 
             span_converter.convert_program(program);

--- a/crates/oxc_estree_tokens/src/options.rs
+++ b/crates/oxc_estree_tokens/src/options.rs
@@ -1,0 +1,138 @@
+// `#[inline(always)]` used on all methods as they're tiny, and to ensure compiler removes dead code
+// resulting from static values
+#![expect(clippy::inline_always)]
+
+use crate::{JSXState, JSXStateJS, JSXStateTS};
+
+/// Trait for options for serializing tokens.
+///
+/// # Token styles
+///
+/// Espree (JS) and TS-ESLint (TS) differ in several ways in the tokens they produce.
+///
+/// 1. `yield`, `let`, `static` used as identifiers (`obj = { yield: 1, let: 2, static: 3 };`)
+///   * Espree emits these as `Keyword` tokens.
+///   * TS-ESLint as `Identifier` tokens.
+///
+/// 2. Escaped identifiers (e.g. `\u0061`)
+///   * Espree decodes escapes in the token `value`.
+///   * TS-ESLint preserves the raw source text.
+///
+/// 3. JSX namespaced names (`<ns:tag>`)
+///   * Espree emits `JSXIdentifier` tokens for both parts,
+///   * TS-ESLint leaves them as their default token type (`Identifier`).
+///
+/// 4. Member expressions in JSX expressions (`<C x={a.b}>`)
+///   * Espree emits them as `Identifier` tokens.
+///   * TS-ESLint emits `JSXIdentifier` tokens for non-computed member expression identifiers
+///     inside JSX expression containers.
+///
+/// # Options
+///
+/// This trait is implemented by 3 structs which can be passed as options to [`to_estree_tokens_json`] and
+/// [`to_estree_tokens_pretty_json`]:
+///
+/// * [`ESTreeTokenOptions`]
+/// * [`ESTreeTokenOptionsJS`]
+/// * [`ESTreeTokenOptionsTS`]
+///
+/// The difference between them is:
+/// * [`ESTreeTokenOptions`] supports both JS and TS styles, and branches at runtime to handle the differences.
+/// * [`ESTreeTokenOptionsJS`] and [`ESTreeTokenOptionsTS`] only support a single style, and branches for the other
+///   style are removed as dead code at compile time.
+///
+/// If your application only uses one style of tokens, use [`ESTreeTokenOptionsJS`] or [`ESTreeTokenOptionsTS`].
+/// That will produce the smallest binary size and fastest runtime performance.
+///
+/// If your application uses either JS and TS style tokens depending on a condition only known at runtime,
+/// [`ESTreeTokenOptions`] is likely preferable. It is marginally slower, but avoids compiling the code for serializing
+/// tokens twice in the binary.
+///
+/// [`to_estree_tokens_json`]: crate::to_estree_tokens_json
+/// [`to_estree_tokens_pretty_json`]: crate::to_estree_tokens_pretty_json
+pub trait ESTreeTokenConfig {
+    /// JSX state type.
+    type JSXState: JSXState;
+
+    /// Returns `true` if serializing in TS style.
+    fn is_ts(&self) -> bool;
+
+    /// Returns `true` if serializing in JS style.
+    #[inline(always)]
+    fn is_js(&self) -> bool {
+        !self.is_ts()
+    }
+}
+
+/// Options for serializing tokens in JS style.
+///
+/// Prefer this over [`ESTreeTokenOptions`] when your application only uses JS style tokens,
+/// as the code paths for TS style can be removed.
+///
+/// If your application uses both JS and TS style tokens, [`ESTreeTokenOptions`] is probably preferable
+/// as it can be used to serialize both styles without binary including all this code twice.
+///
+/// See [`ESTreeTokenConfig`] for more details.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct ESTreeTokenOptionsJS;
+
+impl ESTreeTokenConfig for ESTreeTokenOptionsJS {
+    /// No-op JSX state, because no state is required for JS-style tokens.
+    type JSXState = JSXStateJS;
+
+    #[inline(always)]
+    fn is_ts(&self) -> bool {
+        false
+    }
+}
+
+/// Options for serializing tokens in TS style.
+///
+/// Prefer this over [`ESTreeTokenOptions`] when your application only uses TS style tokens,
+/// as the code paths for JS style can be removed.
+///
+/// If your application uses both JS and TS style tokens, [`ESTreeTokenOptions`] is probably preferable
+/// as it can be used to serialize both styles without binary including all this code twice.
+///
+/// See [`ESTreeTokenConfig`] for more details.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct ESTreeTokenOptionsTS;
+
+impl ESTreeTokenConfig for ESTreeTokenOptionsTS {
+    /// Working JSX state, because state is required for TS-style tokens.
+    type JSXState = JSXStateTS;
+
+    #[inline(always)]
+    fn is_ts(&self) -> bool {
+        true
+    }
+}
+
+/// Options for serializing tokens in either JS or TS style.
+///
+/// If your application uses both JS and TS style tokens, [`ESTreeTokenOptions`] is probably preferable
+/// over [`ESTreeTokenOptionsJS`] and [`ESTreeTokenOptionsTS`], as it can be used to serialize both styles
+/// without binary including all this code twice.
+///
+/// See [`ESTreeTokenConfig`] for more details.
+#[derive(Clone, Copy, Debug)]
+pub struct ESTreeTokenOptions {
+    is_ts: bool,
+}
+
+impl ESTreeTokenOptions {
+    #[inline(always)]
+    pub fn new(is_ts: bool) -> Self {
+        Self { is_ts }
+    }
+}
+
+impl ESTreeTokenConfig for ESTreeTokenOptions {
+    /// Working JSX state, because state is required for TS-style tokens.
+    type JSXState = JSXStateTS;
+
+    #[inline(always)]
+    fn is_ts(&self) -> bool {
+        self.is_ts
+    }
+}

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -20,7 +20,7 @@ use oxc_ast_macros::ast;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_data_structures::box_macros::boxed_array;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptionsJS, to_estree_tokens_json};
 use oxc_semantic::AstNode;
 use oxc_span::Span;
 
@@ -576,7 +576,7 @@ impl Linter {
                     program,
                     original_source_text,
                     &span_converter,
-                    ESTreeTokenOptions::test262(),
+                    ESTreeTokenOptionsJS,
                 );
                 let tokens_json = allocator.alloc_str(&tokens_json);
                 let tokens_offset = tokens_json.as_ptr() as u32;

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_benchmark::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use oxc_estree_tokens::{ESTreeTokenOptions, to_estree_tokens_json};
+use oxc_estree_tokens::{ESTreeTokenOptionsJS, to_estree_tokens_json};
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
 use oxc_tasks_common::TestFiles;
 
@@ -145,7 +145,7 @@ fn bench_estree_tokens(criterion: &mut Criterion) {
                         &program,
                         program.source_text,
                         &span_converter,
-                        ESTreeTokenOptions::test262(),
+                        ESTreeTokenOptionsJS,
                     );
                     let tokens_json = black_box(tokens_json);
                     // Allocate tokens JSON into arena, same as linter and NAPI parser package do

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -854,7 +854,7 @@ pub fn run_estree_test262_tokens(files: &[Test262File]) -> Vec<CoverageResult> {
                 &program,
                 source_text,
                 &span_converter,
-                ESTreeTokenOptions::test262(),
+                ESTreeTokenOptions::new(false),
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -904,7 +904,7 @@ pub fn run_estree_acorn_jsx_tokens(files: &[AcornJsxFile]) -> Vec<CoverageResult
                 &program,
                 source_text,
                 &span_converter,
-                ESTreeTokenOptions::test262(),
+                ESTreeTokenOptions::new(false),
             );
 
             span_converter.convert_program_with_ascending_order_checks(&mut program);
@@ -1080,7 +1080,7 @@ pub fn run_estree_typescript_tokens(files: &[TypeScriptFile]) -> Vec<CoverageRes
                     &program,
                     source_text,
                     &span_converter,
-                    ESTreeTokenOptions::typescript(),
+                    ESTreeTokenOptions::new(true),
                 );
 
                 span_converter.convert_program_with_ascending_order_checks(&mut program);


### PR DESCRIPTION
Introduce `ESTreeTokenConfig` trait and allow option for the "flavor" of tokens to be set at compile time.

When producing Espree-style tokens, this allows cutting out all the special-case logic related to `JSXIdentifier` tokens and removing 2 branches from `emit_identifier_at`.

Small effect on perf - only +0.3% on ESTree tokens benchmark.