### PR TITLE
fix(linter/role-supports-aria-props): add `aria-posinset` to supported `option` ARIA properties

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -892,6 +892,7 @@ const OPTION_PROPS: &[AriaProperty] = &[
     AriaProperty::LabelledBy,
     AriaProperty::Live,
     AriaProperty::Owns,
+    AriaProperty::PosInSet,
     AriaProperty::Relevant,
     AriaProperty::RoleDescription,
     AriaProperty::Selected,
@@ -1639,6 +1640,7 @@ fn test() {
         (r"<datalist aria-expanded />", None, None),
         (r#"<div role="heading" aria-level />"#, None, None),
         (r#"<div role="heading" aria-level="1" />"#, None, None),
+        (r#"<option aria-posinset="1" />"#, None, None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
## Description
Fixes #19950

WAI-ARIA 1.3 and MDN documentation specify that the `aria-posinset` attribute is supported by the `option` role. However, `oxlint`'s `jsx-a11y/role-supports-aria-props` rule was incorrectly flagging it as an invalid attribute.

This PR adds `aria-posinset` (via `AriaProperty::PosInSet`) to the allowed properties (`OPTION_PROPS`) for the `option` role. It also adds the corresponding test cases to prevent future regressions.

## References
- [WAI-ARIA 1.3 `option` role](https://w3c.github.io/aria/#option)
- [MDN Web Docs: `aria-posinset` - Associated roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-posinset#associated_roles)

## Test Plan
- Added pass test cases for `<option aria-posinset="1" />` 
- Ran `cargo test -p oxc_linter -- role_supports_aria_props` to verify all tests pass successfully.
