### PR TITLE
docs(linter): Improve docs for `unicorn/require-post-message-target-origin` rule.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
@@ -9,7 +9,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn require_post_message_target_origin_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Missing the `targetOrigin` argument.").with_label(span)
+    OxcDiagnostic::warn("Missing the `targetOrigin` argument.")
+        .with_label(span)
+        .with_note("https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage")
 }
 
 #[derive(Debug, Default, Clone)]
@@ -18,11 +20,18 @@ pub struct RequirePostMessageTargetOrigin;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce using the targetOrigin argument with window.postMessage()
+    /// Enforce using the `targetOrigin` argument with `window.postMessage()`.
+    ///
+    /// Note that this rule may have false positives, as it is not capable of
+    /// detecting all cases correctly without type information. As such, it
+    /// may not be a good idea to enable in cases where `postMessage()` may
+    /// be used with `BroadcastChannel` or worker/service worker contexts
+    /// (for example, `WorkerGlobalScope#postMessage`, where the second argument
+    /// is a transfer list or options object, not `targetOrigin`).
     ///
     /// ### Why is this bad?
     ///
-    /// When calling window.postMessage() without the targetOrigin argument,
+    /// When calling `window.postMessage()` without the `targetOrigin` argument,
     /// the message cannot be received by any window.
     ///
     /// ### Examples
@@ -129,7 +138,6 @@ fn test() {
         r#"window["postMessage"](message)"#,
         "window.notPostMessage(message)",
         "window.postMessage?.(message)",
-        "window?.postMessage(message)",
         "window?.[postMessage](message)",
         r"window?.['postMessage'](message)",
         "window.c?.postMessage(message)",

--- a/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
@@ -8,6 +8,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ▲
    ╰────
   help: Insert `, window.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:25]
@@ -15,6 +16,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                         ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:31]
@@ -22,6 +24,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ▲
    ╰────
   help: Insert `, globalThis.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:24]
@@ -29,6 +32,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ▲
    ╰────
   help: Insert `, foo.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:29]
@@ -36,6 +40,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ▲
    ╰────
   help: Insert `, foo.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:24]
@@ -43,6 +48,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ▲
    ╰────
   help: Insert `, foo.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:24]
@@ -50,6 +56,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                        ▲
    ╰────
   help: Insert `, foo.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:31]
@@ -57,6 +64,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:41]
@@ -64,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                         ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:32]
@@ -71,6 +80,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:27]
@@ -78,6 +88,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ▲
    ╰────
   help: Insert `, window.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:29]
@@ -85,6 +96,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:30]
@@ -92,6 +104,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                              ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:32]
@@ -99,6 +112,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:32]
@@ -106,6 +120,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
    ╭─[require_post_message_target_origin.tsx:1:33]
@@ -113,3 +128,4 @@ source: crates/oxc_linter/src/tester.rs
    ·                                 ▲
    ╰────
   help: Insert `, self.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage


### PR DESCRIPTION
Improve the diagnostic with a link to the MDN article.

Also note that the rule has cases it is not capable of handling correctly without type information, and as such may not be a good idea to enable in cases where `postMessage()` may be used elsewhere. See https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1396 for reference.