### PR TITLE
chore(apps, napi): restrict global types to NodeJS in tsconfig

### DIFF
--- a/apps/oxfmt/tsconfig.json
+++ b/apps/oxfmt/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "ESNext",
     "strict": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "types": ["node"]
   },
   "include": ["scripts", "conformance/*.ts", "src-js", "test/**/*.ts"],
   "exclude": ["test/**/fixtures"]

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -10,7 +10,8 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
-    "useUnknownInCatchVariables": true
+    "useUnknownInCatchVariables": true,
+    "types": ["node"]
   },
   "exclude": ["node_modules", "fixtures", "test/fixtures/*/files", "conformance/submodules"]
 }

--- a/napi/minify/tsconfig.json
+++ b/napi/minify/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "target": "ESNext",
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "types": ["node"]
   }
 }

--- a/napi/parser/tsconfig.json
+++ b/napi/parser/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "noUnusedLocals": true,
-    "strict": false
+    "strict": false,
+    "types": ["node"]
   }
 }

--- a/napi/transform/tsconfig.json
+++ b/napi/transform/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "target": "ESNext",
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
Add `"types": ["node"]` to `tsconfig.json` in `apps/oxfmt`, `apps/oxlint`, `napi/minify`, `napi/parser`, and `napi/transform`.

This restricts auto-included global type declarations to `@types/node` only, preventing unintended ambient types from transitive `@types/*` packages from leaking into the type-checking scope.

This change was broken out from #19675.