### PR TITLE
test(estree/tokens): add tests for tokens via raw transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
         name: Run tests in workspace
         env:
           RUN_RAW_RANGE_TESTS: "true"
+          RUN_RAW_TOKENS_TESTS: "true"
         run: |
           rustup target add wasm32-wasip1-threads
           pnpm run build-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "oxc",
  "oxc_ast_macros",
  "oxc_estree",
+ "oxc_estree_tokens",
  "oxc_napi",
  "rustc-hash",
 ]

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -25,6 +25,7 @@ doctest = false
 oxc = { workspace = true, features = ["ast_visit", "regular_expression", "semantic", "serialize"] }
 oxc_ast_macros = { workspace = true }
 oxc_estree = { workspace = true }
+oxc_estree_tokens = { workspace = true }
 oxc_napi = { workspace = true }
 
 rustc-hash = { workspace = true }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -5,7 +5,7 @@ use napi_derive::napi;
 
 use oxc::{
     allocator::Allocator,
-    parser::{ParseOptions, Parser, ParserReturn},
+    parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig},
     semantic::SemanticBuilder,
     span::SourceType,
 };
@@ -85,6 +85,7 @@ fn parse_impl<'a>(
             preserve_parens: options.preserve_parens.unwrap_or(true),
             ..ParseOptions::default()
         })
