### PR TITLE
test(linter): Add a few more tests for the no-useless-concat rule.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -135,6 +135,16 @@ fn test() {
         "'a' + foo + 'b'",
         "'a' + foo + 'b' + bar + 'b'",
         "'a' - 'b'",
+        "'a + b'",
+        "// 'a' + 'b'",
+        "/* 'a' + 'b' */",
+        "'`a` + b'",
+        "'`a` + `b`'",
+        r#""`a` + `b`""#,
+        "`a + ${b + c}`",
+        "foo['a'] + foo['b']",
+        "`${1 + 1}`",
+        "`${'1' + 1}`",
     ];
 
     let fail = vec![
@@ -153,6 +163,8 @@ fn test() {
         + 'd'
         ",
         "'a' + 'b' + 'c' + 'd' + 'e' + foo",
+        "`${'a' + 'b'}` + 'c'",
+        "foo['a' + 'b']",
     ];
 
     // TODO: Implement a suggestion for this rule.
@@ -172,7 +184,31 @@ fn test() {
         ("'foo bar   ' + ' whatever'", "'foo bar    whatever'"),
         ("'foo' + '' + '' + 'bar'", "'foobar'"),
         ("(foo + 'a') + ('b' + 'c')", "(foo + 'a') + ('bc')"),
-        // TODO: Add more test cases for the fixer.
+        ("`${'a' + 'b'}` + 'c'", "`${'ab'}` + 'c'"), // this one is maybe too complex and we can opt to ignore fixing it?
+        ("'a + b' + 'c'", "'a + bc'"),
+        ("foo['a' + 'b']", "foo['ab']"),
+        ("foo[`a` + 'b']", "foo[`ab`]"),
+        // The below may be too complex and can be ignored for now.
+        (
+            "'a' +
+            'b' + 'c'
+            + 'd'",
+            "'a' +
+            'bc'
+            + 'd'",
+        ),
+        (
+            "'a' +
+            // comment
+            'b' + 'c'
+            // another comment
+            + 'd'",
+            "'a' +
+            // comment
+            'bc'
+            // another comment
+            + 'd'",
+        ),
     ];
 
     Tester::new(NoUselessConcat::NAME, NoUselessConcat::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_concat.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_concat.snap
@@ -109,3 +109,24 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────
    ╰────
   help: Rewrite into one string literal.
+
+  ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
+   ╭─[no_useless_concat.tsx:1:1]
+ 1 │ `${'a' + 'b'}` + 'c'
+   · ────────────────────
+   ╰────
+  help: Rewrite into one string literal.
+
+  ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
+   ╭─[no_useless_concat.tsx:1:4]
+ 1 │ `${'a' + 'b'}` + 'c'
+   ·    ─────────
+   ╰────
+  help: Rewrite into one string literal.
+
+  ⚠ eslint(no-useless-concat): Unexpected string concatenation of literals.
+   ╭─[no_useless_concat.tsx:1:5]
+ 1 │ foo['a' + 'b']
+   ·     ─────────
+   ╰────
+  help: Rewrite into one string literal.


### PR DESCRIPTION
Added various weird additional cases that I could come up with.