### PR TITLE
fix(linter/plugins): fix type definition for `VisitorObject`

### DIFF
--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "./types.d.ts";
 
-export interface VisitorObject {
+type BivarianceHackHandler<Handler extends (...args: any) => any> = {
+  bivarianceHack(...args: Parameters<Handler>): ReturnType<Handler>;
+}["bivarianceHack"];
+
+interface StrictVisitorObject {
   DebuggerStatement?: (node: ESTree.DebuggerStatement) => void;
   "DebuggerStatement:exit"?: (node: ESTree.DebuggerStatement) => void;
   EmptyStatement?: (node: ESTree.EmptyStatement) => void;
@@ -384,5 +388,10 @@ export interface VisitorObject {
   "TSTypeReference:exit"?: (node: ESTree.TSTypeReference) => void;
   TSUnionType?: (node: ESTree.TSUnionType) => void;
   "TSUnionType:exit"?: (node: ESTree.TSUnionType) => void;
-  [key: string]: (node: ESTree.Node) => void;
 }
+
+export type VisitorObject = {
+  [K in keyof StrictVisitorObject]?:
+    | BivarianceHackHandler<Exclude<StrictVisitorObject[K], undefined>>
+    | undefined;
+} & Record<string, BivarianceHackHandler<(node: ESTree.Node) => void> | undefined>;

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -507,13 +507,22 @@ fn generate(codegen: &Codegen) -> Codes {
         }}
     ");
 
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20219 for why we need "Bivariance hack"
     #[rustfmt::skip]
     let visitor_type_oxlint = format!("
         import type * as ESTree from './types.d.ts';
 
-        export interface VisitorObject {{
-            {visitor_type} [key: string]: (node: ESTree.Node) => void;
+        type BivarianceHackHandler<Handler extends (...args: any) => any> = {{
+            bivarianceHack(...args: Parameters<Handler>): ReturnType<Handler>;
+        }}[\"bivarianceHack\"];
+
+        interface StrictVisitorObject {{
+            {visitor_type}
         }}
+
+        export type VisitorObject = {{
+            [K in keyof StrictVisitorObject]?: BivarianceHackHandler<Exclude<StrictVisitorObject[K], undefined>> | undefined;
+        }} & Record<string, BivarianceHackHandler<(node: ESTree.Node) => void> | undefined>;
     ");
 
     // Type definitions for walk.js.


### PR DESCRIPTION
Fixes #18154, #14745.

Use the bivariance hack to fix the type def for `VisitorObject`. The bivariance hack is taken from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20219.

This was originally written by @sapphi-red in #19675. I've split it out into a separate PR. I can't claim to understand this witchcraft!