### PR TITLE
fix(linter): no-unused-vars with ignoreRestSiblings false positive

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -143,6 +143,10 @@ impl NoUnusedVars {
             return true;
         }
 
+        if self.ignore_rest_siblings && symbol.is_allowed_for_of_array_destructure_sibling(decl) {
+            return true;
+        }
+
         false
     }
 
@@ -305,5 +309,21 @@ impl NoUnusedVars {
         }
 
         false
+    }
+}
+
+impl Symbol<'_, '_> {
+    fn is_allowed_for_of_array_destructure_sibling(&self, decl: &VariableDeclarator<'_>) -> bool {
+        if !matches!(decl.id, BindingPattern::ArrayPattern(_)) {
+            return false;
+        }
+
+        if !self.iter_parents().any(|node| matches!(node.kind(), AstKind::ForOfStatement(_))) {
+            return false;
+        }
+
+        decl.id.get_binding_identifiers().iter().any(|ident| {
+            ident.symbol_id() != self.id() && !self.scoping().symbol_is_unused(ident.symbol_id())
+        })
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -400,6 +400,10 @@ fn test_vars_destructure() {
             Some(json![[{ "ignoreRestSiblings": true }]]),
         ),
         (
+            "const someMap = new Map([['foo', 'bar']]); for (const [key, val] of someMap) { console.log(val); }",
+            Some(json![[{ "ignoreRestSiblings": true }]]),
+        ),
+        (
             "const { a, ...rest } = obj; console.log(rest)",
             Some(json!( [{ "ignoreRestSiblings": true, "vars": "all" }] )),
         ),


### PR DESCRIPTION
specifically with array destructuring. Reports unused array key values as unused only when ignoreRestSibling is set to true.
Used AI to come up with a fix. Found while enabling rules in company's codebase