### PR TITLE
docs(ai): Add migration skills

### DIFF
--- a/.agents/skills/migrate-oxfmt/SKILL.md
+++ b/.agents/skills/migrate-oxfmt/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: migrate-oxfmt
+description: Guide for migrating a project from Prettier or Biome to Oxfmt. Use when asked to migrate, convert, or switch a JavaScript/TypeScript project's formatter from Prettier or Biome to Oxfmt.
+---
+
+This skill guides you through migrating a JavaScript/TypeScript project from Prettier or Biome to [Oxfmt](https://oxc.rs/docs/guide/usage/formatter).
+
+## Overview
+
+Oxfmt is a high-performance, Prettier-compatible code formatter. Most Prettier options are supported directly.
+
+An automated migration tool is built into oxfmt, supporting both Prettier and Biome as migration sources.
+
+## Step 1: Run Automated Migration
+
+### From Prettier
+
+```bash
+npx oxfmt@latest --migrate prettier
+```
+
+This will:
+
+- Find and read your Prettier config (any format Prettier supports)
+- Create `.oxfmtrc.json` with migrated options
+- Migrate `.prettierignore` patterns to `ignorePatterns`
+- Migrate `prettier-plugin-tailwindcss` options to `sortTailwindcss`
+- Detect `prettier-plugin-packagejson` and enable `sortPackageJson`
+
+### From Biome
+
+```bash
+npx oxfmt@latest --migrate biome
+```
+
+This will:
+
+- Find and read `biome.json` or `biome.jsonc`
+- Create `.oxfmtrc.json` with migrated options
+- Migrate negated patterns from `files.includes` to `ignorePatterns`
+- Map Biome's two-level config (`formatter.*` and `javascript.formatter.*`) to oxfmt options
+
+Biome option mapping:
+
+| Biome                                                       | oxfmt                             |
+| ----------------------------------------------------------- | --------------------------------- |
+| `formatter.indentStyle` (`"tab"`/`"space"`)                 | `useTabs` (`true`/`false`)        |
+| `formatter.indentWidth`                                     | `tabWidth`                        |
+| `formatter.lineWidth`                                       | `printWidth`                      |
+| `javascript.formatter.quoteStyle`                           | `singleQuote`                     |
+| `javascript.formatter.jsxQuoteStyle`                        | `jsxSingleQuote`                  |
+| `javascript.formatter.quoteProperties` (`"asNeeded"`)       | `quoteProps` (`"as-needed"`)      |
+| `javascript.formatter.trailingCommas`                       | `trailingComma`                   |
+| `javascript.formatter.semicolons` (`"always"`/`"asNeeded"`) | `semi` (`true`/`false`)           |
+| `javascript.formatter.arrowParentheses` (`"asNeeded"`)      | `arrowParens` (`"avoid"`)         |
+| `formatter.bracketSameLine`                                 | `bracketSameLine`                 |
+| `formatter.bracketSpacing`                                  | `bracketSpacing`                  |
+| `formatter.attributePosition` (`"multiline"`)               | `singleAttributePerLine` (`true`) |
+
+Notes (both sources):
+
+- Fails if `.oxfmtrc.json` already exists. Delete it first if you want to re-run.
+- If no source config is found, creates a blank `.oxfmtrc.json` instead.
+- `overrides` cannot be auto-migrated for either source and must be converted manually.
+
+## Step 2: Review Generated Config
+
+After migration, review the generated `.oxfmtrc.json` for these key differences:
+
+### printWidth
+
+Prettier and Biome default is 80, oxfmt default is 100. The migration tool sets `printWidth: 80` if not specified in your source config. Decide whether to keep 80 or adopt 100.
+
+### Unsupported Options (Prettier only)
+
+These Prettier options are skipped during migration:
+
+| Option                         | Status                                           |
+| ------------------------------ | ------------------------------------------------ |
+| `endOfLine: "auto"`            | Not supported. Use `"lf"` or `"crlf"` explicitly |
+| `experimentalTernaries`        | Not supported in JS/TS files yet                 |
+| `experimentalOperatorPosition` | Not supported in JS/TS files yet                 |
+
+### sortPackageJson (Prettier only)
+
+Enabled by default in oxfmt, but the migration tool disables it unless `prettier-plugin-packagejson` was detected. Review whether you want this enabled.
+
+Note: Oxfmt's sorting algorithm differs from `prettier-plugin-packagejson`.
+
+### embeddedLanguageFormatting (Prettier only)
+
+Embedded language formatting (e.g., CSS-in-JS) generally works, but some formatting may differ from Prettier.
+
+### overrides
+
+The `overrides` field cannot be auto-migrated from either Prettier or Biome. Convert manually:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "options": { "tabWidth": 4 }
+    }
+  ]
+}
+```
+
+### Nested Config
+
+Oxfmt does not support nested configuration files (e.g., a separate `.oxfmtrc.json` in a subdirectory). If your project used per-directory Prettier or Biome configs, consolidate them using `overrides` with file glob patterns, or run oxfmt separately per directory with different working directories.
+
+### Prettier-Compatible Options
+
+These options transfer directly with the same behavior:
+`tabWidth`, `useTabs`, `semi`, `singleQuote`, `jsxSingleQuote`, `quoteProps`, `trailingComma`, `arrowParens`, `bracketSpacing`, `bracketSameLine`, `endOfLine`, `proseWrap`, `htmlWhitespaceSensitivity`, `singleAttributePerLine`, `vueIndentScriptAndStyle`
+
+## Step 3: Configure Oxfmt Extensions
+
+Oxfmt offers features not available in Prettier:
+
+### sortImports
+
+Sort import statements, inspired by `eslint-plugin-perfectionist/sort-imports` (disabled by default):
+
+```json
+{
+  "sortImports": {
+    "partitionByNewline": true,
+    "newlinesBetween": false
+  }
+}
+```
+
+### sortTailwindcss
+
+Replaces `prettier-plugin-tailwindcss`. Auto-migrated with renamed options:
+
+| Prettier (top-level)         | oxfmt (`sortTailwindcss.*`) |
+| ---------------------------- | --------------------------- |
+| `tailwindConfig`             | `config`                    |
+| `tailwindStylesheet`         | `stylesheet`                |
+| `tailwindFunctions`          | `functions`                 |
+| `tailwindAttributes`         | `attributes`                |
+| `tailwindPreserveWhitespace` | `preserveWhitespace`        |
+| `tailwindPreserveDuplicates` | `preserveDuplicates`        |
+
+### Other Extensions
+
+| Option               | Default | Description                                                                  |
+| -------------------- | ------- | ---------------------------------------------------------------------------- |
+| `insertFinalNewline` | `true`  | Whether to add a final newline at end of file                                |
+| `sortPackageJson`    | `true`  | Sort `package.json` keys. Set `{ "sortScripts": true }` to also sort scripts |
+
+## Step 4: Update CI and Scripts
+
+Replace formatter commands with oxfmt:
+
+```bash
+# Before (Prettier)
+npx prettier --write .
+npx prettier --check .
+
+# Before (Biome)
+npx biome format --write .
+npx biome check .
+
+# After
+npx oxfmt@latest
+npx oxfmt@latest --check
+```
+
+### Common CLI Options
+
+| Prettier / Biome                                | oxfmt                                        |
+| ----------------------------------------------- | -------------------------------------------- |
+| `prettier --write .` / `biome format --write .` | `oxfmt` (default: cwd, `--write` mode)       |
+| `prettier --check .` / `biome check .`          | `oxfmt --check`                              |
+| `prettier --list-different .`                   | `oxfmt --list-different`                     |
+| `prettier --config path`                        | `oxfmt --config path`                        |
+| `prettier --ignore-path .prettierignore`        | `oxfmt --ignore-path .prettierignore`        |
+| `cat file \| prettier --stdin-filepath=file.ts` | `cat file \| oxfmt --stdin-filepath=file.ts` |
+
+### File Type Coverage
+
+- JS/TS: Formatted natively by oxfmt
+- TOML: Formatted natively (via taplo)
+- CSS, HTML, YAML, Markdown, GraphQL, etc.: Delegated to Prettier internally (when using `npx oxfmt`)
+
+## Tips
+
+- EditorConfig: Oxfmt reads `.editorconfig` automatically for `useTabs`, `tabWidth`, `endOfLine`, `insertFinalNewline`, and `printWidth`. Options in `.oxfmtrc.json` take precedence.
+- CI: Use `npx oxfmt@latest --check` to enforce formatting in CI.
+- LSP: Run `oxfmt --lsp` for editor integration via Language Server Protocol.
+- Schema support: Add `"$schema": "./node_modules/oxfmt/configuration_schema.json"` to `.oxfmtrc.json` for editor autocompletion.
+- Init: Run `npx oxfmt@latest --init` to create a default `.oxfmtrc.json` without migration.
+
+## References
+
+- [CLI Reference](https://oxc.rs/docs/guide/usage/formatter/cli.html)
+- [Config File Reference](https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html)
+- [Unsupported Features](https://oxc.rs/docs/guide/usage/formatter/unsupported-features.html)

--- a/.agents/skills/migrate-oxlint/SKILL.md
+++ b/.agents/skills/migrate-oxlint/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: migrate-oxlint
+description: Guide for migrating a project from ESLint to Oxlint. Use when asked to migrate, convert, or switch a JavaScript/TypeScript project's linter from ESLint to Oxlint.
+---
+
+This skill guides you through migrating a JavaScript/TypeScript project from ESLint to [Oxlint](https://oxc.rs/docs/guide/usage/linter/).
+
+## Overview
+
+Oxlint is a high-performance linter that implements many popular ESLint rules natively in Rust. It can be used alongside ESLint or as a full replacement.
+
+An official migration tool is available: [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate)
+
+## Step 1: Run Automated Migration
+
+Run the migration tool in the project root:
+
+```bash
+npx @oxlint/migrate
+```
+
+This reads your ESLint flat config and generates a `.oxlintrc.json` file.
+
+### Key Options
+
+| Option                      | Description                                                               |
+| --------------------------- | ------------------------------------------------------------------------- |
+| `--merge`                   | Merge with an existing `.oxlintrc.json` instead of overwriting            |
+| `--type-aware`              | Include type-aware rules (requires running oxlint with `--type-aware`)    |
+| `--with-nursery`            | Include experimental rules still under development                        |
+| `--js-plugins [bool]`       | Enable/disable ESLint plugin migration via `jsPlugins` (default: enabled) |
+| `--details`                 | List rules that could not be migrated                                     |
+| `--replace-eslint-comments` | Convert `// eslint-disable` comments to `// oxlint-disable`               |
+| `--output-file <file>`      | Specify output path (default: `.oxlintrc.json`)                           |
+
+If your ESLint config is not at the default location, pass the path explicitly:
+
+```bash
+npx @oxlint/migrate ./path/to/eslint.config.js
+```
+
+## Step 2: Review Generated Config
+
+After migration, review the generated `.oxlintrc.json`.
+
+### Plugin Mapping
+
+The migration tool automatically maps ESLint plugins to oxlint's built-in equivalents. The following table is for reference when reviewing the generated config:
+
+| ESLint Plugin                                       | Oxlint Plugin Name |
+| --------------------------------------------------- | ------------------ |
+| `@typescript-eslint/eslint-plugin`                  | `typescript`       |
+| `eslint-plugin-react` / `eslint-plugin-react-hooks` | `react`            |
+| `eslint-plugin-import` / `eslint-plugin-import-x`   | `import`           |
+| `eslint-plugin-unicorn`                             | `unicorn`          |
+| `eslint-plugin-jsx-a11y`                            | `jsx-a11y`         |
+| `eslint-plugin-react-perf`                          | `react-perf`       |
+| `eslint-plugin-promise`                             | `promise`          |
+| `eslint-plugin-jest`                                | `jest`             |
+| `@vitest/eslint-plugin`                             | `vitest`           |
+| `eslint-plugin-jsdoc`                               | `jsdoc`            |
+| `eslint-plugin-next`                                | `nextjs`           |
+| `eslint-plugin-node`                                | `node`             |
+| `eslint-plugin-vue`                                 | `vue`              |
+
+Default plugins (enabled when `plugins` field is omitted): `unicorn`, `typescript`, `oxc`.
+Setting the `plugins` array explicitly overrides these defaults.
+
+### Rule Categories
+
+Oxlint groups rules into categories for bulk configuration:
+
+```json
+{
+  "categories": {
+    "correctness": "warn",
+    "suspicious": "warn"
+  }
+}
+```
+
+Available categories: `correctness` (default: enabled), `suspicious`, `pedantic`, `perf`, `style`, `restriction`, `nursery`.
+
+Individual rule settings in `rules` override category settings.
+
+### Check Unmigrated Rules
+
+Run with `--details` to see which ESLint rules could not be migrated:
+
+```bash
+npx @oxlint/migrate --details
+```
+
+Review the output and decide whether to keep ESLint for those rules or find oxlint alternatives.
+
+## Step 3: Handle Unsupported Features
+
+Some features require manual attention:
+
+- Local plugins (relative path imports): Must be migrated manually to `jsPlugins`
+- `eslint-plugin-prettier`: Not supported. Use [oxfmt](https://oxc.rs/docs/guide/usage/formatter) instead
+- `settings` in override configs: Oxlint does not support `settings` inside `overrides` blocks
+- ESLint v9+ plugins: Not all work with oxlint's JS Plugins API. Test with `--js-plugins`
+
+### External ESLint Plugins
+
+For ESLint plugins without a built-in oxlint equivalent, use the `jsPlugins` field to load them:
+
+```json
+{
+  "jsPlugins": ["eslint-plugin-custom"],
+  "rules": {
+    "custom/my-rule": "warn"
+  }
+}
+```
+
+## Step 4: Update CI and Scripts
+
+Replace ESLint commands with oxlint. Path arguments are optional; oxlint defaults to the current working directory.
+
+```bash
+# Before
+npx eslint src/
+npx eslint --fix src/
+
+# After
+npx oxlint@latest
+npx oxlint@latest --fix
+```
+
+### Common CLI Options
+
+| ESLint                    | oxlint                                         |
+| ------------------------- | ---------------------------------------------- |
+| `eslint .`                | `oxlint` (default: cwd)                        |
+| `eslint src/`             | `oxlint src/`                                  |
+| `eslint --fix`            | `oxlint --fix`                                 |
+| `eslint --max-warnings 0` | `oxlint --deny-warnings` or `--max-warnings 0` |
+| `eslint --format json`    | `oxlint --format json`                         |
+| `eslint -c config.json`   | `oxlint --config config.json`                  |
+
+Additional oxlint options:
+
+- `--type-aware`: Enable rules requiring TypeScript type information
+- `--tsconfig <path>`: Specify tsconfig.json path for type-aware linting
+
+## Tips
+
+- Start gradually: Enable `correctness` rules first (the default), then progressively add `suspicious`, `pedantic`, etc.
+- Run alongside ESLint: Oxlint is designed to complement ESLint during migration. You can run both until all rules are covered.
+- Disable comments work: `// eslint-disable` and `// eslint-disable-next-line` comments are supported by oxlint. Use `--replace-eslint-comments` to convert them to `// oxlint-disable` if desired.
+- List available rules: Run `npx oxlint@latest --rules` to see all supported rules.
+- Schema support: Add `"$schema": "./node_modules/oxlint/configuration_schema.json"` to `.oxlintrc.json` for editor autocompletion.
+- Output formats: `default`, `stylish`, `json`, `github`, `gitlab`, `junit`, `checkstyle`, `unix`
+
+## References
+
+- [CLI Reference](https://oxc.rs/docs/guide/usage/linter/cli.html)
+- [Config File Reference](https://oxc.rs/docs/guide/usage/linter/config-file-reference.html)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ To give you an idea of its capabilities, here is an example from the [vscode] re
 </p>
 
 → [oxlint documentation](https://oxc.rs/docs/guide/usage/linter/cli.html)
+→ AI migration skill is also available: `npx skills add oxc-project/oxc --skill migrate-oxlint`
 
 ### Formatter
 
@@ -88,6 +89,7 @@ npx oxfmt@latest
 ```
 
 → [Formatter documentation](https://oxc.rs/docs/guide/usage/formatter)
+→ AI migration skill is also available: `npx skills add oxc-project/oxc --skill migrate-oxfmt`
 
 ### Parser (Node.js)
 


### PR DESCRIPTION
Fixes #19945

---

TIL: About `skills` CLI

- Never read the `README.md`
- Search `SKILL.md` for `<root>/`, `skills/`, `.agent/skills`, etc...
- We already have `.agents/skills/insta-snapshots`, this also become discoverable