### PR TITLE
docs(linter): Fix some identation issues for the generated types used in `oxlint.config.ts`.

### DIFF
--- a/apps/oxlint/scripts/generate-config-types.ts
+++ b/apps/oxlint/scripts/generate-config-types.ts
@@ -19,6 +19,57 @@ if (!existsSync(schemaPath)) {
 
 const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
 
+// Sanitize and format JSON code blocks so they are indented properly.
+function sanitizeJsonCodeBlocks(text: string): string {
+  const marker = "```json";
+  let result = text;
+  let searchFrom = 0;
+
+  while (true) {
+    const start = result.indexOf(marker, searchFrom);
+    if (start === -1) break;
+
+    const contentStart = start + marker.length;
+    const end = result.indexOf("```", contentStart);
+    if (end === -1) break;
+
+    const jsonStr = result.slice(contentStart, end).trim();
+    let json: unknown;
+    try {
+      json = JSON.parse(jsonStr);
+    } catch {
+      searchFrom = end + 3;
+      continue;
+    }
+
+    const formatted = "\n" + JSON.stringify(json, null, 2) + "\n";
+    result = result.slice(0, contentStart) + formatted + result.slice(end);
+    searchFrom = contentStart + formatted.length;
+  }
+
+  return result;
+}
+
+function sanitizeSchema(value: any): void {
+  if (typeof value !== "object" || value === null) return;
+  if (Array.isArray(value)) {
+    value.forEach(sanitizeSchema);
+    return;
+  }
+  for (const key of Object.keys(value)) {
+    if (
+      (key === "description" || key === "markdownDescription") &&
+      typeof value[key] === "string"
+    ) {
+      value[key] = sanitizeJsonCodeBlocks(value[key]);
+    } else {
+      sanitizeSchema(value[key]);
+    }
+  }
+}
+
+sanitizeSchema(schema);
+
 const bannerComment =
   "/*\n" +
   " * This file is generated from npm/oxlint/configuration_schema.json.\n" +

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -98,34 +98,84 @@ export type CustomComponent =
  *
  * ```json
  * {
- * "$schema": "./node_modules/oxlint/configuration_schema.json",
- * "plugins": ["import", "typescript", "unicorn"],
- * "env": {
+ *   "$schema": "./node_modules/oxlint/configuration_schema.json",
+ *   "plugins": [
+ *     "import",
+ *     "typescript",
+ *     "unicorn"
+ *   ],
+ *   "env": {
+ *     "browser": true
+ *   },
+ *   "globals": {
+ *     "foo": "readonly"
+ *   },
+ *   "settings": {
+ *     "react": {
+ *       "version": "18.2.0"
+ *     },
+ *     "custom": {
+ *       "option": true
+ *     }
+ *   },
+ *   "rules": {
+ *     "eqeqeq": "warn",
+ *     "import/no-cycle": "error",
+ *     "react/self-closing-comp": [
+ *       "error",
+ *       {
+ *         "html": false
+ *       }
+ *     ]
+ *   },
+ *   "overrides": [
+ *     {
+ *       "files": [
+ *         "*.test.ts",
+ *         "*.spec.ts"
+ *       ],
+ *       "rules": {
+ *         "@typescript-eslint/no-explicit-any": "off"
+ *       }
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * `oxlint.config.ts`
+ *
+ * ```ts
+ * import { defineConfig } from "oxlint";
+ *
+ * export default defineConfig({
+ * plugins: ["import", "typescript", "unicorn"],
+ * env: {
  * "browser": true
  * },
- * "globals": {
+ * globals: {
  * "foo": "readonly"
  * },
- * "settings": {
- * "react": {
- * "version": "18.2.0"
+ * settings: {
+ * react: {
+ * version: "18.2.0"
  * },
- * "custom": { "option": true }
+ * custom: { option: true }
  * },
- * "rules": {
+ * rules: {
  * "eqeqeq": "warn",
  * "import/no-cycle": "error",
  * "react/self-closing-comp": ["error", { "html": false }]
  * },
- * "overrides": [
+ * overrides: [
  * {
- * "files": ["*.test.ts", "*.spec.ts"],
- * "rules": {
+ * files: ["*.test.ts", "*.spec.ts"],
+ * rules: {
  * "@typescript-eslint/no-explicit-any": "off"
  * }
  * }
  * ]
  * }
+ * });
  * ```
  *
  * `oxlint.config.ts`
@@ -203,10 +253,12 @@ export interface Oxlintrc {
    *
    * ```json
    * {
-   * "jsPlugins": ["./custom-plugin.js"],
-   * "rules": {
-   * "custom/rule-name": "warn"
-   * }
+   *   "jsPlugins": [
+   *     "./custom-plugin.js"
+   *   ],
+   *   "rules": {
+   *     "custom/rule-name": "warn"
+   *   }
    * }
    * ```
    *
@@ -215,14 +267,19 @@ export interface Oxlintrc {
    *
    * ```json
    * {
-   * "plugins": ["import"],
-   * "jsPlugins": [
-   * { "name": "import-js", "specifier": "eslint-plugin-import" }
-   * ],
-   * "rules": {
-   * "import/no-cycle": "error",
-   * "import-js/no-unresolved": "warn"
-   * }
+   *   "plugins": [
+   *     "import"
+   *   ],
+   *   "jsPlugins": [
+   *     {
+   *       "name": "import-js",
+   *       "specifier": "eslint-plugin-import"
+   *     }
+   *   ],
+   *   "rules": {
+   *     "import/no-cycle": "error",
+   *     "import-js/no-unresolved": "warn"
+   *   }
    * }
    * ```
    */
@@ -251,12 +308,17 @@ export interface Oxlintrc {
    *
    * ```json
    * {
-   * "$schema": "./node_modules/oxlint/configuration_schema.json",
-   * "rules": {
-   * "eqeqeq": "warn",
-   * "import/no-cycle": "error",
-   * "prefer-const": ["error", { "ignoreReadBeforeAssign": true }]
-   * }
+   *   "$schema": "./node_modules/oxlint/configuration_schema.json",
+   *   "rules": {
+   *     "eqeqeq": "warn",
+   *     "import/no-cycle": "error",
+   *     "prefer-const": [
+   *       "error",
+   *       {
+   *         "ignoreReadBeforeAssign": true
+   *       }
+   *     ]
+   *   }
    * }
    * ```
    *
@@ -279,13 +341,13 @@ export interface Oxlintrc {
  * Example
  * ```json
  * {
- *     "$schema": "./node_modules/oxlint/configuration_schema.json",
- *     "categories": {
- *         "correctness": "warn"
- *     },
- *     "rules": {
- *         "eslint/no-unused-vars": "error"
- *     }
+ *   "$schema": "./node_modules/oxlint/configuration_schema.json",
+ *   "categories": {
+ *     "correctness": "warn"
+ *   },
+ *   "rules": {
+ *     "eslint/no-unused-vars": "error"
+ *   }
  * }
  * ```
  */
@@ -319,17 +381,15 @@ export interface OxlintEnv {
  * you might use this config:
  *
  * ```json
- *
  * {
- * "$schema": "./node_modules/oxlint/configuration_schema.json",
- * "env": {
- * "es6": true
- * },
- * "globals": {
- * "Promise": "off"
+ *   "$schema": "./node_modules/oxlint/configuration_schema.json",
+ *   "env": {
+ *     "es6": true
+ *   },
+ *   "globals": {
+ *     "Promise": "off"
+ *   }
  * }
- * }
- *
  * ```
  *
  * You may also use `"readable"` or `false` to represent `"readonly"`, and
@@ -416,22 +476,25 @@ export interface DummyRuleMap {
  *
  * ```json
  * {
- * "settings": {
- * "next": {
- * "rootDir": "apps/dashboard/"
- * },
- * "react": {
- * "linkComponents": [
- * { "name": "Link", "linkAttribute": "to" }
- * ]
- * },
- * "jsx-a11y": {
- * "components": {
- * "Link": "a",
- * "Button": "button"
- * }
- * }
- * }
+ *   "settings": {
+ *     "next": {
+ *       "rootDir": "apps/dashboard/"
+ *     },
+ *     "react": {
+ *       "linkComponents": [
+ *         {
+ *           "name": "Link",
+ *           "linkAttribute": "to"
+ *         }
+ *       ]
+ *     },
+ *     "jsx-a11y": {
+ *       "components": {
+ *         "Link": "a",
+ *         "Button": "button"
+ *       }
+ *     }
+ *   }
  * }
  * ```
  */
@@ -493,13 +556,16 @@ export interface JSXA11YPluginSettings {
    *
    * ```json
    * {
-   * "settings": {
-   * "jsx-a11y": {
-   * "attributes": {
-   * "for": ["htmlFor", "for"]
-   * }
-   * }
-   * }
+   *   "settings": {
+   *     "jsx-a11y": {
+   *       "attributes": {
+   *         "for": [
+   *           "htmlFor",
+   *           "for"
+   *         ]
+   *       }
+   *     }
+   *   }
    * }
    * ```
    */
@@ -514,14 +580,14 @@ export interface JSXA11YPluginSettings {
    *
    * ```json
    * {
-   * "settings": {
-   * "jsx-a11y": {
-   * "components": {
-   * "Link": "a",
-   * "IconButton": "button"
-   * }
-   * }
-   * }
+   *   "settings": {
+   *     "jsx-a11y": {
+   *       "components": {
+   *         "Link": "a",
+   *         "IconButton": "button"
+   *       }
+   *     }
+   *   }
    * }
    * ```
    */
@@ -559,11 +625,11 @@ export interface NextPluginSettings {
    *
    * ```json
    * {
-   * "settings": {
-   * "next": {
-   * "rootDir": "apps/dashboard/"
-   * }
-   * }
+   *   "settings": {
+   *     "next": {
+   *       "rootDir": "apps/dashboard/"
+   *     }
+   *   }
    * }
    * ```
    */


### PR DESCRIPTION
I think we may want to consider alternatively calling oxfmt in order to do this, rather than a bespoke solution here? That would also fix the formatting of typescript code blocks. 

Right now, this also doesn't handle `jsonc` code blocks.

But for now, good enough.

Without this fix, the editor suggestions have docs like this:

<img width="976" height="441" alt="Screenshot 2026-03-02 at 8 46 34 PM" src="https://github.com/user-attachments/assets/243af8fb-a7d4-4954-a272-51dadfb9e488" />

AI Disclosure: Changeset generated by Claude Code.
