### PR TITLE
perf(linter/plugins): transfer tokens via raw transfer

### DIFF
--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -29,7 +29,7 @@ import type { BufferWithArrays, Comment, Node } from "./types.ts";
 import type { ScopeManager } from "./scope.ts";
 
 // Text decoder, for decoding source text from buffer
-export const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
+const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 
 // Buffer containing AST. Set before linting a file by `setupSourceForFile`.
 export let buffer: BufferWithArrays | null = null;
@@ -245,10 +245,7 @@ export const SOURCE_CODE = Object.freeze({
   // This property is present in ESLint's `SourceCode`, but is undocumented
   get tokensAndComments(): (Token | Comment)[] {
     if (tokensAndComments === null) {
-      if (tokens === null) {
-        if (sourceText === null) initSourceText();
-        initTokens();
-      }
+      if (tokens === null) initTokens();
       initTokensAndComments();
     }
     debugAssertIsNonNull(tokensAndComments);

--- a/apps/oxlint/src-js/utils/globals.ts
+++ b/apps/oxlint/src-js/utils/globals.ts
@@ -32,3 +32,5 @@ export const { parse: JSONParse, stringify: JSONStringify } = JSON;
 export const { ownKeys: ReflectOwnKeys } = Reflect;
 
 export const { iterator: SymbolIterator } = Symbol;
+
+export const { fromCodePoint: StringFromCodePoint } = String;

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -109,11 +109,6 @@ impl<'a> ContextSubHost<'a> {
     pub fn framework_options(&self) -> FrameworkOptions {
         self.framework_options
     }
-
-    /// Parser tokens collected for this script block.
-    pub fn parser_tokens(&self) -> Option<&[Token]> {
-        self.parser_tokens.as_ref().map(|tokens| &tokens[..])
-    }
 }
 
 /// Stores shared information about a file being linted.
@@ -237,6 +232,16 @@ impl<'a> ContextHost<'a> {
     /// Shared reference to the [`DisableDirectives`] of the current script block.
     pub fn disable_directives(&self) -> &DisableDirectives {
         &self.current_sub_host().disable_directives
+    }
+
+    /// Shared reference to the parser tokens collected for this script block.
+    pub fn parser_tokens(&self) -> Option<&[Token]> {
+        self.current_sub_host().parser_tokens.as_ref().map(|tokens| &tokens[..])
+    }
+
+    /// Mutable reference to the parser tokens collected for this script block.
+    pub fn parser_tokens_mut(&mut self) -> Option<&mut ArenaVec<'a, Token>> {
+        self.current_sub_host_mut().parser_tokens.as_mut()
     }
 
     /// Path to the file being linted.

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -40,11 +40,9 @@ pub struct RawTransferMetadata {
     pub is_jsx: bool,
     /// This field always contains `false` in parser. It's only used in linter.
     pub has_bom: bool,
-    /// Offset of serialized ESTree tokens JSON within buffer.
-    /// This field always contains 0 in parser. It's only used in linter.
+    /// Offset of lexer `Token`s within buffer.
     pub tokens_offset: u32,
-    /// UTF-8 byte length of serialized ESTree tokens JSON.
-    /// This field always contains 0 in parser. It's only used in linter.
+    /// Number of lexer `Token`s.
     pub tokens_len: u32,
 }
 

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -1305,9 +1305,9 @@ struct Constants {
     is_jsx_pos: u32,
     /// Offset within buffer of `bool` indicating if source text has BOM
     has_bom_pos: u32,
-    /// Offset within buffer of `u32` containing serialized ESTree tokens JSON start
+    /// Offset within buffer of `u32` containing position of lexer `Token`s
     tokens_offset_pos: u32,
-    /// Offset within buffer of `u32` containing serialized ESTree tokens JSON length
+    /// Offset within buffer of `u32` containing number of lexer `Token`s
     tokens_len_pos: u32,
     /// Offset of `Program` in buffer, relative to position of `RawTransferData`
     program_offset: u32,


### PR DESCRIPTION
Transfer tokens via raw transfer in Oxlint JS plugins.

Deserializer is written by hand. `Token` is not a normal struct, so deserializer cannot be generated.