### PR TITLE
fix(linter/plugins): allow `null` and `undefined` for `rule.meta.fixable`

### DIFF
--- a/apps/oxlint/src-js/plugins/rule_meta.ts
+++ b/apps/oxlint/src-js/plugins/rule_meta.ts
@@ -29,7 +29,7 @@ export interface RuleMeta {
    * Type of fixes that the rule provides.
    * Must be `'code'` or `'whitespace'` if the rule provides fixes.
    */
-  fixable?: "code" | "whitespace";
+  fixable?: "code" | "whitespace" | null | undefined;
   /**
    * Specifies whether rule can return suggestions.
    * Must be `true` if the rule provides suggestions.


### PR DESCRIPTION
While working on #20009, discovered than many of ESLint's built-in rules define `rule.meta.fixable` as `null`.

Since this is clearly an established pattern, correct TS types to accept `null`. Also accept `undefined`, as we do pretty much everywhere else that we accept `null`.

Both `null` and `undefined` were already handled at runtime. This just makes that support "official" in the TS types.