### PR TITLE
test(napi/parser): fix tests for range, parent, and lazy on TS fixtures

### DIFF
--- a/napi/parser/test/parse-raw-worker.ts
+++ b/napi/parser/test/parse-raw-worker.ts
@@ -186,11 +186,11 @@ async function runTsCase(
     };
 
     if (rangeParent) {
-      testRangeParent(filename, sourceText, options, expect);
+      testRangeParent(filename, code, options, expect);
       continue;
     }
     if (lazy) {
-      testLazy(filename, sourceText, options);
+      testLazy(filename, code, options);
       continue;
     }
 


### PR DESCRIPTION
`napi/parser`'s tests for raw transfer ranges, parents, and lazy deserialization were incorrect. They were testing parsing the entire TS fixture file, which can contain multiple parts, instead of testing each part individually. Fix that.