### PR TITLE
fix(linter): handle array-type shorthand inside union members

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -254,6 +254,8 @@ fn check(
     readonly_config: &ArrayOption,
     ctx: &LintContext,
 ) {
+    let type_annotation = type_annotation.without_parenthesized();
+
     if let TSType::TSArrayType(array_type) = &type_annotation {
         check_and_report_error_generic(
             default_config,
@@ -279,6 +281,18 @@ fn check(
 
     if let TSType::TSTypeReference(ts_type_reference) = &type_annotation {
         check_and_report_error_reference(default_config, readonly_config, ts_type_reference, ctx);
+    }
+
+    if let TSType::TSUnionType(ts_union_type) = &type_annotation {
+        for type_annotation in &ts_union_type.types {
+            check(type_annotation, default_config, readonly_config, ctx);
+        }
+    }
+
+    if let TSType::TSIntersectionType(ts_intersection_type) = &type_annotation {
+        for type_annotation in &ts_intersection_type.types {
+            check(type_annotation, default_config, readonly_config, ctx);
+        }
     }
 }
 
@@ -1100,6 +1114,7 @@ const instance = new MyClass<number>(42);",
         ),
         ("let a: number[] = [];", Some(serde_json::json!([{"default":"generic"}]))),
         ("let a: (string | number)[] = [];", Some(serde_json::json!([{"default":"generic"}]))),
+        ("interface I { b: string | string[]; }", Some(serde_json::json!([{"default":"generic"}]))),
         ("let a: readonly number[] = [];", Some(serde_json::json!([{"default":"generic"}]))),
         (
             "let a: readonly (string | number)[] = [];",
@@ -1660,6 +1675,11 @@ export const test8 = testFn<Array<string>, number[]>([]);",
         (
             "let a: (string | number)[] = [];",
             "let a: Array<string | number> = [];",
+            Some(serde_json::json!([{"default":"generic"}])),
+        ),
+        (
+            "interface I { b: string | string[]; }",
+            "interface I { b: string | Array<string>; }",
             Some(serde_json::json!([{"default":"generic"}])),
         ),
         (

--- a/crates/oxc_linter/src/snapshots/typescript_array_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_array_type.snap
@@ -247,6 +247,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
+  ⚠ typescript-eslint(array-type): Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
+   ╭─[array_type.ts:1:27]
+ 1 │ interface I { b: string | string[]; }
+   ·                           ────────
+   ╰────
+  help: Replace `string[]` with `Array<string>`.
+
   ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
    ╭─[array_type.ts:1:8]
  1 │ let a: readonly number[] = [];


### PR DESCRIPTION
- fix `typescript/array-type` so `T[]` and `readonly T[]` are also checked when nested in union/intersection members
- normalize by unwrapping parenthesized types before checking
- add regression tests and snapshot coverage for `string | string[]` with `default: "generic"`

fixes #20032