### PR TITLE
fix(linter/vitest/hoisted-apis-on-top): only check first member

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
+++ b/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
@@ -241,7 +241,6 @@ fn test() {
 			vi.unmock(baz);
 			    ",
         "import 'vi';\nconst foo = await vi.hoisted(async () => {});",
-        // vi.mocked(...).mock.calls and similar chains should not be flagged
         "vi.mocked(something).mock.calls",
         "if (condition) { vi.mocked(something).mock.calls.forEach(call => {}) }",
         "if (condition) { const calls = vi.mocked(fn).mock.calls }",

--- a/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
+++ b/crates/oxc_linter/src/rules/vitest/hoisted_apis_on_top.rs
@@ -131,7 +131,7 @@ impl HoistedApisOnTop {
             return;
         }
 
-        if !vitest_fn.members.iter().any(is_hoisted_api) {
+        if !vitest_fn.members.first().is_some_and(is_hoisted_api) {
             return;
         }
 
@@ -241,6 +241,10 @@ fn test() {
 			vi.unmock(baz);
 			    ",
         "import 'vi';\nconst foo = await vi.hoisted(async () => {});",
+        // vi.mocked(...).mock.calls and similar chains should not be flagged
+        "vi.mocked(something).mock.calls",
+        "if (condition) { vi.mocked(something).mock.calls.forEach(call => {}) }",
+        "if (condition) { const calls = vi.mocked(fn).mock.calls }",
     ];
 
     let fail = vec![


### PR DESCRIPTION
Fixes the `vitest/hoisted_apis_on_top` to check only if the first member is a hoisted api. 
This removes false positives like `vi.mocked(something).mock...` being flagged as hoisted.

Rule introduced in https://github.com/oxc-project/oxc/pull/17658