### PR TITLE
docs(linter): Add a note that the typeAware and typeCheck options require oxlint-tsgolint

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -328,12 +328,16 @@ export interface OxlintOptions {
    * Enable rules that require type information.
    *
    * Equivalent to passing `--type-aware` on the CLI.
+   *
+   * Note that this requires the `oxlint-tsgolint` package to be installed.
    */
   typeAware?: boolean | null;
   /**
    * Enable experimental type checking (includes TypeScript compiler diagnostics).
    *
    * Equivalent to passing `--type-check` on the CLI.
+   *
+   * Note that this requires the `oxlint-tsgolint` package to be installed.
    */
   typeCheck?: boolean | null;
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -29,11 +29,15 @@ pub struct OxlintOptions {
     /// Enable rules that require type information.
     ///
     /// Equivalent to passing `--type-aware` on the CLI.
+    ///
+    /// Note that this requires the `oxlint-tsgolint` package to be installed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_aware: Option<bool>,
     /// Enable experimental type checking (includes TypeScript compiler diagnostics).
     ///
     /// Equivalent to passing `--type-check` on the CLI.
+    ///
+    /// Note that this requires the `oxlint-tsgolint` package to be installed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_check: Option<bool>,
     /// Ensure warnings produce a non-zero exit code.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -513,20 +513,20 @@
           "markdownDescription": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI."
         },
         "typeAware": {
-          "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.",
+          "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI."
+          "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         },
         "typeCheck": {
-          "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.",
+          "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI."
+          "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         }
       },
       "additionalProperties": false,

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -517,20 +517,20 @@ expression: json
           "markdownDescription": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI."
         },
         "typeAware": {
-          "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.",
+          "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI."
+          "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         },
         "typeCheck": {
-          "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.",
+          "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
           "type": [
             "boolean",
             "null"
           ],
-          "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI."
+          "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         }
       },
       "additionalProperties": false,

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -333,6 +333,8 @@ Enable rules that require type information.
 
 Equivalent to passing `--type-aware` on the CLI.
 
+Note that this requires the `oxlint-tsgolint` package to be installed.
+
 
 ### options.typeCheck
 
@@ -342,6 +344,8 @@ type: `boolean`
 Enable experimental type checking (includes TypeScript compiler diagnostics).
 
 Equivalent to passing `--type-check` on the CLI.
+
+Note that this requires the `oxlint-tsgolint` package to be installed.
 
 
 ## overrides


### PR DESCRIPTION
Just making sure that that is clear for users.