### PR TITLE
fix(linter/no-restricted-imports): apply regex pattern checks to side-effect imports

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -857,6 +857,11 @@ impl RestrictedPattern {
         }
     }
 
+    fn is_side_effect_import_allowed(&self) -> bool {
+        let unused_name = CompactStr::from("__<>import_name_that_cant_be_used<>__");
+        self.is_name_span_allowed(&unused_name) == NameSpanAllowedResult::Allowed
+    }
+
     fn get_group_glob_result(&self, name: &str) -> GlobResult {
         let Some(groups) = &self.group else {
             return GlobResult::None;
@@ -1040,6 +1045,15 @@ impl NoRestrictedImports {
                         ));
                     }
                     GlobResult::None => {}
+                }
+
+                if pattern.get_regex_result(source) && !pattern.is_side_effect_import_allowed() {
+                    ctx.diagnostic(get_diagnostic_from_import_name_result_pattern(
+                        spans[0],
+                        source,
+                        &ImportNameResult::GeneralDisallowed,
+                        pattern,
+                    ));
                 }
             }
             if !whitelist_found && let Some(err) = err {
@@ -1805,6 +1819,15 @@ fn test() {
                 "patterns": [{
                     "regex": "my/relative-module",
                     "importNamePattern": "^Foo"
+                }]
+            }])),
+        ),
+        (
+            "import 'foo';",
+            Some(serde_json::json!([{
+                "patterns": [{
+                    "regex": "foo",
+                    "importNames": ["Bar"],
                 }]
             }])),
         ),
@@ -3071,6 +3094,12 @@ fn test() {
             r"import 'foo'",
             Some(
                 serde_json::json!([{ "patterns": [{ "group": ["foo"], "message": "foo is forbidden, use bar instead" }] }]),
+            ),
+        ),
+        (
+            r"import 'foo'",
+            Some(
+                serde_json::json!([{ "patterns": [{ "regex": "foo", "message": "foo is forbidden, use bar instead" }] }]),
             ),
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_imports.snap
@@ -823,6 +823,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: foo is forbidden, use bar instead
 
+  ⚠ eslint(no-restricted-imports): 'foo' import is restricted from being used by a pattern.
+   ╭─[no_restricted_imports.tsx:1:1]
+ 1 │ import 'foo'
+   · ────────────
+   ╰────
+  help: foo is forbidden, use bar instead
+
   ⚠ eslint(no-restricted-imports): 'import1' import is restricted from being used.
    ╭─[no_restricted_imports.tsx:1:1]
  1 │ import foo from 'import1';


### PR DESCRIPTION
fixes #19956