### PR TITLE
feat(oxlint): auto-enable github formatter on GitHub Actions

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -245,8 +245,19 @@ pub struct WarningOptions {
 pub struct OutputOptions {
     /// Use a specific output format. Possible values:
     /// `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
-    #[bpaf(long, short, fallback(OutputFormat::Default), hide_usage)]
+    #[bpaf(long, short, fallback_with(default_output_format), hide_usage)]
     pub format: OutputFormat,
+}
+
+#[expect(clippy::unnecessary_wraps)]
+fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
+    if cfg!(debug_assertions) {
+        Ok(OutputFormat::Default)
+    } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
+        Ok(OutputFormat::Github)
+    } else {
+        Ok(OutputFormat::Default)
+    }
 }
 
 /// Enable/Disable Plugins


### PR DESCRIPTION
## Summary
- make `--format` fallback dynamic with `bpaf` `fallback_with`
- when `GITHUB_ACTIONS=true`, default formatter becomes `github`
- keep explicit `--format` values unchanged

## Testing
- `cargo test -p oxlint command::lint:: -- --nocapture`

Fixes #19943

## AI Usage
- This PR was prepared with AI assistance (Codex), then reviewed and validated with local tests.
