### PR TITLE
fix(linter): add help text to oxc/no-rest-spread-properties rule

### DIFF
--- a/crates/oxc_linter/src/snapshots/oxc_no_rest_spread_properties.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_rest_spread_properties.snap
@@ -7,33 +7,39 @@ source: crates/oxc_linter/src/tester.rs
  1 │ ({...a})
    ·   ────
    ╰────
+  help: Use `Object.assign()` to combine objects instead of object spread syntax.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a} = obj)
    ·   ────
    ╰────
+  help: List the properties you need explicitly instead of using object rest syntax.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:7]
  1 │ for ({...a} in foo) {}
    ·       ────
    ╰────
+  help: List the properties you need explicitly instead of using object rest syntax.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
    ╭─[no_rest_spread_properties.tsx:1:13]
  1 │ function f({...a}) {}
    ·             ────
    ╰────
+  help: List the properties you need explicitly instead of using object rest syntax.
 
   ⚠ oxc(no-rest-spread-properties): object spread property are not allowed. Our codebase does not allow object spread properties.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a})
    ·   ────
    ╰────
+  help: Use `Object.assign()` to combine objects instead of object spread syntax.
 
   ⚠ oxc(no-rest-spread-properties): object rest property are not allowed. Our codebase does not allow object rest properties.
    ╭─[no_rest_spread_properties.tsx:1:3]
  1 │ ({...a} = obj)
    ·   ────
    ╰────
+  help: List the properties you need explicitly instead of using object rest syntax.


### PR DESCRIPTION
## Summary

This pr is part of #19121.

Add `.with_help` to the `oxc/no-rest-spread-properties` rule as follows:

```sh
help: Use `Object.assign()` to combine objects instead of object spread syntax.
help: List the properties you need explicitly instead of using object rest syntax.
```

## Snapshot

```sh
⚠ oxc(no-rest-spread-properties): object spread property are not allowed.
  ╭─[no_rest_spread_properties.tsx:1:3]
1 │ ({...a})
  ·   ────
  ╰────
help: Use `Object.assign()` to combine objects instead of object spread syntax.

⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
  ╭─[no_rest_spread_properties.tsx:1:3]
1 │ ({...a} = obj)
  ·   ────
  ╰────
help: List the properties you need explicitly instead of using object rest syntax.

⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
  ╭─[no_rest_spread_properties.tsx:1:7]
1 │ for ({...a} in foo) {}
  ·       ────
  ╰────
help: List the properties you need explicitly instead of using object rest syntax.

⚠ oxc(no-rest-spread-properties): object rest property are not allowed.
  ╭─[no_rest_spread_properties.tsx:1:13]
1 │ function f({...a}) {}
  ·             ────
  ╰────
help: List the properties you need explicitly instead of using object rest syntax.

⚠ oxc(no-rest-spread-properties): object spread property are not allowed. Our codebase does not allow object spread properties.
  ╭─[no_rest_spread_properties.tsx:1:3]
1 │ ({...a})
  ·   ────
  ╰────
help: Use `Object.assign()` to combine objects instead of object spread syntax.

⚠ oxc(no-rest-spread-properties): object rest property are not allowed. Our codebase does not allow object rest properties.
  ╭─[no_rest_spread_properties.tsx:1:3]
1 │ ({...a} = obj)
  ·   ────
  ╰────
help: List the properties you need explicitly instead of using object rest syntax.
```