### PR TITLE
chore(oxfmt): Handle `tsdown@0.21` warnings

### DIFF
--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -12,34 +12,37 @@ export default defineConfig({
   outDir: "dist",
   shims: false,
   fixedExtension: false,
-  // Optional peer plugins that `prettier-plugin-tailwindcss` tries to dynamic import.
-  // They are not installed and not needed for us,
-  // mark as external to suppress "UNRESOLVED_IMPORT" warnings.
-  external: [
-    "@prettier/plugin-oxc",
-    "@prettier/plugin-hermes",
-    "@prettier/plugin-pug",
-    "@shopify/prettier-plugin-liquid",
-    "@zackad/prettier-plugin-twig",
-    "prettier-plugin-astro",
-    "prettier-plugin-marko",
-    "prettier-plugin-svelte",
-  ],
-  noExternal: [
-    // Bundle it to control version
-    "prettier",
+  deps: {
+    // Optional peer plugins that `prettier-plugin-tailwindcss` tries to dynamic import.
+    // They are not installed and not needed for us,
+    // mark as external to suppress "UNRESOLVED_IMPORT" warnings.
+    neverBundle: [
+      "@prettier/plugin-oxc",
+      "@prettier/plugin-hermes",
+      "@prettier/plugin-pug",
+      "@shopify/prettier-plugin-liquid",
+      "@zackad/prettier-plugin-twig",
+      "prettier-plugin-astro",
+      "prettier-plugin-marko",
+      "prettier-plugin-svelte",
+    ],
+    alwaysBundle: [
+      // Bundle it to control version
+      "prettier",
 
-    // We are using patched version, so we must bundle it
-    // Also, it internally loads plugins dynamically, so they also must be bundled
-    "prettier-plugin-tailwindcss",
-    "prettier-plugin-tailwindcss/sorter",
-    /^prettier\/plugins\//,
+      // Need to bundle plugins, since they depend on Prettier,
+      // and must be resolved to the same instance of Prettier at runtime.
+      "prettier-plugin-tailwindcss",
+      "prettier-plugin-tailwindcss/sorter",
+      // Also, it internally loads plugins dynamically, so they also must be bundled
+      /^prettier\/plugins\//,
 
-    // Cannot bundle: `cli-worker.js` runs in separate thread and can't resolve bundled chunks
-    // Be sure to add it to "dependencies" in `npm/oxfmt/package.json`!
-    // "tinypool",
-  ],
-  // tsdown warns about final bundled modules by `noExternal`.
-  // But we know what we are doing, just suppress the warnings.
-  inlineOnly: false,
+      // Cannot bundle: `cli-worker.js` runs in separate thread and can't resolve bundled chunks
+      // Be sure to add it to "dependencies" in `npm/oxfmt/package.json`!
+      // "tinypool",
+    ],
+    // tsdown warns about final bundled modules by `alwaysBundle`.
+    // But we know what we are doing, just suppress the warnings.
+    onlyAllowBundle: false,
+  },
 });


### PR DESCRIPTION
https://github.com/rolldown/tsdown/releases/tag/v0.21.0