### PR TITLE
fix(oxlint/lsp): send other code actions besides `source.fixAll` if requested

### DIFF
--- a/apps/oxlint/src/lsp/code_actions.rs
+++ b/apps/oxlint/src/lsp/code_actions.rs
@@ -64,7 +64,7 @@ pub fn apply_all_fix_code_action(
     }
 
     Some(CodeAction {
-        title: "quick fix".to_string(),
+        title: "fix all safe fixable oxlint issues".to_string(),
         kind: Some(CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC),
         is_preferred: Some(true),
         edit: Some(WorkspaceEdit {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -606,24 +606,57 @@ impl Tool for ServerLinter {
 
         let actions =
             actions.into_iter().filter(|r| r.range == *range || range_overlaps(*range, r.range));
-        // if `source.fixAll.oxc` or `source.fixAll` is requested, return a single code action that applies all fixes
-        let is_source_fix_all = context.only.as_ref().is_some_and(|only| {
-            only.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC)
-                || only.contains(&CodeActionKind::SOURCE_FIX_ALL)
-        });
 
-        if is_source_fix_all {
-            return apply_all_fix_code_action(actions, uri.clone())
-                .map_or(vec![], |code_actions| {
-                    vec![CodeActionOrCommand::CodeAction(code_actions)]
-                });
-        }
+        // `context.only` is a special case here. ESLint behavior is if `source.fixAll` is the first element in `context.only`,
+        // then only return fix all code action, and ignore other code actions, even if they are requested.
+        // https://github.com/microsoft/vscode-eslint/blob/1572a25c619861a812c6593c9b130ee52361bcf0/server/src/eslintServer.ts#L587-L589
+        // This works for zed editor too, it sends always with this layout: `"only": ["quickfix", "source.fixAll.oxc", "source.fixAll"]`
+        // https://github.com/oxc-project/oxc-zed/issues/133#issuecomment-4007046920
+        // To align more with the official LSP specs, we implement it a bit differently:
+        // If no `context.only` is applied, only return the quick fix code actions.
+        // If it is provided, we should loop over it and return the actions in the same order.
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionContext
+        let applying_kinds = match &context.only {
+            Some(only) => {
+                // `source.fixAll` and `source.fixAll.oxc` should behave the same, filter duplicate out
+                let mut seen = FxHashSet::default();
+                only.iter()
+                    .filter_map(|kind| {
+                        if kind == &CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC
+                            || kind == &CodeActionKind::SOURCE_FIX_ALL
+                        {
+                            if seen.contains(&CodeActionKind::SOURCE_FIX_ALL) {
+                                None
+                            } else {
+                                seen.insert(CodeActionKind::SOURCE_FIX_ALL);
+                                Some(CodeActionKind::SOURCE_FIX_ALL)
+                            }
+                        } else {
+                            Some(kind.clone())
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            }
+            // if `only` is not provided, only return quickfixes
+            None => vec![CodeActionKind::QUICKFIX],
+        };
 
         let mut code_actions_vec: Vec<CodeActionOrCommand> = vec![];
 
-        for action in actions {
-            let fix_actions = apply_fix_code_actions(action, uri);
-            code_actions_vec.extend(fix_actions.into_iter().map(CodeActionOrCommand::CodeAction));
+        for kind in applying_kinds {
+            // `CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC` was filtered out by `applying_kinds`, so we don't need to check it here.
+            if kind == CodeActionKind::SOURCE_FIX_ALL {
+                let Some(fix_all) = apply_all_fix_code_action(actions.clone(), uri.clone()) else {
+                    continue;
+                };
+                code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_all));
+            } else if kind == CodeActionKind::QUICKFIX {
+                for action in actions.clone() {
+                    let fix_actions = apply_fix_code_actions(action, uri);
+                    code_actions_vec
+                        .extend(fix_actions.into_iter().map(CodeActionOrCommand::CodeAction));
+                }
+            }
         }
 
         code_actions_vec
@@ -1189,11 +1222,14 @@ mod test_watchers {
 mod test {
     use std::path::PathBuf;
 
+    use oxc_language_server::Tool;
     use oxc_linter::ExternalPluginStore;
     use rustc_hash::FxHashSet;
     use serde_json::json;
+    use tower_lsp_server::ls_types::{CodeActionContext, CodeActionKind, Position, Range};
 
     use crate::lsp::{
+        code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC,
         server_linter::ServerLinterBuilder,
         tester::{Tester, get_file_path},
     };
@@ -1219,6 +1255,70 @@ mod test {
         assert!(configs_dirs[2].ends_with("deep2"));
         assert!(configs_dirs[1].ends_with("deep1"));
         assert!(configs_dirs[0].ends_with("init_nested_configs"));
+    }
+
+    #[test]
+    fn test_code_action() {
+        // this directory does not exist, but it doesn't matter because we are directly calling the linter methods, and not relying on the file system for this test.
+        let tester = Tester::new("fixtures/lsp/code_action", json!({}));
+        let linter = tester.create_linter();
+        let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
+        let uri = tester.get_file_uri("quickfix.js");
+        let _ = linter.run_file(&uri, Some("debugger;")).unwrap();
+        let code_actions =
+            linter.get_code_actions_or_commands(&uri, &range, &CodeActionContext::default());
+        assert_eq!(
+            code_actions.len(),
+            3,
+            "Default Context: Should return 3 code actions: 1 rule fix + 2 ignore actions"
+        );
+
+        let code_actions = linter.get_code_actions_or_commands(
+            &uri,
+            &range,
+            &CodeActionContext { only: Some(vec![CodeActionKind::QUICKFIX]), ..Default::default() },
+        );
+
+        assert_eq!(
+            code_actions.len(),
+            3,
+            "Quickfix Context: Should return 3 code actions: 1 rule fix + 2 ignore actions"
+        );
+
+        let code_actions = linter.get_code_actions_or_commands(
+            &uri,
+            &range,
+            &CodeActionContext {
+                only: Some(vec![CodeActionKind::QUICKFIX, CodeActionKind::SOURCE_FIX_ALL]),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            code_actions.len(),
+            4,
+            "Quickfix & FixAll Context: Should return 4 code actions: 1 rule fix + 2 ignore actions, and 1 fix all action"
+        );
+
+        let code_actions = linter.get_code_actions_or_commands(
+            &uri,
+            &range,
+            &CodeActionContext {
+                only: Some(vec![
+                    CodeActionKind::QUICKFIX,
+                    CodeActionKind::SOURCE_FIX_ALL,
+                    CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC,
+                ]),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            code_actions.len(),
+            4,
+            "Quickfix & FixAll Context: Should return 4 code actions even if both `source.fixAll` and `source.fixAll.oxc` are requested,
+            because they are the same action, we should filter out duplicates."
+        );
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@debugger.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_cross_module@debugger.ts.snap
@@ -75,7 +75,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_frameworks@astro__debugger.astro_vue__debugger.vue_svelte__debugger.svelte_nextjs__[[..rest]]__debugger.ts.snap
@@ -270,7 +270,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -465,7 +465,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -663,7 +663,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {
@@ -754,7 +754,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_ignore_patterns@ignored-file.ts_another_config__not-ignored-file.ts.snap
@@ -85,7 +85,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_js_plugins@index.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_js_plugins@index.js.snap
@@ -75,7 +75,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_multiple_suggestions@forward_ref.ts.snap
@@ -93,7 +93,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_regexp_feature@index.ts.snap
@@ -122,7 +122,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_tsgolint@no-floating-promises__index.ts.snap
@@ -436,7 +436,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
+++ b/apps/oxlint/src/lsp/snapshots/fixtures_lsp_unused_disabled_directives@test.js.snap
@@ -203,7 +203,7 @@ TextEdit: TextEdit {
 
 ########### Fix All Action
 CodeAction: 
-Title: quick fix
+Title: fix all safe fixable oxlint issues
 Is Preferred: Some(true)
 TextEdit: TextEdit {
     range: Range {

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -191,7 +191,7 @@ impl Tester<'_> {
         Self { relative_root_dir, options }
     }
 
-    fn create_linter(&self) -> ServerLinter {
+    pub fn create_linter(&self) -> ServerLinter {
         ServerLinterBuilder::default()
             .build(&Self::get_root_uri(self.relative_root_dir), self.options.clone())
     }
@@ -209,6 +209,10 @@ impl Tester<'_> {
         self.test_and_snapshot_multiple_file(&[relative_file_path]);
     }
 
+    pub fn get_file_uri(&self, relative_file_path: &str) -> Uri {
+        get_file_uri(&format!("{}/{}", self.relative_root_dir, relative_file_path))
+    }
+
     pub fn test_and_snapshot_multiple_file(&self, relative_file_paths: &[&str]) {
         let mut snapshot_result = String::new();
         let context = CodeActionContext::default();
@@ -217,7 +221,7 @@ impl Tester<'_> {
             ..Default::default()
         };
         for relative_file_path in relative_file_paths {
-            let uri = get_file_uri(&format!("{}/{}", self.relative_root_dir, relative_file_path));
+            let uri = self.get_file_uri(relative_file_path);
             let linter = self.create_linter();
             let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
             let reports = FileResult {


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-zed/issues/133

> ## Pull request overview
> 
> This PR fixes the LSP code action handling to properly respond to `context.only` requests. Previously, the server checked if `source.fixAll` was requested and returned only the fix-all action, ignoring other requested kinds like `quickfix`. Now it loops over all requested kinds in `context.only` and returns the appropriate actions for each, enabling editors like Zed to receive both quickfix and fix-all actions when both are requested. The fix-all code action title was also changed from the generic "quick fix" to "fix all safe fixable oxlint issues" for clarity.