### PR TITLE
fix(tools): fix cargo-shear warning in benchmarks

### DIFF
--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -135,6 +135,7 @@ ignored = [
   "oxc_ast",
   "oxc_ast_visit",
   "oxc_codegen",
+  "oxc_estree_tokens",
   "oxc_formatter",
   "oxc_isolated_declarations",
   "oxc_linter",


### PR DESCRIPTION
`cargo-shear` is giving warnings on `tasks/benchmark`. Fix that.