### PR TITLE
docs(transform): use the `node:` namespace in the example

### DIFF
--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -5,7 +5,7 @@ See [usage instructions](https://oxc.rs/docs/guide/usage/transformer).
 ## TypeScript and React JSX Transform
 
 ```javascript
-import assert from "assert";
+import assert from "node:assert";
 import { transformSync } from "oxc-transform";
 
 const { code, declaration, errors } = transformSync("test.ts", "class A<T> {}", {
@@ -27,7 +27,7 @@ Conforms to TypeScript compiler's `--isolatedDeclarations` `.d.ts` emit.
 ### Usage
 
 ```javascript
-import assert from "assert";
+import assert from "node:assert";
 import { isolatedDeclarationSync } from "oxc-transform";
 
 const { map, code, errors } = isolatedDeclarationSync("test.ts", "class A {}");


### PR DESCRIPTION
Hi,

This PR simply updates the documentation example in `napi/transform/README.md` to use the `node:` namespace when importing a Node.js built-in module.

As far as I know, the `node:` namespace prefix for built-in modules was introduced in Node.js `14.18.0` and `16.0.0`, so it should work with the current Node.js supported version range.

https://github.com/oxc-project/oxc/blob/6245c5629f2ca3bbbfbaffd1400fad06cc23d659/napi/transform/package.json#L87-L89

Also, it appears that the other source files already use it when importing Node.js built-in modules.

https://github.com/oxc-project/oxc/blob/6245c5629f2ca3bbbfbaffd1400fad06cc23d659/napi/transform/scripts/patch.js#L1-L2

https://github.com/oxc-project/oxc/blob/6245c5629f2ca3bbbfbaffd1400fad06cc23d659/napi/transform/webcontainer-fallback.cjs#L1-L2

Please let me know if there's anything wrong with this change!