### PR TITLE
docs(oxlint/lsp): remove outdated ToDo for `LintOptions.run`

### DIFF
--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -24,7 +24,7 @@ pub enum Run {
 #[derive(Debug, Default, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LintOptions {
-    pub run: Run, // TODO: the client wants maybe only the formatter, make it optional
+    pub run: Run,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This TODO was from a time when the language server was shipped as one single binary, including oxlint and oxfmt.
We live now in the future and implement one language server for each tool