### PR TITLE
feat(linter): add .oxlintrc.jsonc config file support

### DIFF
--- a/apps/oxlint/fixtures/auto_config_detection_jsonc/.oxlintrc.jsonc
+++ b/apps/oxlint/fixtures/auto_config_detection_jsonc/.oxlintrc.jsonc
@@ -1,5 +1,4 @@
 {
-  // Intentionally JSONC to verify auto config detection supports .jsonc.
   "categories": {
     "correctness": "off"
   },

--- a/apps/oxlint/fixtures/auto_config_detection_jsonc/.oxlintrc.jsonc
+++ b/apps/oxlint/fixtures/auto_config_detection_jsonc/.oxlintrc.jsonc
@@ -1,0 +1,9 @@
+{
+  // Intentionally JSONC to verify auto config detection supports .jsonc.
+  "categories": {
+    "correctness": "off"
+  },
+  "rules": {
+    "no-debugger": "error"
+  }
+}

--- a/apps/oxlint/fixtures/auto_config_detection_jsonc/debugger.js
+++ b/apps/oxlint/fixtures/auto_config_detection_jsonc/debugger.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -119,7 +119,7 @@ pub struct BasicOptions {
     ///  * you can use comments in configuration files.
     ///  * tries to be compatible with ESLint v8's format
     ///
-    /// If not provided, Oxlint will look for a `.oxlintrc.json` or `oxlint.config.ts` file in the current working directory.
+    /// If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` file in the current working directory.
     #[bpaf(long, short, argument("./.oxlintrc.json"))]
     pub config: Option<PathBuf>,
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -114,7 +114,7 @@ impl LintCommand {
 #[derive(Debug, Clone, Bpaf)]
 pub struct BasicOptions {
     /// Oxlint configuration file
-    ///  * `.json` config files are supported in all runtimes
+    ///  * `.json` and `.jsonc` config files are supported in all runtimes
     ///  * JavaScript/TypeScript config files are experimental and require running via Node.js
     ///  * you can use comments in configuration files.
     ///  * tries to be compatible with ESLint v8's format
@@ -521,6 +521,7 @@ mod warning_options {
 mod lint_options {
     use std::{fs::File, path::PathBuf};
 
+    use insta::assert_snapshot;
     use oxc_linter::AllowWarnDeny;
 
     use super::{LintCommand, OutputFormat, lint_command};
@@ -637,6 +638,18 @@ mod lint_options {
         assert!(options.type_check);
         let options = get_lint_options(".");
         assert!(!options.type_check);
+    }
+
+    #[test]
+    fn help_mentions_jsonc_in_config_line() {
+        let help = lint_command().run_inner(&["--help"]).unwrap_err().unwrap_stdout();
+        let json_config_line = help
+            .lines()
+            .find(|line| line.contains("config files are supported in all runtimes"))
+            .expect("expected JSON/JSONC config support line in --help output")
+            .trim();
+
+        assert_snapshot!("lint_config_json_support_help_line", json_config_line);
     }
 }
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -521,7 +521,6 @@ mod warning_options {
 mod lint_options {
     use std::{fs::File, path::PathBuf};
 
-    use insta::assert_snapshot;
     use oxc_linter::AllowWarnDeny;
 
     use super::{LintCommand, OutputFormat, lint_command};
@@ -638,18 +637,6 @@ mod lint_options {
         assert!(options.type_check);
         let options = get_lint_options(".");
         assert!(!options.type_check);
-    }
-
-    #[test]
-    fn help_mentions_jsonc_in_config_line() {
-        let help = lint_command().run_inner(&["--help"]).unwrap_err().unwrap_stdout();
-        let json_config_line = help
-            .lines()
-            .find(|line| line.contains("config files are supported in all runtimes"))
-            .expect("expected JSON/JSONC config support line in --help output")
-            .trim();
-
-        assert_snapshot!("lint_config_json_support_help_line", json_config_line);
     }
 }
 

--- a/apps/oxlint/src/command/snapshots/oxlint__command__lint__lint_options__lint_config_json_support_help_line.snap
+++ b/apps/oxlint/src/command/snapshots/oxlint__command__lint__lint_options__lint_config_json_support_help_line.snap
@@ -1,5 +1,0 @@
----
-source: apps/oxlint/src/command/lint.rs
-expression: json_config_line
----
-* `.json` and `.jsonc` config files are supported in all runtimes

--- a/apps/oxlint/src/command/snapshots/oxlint__command__lint__lint_options__lint_config_json_support_help_line.snap
+++ b/apps/oxlint/src/command/snapshots/oxlint__command__lint__lint_options__lint_config_json_support_help_line.snap
@@ -1,0 +1,5 @@
+---
+source: apps/oxlint/src/command/lint.rs
+expression: json_config_line
+---
+* `.json` and `.jsonc` config files are supported in all runtimes

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -82,7 +82,7 @@ pub fn discover_configs_in_tree(root: &Path) -> impl IntoIterator<Item = Discove
 fn find_configs_in_directory(dir: &Path) -> Vec<DiscoveredConfig> {
     let mut configs = Vec::new();
 
-    // Prefer .json over .jsonc (check .json first)
+    // Collect both JSON config variants so conflicts can be diagnosed.
     let json_path = dir.join(DEFAULT_OXLINTRC_NAME);
     let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if json_path.is_file() {
@@ -308,7 +308,8 @@ impl<'a> ConfigLoader<'a> {
         let mut configs = Vec::new();
         let mut errors = Vec::new();
 
-        let mut by_dir = FxHashMap::<PathBuf, (Option<PathBuf>, Option<PathBuf>)>::default();
+        let mut by_dir =
+            FxHashMap::<PathBuf, (Option<PathBuf>, Option<PathBuf>, Option<PathBuf>)>::default();
 
         for config in paths {
             match config {
@@ -317,34 +318,33 @@ impl<'a> ConfigLoader<'a> {
                         continue;
                     };
                     let entry = by_dir.entry(dir).or_default();
-                    // Prefer .json over .jsonc: don't overwrite a .json path with a .jsonc path
-                    if entry
-                        .0
-                        .as_ref()
-                        .is_some_and(|p| p.extension().is_some_and(|ext| ext == "json"))
-                    {
-                        continue;
+                    if path.extension() == Some(OsStr::new("jsonc")) {
+                        entry.1 = Some(path);
+                    } else {
+                        entry.0 = Some(path);
                     }
-                    entry.0 = Some(path);
                 }
                 DiscoveredConfig::Js(path) => {
                     let Some(dir) = path.parent().map(Path::to_path_buf) else {
                         continue;
                     };
-                    by_dir.entry(dir).or_default().1 = Some(path);
+                    by_dir.entry(dir).or_default().2 = Some(path);
                 }
             }
         }
 
         let mut js_configs = Vec::new();
 
-        for (dir, (json_path, ts_path)) in by_dir {
-            if json_path.is_some() && ts_path.is_some() {
+        for (dir, (json_path, jsonc_path, ts_path)) in by_dir {
+            let config_count = usize::from(json_path.is_some())
+                + usize::from(jsonc_path.is_some())
+                + usize::from(ts_path.is_some());
+            if config_count > 1 {
                 errors.push(ConfigLoadError::Diagnostic(config_conflict_diagnostic(&dir)));
                 continue;
             }
 
-            if let Some(path) = json_path {
+            if let Some(path) = json_path.or(jsonc_path) {
                 match Self::load(&path) {
                     Ok(config) => configs.push(config),
                     Err(e) => errors.push(e),
@@ -462,8 +462,9 @@ impl<'a> ConfigLoader<'a> {
         let jsonc_exists = jsonc_path.is_file();
         let ts_exists = ts_path.is_file();
 
-        // Error if any JSON config conflicts with TS config
-        if (json_exists || jsonc_exists) && ts_exists {
+        let config_count =
+            usize::from(json_exists) + usize::from(jsonc_exists) + usize::from(ts_exists);
+        if config_count > 1 {
             return Err(config_conflict_diagnostic(dir));
         }
 
@@ -1101,7 +1102,7 @@ mod test {
     }
 
     #[test]
-    fn test_json_preferred_over_jsonc() {
+    fn test_json_and_jsonc_conflict() {
         let root_dir = tempfile::tempdir().unwrap();
         // Create both .oxlintrc.json and .oxlintrc.jsonc
         std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
@@ -1115,13 +1116,39 @@ mod test {
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
         let result = loader.load_root_config(root_dir.path(), None);
-        assert!(result.is_ok(), "Expected .oxlintrc.json to be preferred over .oxlintrc.jsonc");
-        let config = result.unwrap();
         assert!(
-            config.path.to_string_lossy().ends_with(".oxlintrc.json")
-                && !config.path.to_string_lossy().ends_with(".oxlintrc.jsonc"),
-            "Expected config path to end with .oxlintrc.json (not .jsonc), got: {}",
-            config.path.display()
+            result.is_err(),
+            "Expected an error when both .oxlintrc.json and .oxlintrc.jsonc exist"
         );
+    }
+
+    #[test]
+    fn test_json_and_ts_conflict() {
+        let root_dir = tempfile::tempdir().unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
+        std::fs::write(root_dir.path().join("oxlint.config.ts"), "export default {};").unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_err(), "Expected an error when both JSON and TS configs exist");
+    }
+
+    #[test]
+    fn test_jsonc_and_ts_conflict() {
+        let root_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root_dir.path().join(".oxlintrc.jsonc"),
+            r#"{ /* comment */ "rules": {} }"#,
+        )
+        .unwrap();
+        std::fs::write(root_dir.path().join("oxlint.config.ts"), "export default {};").unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_err(), "Expected an error when both JSONC and TS configs exist");
     }
 }

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -82,12 +82,11 @@ pub fn discover_configs_in_tree(root: &Path) -> impl IntoIterator<Item = Discove
 fn find_configs_in_directory(dir: &Path) -> Vec<DiscoveredConfig> {
     let mut configs = Vec::new();
 
-    // Collect both JSON config variants so conflicts can be diagnosed.
     let json_path = dir.join(DEFAULT_OXLINTRC_NAME);
-    let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if json_path.is_file() {
         configs.push(DiscoveredConfig::Json(json_path));
     }
+    let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if jsonc_path.is_file() {
         configs.push(DiscoveredConfig::Json(jsonc_path));
     }
@@ -340,7 +339,12 @@ impl<'a> ConfigLoader<'a> {
                 + usize::from(jsonc_path.is_some())
                 + usize::from(ts_path.is_some());
             if config_count > 1 {
-                errors.push(ConfigLoadError::Diagnostic(config_conflict_diagnostic(&dir)));
+                errors.push(ConfigLoadError::Diagnostic(config_conflict_diagnostic(
+                    &dir,
+                    json_path.is_some(),
+                    jsonc_path.is_some(),
+                    ts_path.is_some(),
+                )));
                 continue;
             }
 
@@ -465,14 +469,13 @@ impl<'a> ConfigLoader<'a> {
         let config_count =
             usize::from(json_exists) + usize::from(jsonc_exists) + usize::from(ts_exists);
         if config_count > 1 {
-            return Err(config_conflict_diagnostic(dir));
+            return Err(config_conflict_diagnostic(dir, json_exists, jsonc_exists, ts_exists));
         }
 
         if ts_exists {
             return self.load_root_js_config(&ts_path).map(Some);
         }
 
-        // Prefer .json over .jsonc
         if json_exists {
             return Oxlintrc::from_file(&json_path).map(Some);
         }
@@ -647,13 +650,43 @@ pub fn build_nested_configs(
     nested_configs
 }
 
-fn config_conflict_diagnostic(dir: &Path) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!(
-        "Both '{}' and '{}' found in {}.",
-        DEFAULT_OXLINTRC_NAME,
-        DEFAULT_TS_OXLINTRC_NAME,
-        dir.display()
-    ))
+fn config_conflict_diagnostic(
+    dir: &Path,
+    has_json: bool,
+    has_jsonc: bool,
+    has_ts: bool,
+) -> OxcDiagnostic {
+    fn format_conflicting_config_names(config_names: &[&str]) -> String {
+        debug_assert!(config_names.len() > 1);
+
+        let mut quoted_names =
+            config_names.iter().map(|name| format!("'{name}'")).collect::<Vec<_>>();
+        if quoted_names.len() == 2 {
+            return format!("{} and {}", quoted_names[0], quoted_names[1]);
+        }
+
+        let last = quoted_names.pop().unwrap();
+        format!("{}, and {last}", quoted_names.join(", "))
+    }
+    let mut config_names = Vec::with_capacity(3);
+    if has_json {
+        config_names.push(DEFAULT_OXLINTRC_NAME);
+    }
+    if has_jsonc {
+        config_names.push(DEFAULT_JSONC_OXLINTRC_NAME);
+    }
+    if has_ts {
+        config_names.push(DEFAULT_TS_OXLINTRC_NAME);
+    }
+
+    let config_list = format_conflicting_config_names(&config_names);
+    let message = if config_names.len() == 2 {
+        format!("Both {config_list} found in {}.", dir.display())
+    } else {
+        format!("Multiple config files found in {}: {config_list}.", dir.display())
+    };
+
+    OxcDiagnostic::error(message)
     .with_note("Only one of `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` is allowed per directory.")
     .with_help("Delete one of the configuration files.")
 }

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -20,6 +20,7 @@ use crate::js_config;
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub enum DiscoveredConfig {
     Json(PathBuf),
+    Jsonc(PathBuf),
     Js(PathBuf),
 }
 
@@ -30,7 +31,7 @@ pub enum DiscoveredConfig {
 ///
 /// Example: For files `/project/src/foo.js` and `/project/src/bar/baz.js`:
 /// - Checks `/project/src/bar/`, `/project/src/`, `/project/`, `/`
-/// - Returns paths to any `.oxlintrc.json` files found
+/// - Returns paths to any `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` files found
 pub fn discover_configs_in_ancestors<P: AsRef<Path>>(
     files: &[P],
 ) -> impl IntoIterator<Item = DiscoveredConfig> {
@@ -88,7 +89,7 @@ fn find_configs_in_directory(dir: &Path) -> Vec<DiscoveredConfig> {
     }
     let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if jsonc_path.is_file() {
-        configs.push(DiscoveredConfig::Json(jsonc_path));
+        configs.push(DiscoveredConfig::Jsonc(jsonc_path));
     }
 
     let ts_path = dir.join(DEFAULT_TS_OXLINTRC_NAME);
@@ -142,8 +143,10 @@ fn to_discovered_config(entry: &DirEntry) -> Option<DiscoveredConfig> {
         return None;
     }
     let file_name = entry.path().file_name()?;
-    if file_name == DEFAULT_OXLINTRC_NAME || file_name == DEFAULT_JSONC_OXLINTRC_NAME {
+    if file_name == DEFAULT_OXLINTRC_NAME {
         Some(DiscoveredConfig::Json(entry.path().to_path_buf()))
+    } else if file_name == DEFAULT_JSONC_OXLINTRC_NAME {
+        Some(DiscoveredConfig::Jsonc(entry.path().to_path_buf()))
     } else if file_name == DEFAULT_TS_OXLINTRC_NAME {
         Some(DiscoveredConfig::Js(entry.path().to_path_buf()))
     } else {
@@ -316,12 +319,13 @@ impl<'a> ConfigLoader<'a> {
                     let Some(dir) = path.parent().map(Path::to_path_buf) else {
                         continue;
                     };
-                    let entry = by_dir.entry(dir).or_default();
-                    if path.extension() == Some(OsStr::new("jsonc")) {
-                        entry.1 = Some(path);
-                    } else {
-                        entry.0 = Some(path);
-                    }
+                    by_dir.entry(dir).or_default().0 = Some(path);
+                }
+                DiscoveredConfig::Jsonc(path) => {
+                    let Some(dir) = path.parent().map(Path::to_path_buf) else {
+                        continue;
+                    };
+                    by_dir.entry(dir).or_default().1 = Some(path);
                 }
                 DiscoveredConfig::Js(path) => {
                     let Some(dir) = path.parent().map(Path::to_path_buf) else {

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -87,7 +87,8 @@ fn find_configs_in_directory(dir: &Path) -> Vec<DiscoveredConfig> {
     let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if json_path.is_file() {
         configs.push(DiscoveredConfig::Json(json_path));
-    } else if jsonc_path.is_file() {
+    }
+    if jsonc_path.is_file() {
         configs.push(DiscoveredConfig::Json(jsonc_path));
     }
 

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -12,7 +12,7 @@ use oxc_linter::{
 };
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use crate::{DEFAULT_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME};
+use crate::{DEFAULT_JSONC_OXLINTRC_NAME, DEFAULT_OXLINTRC_NAME, DEFAULT_TS_OXLINTRC_NAME};
 
 #[cfg(feature = "napi")]
 use crate::js_config;
@@ -82,9 +82,13 @@ pub fn discover_configs_in_tree(root: &Path) -> impl IntoIterator<Item = Discove
 fn find_configs_in_directory(dir: &Path) -> Vec<DiscoveredConfig> {
     let mut configs = Vec::new();
 
+    // Prefer .json over .jsonc (check .json first)
     let json_path = dir.join(DEFAULT_OXLINTRC_NAME);
+    let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
     if json_path.is_file() {
         configs.push(DiscoveredConfig::Json(json_path));
+    } else if jsonc_path.is_file() {
+        configs.push(DiscoveredConfig::Json(jsonc_path));
     }
 
     let ts_path = dir.join(DEFAULT_TS_OXLINTRC_NAME);
@@ -138,7 +142,7 @@ fn to_discovered_config(entry: &DirEntry) -> Option<DiscoveredConfig> {
         return None;
     }
     let file_name = entry.path().file_name()?;
-    if file_name == DEFAULT_OXLINTRC_NAME {
+    if file_name == DEFAULT_OXLINTRC_NAME || file_name == DEFAULT_JSONC_OXLINTRC_NAME {
         Some(DiscoveredConfig::Json(entry.path().to_path_buf()))
     } else if file_name == DEFAULT_TS_OXLINTRC_NAME {
         Some(DiscoveredConfig::Js(entry.path().to_path_buf()))
@@ -311,7 +315,16 @@ impl<'a> ConfigLoader<'a> {
                     let Some(dir) = path.parent().map(Path::to_path_buf) else {
                         continue;
                     };
-                    by_dir.entry(dir).or_default().0 = Some(path);
+                    let entry = by_dir.entry(dir).or_default();
+                    // Prefer .json over .jsonc: don't overwrite a .json path with a .jsonc path
+                    if entry
+                        .0
+                        .as_ref()
+                        .is_some_and(|p| p.extension().is_some_and(|ext| ext == "json"))
+                    {
+                        continue;
+                    }
+                    entry.0 = Some(path);
                 }
                 DiscoveredConfig::Js(path) => {
                     let Some(dir) = path.parent().map(Path::to_path_buf) else {
@@ -441,12 +454,15 @@ impl<'a> ConfigLoader<'a> {
     /// Returns `Ok(Some(config))` if found, `Ok(None)` if not found, or `Err` on error.
     fn try_load_config_from_dir(&self, dir: &Path) -> Result<Option<Oxlintrc>, OxcDiagnostic> {
         let json_path = dir.join(DEFAULT_OXLINTRC_NAME);
+        let jsonc_path = dir.join(DEFAULT_JSONC_OXLINTRC_NAME);
         let ts_path = dir.join(DEFAULT_TS_OXLINTRC_NAME);
 
         let json_exists = json_path.is_file();
+        let jsonc_exists = jsonc_path.is_file();
         let ts_exists = ts_path.is_file();
 
-        if json_exists && ts_exists {
+        // Error if any JSON config conflicts with TS config
+        if (json_exists || jsonc_exists) && ts_exists {
             return Err(config_conflict_diagnostic(dir));
         }
 
@@ -454,8 +470,12 @@ impl<'a> ConfigLoader<'a> {
             return self.load_root_js_config(&ts_path).map(Some);
         }
 
+        // Prefer .json over .jsonc
         if json_exists {
             return Oxlintrc::from_file(&json_path).map(Some);
+        }
+        if jsonc_exists {
+            return Oxlintrc::from_file(&jsonc_path).map(Some);
         }
 
         Ok(None)
@@ -632,7 +652,7 @@ fn config_conflict_diagnostic(dir: &Path) -> OxcDiagnostic {
         DEFAULT_TS_OXLINTRC_NAME,
         dir.display()
     ))
-    .with_note("Only `.oxlintrc.json` or `oxlint.config.ts` are allowed, not both.")
+    .with_note("Only one of `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` is allowed per directory.")
     .with_help("Delete one of the configuration files.")
 }
 
@@ -641,7 +661,7 @@ fn js_config_not_supported_diagnostic(path: &Path) -> OxcDiagnostic {
         "JavaScript/TypeScript config file ({}) found but JS runtime not available.",
         path.display()
     ))
-    .with_help("Run oxlint via the npm package, or use JSON config files (.oxlintrc.json).")
+    .with_help("Run oxlint via the npm package, or use JSON config files (.oxlintrc.json or .oxlintrc.jsonc).")
 }
 
 fn is_js_config_path(path: &Path) -> bool {
@@ -1054,5 +1074,53 @@ mod test {
             .load_discovered_with_root_dir(root_dir.path(), [DiscoveredConfig::Js(nested_path)]);
         assert_eq!(errors.len(), 1);
         assert!(matches!(errors[0], ConfigLoadError::Diagnostic(_)));
+    }
+
+    #[test]
+    fn test_jsonc_config_discovery() {
+        let root_dir = tempfile::tempdir().unwrap();
+        // Create only a .oxlintrc.jsonc file
+        std::fs::write(
+            root_dir.path().join(".oxlintrc.jsonc"),
+            r#"{ /* comment */ "rules": {} }"#,
+        )
+        .unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_ok(), "Expected .oxlintrc.jsonc to be discovered and loaded");
+        let config = result.unwrap();
+        assert!(
+            config.path.to_string_lossy().ends_with(".oxlintrc.jsonc"),
+            "Expected config path to end with .oxlintrc.jsonc, got: {}",
+            config.path.display()
+        );
+    }
+
+    #[test]
+    fn test_json_preferred_over_jsonc() {
+        let root_dir = tempfile::tempdir().unwrap();
+        // Create both .oxlintrc.json and .oxlintrc.jsonc
+        std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
+        std::fs::write(
+            root_dir.path().join(".oxlintrc.jsonc"),
+            r#"{ /* comment */ "rules": {} }"#,
+        )
+        .unwrap();
+
+        let mut external_plugin_store = ExternalPluginStore::new(false);
+        let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
+
+        let result = loader.load_root_config(root_dir.path(), None);
+        assert!(result.is_ok(), "Expected .oxlintrc.json to be preferred over .oxlintrc.jsonc");
+        let config = result.unwrap();
+        assert!(
+            config.path.to_string_lossy().ends_with(".oxlintrc.json")
+                && !config.path.to_string_lossy().ends_with(".oxlintrc.jsonc"),
+            "Expected config path to end with .oxlintrc.json (not .jsonc), got: {}",
+            config.path.display()
+        );
     }
 }

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -1082,11 +1082,8 @@ mod test {
     fn test_jsonc_config_discovery() {
         let root_dir = tempfile::tempdir().unwrap();
         // Create only a .oxlintrc.jsonc file
-        std::fs::write(
-            root_dir.path().join(".oxlintrc.jsonc"),
-            r#"{ /* comment */ "rules": {} }"#,
-        )
-        .unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.jsonc"), r#"{ /* comment */ "rules": {} }"#)
+            .unwrap();
 
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
@@ -1106,11 +1103,8 @@ mod test {
         let root_dir = tempfile::tempdir().unwrap();
         // Create both .oxlintrc.json and .oxlintrc.jsonc
         std::fs::write(root_dir.path().join(".oxlintrc.json"), r#"{ "rules": {} }"#).unwrap();
-        std::fs::write(
-            root_dir.path().join(".oxlintrc.jsonc"),
-            r#"{ /* comment */ "rules": {} }"#,
-        )
-        .unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.jsonc"), r#"{ /* comment */ "rules": {} }"#)
+            .unwrap();
 
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
@@ -1138,11 +1132,8 @@ mod test {
     #[test]
     fn test_jsonc_and_ts_conflict() {
         let root_dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            root_dir.path().join(".oxlintrc.jsonc"),
-            r#"{ /* comment */ "rules": {} }"#,
-        )
-        .unwrap();
+        std::fs::write(root_dir.path().join(".oxlintrc.jsonc"), r#"{ /* comment */ "rules": {} }"#)
+            .unwrap();
         std::fs::write(root_dir.path().join("oxlint.config.ts"), "export default {};").unwrap();
 
         let mut external_plugin_store = ExternalPluginStore::new(false);

--- a/apps/oxlint/src/lib.rs
+++ b/apps/oxlint/src/lib.rs
@@ -57,6 +57,7 @@ mod js_plugins;
 static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 const DEFAULT_OXLINTRC_NAME: &str = ".oxlintrc.json";
+const DEFAULT_JSONC_OXLINTRC_NAME: &str = ".oxlintrc.jsonc";
 const DEFAULT_TS_OXLINTRC_NAME: &str = "oxlint.config.ts";
 
 /// Return a JSON blob containing metadata for all available oxlint rules.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -255,7 +255,7 @@ impl CliRunner {
                                 ConfigLoadError::JsConfigFileFoundButJsRuntimeNotAvailable => {
                                     "Error: JavaScript/TypeScript config files found but JS runtime not available.\n\
                                      This is an experimental feature that requires running oxlint via Node.js.\n\
-                                     Please use JSON config files (.oxlintrc.json) instead, or run oxlint via the npm package.\n".to_string()
+                                     Please use JSON config files (.oxlintrc.json or .oxlintrc.jsonc) instead, or run oxlint via the npm package.\n".to_string()
                                 }
                                 ConfigLoadError::Diagnostic(error) => {
                                     let report = render_report(&handler, error);

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -730,6 +730,14 @@ mod test {
     }
 
     #[test]
+    fn oxlint_config_auto_detection_jsonc() {
+        let args = &["debugger.js"];
+        Tester::new()
+            .with_cwd("fixtures/auto_config_detection_jsonc".into())
+            .test_and_snapshot(args);
+    }
+
+    #[test]
     #[cfg(not(target_os = "windows"))] // Skipped on Windows due to snapshot diffs from path separators (`/` vs `\`)
     fn oxlint_config_auto_detection_parse_error() {
         let args = &["debugger.js"];

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -482,15 +482,21 @@ impl Tool for ServerLinter {
         };
         let mut watchers = match options.config_path.as_deref() {
             Some("") | None => {
-                // Watch both JSON and TS config files
-                vec!["**/.oxlintrc.json".to_string(), "**/oxlint.config.ts".to_string()]
+                // Watch both JSON/JSONC and TS config files
+                vec![
+                    "**/.oxlintrc.json".to_string(),
+                    "**/.oxlintrc.jsonc".to_string(),
+                    "**/oxlint.config.ts".to_string(),
+                ]
             }
             Some(v) => vec![v.to_string()],
         };
 
         for path in &self.extended_paths {
             // ignore .oxlintrc.json and oxlint.config.ts files when using nested configs
-            if (path.ends_with(".oxlintrc.json") || path.ends_with("oxlint.config.ts"))
+            if (path.ends_with(".oxlintrc.json")
+                || path.ends_with(".oxlintrc.jsonc")
+                || path.ends_with("oxlint.config.ts"))
                 && options.use_nested_configs()
             {
                 continue;
@@ -1034,9 +1040,10 @@ mod test_watchers {
             let patterns =
                 Tester::new("fixtures/lsp/watchers/default", json!({})).get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 2);
+            assert_eq!(patterns.len(), 3);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
-            assert_eq!(patterns[1], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
+            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
         }
 
         #[test]
@@ -1049,9 +1056,10 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 2);
+            assert_eq!(patterns.len(), 3);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
-            assert_eq!(patterns[1], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
+            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
         }
 
         #[test]
@@ -1073,11 +1081,12 @@ mod test_watchers {
             let patterns = Tester::new("fixtures/lsp/watchers/linter_extends", json!({}))
                 .get_watcher_patterns();
 
-            // The `.oxlintrc.json` extends `./lint.json` -> 3 watchers (json, ts, lint.json)
-            assert_eq!(patterns.len(), 3);
+            // The `.oxlintrc.json` extends `./lint.json` -> 4 watchers (json, jsonc, ts, lint.json)
+            assert_eq!(patterns.len(), 4);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
-            assert_eq!(patterns[1], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[2], "lint.json".to_string());
+            assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
+            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "lint.json".to_string());
         }
 
         #[test]
@@ -1105,10 +1114,11 @@ mod test_watchers {
             )
             .get_watcher_patterns();
 
-            assert_eq!(patterns.len(), 3);
+            assert_eq!(patterns.len(), 4);
             assert_eq!(patterns[0], "**/.oxlintrc.json".to_string());
-            assert_eq!(patterns[1], "**/oxlint.config.ts".to_string());
-            assert_eq!(patterns[2], "**/tsconfig*.json".to_string());
+            assert_eq!(patterns[1], "**/.oxlintrc.jsonc".to_string());
+            assert_eq!(patterns[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(patterns[3], "**/tsconfig*.json".to_string());
         }
     }
 
@@ -1159,10 +1169,11 @@ mod test_watchers {
                         "typeAware": true
                     }));
             assert!(watch_patterns.is_some());
-            assert_eq!(watch_patterns.as_ref().unwrap().len(), 3);
+            assert_eq!(watch_patterns.as_ref().unwrap().len(), 4);
             assert_eq!(watch_patterns.as_ref().unwrap()[0], "**/.oxlintrc.json".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[1], "**/oxlint.config.ts".to_string());
-            assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/tsconfig*.json".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[1], "**/.oxlintrc.jsonc".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[2], "**/oxlint.config.ts".to_string());
+            assert_eq!(watch_patterns.as_ref().unwrap()[3], "**/tsconfig*.json".to_string());
         }
     }
 }

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_jsonc_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_jsonc_debugger.js@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: debugger.js
+working directory: fixtures/auto_config_detection_jsonc
+----------
+
+  x eslint(no-debugger): `debugger` statement is not allowed
+   ,-[debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 1 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/test/fixtures/js_config_conflict/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_conflict/output.snap.md
@@ -7,7 +7,7 @@ Failed to parse oxlint configuration file.
 
   x Both '.oxlintrc.json' and 'oxlint.config.ts' found in <fixtures>/js_config_conflict.
   help: Delete one of the configuration files.
-  note: Only `.oxlintrc.json` or `oxlint.config.ts` are allowed, not both.
+  note: Only one of `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` is allowed per directory.
 ```
 
 # stderr

--- a/apps/oxlint/test/fixtures/js_config_nested_conflict/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_nested_conflict/output.snap.md
@@ -7,7 +7,7 @@ Failed to parse oxlint configuration file.
 
   x Both '.oxlintrc.json' and 'oxlint.config.ts' found in <fixture>/files/nested.
   help: Delete one of the configuration files.
-  note: Only `.oxlintrc.json` or `oxlint.config.ts` are allowed, not both.
+  note: Only one of `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` is allowed per directory.
 ```
 
 # stderr

--- a/apps/oxlint/test/lsp/init/init.test.ts
+++ b/apps/oxlint/test/lsp/init/init.test.ts
@@ -37,8 +37,8 @@ describe("LSP initialization", () => {
   });
 
   it.each([
-    [undefined, ["**/.oxlintrc.json", "**/oxlint.config.ts"]],
-    [{ configPath: "" }, ["**/.oxlintrc.json", "**/oxlint.config.ts"]],
+    [undefined, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
+    [{ configPath: "" }, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
     [{ configPath: "./custom-config.json" }, ["./custom-config.json"]],
   ])(
     "should send correct dynamic watch pattern registration for config: %s",

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -13,12 +13,12 @@ search: false
 ## Basic Configuration
 - **`-c`**, **`--config`**=_`<./.oxlintrc.json>`_ &mdash; 
   Oxlint configuration file
-* `.json` config files are supported in all runtimes
+* `.json` and `.jsonc` config files are supported in all runtimes
 * JavaScript/TypeScript config files are experimental and require running via Node.js
 * you can use comments in configuration files.
 * tries to be compatible with ESLint v8's format
 
-  If not provided, Oxlint will look for a `.oxlintrc.json` or `oxlint.config.ts` file in the current working directory.
+  If not provided, Oxlint will look for a `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` file in the current working directory.
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
   TypeScript `tsconfig.json` path for reading path alias and project references for import plugin. If not provided, will look for `tsconfig.json` in the current working directory.
 - **`    --init`** &mdash; 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -6,7 +6,7 @@ Usage: [-c=<./.oxlintrc.json>] [PATH]...
 
 Basic Configuration
     -c, --config=<./.oxlintrc.json>  Oxlint configuration file
-                              * `.json` config files are supported in all runtimes
+                              * `.json` and `.jsonc` config files are supported in all runtimes
                               * JavaScript/TypeScript config files are experimental and require
                               running via Node.js
                               * you can use comments in configuration files.


### PR DESCRIPTION
   ## Summary

   - Teach config discovery to recognize `.oxlintrc.jsonc` alongside `.oxlintrc.json`
   - JSONC parsing already works via `json_strip_comments::strip()` in `Oxlintrc::from_file()`, so this is purely a filename discovery change
   - Prefer `.json` over `.jsonc` when both exist in the same directory (matches oxfmt behavior)
   - Add `.oxlintrc.jsonc` to LSP file watch patterns
   - Update CLI help text, error messages, and diagnostic notes to mention `.jsonc`

   ## Changes

   | File | Change |
   |------|--------|
   | `apps/oxlint/src/lib.rs` | Add `DEFAULT_JSONC_OXLINTRC_NAME` constant |
   | `apps/oxlint/src/config_loader.rs` | Update discovery functions (`find_configs_in_directory`, `to_discovered_config`, `try_load_config_from_dir`, `load_many`) + add tests |
   | `apps/oxlint/src/lsp/server_linter.rs` | Add `.jsonc` to watch patterns and extended path filter + update tests |
   | `apps/oxlint/src/command/lint.rs` | Update CLI help text |
   | `apps/oxlint/src/lint.rs` | Update fallback error message |

   ## Test plan

   - [x] `cargo check -p oxlint` — compiles cleanly
   - [x] `cargo test -p oxlint -- test_jsonc_config_discovery` — new test: `.oxlintrc.jsonc` is discovered and loaded
   - [x] `cargo test -p oxlint -- test_json_preferred_over_jsonc` — new test: `.json` preferred when both exist
   - [x] `cargo test -p oxlint -- test_watchers` — all 10 watcher tests pass with updated pattern counts

   Closes #19729 