### PR TITLE
perf(linter/plugins): store tokens as a `Box<[Token]>`

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::Box as ArenaBox;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_parser::Token;
 use oxc_semantic::Semantic;
@@ -38,8 +38,9 @@ pub struct ContextSubHost<'a> {
     pub(super) disable_directives: DisableDirectives,
     // Specific framework options, for example, whether the context is inside `<script setup>` in Vue files.
     pub(super) framework_options: FrameworkOptions,
-    /// Parser tokens collected during parsing, when available.
-    pub(super) parser_tokens: Option<ArenaVec<'a, Token>>,
+    /// Parser tokens collected during parsing.
+    /// Empty if parsing failed, or tokens are disabled (no JS plugins).
+    pub(super) parser_tokens: ArenaBox<'a, [Token]>,
     /// The source text offset of the sub host
     pub(super) source_text_offset: u32,
 }
@@ -55,7 +56,7 @@ impl<'a> ContextSubHost<'a> {
             module_record,
             source_text_offset,
             FrameworkOptions::Default,
-            None,
+            ArenaBox::new_empty_boxed_slice(),
         )
     }
 
@@ -66,7 +67,7 @@ impl<'a> ContextSubHost<'a> {
         module_record: Arc<ModuleRecord>,
         source_text_offset: u32,
         frameworks_options: FrameworkOptions,
-        parser_tokens: Option<ArenaVec<'a, Token>>,
+        parser_tokens: ArenaBox<'a, [Token]>,
     ) -> Self {
         // We should always check for `semantic.cfg()` being `Some` since we depend on it and it is
         // unwrapped without any runtime checks after construction.
@@ -235,13 +236,13 @@ impl<'a> ContextHost<'a> {
     }
 
     /// Shared reference to the parser tokens collected for this script block.
-    pub fn parser_tokens(&self) -> Option<&[Token]> {
-        self.current_sub_host().parser_tokens.as_ref().map(|tokens| &tokens[..])
+    pub fn parser_tokens(&self) -> &[Token] {
+        &self.current_sub_host().parser_tokens[..]
     }
 
     /// Mutable reference to the parser tokens collected for this script block.
-    pub fn parser_tokens_mut(&mut self) -> Option<&mut ArenaVec<'a, Token>> {
-        self.current_sub_host_mut().parser_tokens.as_mut()
+    pub fn parser_tokens_mut(&mut self) -> &mut ArenaBox<'a, [Token]> {
+        &mut self.current_sub_host_mut().parser_tokens
     }
 
     /// Path to the file being linted.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -475,9 +475,7 @@ impl Linter {
         }
 
         // `allocator` is a fixed-size allocator, so no need to clone AST into a new one
