### PR TITLE
chore(oxfmt): Align the definition order of external APIs

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -34,7 +34,7 @@ export declare const enum Severity {
  * # Panics
  * Panics if the current working directory cannot be determined.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -49,7 +49,7 @@ export interface FormatResult {
  * This API is specialized for JS/TS snippets embedded in non-JS files.
  * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -58,12 +58,12 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * JS side passes in:
  * 1. `args`: Command line arguments (process.argv.slice(2))
  * 2. `init_external_formatter_cb`: Callback to initialize external formatter
- * 3. `format_embedded_cb`: Callback to format embedded code in templates
- * 4. `format_file_cb`: Callback to format files
+ * 3. `format_file_cb`: Callback to format files
+ * 4. `format_embedded_cb`: Callback to format embedded code in templates
  * 5. `sort_tailwindcss_classes_cb`: Callback to sort Tailwind classes
  *
  * Returns a tuple of `[mode, exitCode]`:
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli.ts
+++ b/apps/oxfmt/src-js/cli.ts
@@ -1,11 +1,11 @@
 import { runCli } from "./bindings";
 import {
   initExternalFormatter,
+  disposeExternalFormatter,
+  formatFile,
   formatEmbeddedCode,
   formatEmbeddedDoc,
-  formatFile,
   sortTailwindClasses,
-  disposeExternalFormatter,
 } from "./cli/worker-proxy";
 
 // napi-JS `oxfmt` CLI entry point
@@ -28,9 +28,9 @@ void (async () => {
   const [mode, exitCode] = await runCli(
     args,
     initExternalFormatter,
+    formatFile,
     formatEmbeddedCode,
     formatEmbeddedDoc,
-    formatFile,
     sortTailwindClasses,
   );
 

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -1,9 +1,9 @@
 import Tinypool from "tinypool";
 import { resolvePlugins } from "../libs/apis";
 import type {
+  FormatFileParam,
   FormatEmbeddedCodeParam,
   FormatEmbeddedDocParam,
-  FormatFileParam,
   SortTailwindClassesArgs,
 } from "../libs/apis";
 

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,9 +1,9 @@
 import { format as napiFormat, jsTextToDoc as napiJsTextToDoc } from "./bindings";
 import {
   resolvePlugins,
+  formatFile,
   formatEmbeddedCode,
   formatEmbeddedDoc,
-  formatFile,
   sortTailwindClasses,
 } from "./libs/apis";
 import type { Options } from "prettier";
@@ -23,9 +23,9 @@ export async function format(fileName: string, sourceText: string, options?: For
     sourceText,
     options ?? {},
     resolvePlugins,
+    (options, code) => formatFile({ options, code }),
     (options, code) => formatEmbeddedCode({ options, code }),
     (options, texts) => formatEmbeddedDoc({ options, texts }),
-    (options, code) => formatFile({ options, code }),
     (options, classes) => sortTailwindClasses({ options, classes }),
   );
 }
@@ -45,9 +45,9 @@ export async function jsTextToDoc(
     oxfmtPluginOptionsJson,
     parentContext,
     resolvePlugins,
+    (_options, _code) => Promise.reject(/* Unreachable */),
     (options, code) => formatEmbeddedCode({ options, code }),
     (options, texts) => formatEmbeddedDoc({ options, texts }),
-    (_options, _code) => Promise.reject(/* Unreachable */),
     (options, classes) => sortTailwindClasses({ options, classes }),
   );
 }

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -44,6 +44,30 @@ export async function resolvePlugins(): Promise<string[]> {
 
 // ---
 
+export type FormatFileParam = {
+  code: string;
+  options: Options;
+};
+
+/**
+ * Format non-js file
+ *
+ * @returns Formatted code
+ */
+export async function formatFile({ code, options }: FormatFileParam): Promise<string> {
+  const prettier = await loadPrettier();
+
+  // Enable Tailwind CSS plugin for non-JS files if needed
+  await setupTailwindPlugin(options);
+  // Add oxfmt plugin for (j|t)-in-xxx files to use `oxc_formatter` instead of built-in formatter.
+  // NOTE: This must be last since Prettier plugins are applied in order
+  await setupOxfmtPlugin(options);
+
+  return prettier.format(code, options);
+}
+
+// ---
+
 export type FormatEmbeddedCodeParam = {
   code: string;
   options: Options;
@@ -125,30 +149,6 @@ export async function formatEmbeddedDoc({
       });
     }),
   );
-}
-
-// ---
-
-export type FormatFileParam = {
-  code: string;
-  options: Options;
-};
-
-/**
- * Format non-js file
- *
- * @returns Formatted code
- */
-export async function formatFile({ code, options }: FormatFileParam): Promise<string> {
-  const prettier = await loadPrettier();
-
-  // Enable Tailwind CSS plugin for non-JS files if needed
-  await setupTailwindPlugin(options);
-  // Add oxfmt plugin for (j|t)-in-xxx files to use `oxc_formatter` instead of built-in formatter.
-  // NOTE: This must be last since Prettier plugins are applied in order
-  await setupOxfmtPlugin(options);
-
-  return prettier.format(code, options);
 }
 
 // ---