+        .with_config(RuntimeParserConfig::new(options.tokens.unwrap_or(false)))
         .parse()
 }
 

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -49,8 +49,8 @@ pub struct RawTransferMetadata {
 }
 
 impl RawTransferMetadata {
-    pub fn new(data_offset: u32, is_ts: bool) -> Self {
-        Self { data_offset, is_ts, is_jsx: false, has_bom: false, tokens_offset: 0, tokens_len: 0 }
+    pub fn new(data_offset: u32, is_ts: bool, tokens_offset: u32, tokens_len: u32) -> Self {
+        Self { data_offset, is_ts, is_jsx: false, has_bom: false, tokens_offset, tokens_len }
     }
 }
 

--- a/napi/parser/src/types.rs
+++ b/napi/parser/src/types.rs
@@ -31,6 +31,14 @@ pub struct ParserOptions {
     #[napi(ts_type = "boolean")]
     pub range: Option<bool>,
 
+    /// Controls whether parser should return tokens.
+    ///
+    /// This option is not stable yet, and only available with experimental raw transfer.
+    ///
+    /// @default false
+    #[napi(skip_typescript, js_name = "experimentalTokens")]
+    pub tokens: Option<bool>,
+
     /// Emit `ParenthesizedExpression` and `TSParenthesizedType` in AST.
     ///
     /// If this option is true, parenthesized expressions are represented by

--- a/napi/parser/test/parse-raw-common.ts
+++ b/napi/parser/test/parse-raw-common.ts
@@ -10,8 +10,9 @@ export const TEST_TYPE_INLINE_FIXTURE = 4;
 
 export const TEST_TYPE_MAIN_MASK = 7;
 export const TEST_TYPE_RANGE_PARENT = 8;
-export const TEST_TYPE_LAZY = 16;
-export const TEST_TYPE_PRETTY = 32;
+export const TEST_TYPE_TOKENS = 16;
+export const TEST_TYPE_LAZY = 32;
+export const TEST_TYPE_PRETTY = 64;
 
 export const ROOT_DIR_PATH = pathJoin(import.meta.dirname, "../../..");
 export const TARGET_DIR_PATH = pathJoin(ROOT_DIR_PATH, "target");
@@ -22,6 +23,10 @@ export const TS_DIR_PATH = pathJoin(ROOT_DIR_PATH, TS_SHORT_DIR_PATH);
 export const ACORN_TEST262_DIR_PATH = pathJoin(
   ROOT_DIR_PATH,
   "tasks/coverage/estree-conformance/tests/test262/test",
+);
+export const ACORN_TEST262_TOKENS_DIR_PATH = pathJoin(
+  ROOT_DIR_PATH,
+  "tasks/coverage/estree-conformance/tests/test262-tokens/test",
 );
 export const JSX_SHORT_DIR_PATH = "tasks/coverage/estree-conformance/tests/acorn-jsx/pass";
 export const JSX_DIR_PATH = pathJoin(ROOT_DIR_PATH, JSX_SHORT_DIR_PATH);

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -21,6 +21,7 @@ import {
   TEST_TYPE_LAZY,
   TEST_TYPE_PRETTY,
   TEST_TYPE_RANGE_PARENT,
+  TEST_TYPE_TOKENS,
   TEST_TYPE_TEST262,
   TEST_TYPE_TS,
   TS_ESTREE_DIR_PATH,
@@ -35,6 +36,10 @@ const { env } = process;
 const isEnabled = (envValue) => envValue === "true" || envValue === "1";
 
 const [describeRangeParent, itRangeParent] = isEnabled(env.RUN_RAW_RANGE_TESTS)
+  ? [describe, it]
+  : ((noop) => [noop, noop])(Object.assign(() => {}, { concurrent() {} }));
+
+const [describeTokens, _itTokens] = isEnabled(env.RUN_RAW_TOKENS_TESTS)
   ? [describe, it]
   : ((noop) => [noop, noop])(Object.assign(() => {}, { concurrent() {} }));
 
@@ -133,6 +138,13 @@ describeRangeParent.concurrent("range & parent test262", () => {
   );
 });
 
+describeTokens.concurrent("tokens test262", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  it.each(test262FixturePaths)("%s", (path) =>
+    runCaseInWorker(TEST_TYPE_TEST262 | TEST_TYPE_TOKENS, path),
+  );
+});
+
 // Check lazy deserialization doesn't throw
 describeLazy.concurrent("lazy test262", () => {
   // oxlint-disable-next-line jest/expect-expect
@@ -160,6 +172,11 @@ describeRangeParent.concurrent("range & parent JSX", () => {
   it.each(jsxFixturePaths)("%s", (filename) =>
     runCaseInWorker(TEST_TYPE_JSX | TEST_TYPE_RANGE_PARENT, filename),
   );
+});
+
+describeTokens.concurrent("tokens JSX", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  it.each(jsxFixturePaths)("%s", (path) => runCaseInWorker(TEST_TYPE_JSX | TEST_TYPE_TOKENS, path));
 });
 
 // Check lazy deserialization doesn't throw
@@ -193,6 +210,11 @@ describeRangeParent.concurrent("range & parent TypeScript", () => {
   it.each(tsFixturePaths)("%s", (path) =>
     runCaseInWorker(TEST_TYPE_TS | TEST_TYPE_RANGE_PARENT, path),
   );
+});
+
+describeTokens.concurrent("tokens TypeScript", () => {
+  // oxlint-disable-next-line jest/expect-expect
+  it.each(tsFixturePaths)("%s", (path) => runCaseInWorker(TEST_TYPE_TS | TEST_TYPE_TOKENS, path));
 });
 
 // Check lazy deserialization doesn't throw

--- a/napi/parser/test/parser.ts
+++ b/napi/parser/test/parser.ts
@@ -12,6 +12,7 @@ export type * from "../src-js/index.js";
 interface ExperimentalParserOptions {
   experimentalRawTransfer?: boolean;
   experimentalParent?: boolean;
+  experimentalTokens?: boolean;
   experimentalLazy?: boolean;
 }
 

--- a/napi/parser/vitest.config.ts
+++ b/napi/parser/vitest.config.ts
@@ -5,7 +5,10 @@ const isEnabled = (envValue) => envValue === "true" || envValue === "1";
 
 const runLazyTests = isEnabled(env.RUN_LAZY_TESTS);
 let runRawTests =
-  runLazyTests || isEnabled(env.RUN_RAW_TESTS) || isEnabled(env.RUN_RAW_RANGE_TESTS);
+  runLazyTests ||
+  isEnabled(env.RUN_RAW_TESTS) ||
+  isEnabled(env.RUN_RAW_RANGE_TESTS) ||
+  isEnabled(env.RUN_RAW_TOKENS_TESTS);
 
 // Raw tests use `tinypool`, which doesn't seem to work on Windows with Vitest
 // Ref: https://github.com/vitest-dev/vitest/issues/8201


### PR DESCRIPTION
Implement the beginnings of support for tokens in `napi/parser`.

This PR only adds support for tokens via raw transfer, and behind an undocumented `experimentalTokens` option.

Add tests checking that tokens received on JS side via raw transfer match snapshots for all Test262, AcornJSX, and TypeScript test cases. They do!

The tests are the main purpose of this PR, making sure it works before we switch over to tokens via raw transfer in Oxlint.

We can add full tokens support to `napi/parser` (including via JSON transfer) later on.