### PR TITLE
refactor(estree/tokens): rename `UpdateContext` to `RawContext`

### DIFF
--- a/crates/oxc_estree_tokens/src/context.rs
+++ b/crates/oxc_estree_tokens/src/context.rs
@@ -5,13 +5,13 @@ use oxc_ast::ast::{RegExpLiteral, TemplateElement};
 use crate::{jsx_state::JSXState, token_type::TokenType, visitor::Visitor};
 
 /// Trait abstracting over the two token processing modes:
-/// JSON serialization ([`JsonContext`]) and in-place kind update ([`UpdateContext`]).
+/// JSON serialization ([`JsonContext`]) and raw transfer ([`RawContext`]).
 ///
 /// Each implementation holds its own `options` and `jsx_state`, so `is_ts` / `is_js`
 /// resolve statically when the generic `O: ESTreeTokenConfig` is monomorphized.
 ///
 /// [`JsonContext`]: crate::json::JsonContext
-/// [`UpdateContext`]: crate::raw_transfer::UpdateContext
+/// [`RawContext`]: crate::raw_transfer::RawContext
 pub trait Context: Sized {
     /// JSX state type for tracking when to emit JSX identifiers.
     type JSXState: JSXState;
@@ -26,45 +26,45 @@ pub trait Context: Sized {
         !self.is_ts()
     }
 
-    /// Get reference to [`JSXState`] for the serializer/updater.
+    /// Get reference to [`JSXState`].
     fn jsx_state(&self) -> &Self::JSXState;
 
-    /// Get mutable reference to [`JSXState`] for the serializer/updater.
+    /// Get mutable reference to [`JSXState`].
     fn jsx_state_mut(&mut self) -> &mut Self::JSXState;
 
     /// Emit the token at `start` as an identifier.
     ///
     /// * JSON mode: Serialize with type `Identifier` or `Keyword`.
-    /// * Update mode: Set kind to `Kind::Ident`, unless in JS style and the token is `yield` / `let` / `static`
+    /// * Raw transfer mode: Set kind to `Kind::Ident`, unless in JS style and the token is `yield` / `let` / `static`
     ///   (which should remain as `Keyword`).
     fn emit_identifier_at(&mut self, start: u32, name: &str);
 
     /// Emit the `this` keyword at `start` as `Identifier`.
     ///
     /// * JSON mode: Serialize as `Identifier` / `"this"`.
-    /// * Update mode: Set kind to `Kind::Ident`.
+    /// * Raw transfer mode: Set kind to `Kind::Ident`.
     fn emit_this_identifier_at(&mut self, start: u32);
 
     /// Emit the token at `start` as `JSXIdentifier`.
     ///
     /// * JSON mode: Serialize as `JSXIdentifier`.
-    /// * Update mode: Set kind to `Kind::JSXIdentifier`.
+    /// * Raw transfer mode: Set kind to `Kind::JSXIdentifier`.
     fn emit_jsx_identifier_at(&mut self, start: u32, name: &str);
 
     /// Emit the token at `start` as `PrivateIdentifier`.
     ///
     /// * JSON mode: Serialize with appropriate encoding.
-    /// * Update mode: No-op (token already has `Kind::PrivateIdentifier`).
+    /// * Raw transfer mode: No-op (token already has `Kind::PrivateIdentifier`).
     fn emit_private_identifier_at(&mut self, start: u32, name: &str);
 
     /// Emit a `StringLiteral` in a JSX attribute as `JSXText`.
     ///
-    /// Unlike [`emit_unsafe_token_at`], this changes the token's kind in update mode,
+    /// Unlike [`emit_unsafe_token_at`], this changes the token's kind in raw transfer mode,
     /// because the token has `Kind::Str` but needs to become `Kind::JSXText`.
     /// Use [`emit_unsafe_token_at`] for actual `JSXText` tokens which already have the correct kind.
     ///
     /// * JSON mode: Serialize as `JSXText` with JSON encoding.
-    /// * Update mode: Set kind to `Kind::JSXText`.
+    /// * Raw transfer mode: Set kind to `Kind::JSXText`.
     ///
     /// [`emit_unsafe_token_at`]: Context::emit_unsafe_token_at
     fn emit_jsx_text_at(&mut self, start: u32);
@@ -72,19 +72,19 @@ pub trait Context: Sized {
     /// Emit a token whose value may not be JSON-safe (strings, templates, JSXText).
     ///
     /// * JSON mode: Serialize with JSON encoding.
-    /// * Update mode: No-op (token already has the correct kind).
+    /// * Raw transfer mode: No-op (token already has the correct kind).
     fn emit_unsafe_token_at(&mut self, start: u32, token_type: TokenType);
 
     /// Emit a `RegularExpression` token.
     ///
     /// * JSON mode: Serialize using `ESTreeRegExpToken`.
-    /// * Update mode: No-op (token already has the correct kind).
+    /// * Raw transfer mode: No-op (token already has the correct kind).
     fn emit_regexp(&mut self, regexp: &RegExpLiteral<'_>);
 
     /// Walk template quasis interleaved with their interpolated parts (expressions or TS types).
     ///
     /// * JSON mode: Emit quasi tokens interleaved with interpolation visits.
-    /// * Update mode: Only visit interpolations (quasis don't need `Kind` changes).
+    /// * Raw transfer mode: Only visit interpolations (quasis don't need `Kind` changes).
     fn walk_template_quasis_interleaved<I>(
         visitor: &mut Visitor<Self>,
         quasis: &[TemplateElement<'_>],

--- a/crates/oxc_estree_tokens/src/json.rs
+++ b/crates/oxc_estree_tokens/src/json.rs
@@ -300,7 +300,7 @@ impl<O: ESTreeTokenConfig, S: SequenceSerializer> Context for JsonContext<'_, O,
         self.options.is_ts()
     }
 
-    /// Get reference to [`JSXState`] for the serializer/updater.
+    /// Get reference to [`JSXState`] for the context.
     ///
     /// [`JSXState`]: crate::jsx_state::JSXState
     #[expect(clippy::inline_always)]
@@ -309,7 +309,7 @@ impl<O: ESTreeTokenConfig, S: SequenceSerializer> Context for JsonContext<'_, O,
         &self.jsx_state
     }
 
-    /// Get mutable reference to [`JSXState`] for the serializer/updater.
+    /// Get mutable reference to [`JSXState`] for the context.
     ///
     /// [`JSXState`]: crate::jsx_state::JSXState
     #[expect(clippy::inline_always)]

--- a/crates/oxc_estree_tokens/src/lib.rs
+++ b/crates/oxc_estree_tokens/src/lib.rs
@@ -6,7 +6,7 @@
 //! 2. Update `Kind` of tokens in place so they can be deserialized on JS side (`raw_transfer.rs`).
 //!
 //! Both implementations share the same logic by utilizing the `Context` trait and AST visitor `Visitor`.
-//! `Context` trait is implemented by `JsonContext` and `UpdateContext`.
+//! `Context` trait is implemented by `JsonContext` and `RawContext`.
 //! The implementations only differ in how they process tokens sent to them by the visitor.
 //!
 //! Both implementations also convert UTF-8 spans to UTF-16.

--- a/crates/oxc_estree_tokens/src/visitor.rs
+++ b/crates/oxc_estree_tokens/src/visitor.rs
@@ -61,7 +61,7 @@ impl<'a, C: Context> Visit<'a> for Visitor<C> {
     fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
         // Manual walk.
         // * `source` is a `StringLiteral` — visit to ensure it's emitted with JSON encoding
-        //   (string values are not JSON-safe). No-op in update mode.
+        //   (string values are not JSON-safe). No-op in raw transfer mode.
         // * `options` is an `ObjectExpression`. Manually walk each property, but don't visit the key if it's `with`,
         //   as it needs to remain a `Keyword` token, not get converted to `Identifier`.
         // * `qualifier` and `type_arguments` are visited as usual.
@@ -229,13 +229,13 @@ impl<'a, C: Context> Visit<'a> for Visitor<C> {
     }
 
     fn visit_string_literal(&mut self, literal: &StringLiteral<'a>) {
-        // No-op in update mode - token's `Kind` is already `String`
+        // No-op in raw transfer mode - token's `Kind` is already `String`
         self.ctx.emit_unsafe_token_at(literal.span.start, TokenType::new("String"));
     }
 
     fn visit_jsx_text(&mut self, text: &JSXText<'a>) {
         // Use `emit_unsafe_token_at` not `emit_jsx_text_at`, as the token's `Kind` is already `JSXText`,
-        // so no-op in update mode
+        // so no-op in raw transfer mode
         self.ctx.emit_unsafe_token_at(text.span.start, TokenType::new("JSXText"));
     }
 
@@ -247,7 +247,7 @@ impl<'a, C: Context> Visit<'a> for Visitor<C> {
         match &attribute.value {
             Some(JSXAttributeValue::StringLiteral(string_literal)) => {
                 // Use `emit_jsx_text_at` not `emit_unsafe_token_at`, as the token `Kind`
-                // needs to be updated to `JSXText` in update mode
+                // needs to be set to `JSXText` in raw transfer mode
                 self.ctx.emit_jsx_text_at(string_literal.span.start);
             }
             Some(value) => self.visit_jsx_attribute_value(value),


### PR DESCRIPTION
Pure refactor. Rename `UpdateContext` to `RawContext`, and update references in comments.