-        let tokens = ctx_host
-            .parser_tokens_mut()
-            .map(|tokens| tokens.take_in(allocator).into_bump_slice_mut());
+        let tokens = ctx_host.parser_tokens_mut().take_in(allocator).into_bump_slice_mut();
 
         self.convert_and_call_external_linter(
             external_rules,
@@ -537,7 +535,7 @@ impl Linter {
         };
 
         // Clone tokens into fixed-size allocator
-        let tokens = ctx_host.parser_tokens().map(|tokens| js_allocator.alloc_slice_copy(tokens));
+        let tokens = js_allocator.alloc_slice_copy(ctx_host.parser_tokens());
 
         self.convert_and_call_external_linter(
             external_rules,
@@ -562,7 +560,7 @@ impl Linter {
         path: &Path,
         ctx_host: &ContextHost<'_>,
         program: &mut Program<'_>,
-        tokens: Option<&mut [Token]>,
+        tokens: &mut [Token],
         allocator: &Allocator,
     ) {
         // If has BOM, remove it
@@ -586,12 +584,11 @@ impl Linter {
             Utf8ToUtf16::new(source_text)
         };
 
-        let (tokens_offset, tokens_len) = if let Some(tokens) = tokens {
+        // Convert tokens for raw transfer
+        #[expect(clippy::if_not_else, clippy::cast_possible_truncation)]
+        let (tokens_offset, tokens_len) = if !tokens.is_empty() {
             update_tokens(tokens, program, &span_converter, ESTreeTokenOptionsJS);
-            let tokens_offset = tokens.as_ptr() as u32;
-            #[expect(clippy::cast_possible_truncation)]
-            let tokens_len = tokens.len() as u32;
-            (tokens_offset, tokens_len)
+            (tokens.as_ptr() as u32, tokens.len() as u32)
         } else {
             (0, 0)
         };

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -19,7 +19,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 use self_cell::self_cell;
 use smallvec::SmallVec;
 
-use oxc_allocator::{Allocator, AllocatorGuard, AllocatorPool, Vec as ArenaVec};
+use oxc_allocator::{Allocator, AllocatorGuard, AllocatorPool, Box as ArenaBox};
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic};
 use oxc_parser::{ParseOptions, Parser, Token, config::RuntimeParserConfig};
 use oxc_resolver::Resolver;
@@ -127,8 +127,9 @@ struct SectionContent<'a> {
     /// None if section parsing failed. The corresponding item with the same index in
     /// `ProcessedModule.section_module_records` would be `Err(Vec<OxcDiagnostic>)`.
     semantic: Option<Semantic<'a>>,
-    /// None if section parsing failed, or token collection was not requested.
-    parser_tokens: Option<ArenaVec<'a, Token>>,
+    /// Parser tokens for the section.
+    /// Empty if section parsing failed, or if token collection was not requested (no JS plugins).
+    parser_tokens: ArenaBox<'a, [Token]>,
 }
 
 /// A module with its source text and semantic, ready to be linted.
@@ -1008,7 +1009,7 @@ impl Runtime {
                         sections.push(SectionContent {
                             source: section_source,
                             semantic: None,
-                            parser_tokens: None,
+                            parser_tokens: ArenaBox::new_empty_boxed_slice(),
                         });
                     }
                 }
@@ -1025,7 +1026,7 @@ impl Runtime {
         source_text: &'a str,
         source_type: SourceType,
         check_syntax_errors: bool,
-    ) -> Result<(ResolvedModuleRecord, Semantic<'a>, Option<ArenaVec<'a, Token>>), Vec<OxcDiagnostic>>
+    ) -> Result<(ResolvedModuleRecord, Semantic<'a>, ArenaBox<'a, [Token]>), Vec<OxcDiagnostic>>
     {
         let collect_tokens = self.linter.has_external_linter();
         let ret = Parser::new(allocator, source_text, source_type)
@@ -1055,6 +1056,8 @@ impl Runtime {
 
         let module_record = Arc::new(ModuleRecord::new(path, &ret.module_record, &semantic));
 
+        let tokens = ret.tokens.into_boxed_slice();
+
         let mut resolved_module_requests: Vec<ResolvedModuleRequest> = vec![];
 
         // If import plugin is enabled.
@@ -1073,11 +1076,6 @@ impl Runtime {
                 })
                 .collect();
         }
-        let parser_tokens = collect_tokens.then_some(ret.tokens);
-        Ok((
-            ResolvedModuleRecord { module_record, resolved_module_requests },
-            semantic,
-            parser_tokens,
-        ))
+        Ok((ResolvedModuleRecord { module_record, resolved_module_requests }, semantic, tokens))
     }
 }


### PR DESCRIPTION
Small perf optimization.

Once tokens are collected, we have no reason to add / remove any. So store tokens as a `Box<'a, [Token]>` (16 bytes) instead of a `Vec<'a, Token>` (24 bytes).

Unlike with `std`'s `Vec<T>`, converting arena `Vec<'a, T>` to `Box<'a, [T]>` is zero cost.

Also, now that it's only 16 bytes, remove the `Option` wrapper, as it serves little purpose except to force you to unwrap it. "No tokens" is represented as an empty slice instead.