### PR TITLE
feat(formatter): Add a warning when Oxfmt is used without a configuration file.

### DIFF
--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -3,6 +3,7 @@ use std::{env, io::BufWriter, path::PathBuf, sync::mpsc, time::Instant};
 use oxc_diagnostics::DiagnosticService;
 
 use super::{
+    DEFAULT_CONFIG_NOTE_MESSAGE,
     command::{FormatCommand, Mode, OutputMode},
     reporter::DefaultReporter,
     result::CliRunResult,
@@ -10,7 +11,8 @@ use super::{
     walk::Walk,
 };
 use crate::core::{
-    ConfigResolver, SourceFormatter, resolve_editorconfig_path, resolve_oxfmtrc_path, utils,
+    ConfigResolver, SourceFormatter, resolve_editorconfig_path, resolve_oxfmtrc_path,
+    uses_default_config, utils,
 };
 
 #[derive(Debug)]
@@ -92,6 +94,13 @@ impl FormatRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
+        if uses_default_config(
+            config_options.config.as_deref(),
+            oxfmtrc_path.as_deref(),
+            editorconfig_path.as_deref(),
+        ) {
+            utils::print_and_flush(stderr, DEFAULT_CONFIG_NOTE_MESSAGE);
+        }
 
         // Use `block_in_place()` to avoid nested async runtime access
         #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/cli/mod.rs
+++ b/apps/oxfmt/src/cli/mod.rs
@@ -6,6 +6,9 @@ mod result;
 mod service;
 mod walk;
 
+pub(crate) const DEFAULT_CONFIG_NOTE_MESSAGE: &str =
+    "Using Oxfmt's default configuration. Run `oxfmt --init` to set up Oxfmt in this project.\n";
+
 pub use crate::core::utils::init_tracing;
 #[cfg(feature = "napi")]
 pub use command::MigrateSource;

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -45,6 +45,15 @@ pub fn resolve_editorconfig_path(cwd: &Path) -> Option<PathBuf> {
     cwd.ancestors().map(|dir| dir.join(".editorconfig")).find(|p| p.exists())
 }
 
+/// Returns `true` when neither explicit nor auto-discovered config is found.
+pub fn uses_default_config(
+    explicit_config_path: Option<&Path>,
+    oxfmtrc_path: Option<&Path>,
+    editorconfig_path: Option<&Path>,
+) -> bool {
+    explicit_config_path.is_none() && oxfmtrc_path.is_none() && editorconfig_path.is_none()
+}
+
 /// Resolve format options directly from a raw JSON config value.
 ///
 /// This is the simplified path for the NAPI `format()` API,
@@ -522,5 +531,32 @@ fn apply_editorconfig(config: &mut FormatConfig, props: &EditorConfigProperties)
         && let EditorConfigProperty::Value(v) = props.insert_final_newline
     {
         config.insert_final_newline = Some(v);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::uses_default_config;
+
+    #[test]
+    fn uses_default_config_when_no_configs_are_found() {
+        assert!(uses_default_config(None, None, None));
+    }
+
+    #[test]
+    fn does_not_use_default_config_when_explicit_config_is_set() {
+        assert!(!uses_default_config(Some(Path::new("fmt.json")), None, None));
+    }
+
+    #[test]
+    fn does_not_use_default_config_when_oxfmtrc_is_auto_discovered() {
+        assert!(!uses_default_config(None, Some(Path::new(".oxfmtrc.json")), None));
+    }
+
+    #[test]
+    fn does_not_use_default_config_when_editorconfig_is_auto_discovered() {
+        assert!(!uses_default_config(None, None, Some(Path::new(".editorconfig"))));
     }
 }

--- a/apps/oxfmt/src/core/mod.rs
+++ b/apps/oxfmt/src/core/mod.rs
@@ -11,6 +11,7 @@ mod external_formatter;
 pub use config::resolve_options_from_value;
 pub use config::{
     ConfigResolver, ResolvedOptions, resolve_editorconfig_path, resolve_oxfmtrc_path,
+    uses_default_config,
 };
 pub use format::{FormatResult, SourceFormatter};
 pub use support::FormatFileStrategy;

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -4,10 +4,10 @@ use std::{
     path::PathBuf,
 };
 
-use crate::cli::{CliRunResult, FormatCommand, Mode};
+use crate::cli::{CliRunResult, DEFAULT_CONFIG_NOTE_MESSAGE, FormatCommand, Mode};
 use crate::core::{
     ConfigResolver, ExternalFormatter, FormatFileStrategy, FormatResult, SourceFormatter,
-    resolve_editorconfig_path, resolve_oxfmtrc_path, utils,
+    resolve_editorconfig_path, resolve_oxfmtrc_path, uses_default_config, utils,
 };
 
 #[derive(Debug)]
@@ -73,6 +73,13 @@ impl StdinRunner {
                 utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
                 return CliRunResult::InvalidOptionConfig;
             }
+        }
+        if uses_default_config(
+            config_options.config.as_deref(),
+            oxfmtrc_path.as_deref(),
+            editorconfig_path.as_deref(),
+        ) {
+            utils::print_and_flush(stderr, DEFAULT_CONFIG_NOTE_MESSAGE);
         }
 
         // Use `block_in_place()` to avoid nested async runtime access


### PR DESCRIPTION
Same as https://github.com/oxc-project/oxc/pull/19313 but for Oxfmt. It will show a warning when Oxfmt is invoked without a configuration file.