--- a/apps/oxfmt/src/api/format_api.rs
+++ b/apps/oxfmt/src/api/format_api.rs
@@ -24,9 +24,9 @@ pub fn run(
     source_text: String,
     options: Option<Value>,
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    format_file_cb: JsFormatFileCb,
     format_embedded_cb: JsFormatEmbeddedCb,
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    format_file_cb: JsFormatFileCb,
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
 ) -> ApiFormatResult {
     // NOTE: In NAPI context, we don't have a config file path, since options are passed directly as a JSON.
@@ -37,9 +37,9 @@ pub fn run(
 
     let external_formatter = ExternalFormatter::new(
         init_external_formatter_cb,
+        format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
-        format_file_cb,
         sort_tailwind_classes_cb,
     );
 

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -51,9 +51,9 @@ pub fn run(
     oxfmt_plugin_options_json: &str,
     parent_context: &str,
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    format_file_cb: JsFormatFileCb,
     format_embedded_cb: JsFormatEmbeddedCb,
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    format_file_cb: JsFormatFileCb,
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
 ) -> Option<String> {
     let fragment_kind = match parent_context {
@@ -72,9 +72,9 @@ pub fn run(
             source_text,
             oxfmt_plugin_options_json,
             init_external_formatter_cb,
+            format_file_cb,
             format_embedded_cb,
             format_embedded_doc_cb,
-            format_file_cb,
             sort_tailwind_classes_cb,
         )?
     };
@@ -93,9 +93,9 @@ fn run_full(
     source_text: &str,
     oxfmt_plugin_options_json: &str,
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    format_file_cb: JsFormatFileCb,
     format_embedded_cb: JsFormatEmbeddedCb,
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    format_file_cb: JsFormatFileCb,
     sort_tailwind_classes_cb: JsSortTailwindClassesCb,
 ) -> Option<Value> {
     let num_of_threads = 1;
@@ -107,9 +107,9 @@ fn run_full(
 
     let external_formatter = ExternalFormatter::new(
         init_external_formatter_cb,
+        format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
-        format_file_cb,
         sort_tailwind_classes_cb,
     );
 

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -31,6 +31,22 @@ pub type JsInitExternalFormatterCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
+/// Takes (options, code) as arguments and returns formatted code.
+/// The `options` object includes `parser` and `filepath` fields set by Rust side.
+pub type JsFormatFileCb = ThreadsafeFunction<
+    // Input arguments
+    FnArgs<(Value, String)>, // (options, code)
+    // Return type (what JS function returns)
+    Promise<String>,
+    // Arguments (repeated)
+    FnArgs<(Value, String)>,
+    // Error status
+    Status,
+    // CalleeHandled
+    false,
+>;
+
+/// Type alias for the callback function signature.
 /// Takes (options, code) as arguments and returns formatted code or null on error.
 /// The `options` object includes `parser` field set by Rust side.
 pub type JsFormatEmbeddedCb = ThreadsafeFunction<
@@ -62,22 +78,6 @@ pub type JsFormatEmbeddedDocCb = ThreadsafeFunction<
     false,
 >;
 
-/// Type alias for the callback function signature.
-/// Takes (options, code) as arguments and returns formatted code.
-/// The `options` object includes `parser` and `filepath` fields set by Rust side.
-pub type JsFormatFileCb = ThreadsafeFunction<
-    // Input arguments
-    FnArgs<(Value, String)>, // (options, code)
-    // Return type (what JS function returns)
-    Promise<String>,
-    // Arguments (repeated)
-    FnArgs<(Value, String)>,
-    // Error status
-    Status,
-    // CalleeHandled
-    false,
->;
-
 /// Type alias for Tailwind class processing callback.
 /// Takes (options, classes) and returns sorted array or null on error.
 /// The `filepath` is included in `options`.
@@ -98,9 +98,9 @@ pub type JsSortTailwindClassesCb = ThreadsafeFunction<
 #[derive(Clone)]
 struct TsfnHandles {
     init: Arc<RwLock<Option<JsInitExternalFormatterCb>>>,
+    format_file: Arc<RwLock<Option<JsFormatFileCb>>>,
     format_embedded: Arc<RwLock<Option<JsFormatEmbeddedCb>>>,
     format_embedded_doc: Arc<RwLock<Option<JsFormatEmbeddedDocCb>>>,
-    format_file: Arc<RwLock<Option<JsFormatFileCb>>>,
     sort_tailwind: Arc<RwLock<Option<JsSortTailwindClassesCb>>>,
 }
 
@@ -108,12 +108,23 @@ impl TsfnHandles {
     /// Drop all ThreadsafeFunctions to prevent use-after-free during V8 cleanup.
     fn cleanup(&self) {
         let _ = self.init.write().unwrap().take();
+        let _ = self.format_file.write().unwrap().take();
         let _ = self.format_embedded.write().unwrap().take();
         let _ = self.format_embedded_doc.write().unwrap().take();
-        let _ = self.format_file.write().unwrap().take();
         let _ = self.sort_tailwind.write().unwrap().take();
     }
 }
+
+/// Callback function type for init external formatter.
+/// Takes num_threads and returns plugin languages.
+type InitExternalFormatterCallback =
+    Arc<dyn Fn(usize) -> Result<Vec<String>, String> + Send + Sync>;
+
+/// Callback function type for formatting files with config.
+/// Takes (options, code) and returns formatted code or an error.
+/// The `options` Value is owned and includes `parser` and `filepath` set by the caller.
+type FormatFileWithConfigCallback =
+    Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
 
 /// Callback function type for formatting embedded code with config.
 /// Takes (options, code) and returns formatted code or an error.
@@ -126,17 +137,6 @@ type FormatEmbeddedWithConfigCallback =
 type FormatEmbeddedDocWithConfigCallback =
     Arc<dyn Fn(Value, &[&str]) -> Result<Vec<String>, String> + Send + Sync>;
 
-/// Callback function type for formatting files with config.
-/// Takes (options, code) and returns formatted code or an error.
-/// The `options` Value is owned and includes `parser` and `filepath` set by the caller.
-type FormatFileWithConfigCallback =
-    Arc<dyn Fn(Value, &str) -> Result<String, String> + Send + Sync>;
-
-/// Callback function type for init external formatter.
-/// Takes num_threads and returns plugin languages.
-type InitExternalFormatterCallback =
-    Arc<dyn Fn(usize) -> Result<Vec<String>, String> + Send + Sync>;
-
 /// Internal callback type for Tailwind processing with config.
 /// Takes (options, classes) and returns sorted classes.
 /// The `filepath` is included in `options`.
@@ -148,9 +148,9 @@ pub struct ExternalFormatter {
     /// Handles to raw ThreadsafeFunctions for explicit cleanup
     handles: TsfnHandles,
     pub init: InitExternalFormatterCallback,
+    pub format_file: FormatFileWithConfigCallback,
     pub format_embedded: FormatEmbeddedWithConfigCallback,
     pub format_embedded_doc: FormatEmbeddedDocWithConfigCallback,
-    pub format_file: FormatFileWithConfigCallback,
     pub sort_tailwindcss_classes: TailwindWithConfigCallback,
 }
 
@@ -158,9 +158,9 @@ impl std::fmt::Debug for ExternalFormatter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ExternalFormatter")
             .field("init", &"<callback>")
+            .field("format_file", &"<callback>")
             .field("format_embedded", &"<callback>")
             .field("format_embedded_doc", &"<callback>")
-            .field("format_file", &"<callback>")
             .field("sort_tailwindcss_classes", &"<callback>")
             .finish()
     }
@@ -174,38 +174,38 @@ impl ExternalFormatter {
     /// crashes on Node.js exit when V8 cleans up global handles.
     pub fn new(
         init_cb: JsInitExternalFormatterCb,
+        format_file_cb: JsFormatFileCb,
         format_embedded_cb: JsFormatEmbeddedCb,
         format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-        format_file_cb: JsFormatFileCb,
         sort_tailwindcss_classes_cb: JsSortTailwindClassesCb,
     ) -> Self {
         // Wrap TSFNs in Arc<RwLock<Option<...>>> so they can be explicitly dropped
         let init_handle = Arc::new(RwLock::new(Some(init_cb)));
+        let format_file_handle = Arc::new(RwLock::new(Some(format_file_cb)));
         let format_embedded_handle = Arc::new(RwLock::new(Some(format_embedded_cb)));
         let format_embedded_doc_handle = Arc::new(RwLock::new(Some(format_embedded_doc_cb)));
-        let format_file_handle = Arc::new(RwLock::new(Some(format_file_cb)));
         let sort_tailwind_handle = Arc::new(RwLock::new(Some(sort_tailwindcss_classes_cb)));
 
         // Create handles struct for cleanup
         let handles = TsfnHandles {
             init: Arc::clone(&init_handle),
+            format_file: Arc::clone(&format_file_handle),
             format_embedded: Arc::clone(&format_embedded_handle),
             format_embedded_doc: Arc::clone(&format_embedded_doc_handle),
-            format_file: Arc::clone(&format_file_handle),
             sort_tailwind: Arc::clone(&sort_tailwind_handle),
         };
 
         let rust_init = wrap_init_external_formatter(init_handle);
+        let rust_format_file = wrap_format_file(format_file_handle);
         let rust_format_embedded = wrap_format_embedded(Arc::clone(&format_embedded_handle));
         let rust_format_embedded_doc = wrap_format_embedded_doc(format_embedded_doc_handle);
-        let rust_format_file = wrap_format_file(format_file_handle);
         let rust_tailwind = wrap_sort_tailwind_classes(sort_tailwind_handle);
         Self {
             handles,
             init: rust_init,
+            format_file: rust_format_file,
             format_embedded: rust_format_embedded,
             format_embedded_doc: rust_format_embedded_doc,
-            format_file: rust_format_file,
             sort_tailwindcss_classes: rust_tailwind,
         }
     }
@@ -223,6 +223,12 @@ impl ExternalFormatter {
     pub fn init(&self, num_threads: usize) -> Result<Vec<String>, String> {
         debug_span!("oxfmt::external::init", num_threads = num_threads)
             .in_scope(|| (self.init)(num_threads))
+    }
+
+    /// Format non-js file using the JS callback.
+    /// The `options` Value should already have `parser` and `filepath` set by the caller.
+    pub fn format_file(&self, options: Value, code: &str) -> Result<String, String> {
+        (self.format_file)(options, code)
     }
 
     /// Convert this external formatter to the oxc_formatter::ExternalCallbacks type.
@@ -328,12 +334,6 @@ impl ExternalFormatter {
             .with_tailwind(tailwind_callback)
     }
 
-    /// Format non-js file using the JS callback.
-    /// The `options` Value should already have `parser` and `filepath` set by the caller.
-    pub fn format_file(&self, options: Value, code: &str) -> Result<String, String> {
-        (self.format_file)(options, code)
-    }
-
     #[cfg(test)]
     pub fn dummy() -> Self {
         // Currently, LSP tests are implemented in Rust, while our external formatter relies on JS.
@@ -341,17 +341,17 @@ impl ExternalFormatter {
         Self {
             handles: TsfnHandles {
                 init: Arc::new(RwLock::new(None)),
+                format_file: Arc::new(RwLock::new(None)),
                 format_embedded: Arc::new(RwLock::new(None)),
                 format_embedded_doc: Arc::new(RwLock::new(None)),
-                format_file: Arc::new(RwLock::new(None)),
                 sort_tailwind: Arc::new(RwLock::new(None)),
             },
             init: Arc::new(|_| Err("Dummy init called".to_string())),
+            format_file: Arc::new(|_, _| Err("Dummy format_file called".to_string())),
             format_embedded: Arc::new(|_, _| Err("Dummy format_embedded called".to_string())),
             format_embedded_doc: Arc::new(|_, _: &[&str]| {
                 Err("Dummy format_embedded_doc called".to_string())
             }),
-            format_file: Arc::new(|_, _| Err("Dummy format_file called".to_string())),
             sort_tailwindcss_classes: Arc::new(|_, _| vec![]),
         }
     }
@@ -413,6 +413,31 @@ fn wrap_init_external_formatter(
     })
 }
 
+/// Wrap JS `formatFile` callback as a normal Rust function.
+/// The `options` Value is received with `parser` and `filepath` already set by the caller.
+fn wrap_format_file(
+    cb_handle: Arc<RwLock<Option<JsFormatFileCb>>>,
+) -> FormatFileWithConfigCallback {
+    Arc::new(move |options: Value, code: &str| {
+        let guard = cb_handle.read().unwrap();
+        let Some(cb) = guard.as_ref() else {
+            return Err("JS callback unavailable (environment shutting down)".to_string());
+        };
+        let result = block_on(async {
+            let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
+            match status {
+                Ok(promise) => match promise.await {
+                    Ok(formatted_code) => Ok(formatted_code),
+                    Err(err) => Err(err.reason.clone()),
+                },
+                Err(err) => Err(err.reason.clone()),
+            }
+        });
+        drop(guard);
+        result
+    })
+}
+
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
 /// The `options` Value is received with `parser` already set by the caller.
 fn wrap_format_embedded(
@@ -460,31 +485,6 @@ fn wrap_format_embedded_doc(
                     Ok(None) => Err("Embedded doc formatting failed".to_string()),
                     // JS side never rejects; it returns `null` on error instead.
                     // `Err` here would only come from a napi-rs internal failure.
-                    Err(err) => Err(err.reason.clone()),
-                },
-                Err(err) => Err(err.reason.clone()),
-            }
-        });
-        drop(guard);
-        result
-    })
-}
-
-/// Wrap JS `formatFile` callback as a normal Rust function.
-/// The `options` Value is received with `parser` and `filepath` already set by the caller.
-fn wrap_format_file(
-    cb_handle: Arc<RwLock<Option<JsFormatFileCb>>>,
-) -> FormatFileWithConfigCallback {
-    Arc::new(move |options: Value, code: &str| {
-        let guard = cb_handle.read().unwrap();
-        let Some(cb) = guard.as_ref() else {
-            return Err("JS callback unavailable (environment shutting down)".to_string());
-        };
-        let result = block_on(async {
-            let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
-            match status {
-                Ok(promise) => match promise.await {
-                    Ok(formatted_code) => Ok(formatted_code),
                     Err(err) => Err(err.reason.clone()),
                 },
                 Err(err) => Err(err.reason.clone()),

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -22,8 +22,8 @@ use crate::{
 /// JS side passes in:
 /// 1. `args`: Command line arguments (process.argv.slice(2))
 /// 2. `init_external_formatter_cb`: Callback to initialize external formatter
-/// 3. `format_embedded_cb`: Callback to format embedded code in templates
-/// 4. `format_file_cb`: Callback to format files
+/// 3. `format_file_cb`: Callback to format files
+/// 4. `format_embedded_cb`: Callback to format embedded code in templates
 /// 5. `sort_tailwindcss_classes_cb`: Callback to sort Tailwind classes
 ///
 /// Returns a tuple of `[mode, exitCode]`:
@@ -36,14 +36,14 @@ pub async fn run_cli(
     args: Vec<String>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
     )]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
-    format_file_cb: JsFormatFileCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"
     )]
@@ -82,9 +82,9 @@ pub async fn run_cli(
 
     let external_formatter = ExternalFormatter::new(
         init_external_formatter_cb,
+        format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
-        format_file_cb,
         sort_tailwindcss_classes_cb,
     );
 
@@ -147,14 +147,14 @@ pub async fn format(
     options: Option<Value>,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
     )]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
-    format_file_cb: JsFormatFileCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"
     )]
@@ -165,9 +165,9 @@ pub async fn format(
         source_text,
         options,
         init_external_formatter_cb,
+        format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
-        format_file_cb,
         sort_tailwind_classes_cb,
     );
 
@@ -190,14 +190,14 @@ pub async fn js_text_to_doc(
     parent_context: String,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<string[]>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
+    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, texts: string[]) => Promise<string[] | null>"
     )]
     format_embedded_doc_cb: JsFormatEmbeddedDocCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
-    format_file_cb: JsFormatFileCb,
     #[napi(
         ts_arg_type = "(options: Record<string, any>, classes: string[]) => Promise<string[] | null>"
     )]
@@ -211,9 +211,9 @@ pub async fn js_text_to_doc(
         &oxfmt_plugin_options_json,
         &parent_context,
         init_external_formatter_cb,
+        format_file_cb,
         format_embedded_cb,
         format_embedded_doc_cb,
-        format_file_cb,
         sort_tailwind_classes_cb,
     )
 }


### PR DESCRIPTION
Cosmetic changes; Reorder napi callbacks:

- init+dispose
- format file (for non-js)
- embedded (for js)
- sort tailwind (for js)
