### PR TITLE
refactor(lsp): pass complete `CodeActionContext` to `Tool` trait

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -4,7 +4,9 @@ use std::sync::{Arc, OnceLock};
 use ignore::gitignore::Gitignore;
 use oxc_data_structures::rope::Rope;
 use rustc_hash::{FxHashMap, FxHashSet};
-use tower_lsp_server::ls_types::{DiagnosticOptions, DiagnosticServerCapabilities};
+use tower_lsp_server::ls_types::{
+    CodeActionContext, DiagnosticOptions, DiagnosticServerCapabilities,
+};
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
@@ -590,7 +592,7 @@ impl Tool for ServerLinter {
         &self,
         uri: &Uri,
         range: &Range,
-        only_code_action_kinds: Option<&Vec<CodeActionKind>>,
+        context: &CodeActionContext,
     ) -> Vec<CodeActionOrCommand> {
         let actions = self.get_code_actions_for_uri(uri);
 
@@ -605,7 +607,7 @@ impl Tool for ServerLinter {
         let actions =
             actions.into_iter().filter(|r| r.range == *range || range_overlaps(*range, r.range));
         // if `source.fixAll.oxc` or `source.fixAll` is requested, return a single code action that applies all fixes
-        let is_source_fix_all = only_code_action_kinds.is_some_and(|only| {
+        let is_source_fix_all = context.only.as_ref().is_some_and(|only| {
             only.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC)
                 || only.contains(&CodeActionKind::SOURCE_FIX_ALL)
         });

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -2,8 +2,8 @@ use std::{fmt::Write, path::PathBuf};
 
 use oxc_language_server::{DiagnosticResult, Tool, ToolRestartChanges};
 use tower_lsp_server::ls_types::{
-    CodeAction, CodeActionKind, CodeActionOrCommand, CodeDescription, Diagnostic, NumberOrString,
-    Position, Range, Uri,
+    CodeAction, CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeDescription,
+    Diagnostic, NumberOrString, Position, Range, Uri,
 };
 
 use crate::lsp::server_linter::{ServerLinter, ServerLinterBuilder};
@@ -211,22 +211,20 @@ impl Tester<'_> {
 
     pub fn test_and_snapshot_multiple_file(&self, relative_file_paths: &[&str]) {
         let mut snapshot_result = String::new();
+        let context = CodeActionContext::default();
+        let fix_all_context = CodeActionContext {
+            only: Some(vec![CodeActionKind::SOURCE_FIX_ALL]),
+            ..Default::default()
+        };
         for relative_file_path in relative_file_paths {
             let uri = get_file_uri(&format!("{}/{}", self.relative_root_dir, relative_file_path));
             let linter = self.create_linter();
+            let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
             let reports = FileResult {
                 diagnostic: linter.run_diagnostic(&uri, None),
-                actions: linter.get_code_actions_or_commands(
-                    &uri,
-                    &Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
-                    None,
-                ),
+                actions: linter.get_code_actions_or_commands(&uri, &range, &context),
                 fix_all_action: linter
-                    .get_code_actions_or_commands(
-                        &uri,
-                        &Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
-                        Some(&vec![CodeActionKind::SOURCE_FIX_ALL]),
-                    )
+                    .get_code_actions_or_commands(&uri, &range, &fix_all_context)
                     .into_iter()
                     .next(),
             };

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -718,7 +718,7 @@ impl LanguageServer for Backend {
         };
 
         let code_actions =
-            worker.get_code_actions_or_commands(uri, &params.range, params.context.only).await;
+            worker.get_code_actions_or_commands(uri, &params.range, &params.context).await;
 
         if code_actions.is_empty() {
             return Ok(None);

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -137,7 +137,7 @@ impl Tool for FakeTool {
         &self,
         uri: &Uri,
         _range: &Range,
-        _only_code_action_kinds: Option<&Vec<CodeActionKind>>,
+        _context: &CodeActionContext,
     ) -> Vec<CodeActionOrCommand> {
         if uri.as_str().ends_with("code_action.config") {
             return vec![CodeActionOrCommand::CodeAction(CodeAction {

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -1,7 +1,7 @@
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
-        CodeActionKind, CodeActionOrCommand, Diagnostic, Pattern, Range, ServerCapabilities,
+        CodeActionContext, CodeActionOrCommand, Diagnostic, Pattern, Range, ServerCapabilities,
         TextEdit, Uri, WorkspaceEdit,
     },
 };
@@ -79,12 +79,14 @@ pub trait Tool: Send + Sync {
     }
 
     /// Get code actions or commands provided by this tool for the given URI and range.
-    /// The `only_code_action_kinds` parameter can be used to filter the results based on specific code action kinds.
+    /// The tool should filter the code actions based on the provided range.
+    /// The context can be used to further filter the code actions,
+    /// for example by the `only` field which indicates that only code actions of certain kinds are requested.
     fn get_code_actions_or_commands(
         &self,
         _uri: &Uri,
         _range: &Range,
-        _only_code_action_kinds: Option<&Vec<CodeActionKind>>,
+        _context: &CodeActionContext,
     ) -> Vec<CodeActionOrCommand> {
         Vec::new()
     }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -5,9 +5,10 @@ use tokio::sync::{Mutex, RwLock};
 use tower_lsp_server::{
     jsonrpc::ErrorCode,
     ls_types::{
-        CodeActionKind, CodeActionOrCommand, Diagnostic, DidChangeWatchedFilesRegistrationOptions,
-        FileEvent, FileSystemWatcher, GlobPattern, OneOf, Range, Registration, RelativePattern,
-        TextEdit, Unregistration, Uri, WatchKind, WorkspaceEdit,
+        CodeActionContext, CodeActionOrCommand, Diagnostic,
+        DidChangeWatchedFilesRegistrationOptions, FileEvent, FileSystemWatcher, GlobPattern, OneOf,
+        Range, Registration, RelativePattern, TextEdit, Unregistration, Uri, WatchKind,
+        WorkspaceEdit,
     },
 };
 use tracing::debug;
@@ -230,20 +231,15 @@ impl WorkspaceWorker {
 
     /// Get code actions or commands for the given range.
     /// It calls all tools and collects their code actions or commands.
-    /// If `only_code_action_kinds` is provided, only code actions of the specified kinds are returned.
     pub async fn get_code_actions_or_commands(
         &self,
         uri: &Uri,
         range: &Range,
-        only_code_action_kinds: Option<Vec<CodeActionKind>>,
+        context: &CodeActionContext,
     ) -> Vec<CodeActionOrCommand> {
         let mut actions = Vec::new();
         for tool in self.tools.read().await.iter() {
-            actions.extend(tool.get_code_actions_or_commands(
-                uri,
-                range,
-                only_code_action_kinds.as_ref(),
-            ));
+            actions.extend(tool.get_code_actions_or_commands(uri, range, context));
         }
         actions
     }
@@ -446,7 +442,9 @@ mod tests {
     use std::str::FromStr;
 
     use std::sync::Arc;
-    use tower_lsp_server::ls_types::{CodeActionOrCommand, FileChangeType, FileEvent, Range, Uri};
+    use tower_lsp_server::ls_types::{
+        CodeActionContext, CodeActionOrCommand, FileChangeType, FileEvent, Range, Uri,
+    };
 
     use crate::{
         ToolBuilder,
@@ -696,7 +694,7 @@ mod tests {
             .get_code_actions_or_commands(
                 &Uri::from_str("file:///root/file.js").unwrap(),
                 &Range::default(),
-                None,
+                &CodeActionContext::default(),
             )
             .await;
 
@@ -706,7 +704,7 @@ mod tests {
             .get_code_actions_or_commands(
                 &Uri::from_str("file:///root/code_action.config").unwrap(),
                 &Range::default(),
-                None,
+                &CodeActionContext::default(),
             )
             .await;
 


### PR DESCRIPTION
Little bit of refactoring for later PRs.
Pass the complete context to the tool trait so other parameter of it can be used like `diagnostics` or trigger kind.
There is a little optimization that can be done. When requesting a code action from trigger-kind=automatic or with a diagnostic, we can skip the cache-fallback of linting the file. Mostly the file is linted already by another thread.