### PR TITLE
docs(linter): Improve docs for no-useless-concat, mark as pending fixer.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -14,14 +14,14 @@ pub struct NoUselessConcat;
 
 fn no_useless_concat_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected string concatenation of literals.")
-        .with_help("Rewrite into one string literal")
+        .with_help("Rewrite into one string literal.")
         .with_label(span)
 }
 
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unnecessary concatenation of literals or template literals
+    /// Disallow unnecessary concatenation of literals or template literals.
     ///
     /// ### Why is this bad?
     ///
@@ -42,17 +42,16 @@ declare_oxc_lint!(
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// var foo = 'a' + bar;
-    /// ```
     ///
-    /// // when the string concatenation is multiline
-    /// ```javascript
+    /// // When the string concatenation is multiline
     /// var foo = 'a'
     ///     + 'b'
     ///     + 'c';
     /// ```
     NoUselessConcat,
     eslint,
-    suspicious
+    suspicious,
+    pending // TODO: Make a suggestion fixer for this rule.
 );
 
 impl Rule for NoUselessConcat {
@@ -133,6 +132,9 @@ fn test() {
           + 'b'
           + 'c'
         ",
+        "'a' + foo + 'b'",
+        "'a' + foo + 'b' + bar + 'b'",
+        "'a' - 'b'",
     ];
 
     let fail = vec![
@@ -151,6 +153,26 @@ fn test() {
         + 'd'
         ",
         "'a' + 'b' + 'c' + 'd' + 'e' + foo",
+    ];
+
+    // TODO: Implement a suggestion for this rule.
+    let _fix = vec![
+        ("'a' + 'b'", "'ab'"),
+        (r#""a" + "b""#, r#""ab""#),
+        ("'a' + 'b' + 'c'", "'abc'"),
+        ("`a` + 'b'", "`ab`"),
+        ("`a` + `b`", "`ab`"),
+        ("foo + `a` + `b`", "foo + `ab`"),
+        ("foo + 'a' + 'b'", "foo + 'ab'"),
+        ("'a' + 'b' + 'c' + 'd' + 'e' + foo", "'abcde' + foo"),
+        (
+            "'foo bar ' + 'corge grault garply waldo fred plugh xyzzy thud'",
+            "'foo bar corge grault garply waldo fred plugh xyzzy thud'",
+        ),
+        ("'foo bar   ' + ' whatever'", "'foo bar    whatever'"),
+        ("'foo' + '' + '' + 'bar'", "'foobar'"),
+        ("(foo + 'a') + ('b' + 'c')", "(foo + 'a') + ('bc')"),
+        // TODO: Add more test cases for the fixer.
     ];
 
     Tester::new(NoUselessConcat::NAME, NoUselessConcat::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_concat.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_concat.snap
@@ -7,7 +7,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 'a' + 'b'
    · ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:2:9]
@@ -15,63 +15,63 @@ source: crates/oxc_linter/src/tester.rs
  2 │         'b' + 'c'
    ·         ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:7]
  1 │ foo + 'a' + 'b'
    ·       ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:7]
  1 │ 'a' + 'b' + 'c'
    ·       ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:1]
  1 │ 'a' + 'b' + 'c'
    · ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:16]
  1 │ (foo + 'a') + ('b' + 'c')
    ·                ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:1]
  1 │ `a` + 'b'
    · ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:1]
  1 │ `a` + `b`
    · ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:7]
  1 │ foo + `a` + `b`
    ·       ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:7]
  1 │ foo + 'a' + 'b'
    ·       ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:2:9]
@@ -80,32 +80,32 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────
  3 │         + 'd'
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:19]
  1 │ 'a' + 'b' + 'c' + 'd' + 'e' + foo
    ·                   ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:13]
  1 │ 'a' + 'b' + 'c' + 'd' + 'e' + foo
    ·             ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:7]
  1 │ 'a' + 'b' + 'c' + 'd' + 'e' + foo
    ·       ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.
 
   ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
    ╭─[no_useless_concat.tsx:1:1]
  1 │ 'a' + 'b' + 'c' + 'd' + 'e' + foo
    · ─────────
    ╰────
-  help: Rewrite into one string literal
+  help: Rewrite into one string literal.


### PR DESCRIPTION
And add a handful of test cases for the fixer. I don't see any strong reason not to support at least a suggestion for this rule.