### PR TITLE
fix(linter): Fix the logic for `unicorn/prefer-dom-node-remove` to handle literal callees as well as arguments.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -12,8 +12,9 @@ use crate::{
 
 fn prefer_dom_node_remove_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.")
-        .with_help("Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.")
+        .with_help("Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.")
         .with_label(span)
+        .with_note("https://developer.mozilla.org/en-US/docs/Web/API/Element/remove")
 }
 
 #[derive(Debug, Default, Clone)]
@@ -26,7 +27,8 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// The DOM function [`Node#remove()`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) is preferred over the indirect removal of an object with [`Node#removeChild()`](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild).
+    /// The DOM function [`Node#remove()`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) is preferred
+    /// over the indirect removal of an object with [`Node#removeChild()`](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild).
     ///
     /// ### Examples
     ///
@@ -45,6 +47,21 @@ declare_oxc_lint!(
     pending
 );
 
+/// Returns `true` if the expression is a type that can never be a DOM node
+/// (literals, null, undefined, arrays, arrow functions, classes, functions, objects, template literals).
+fn is_non_dom_node(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::ArrayExpression(_)
+            | Expression::ArrowFunctionExpression(_)
+            | Expression::ClassExpression(_)
+            | Expression::FunctionExpression(_)
+            | Expression::ObjectExpression(_)
+            | Expression::TemplateLiteral(_)
+    ) || expr.is_literal()
+        || expr.is_null_or_undefined()
+}
+
 impl Rule for PreferDomNodeRemove {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
@@ -59,22 +76,20 @@ impl Rule for PreferDomNodeRemove {
             return;
         }
 
+        // Check if the callee object (the thing `.removeChild()` is called on) is a non-DOM type
+        if let Some(member_expr) = call_expr.callee.get_member_expr() {
+            let object = member_expr.object().without_parentheses();
+            if is_non_dom_node(object) {
+                return;
+            }
+        }
+
         let Some(expr) = call_expr.arguments[0].as_expression() else {
             return;
         };
 
         let expr = expr.without_parentheses();
-        if matches!(
-            expr,
-            Expression::ArrayExpression(_)
-                | Expression::ArrowFunctionExpression(_)
-                | Expression::ClassExpression(_)
-                | Expression::FunctionExpression(_)
-                | Expression::ObjectExpression(_)
-                | Expression::TemplateLiteral(_)
-        ) || expr.is_literal()
-            || expr.is_null_or_undefined()
-        {
+        if is_non_dom_node(expr) {
             return;
         }
 
@@ -96,14 +111,61 @@ fn test() {
         "parentNode.removeChild(undefined)",
         "new parentNode.removeChild(bar);",
         "removeChild(foo);",
+        // `callee.property` is not an `Identifier`
         // TODO: Get this passing.
         // "parentNode['removeChild'](bar);",
+        // Computed
         "parentNode[removeChild](bar);",
         "parentNode.foo(bar);",
+        // More or less argument(s)
         "parentNode.removeChild(bar, extra);",
         "parentNode.removeChild();",
         "parentNode.removeChild(...argumentsArray)",
+        // Optional call
         "parentNode.removeChild?.(foo)",
+        // The following are all generated from this JS code upstream:
+        // ...notDomNodeTypes.map(data => `(${data}).removeChild(foo)`),
+        // ...notDomNodeTypes.map(data => `foo.removeChild(${data})`),
+        "([]).removeChild(foo)",
+        "([element]).removeChild(foo)",
+        "([...elements]).removeChild(foo)",
+        "(() => {}).removeChild(foo)",
+        "(class Node {}).removeChild(foo)",
+        "(function() {}).removeChild(foo)",
+        "(0).removeChild(foo)",
+        "(1).removeChild(foo)",
+        "(0.1).removeChild(foo)",
+        r#"("").removeChild(foo)"#,
+        r#"("string").removeChild(foo)"#,
+        "(/regex/).removeChild(foo)",
+        "(null).removeChild(foo)",
+        "(0n).removeChild(foo)",
+        "(1n).removeChild(foo)",
+        "(true).removeChild(foo)",
+        "(false).removeChild(foo)",
+        "({}).removeChild(foo)",
+        "(`templateLiteral`).removeChild(foo)",
+        "(undefined).removeChild(foo)",
+        "foo.removeChild([])",
+        "foo.removeChild([element])",
+        "foo.removeChild([...elements])",
+        "foo.removeChild(() => {})",
+        "foo.removeChild(class Node {})",
+        "foo.removeChild(function() {})",
+        "foo.removeChild(0)",
+        "foo.removeChild(1)",
+        "foo.removeChild(0.1)",
+        r#"foo.removeChild("")"#,
+        r#"foo.removeChild("string")"#,
+        "foo.removeChild(/regex/)",
+        "foo.removeChild(null)",
+        "foo.removeChild(0n)",
+        "foo.removeChild(1n)",
+        "foo.removeChild(true)",
+        "foo.removeChild(false)",
+        "foo.removeChild({})",
+        "foo.removeChild(`templateLiteral`)",
+        "foo.removeChild(undefined)",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_dom_node_remove.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_dom_node_remove.snap
@@ -7,42 +7,48 @@ source: crates/oxc_linter/src/tester.rs
  1 │ parentNode.removeChild(foo)
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(this)
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(some.node)
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(getChild())
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(lib.getChild())
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild((() => childNode)())
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:3:32]
@@ -51,7 +57,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───────────
  4 │                         await getChild()
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:3:24]
@@ -60,28 +67,32 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────
  4 │                 (await getChild())
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild((0, child))
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild( (  (new Image)) )
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild( new Audio )
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:3:20]
@@ -90,7 +101,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ───────────
  4 │         
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:4:24]
@@ -99,7 +111,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────
  5 │                 await getChild()
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:4:24]
@@ -108,7 +121,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────
  5 │                 (0, childNode)
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:4:24]
@@ -117,7 +131,8 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────
  5 │                 (0, childNode)
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:4:24]
@@ -126,179 +141,205 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ───────────
  5 │                 (0, childNode)
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:16]
  1 │ if (parentNode.removeChild(foo)) {}
    ·                ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:26]
  1 │ var removed = parentNode.removeChild(child);
    ·                          ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:24]
  1 │ const foo = parentNode.removeChild(child);
    ·                        ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:20]
  1 │ foo.bar(parentNode.removeChild(child));
    ·                    ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(child) || "foo";
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(child) + 0;
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:13]
  1 │ +parentNode.removeChild(child);
    ·             ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:12]
  1 │ parentNode.removeChild(child) ? "foo" : "bar";
    ·            ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:16]
  1 │ if (parentNode.removeChild(child)) {}
    ·                ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:25]
  1 │ const foo = [parentNode.removeChild(child)]
    ·                         ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:31]
  1 │ const foo = { bar: parentNode.removeChild(child) }
    ·                               ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:36]
  1 │ function foo() { return parentNode.removeChild(child); }
    ·                                    ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:42]
  1 │ const foo = () => { return parentElement.removeChild(child); }
    ·                                          ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:22]
  1 │ foo(bar = parentNode.removeChild(child))
    ·                      ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:7]
  1 │ foo().removeChild(child)
    ·       ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:20]
  1 │ foo[doSomething()].removeChild(child)
    ·                    ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:13]
  1 │ parentNode?.removeChild(foo)
    ·             ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:17]
  1 │ foo?.parentNode.removeChild(foo)
    ·                 ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:17]
  1 │ foo.parentNode?.removeChild(foo)
    ·                 ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:18]
  1 │ foo?.parentNode?.removeChild(foo)
    ·                  ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:21]
  1 │ foo.bar?.parentNode.removeChild(foo.bar)
    ·                     ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:19]
  1 │ a.b?.c.parentNode.removeChild(foo)
    ·                   ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:20]
  1 │ a[b?.c].parentNode.removeChild(foo)
    ·                    ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:17]
  1 │ a?.b.parentNode.removeChild(a.b)
    ·                 ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove
 
   ⚠ eslint-plugin-unicorn(prefer-dom-node-remove): Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.
    ╭─[prefer_dom_node_remove.tsx:1:3]
  1 │ a.removeChild!(k)
    ·   ───────────
    ╰────
-  help: Replace `parentNode.removeChild(childNode)` with `childNode{dotOrQuestionDot}remove()`.
+  help: Replace `parentNode.removeChild(childNode)` with `childNode.remove()`.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Element/remove


### PR DESCRIPTION
Two main changes:

- Fix the diagnostic. It was clearly the victim of a copy-paste mistake at some point. Also added a note with a relevant MDN URL.
- Add a bunch of tests from the upstream that didn't get ported by our rulegen tooling. And then fix the rule so it doesn't miss out on violations in a lot of the test cases.

```js
// Prior to this PR, the rule handled these cases:
foo.removeChild(true)
foo.removeChild("")
foo.removeChild(undefined)

// But not these:
(true).removeChild(foo)
("").removeChild(foo)
(undefined).removeChild(foo)
```

See https://github.com/sindresorhus/eslint-plugin-unicorn/blob/609d4870f3731d39bd5b5f184628e2cf06578dba/test/prefer-dom-node-remove.js for the original test generation logic.

AI Disclosure: I used Claude Code to fix up the logic for catching the extra cases.