### PR TITLE
feat(formatter): add blank line between consecutive function declarations

### DIFF
--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -2405,6 +2405,16 @@ where
         write!(self.fmt, content);
     }
 
+    /// Adds a new node with a forced empty line before it, regardless of the source.
+    /// Used to enforce blank lines between certain node types (e.g., consecutive function declarations).
+    pub fn entry_with_forced_empty_line(&mut self, content: &dyn Format<'ast>) {
+        if self.has_elements {
+            write!(self.fmt, empty_line());
+        }
+        self.has_elements = true;
+        write!(self.fmt, content);
+    }
+
     /// Writes an entry without adding a separating line break or empty line.
     pub fn entry_no_separator(&mut self, content: &dyn Format<'ast>) {
         self.has_elements = true;

--- a/crates/oxc_formatter/tests/fixtures/js/function-blank-lines/consecutive-functions.js
+++ b/crates/oxc_formatter/tests/fixtures/js/function-blank-lines/consecutive-functions.js
@@ -1,0 +1,68 @@
+// Consecutive function declarations without blank lines should get one added
+function one() {
+    return 1;
+}
+function two() {
+    return 2;
+}
+function three() {
+    return 3;
+}
+
+// Already has blank lines - should be preserved
+function four() {
+    return 4;
+}
+
+function five() {
+    return 5;
+}
+
+// Multiple blank lines between functions should be reduced to one
+
+
+
+function twelve() {
+    return 12;
+}
+
+
+
+function thirteen() {
+    return 13;
+}
+
+// Non-function between functions - no forced blank line
+function six() {
+    return 6;
+}
+const x = 1;
+function seven() {
+    return 7;
+}
+
+// Exported functions
+export function eight() {
+    return 8;
+}
+export function nine() {
+    return 9;
+}
+
+// Default export followed by named function
+function ten() {
+    return 10;
+}
+export default function eleven() {
+    return 11;
+}
+
+// Functions inside a block
+{
+    function innerOne() {
+        return 1;
+    }
+    function innerTwo() {
+        return 2;
+    }
+}

--- a/crates/oxc_formatter/tests/fixtures/js/function-blank-lines/consecutive-functions.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/function-blank-lines/consecutive-functions.js.snap
@@ -1,0 +1,221 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Consecutive function declarations without blank lines should get one added
+function one() {
+    return 1;
+}
+function two() {
+    return 2;
+}
+function three() {
+    return 3;
+}
+
+// Already has blank lines - should be preserved
+function four() {
+    return 4;
+}
+
+function five() {
+    return 5;
+}
+
+// Multiple blank lines between functions should be reduced to one
+
+
+
+function twelve() {
+    return 12;
+}
+
+
+
+function thirteen() {
+    return 13;
+}
+
+// Non-function between functions - no forced blank line
+function six() {
+    return 6;
+}
+const x = 1;
+function seven() {
+    return 7;
+}
+
+// Exported functions
+export function eight() {
+    return 8;
+}
+export function nine() {
+    return 9;
+}
+
+// Default export followed by named function
+function ten() {
+    return 10;
+}
+export default function eleven() {
+    return 11;
+}
+
+// Functions inside a block
+{
+    function innerOne() {
+        return 1;
+    }
+    function innerTwo() {
+        return 2;
+    }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Consecutive function declarations without blank lines should get one added
+function one() {
+  return 1;
+}
+
+function two() {
+  return 2;
+}
+
+function three() {
+  return 3;
+}
+
+// Already has blank lines - should be preserved
+function four() {
+  return 4;
+}
+
+function five() {
+  return 5;
+}
+
+// Multiple blank lines between functions should be reduced to one
+
+function twelve() {
+  return 12;
+}
+
+function thirteen() {
+  return 13;
+}
+
+// Non-function between functions - no forced blank line
+function six() {
+  return 6;
+}
+const x = 1;
+function seven() {
+  return 7;
+}
+
+// Exported functions
+export function eight() {
+  return 8;
+}
+
+export function nine() {
+  return 9;
+}
+
+// Default export followed by named function
+function ten() {
+  return 10;
+}
+
+export default function eleven() {
+  return 11;
+}
+
+// Functions inside a block
+{
+  function innerOne() {
+    return 1;
+  }
+
+  function innerTwo() {
+    return 2;
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Consecutive function declarations without blank lines should get one added
+function one() {
+  return 1;
+}
+
+function two() {
+  return 2;
+}
+
+function three() {
+  return 3;
+}
+
+// Already has blank lines - should be preserved
+function four() {
+  return 4;
+}
+
+function five() {
+  return 5;
+}
+
+// Multiple blank lines between functions should be reduced to one
+
+function twelve() {
+  return 12;
+}
+
+function thirteen() {
+  return 13;
+}
+
+// Non-function between functions - no forced blank line
+function six() {
+  return 6;
+}
+const x = 1;
+function seven() {
+  return 7;
+}
+
+// Exported functions
+export function eight() {
+  return 8;
+}
+
+export function nine() {
+  return 9;
+}
+
+// Default export followed by named function
+function ten() {
+  return 10;
+}
+
+export default function eleven() {
+  return 11;
+}
+
+// Functions inside a block
+{
+  function innerOne() {
+    return 1;
+  }
+
+  function innerTwo() {
+    return 2;
+  }
+}
+
+===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/unicode/emoji-sequences.js.snap
@@ -31,6 +31,7 @@ export async function deleteTestWorkspaceAPI() {
     `🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`,
   );
 }
+
 export async function deleteTestWorkspaceAPI2() {
   // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
   console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
@@ -52,6 +53,7 @@ export async function deleteTestWorkspaceAPI() {
   // THIS SHOULD BREAK WITH PRINT WIDTH 80
   console.log(`🗑️ DELETED => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);
 }
+
 export async function deleteTestWorkspaceAPI2() {
   // THIS SHOULD NOT BREAK WITH PRINT WIDTH 80
   console.log(`🗑️ DELETE => TEST WORKSPACE on ${baseURL} (Team ID: ${teamId})`);

--- a/crates/oxc_formatter/tests/fixtures/ts/comments/yield.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/comments/yield.ts.snap
@@ -73,12 +73,14 @@ function* t1() {
     a as any
   );
 }
+
 function* t2() {
   yield (
     // comment
     (a as any) + 1
   );
 }
+
 function* t3() {
   yield (
     // comment
@@ -87,42 +89,49 @@ function* t3() {
       : 1
   );
 }
+
 function* t4() {
   yield (
     // comment
     (a as any).b
   );
 }
+
 function* t5() {
   yield (
     // comment
     (a as any)[a]
   );
 }
+
 function* t6() {
   yield (
     // comment
     (a as any)()
   );
 }
+
 function* t7() {
   yield (
     // comment
     (a as any)``
   );
 }
+
 function* t8() {
   yield (
     // comment
     a as any as any
   );
 }
+
 function* t9() {
   yield (
     // comment
     a as any satisfies any
   );
 }
+
 function* t10() {
   yield (
     // comment
@@ -139,12 +148,14 @@ function* t1() {
     a as any
   );
 }
+
 function* t2() {
   yield (
     // comment
     (a as any) + 1
   );
 }
+
 function* t3() {
   yield (
     // comment
@@ -153,42 +164,49 @@ function* t3() {
       : 1
   );
 }
+
 function* t4() {
   yield (
     // comment
     (a as any).b
   );
 }
+
 function* t5() {
   yield (
     // comment
     (a as any)[a]
   );
 }
+
 function* t6() {
   yield (
     // comment
     (a as any)()
   );
 }
+
 function* t7() {
   yield (
     // comment
     (a as any)``
   );
 }
+
 function* t8() {
   yield (
     // comment
     a as any as any
   );
 }
+
 function* t9() {
   yield (
     // comment
     a as any satisfies any
   );
 }
+
 function* t10() {
   yield (
     // comment

--- a/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/function-parameters/comment-after-param-name.ts.snap
@@ -36,6 +36,7 @@ const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
 
 // Optional parameters with comments
 function optional(x? /* comment */ : number) {}
+
 function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}
 
 -------------------
@@ -55,6 +56,7 @@ const arrow = (x /* c1 */ : number, y /* c2 */ : string) => {};
 
 // Optional parameters with comments
 function optional(x? /* comment */ : number) {}
+
 function optionalMultiple(a? /* c1 */ : string, b? /* c2 */ : number) {}
 
 ===================== End =====================


### PR DESCRIPTION
Closes #19821.

## Summary

- Automatically normalizes blank lines between consecutive function declarations to exactly one
- Adds a blank line when none exists between consecutive functions
- Reduces multiple blank lines to a single one
- Handles plain `function` declarations, `export function`, `export default function`, and functions inside blocks

## Changes

- **`builders.rs`**: Added `entry_with_forced_empty_line` method to `JoinNodesBuilder` that inserts an `empty_line()` before an entry regardless of source formatting
- **`program.rs`**: Added `is_function_like_declaration` helper and modified `FormatProgramBody` to detect consecutive function declarations at the program (top) level and force a blank line between them
- **`block_statement.rs`**: Applied the same consecutive function detection logic for functions inside blocks

## Test plan

- Added new test fixture `consecutive-functions.js` covering:
  - Consecutive functions with no blank line (adds one)
  - Consecutive functions with existing single blank line (preserved)
  - Consecutive functions with multiple blank lines (reduced to one)
  - Non-function statement between functions (no forced blank line)
  - Exported functions (`export function`)
  - Default exported functions (`export default function`)
  - Functions inside a block scope
- 3 existing snapshots updated to reflect the new behavior
- All 194 formatter tests pass

Used Claude Code to help implement this