### PR TITLE
perf(all): use `array_windows` over `windows` with a known size

### DIFF
--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -98,8 +98,8 @@ impl<'a> Format<'a> for AstNode<'a, ArenaVec<'a, Argument<'a>>> {
 
         // Check if there's an empty line (2+ newlines) between any consecutive arguments.
         // This is used to preserve intentional blank lines in the original source.
-        let has_empty_line = arguments.windows(2).any(|window| {
-            let (cur_arg, next_arg) = (&window[0], &window[1]);
+        let has_empty_line = arguments.array_windows().any(|[cur_arg, next_arg]| {
+            // let (cur_arg, next_arg) = (&window[0], &window[1]);
 
             // Count newlines between arguments, short-circuiting at 2 for performance
             // Check if there are at least two newlines between arguments

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -809,7 +809,7 @@ mod test {
             Err(errors) => {
                 let strs: Vec<String> =
                     errors.iter().map(std::string::ToString::to_string).collect();
-                assert!(strs.windows(2).all(|w| w[0] <= w[1]), "errors not sorted: {strs:#?}");
+                assert!(strs.array_windows().all(|[a, b]| a <= b), "errors not sorted: {strs:#?}");
             }
             Ok(()) => panic!("expected errors from invalid configs"),
         }

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -116,11 +116,11 @@ impl Rule for NoRedeclare {
                 continue;
             }
 
-            for windows in ctx.scoping().symbol_redeclarations(symbol_id).windows(2) {
+            for [prev, next] in ctx.scoping().symbol_redeclarations(symbol_id).array_windows() {
                 if is_builtin {
-                    ctx.diagnostic(no_redeclare_as_builtin_in_diagnostic(name, windows[1].span));
+                    ctx.diagnostic(no_redeclare_as_builtin_in_diagnostic(name, next.span));
                 } else {
-                    ctx.diagnostic(no_redeclare_diagnostic(name, windows[0].span, windows[1].span));
+                    ctx.diagnostic(no_redeclare_diagnostic(name, prev.span, next.span));
                 }
             }
         }

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -240,10 +240,10 @@ impl SortImports {
         }
 
         let unsorted = specifiers
-            .windows(2)
-            .find(|window| {
-                let a = window[0].local.name.as_str();
-                let b = window[1].local.name.as_str();
+            .array_windows()
+            .find(|[a, b]| {
+                let a = a.local.name.as_str();
+                let b = b.local.name.as_str();
 
                 if self.ignore_case {
                     a.cow_to_ascii_lowercase() > b.cow_to_ascii_lowercase()
@@ -275,10 +275,10 @@ impl SortImports {
                     // import { a, b,      c, d } from 'foo.js'
                     //            ^  ^^^^^^  ^
                     let mut paddings: Vec<&str> = specifiers
-                        .windows(2)
-                        .map(|window| {
-                            let a = window[0].span;
-                            let b = window[1].span;
+                        .array_windows()
+                        .map(|[a, b]| {
+                            let a = a.span;
+                            let b = b.span;
 
                             let padding = Span::new(a.end, b.start);
                             ctx.source_range(padding)

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 );
 
 fn is_unreadable_array_destructuring<T, U>(elements: &Vec<Option<T>>, rest: Option<&U>) -> bool {
-    if elements.len() >= 3 && elements.windows(2).any(|window| window.iter().all(Option::is_none)) {
+    if elements.len() >= 3 && elements.array_windows().any(|[a, b]| a.is_none() && b.is_none()) {
         return true;
     }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -163,8 +163,8 @@ impl Rule for NoUselessLengthCheck {
             }
             let mut flat_exprs = Vec::new();
             make_flat_logical_expression(log_expr, &mut flat_exprs);
-            for window in flat_exprs.windows(2) {
-                if let Some(diag) = is_useless_check(window[0], window[1], log_expr.operator) {
+            for [a, b] in flat_exprs.array_windows() {
+                if let Some(diag) = is_useless_check(a, b, log_expr.operator) {
                     ctx.diagnostic(diag);
                 }
             }

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -921,7 +921,9 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
 
                 // Find end of comment
                 let start_index = if is_block_comment {
-                    let Some(pos) = bytes.windows(2).position(|q| q == b"*/") else {
+                    let Some(pos) =
+                        bytes.array_windows().position(|[a, b]| *a == b'*' && *b == b'/')
+                    else {
                         // Comment contains whole of this quasi
                         continue;
                     };
@@ -1007,8 +1009,9 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                                         break;
                                     }
                                     Some(&b) if b != b'!' => {
-                                        let end_index =
-                                            bytes[i + 2..].windows(2).position(|q| q == b"*/");
+                                        let end_index = bytes[i + 2..]
+                                            .array_windows()
+                                            .position(|[a, b]| *a == b'*' && *b == b'/');
                                         if let Some(end_index) = end_index {
                                             // Block comments behave like whitespace.
                                             // `padding: 10/* */0` is equivalent to `padding: 10 0`, not `padding: 100`.


### PR DESCRIPTION
> ```
> fn has_abba(s: &str) -> bool {
>     s.as_bytes()
>         .array_windows()
>         .any(|[a1, b1, b2, a2]| (a1 != b1) && (a1 == a2) && (b1 == b2))
> }
> ```
>
> The destructuring argument pattern in that closure lets the compiler infer that we want windows of 4 here. If we had used the older .windows(4) iterator, then that argument would be a slice which we would have to index manually, hoping that runtime bounds-checking will be optimized away.

From the release notes: https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/