### PR TITLE
fix(formatter): Honor trailing ignore comments after list separators

### DIFF
--- a/crates/oxc_formatter/src/ast_nodes/generated/format.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/format.rs
@@ -25,6 +25,17 @@ impl<'a> Format<'a> for AstNode<'a, Program<'a>> {
 impl<'a> Format<'a> for AstNode<'a, Expression<'a>> {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
+        if f.comments().has_trailing_suppression_comment(self.span().end) {
+            format_leading_comments(self.span()).fmt(f);
+            FormatSuppressedNode(self.span()).fmt(f);
+            format_trailing_comments(
+                self.parent.span(),
+                self.inner.span(),
+                self.following_span_start,
+            )
+            .fmt(f);
+            return;
+        }
         let allocator = self.allocator;
         let parent = self.parent;
         match self.inner {

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -140,6 +140,35 @@ pub struct Comments<'a> {
 }
 
 impl<'a> Comments<'a> {
+    #[inline]
+    const fn is_end_of_line_comment_gap_byte(byte: u8) -> bool {
+        matches!(byte, b'\t' | b' ' | b'=' | b':')
+    }
+
+    #[inline]
+    const fn is_trailing_suppression_gap_byte(byte: u8) -> bool {
+        Self::is_end_of_line_comment_gap_byte(byte) || matches!(byte, b',' | b';')
+    }
+
+    fn end_of_line_comments_after_with(
+        &self,
+        mut pos: u32,
+        is_allowed_gap_byte: impl Fn(u8) -> bool + Copy,
+    ) -> &'a [Comment] {
+        let comments = self.comments_after(pos);
+        for (index, comment) in comments.iter().enumerate() {
+            if self.source_text.all_bytes_match(pos, comment.span.start, is_allowed_gap_byte) {
+                if comment.is_line() || comment.followed_by_newline() {
+                    return &comments[..=index];
+                }
+                pos = comment.span.end;
+            } else {
+                break;
+            }
+        }
+        &[]
+    }
+
     pub fn new(source_text: SourceText<'a>, comments: &'a [Comment]) -> Self {
         Comments {
             source_text,
@@ -194,21 +223,8 @@ impl<'a> Comments<'a> {
     }
 
     /// Returns end-of-line comments that are after the given position (excluding printed ones).
-    pub fn end_of_line_comments_after(&self, mut pos: u32) -> &'a [Comment] {
-        let comments = self.comments_after(pos);
-        for (index, comment) in comments.iter().enumerate() {
-            if self.source_text.all_bytes_match(pos, comment.span.start, |b| {
-                matches!(b, b'\t' | b' ' | b'=' | b':')
-            }) {
-                if comment.is_line() || comment.followed_by_newline() {
-                    return &comments[..=index];
-                }
-                pos = comment.span.end;
-            } else {
-                break;
-            }
-        }
-        &[]
+    pub fn end_of_line_comments_after(&self, pos: u32) -> &'a [Comment] {
+        self.end_of_line_comments_after_with(pos, Self::is_end_of_line_comment_gap_byte)
     }
 
     /// Returns comments that start after the given position (excluding printed ones).
@@ -394,8 +410,9 @@ impl<'a> Comments<'a> {
     /// This supports patterns like:
     /// `statement(); // prettier-ignore`
     /// `statement(); /* prettier-ignore */`
+    /// `value, // prettier-ignore`
     pub fn has_trailing_suppression_comment(&self, pos: u32) -> bool {
-        self.end_of_line_comments_after(pos)
+        self.end_of_line_comments_after_with(pos, Self::is_trailing_suppression_gap_byte)
             .iter()
             .any(|comment| self.is_suppression_comment(comment))
     }

--- a/crates/oxc_formatter/src/formatter/comments.rs
+++ b/crates/oxc_formatter/src/formatter/comments.rs
@@ -140,35 +140,6 @@ pub struct Comments<'a> {
 }
 
 impl<'a> Comments<'a> {
-    #[inline]
-    const fn is_end_of_line_comment_gap_byte(byte: u8) -> bool {
-        matches!(byte, b'\t' | b' ' | b'=' | b':')
-    }
-
-    #[inline]
-    const fn is_trailing_suppression_gap_byte(byte: u8) -> bool {
-        Self::is_end_of_line_comment_gap_byte(byte) || matches!(byte, b',' | b';')
-    }
-
-    fn end_of_line_comments_after_with(
-        &self,
-        mut pos: u32,
-        is_allowed_gap_byte: impl Fn(u8) -> bool + Copy,
-    ) -> &'a [Comment] {
-        let comments = self.comments_after(pos);
-        for (index, comment) in comments.iter().enumerate() {
-            if self.source_text.all_bytes_match(pos, comment.span.start, is_allowed_gap_byte) {
-                if comment.is_line() || comment.followed_by_newline() {
-                    return &comments[..=index];
-                }
-                pos = comment.span.end;
-            } else {
-                break;
-            }
-        }
-        &[]
-    }
-
     pub fn new(source_text: SourceText<'a>, comments: &'a [Comment]) -> Self {
         Comments {
             source_text,
@@ -223,8 +194,21 @@ impl<'a> Comments<'a> {
     }
 
     /// Returns end-of-line comments that are after the given position (excluding printed ones).
-    pub fn end_of_line_comments_after(&self, pos: u32) -> &'a [Comment] {
-        self.end_of_line_comments_after_with(pos, Self::is_end_of_line_comment_gap_byte)
+    pub fn end_of_line_comments_after(&self, mut pos: u32) -> &'a [Comment] {
+        let comments = self.comments_after(pos);
+        for (index, comment) in comments.iter().enumerate() {
+            if self.source_text.all_bytes_match(pos, comment.span.start, |b| {
+                matches!(b, b'\t' | b' ' | b'=' | b':' | b',')
+            }) {
+                if comment.is_line() || comment.followed_by_newline() {
+                    return &comments[..=index];
+                }
+                pos = comment.span.end;
+            } else {
+                break;
+            }
+        }
+        &[]
     }
 
     /// Returns comments that start after the given position (excluding printed ones).
@@ -412,7 +396,7 @@ impl<'a> Comments<'a> {
     /// `statement(); /* prettier-ignore */`
     /// `value, // prettier-ignore`
     pub fn has_trailing_suppression_comment(&self, pos: u32) -> bool {
-        self.end_of_line_comments_after_with(pos, Self::is_trailing_suppression_gap_byte)
+        self.end_of_line_comments_after(pos)
             .iter()
             .any(|comment| self.is_suppression_comment(comment))
     }

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js
@@ -69,6 +69,10 @@ const items = [
   {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
 ];
 
+foo(  {a:1,b:2},  // prettier-ignore
+  {c:3,d:4}
+);
+
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
 }

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js
@@ -65,6 +65,10 @@ export const item={  a:1,b:2}; // prettier-ignore
 const config={  retries:10,timeout:5000}; // prettier-ignore
 let data=[ 1,2,3 ]; // prettier-ignore
 
+const items = [
+  {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
+];
+
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
 }

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 229
 ---
 ==================== Input ====================
 // This file copies from https://github.com/prettier/prettier/blob/main/tests/format/js/ignore/ignore.js,
@@ -68,6 +69,10 @@ export const item={  a:1,b:2}; // prettier-ignore
 
 const config={  retries:10,timeout:5000}; // prettier-ignore
 let data=[ 1,2,3 ]; // prettier-ignore
+
+const items = [
+  {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
+];
 
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
@@ -169,6 +174,10 @@ export const item={  a:1,b:2}; // prettier-ignore
 const config={  retries:10,timeout:5000}; // prettier-ignore
 let data=[ 1,2,3 ]; // prettier-ignore
 
+const items = [
+  {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
+];
+
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
 }
@@ -267,6 +276,10 @@ export const item={  a:1,b:2}; // prettier-ignore
 
 const config={  retries:10,timeout:5000}; // prettier-ignore
 let data=[ 1,2,3 ]; // prettier-ignore
+
+const items = [
+  {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
+];
 
 function demo() {
   return   {a:1,b:2}; // prettier-ignore

--- a/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/ignore/oxfmt.js.snap
@@ -74,6 +74,10 @@ const items = [
   {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
 ];
 
+foo(  {a:1,b:2},  // prettier-ignore
+  {c:3,d:4}
+);
+
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
 }
@@ -178,6 +182,11 @@ const items = [
   {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
 ];
 
+foo(
+  {a:1,b:2}, // prettier-ignore
+  { c: 3, d: 4 },
+);
+
 function demo() {
   return   {a:1,b:2}; // prettier-ignore
 }
@@ -280,6 +289,11 @@ let data=[ 1,2,3 ]; // prettier-ignore
 const items = [
   {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
 ];
+
+foo(
+  {a:1,b:2}, // prettier-ignore
+  { c: 3, d: 4 },
+);
 
 function demo() {
   return   {a:1,b:2}; // prettier-ignore

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -318,22 +318,34 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
     };
     let node_type = get_node_type(&enum_ty);
 
-    let inline_trailing_suppression = if enum_def.name() == "Statement" {
-        // Expression statements need specialized ASI-safe suppression handling in
-        // `AstNode<ExpressionStatement>::write`.
-        quote! {
-            if !matches!(self.inner, Statement::ExpressionStatement(_))
-                && f.comments().has_trailing_suppression_comment(self.span().end)
-            {
-                format_leading_comments(self.span()).fmt(f);
-                FormatSuppressedNode(self.span()).fmt(f);
-                format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
-                    .fmt(f);
-                return;
+    let inline_trailing_suppression = match enum_def.name() {
+        "Statement" => {
+            // Expression statements need specialized ASI-safe suppression handling in
+            // `AstNode<ExpressionStatement>::write`.
+            quote! {
+                if !matches!(self.inner, Statement::ExpressionStatement(_))
+                    && f.comments().has_trailing_suppression_comment(self.span().end)
+                {
+                    format_leading_comments(self.span()).fmt(f);
+                    FormatSuppressedNode(self.span()).fmt(f);
+                    format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+                        .fmt(f);
+                    return;
+                }
             }
         }
-    } else {
-        quote! {}
+        "Expression" => {
+            quote! {
+                if f.comments().has_trailing_suppression_comment(self.span().end) {
+                    format_leading_comments(self.span()).fmt(f);
+                    FormatSuppressedNode(self.span()).fmt(f);
+                    format_trailing_comments(self.parent.span(), self.inner.span(), self.following_span_start)
+                        .fmt(f);
+                    return;
+                }
+            }
+        }
+        _ => quote! {},
     };
 
     quote! {


### PR DESCRIPTION
## Summary
After running the new oxfmt release (which comes with https://github.com/oxc-project/oxc/pull/19304) against our code base, we found one case where trailing ignore comments aren't properly interpreted (playground link at the end of this PR).

```js
const items = [
  {a:aa(),b:bb(),c:cc(),d:dd(),e:ee(),f:ff(),g:gg()}, // prettier-ignore
];
```
Prettier keeps the code as-is, but oxfmt turns it into:

```js
const items = [
  { a: aa(), b: bb(), c: cc(), d: dd(), e: ee(), f: ff(), g: gg() }, // prettier-ignore
];
```

## Root cause
- Trailing suppression detection only allowed whitespace/`=`/`:` between node end and comment.
- In list items, there is typically a comma before the trailing comment (`}, // prettier-ignore`).
- `Expression` formatting path also needed trailing suppression handling.

## Changes
- Extended trailing suppression gap handling to include list separators (`','`, `';'`).
- Reused a shared internal comment scan helper to avoid duplicated logic between:
  - end-of-line comment detection
  - trailing suppression detection
- Added trailing suppression handling for `AstNode<Expression>`.
- Updated the formatter generator accordingly so regenerated code keeps this behavior.

## Validation
Ran:
- `cargo test -p oxc_formatter --test mod fixtures::js::ignore`
- `cargo test -p oxc_formatter --test mod fixtures::ts::ignore`

Both pass.

## AI disclosure
This PR was prepared with AI assistance (Codex), and all changes were reviewed and validated by the author.


https://playground.oxc.rs/?t=formatter&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Atrue%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=const+items+%3D+%5B%0A++%7Ba%3Aaa%28%29%2Cb%3Abb%28%29%2Cc%3Acc%28%29%2Cd%3Add%28%29%2Ce%3Aee%28%29%2Cf%3Aff%28%29%2Cg%3Agg%28%29%7D%2C+%2F%2F+prettier-ignore%0A%5D%3B%0A
