### PR TITLE
fix(apps,napi): explicitly specify libs in tsconfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 /tasks/e2e/tests/nestjs/node_modules/
 /npm/*/node_modules
 /napi/*/npm-dir
+/napi/parser/tsconfig.browser.tsbuildinfo
 
 # Cloned conformance repos
 tasks/coverage/babel/

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ESNext"],
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,

--- a/napi/minify/tsconfig.json
+++ b/napi/minify/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ESNext"],
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,

--- a/napi/parser/tsconfig.browser.json
+++ b/napi/parser/tsconfig.browser.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "./.tsbuild/browser",
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable",
+      "DOM.AsyncIterable",
+      "WebWorker.ImportScripts",
+      "ScriptHost"
+    ]
+  },
+  "include": ["test-browser/**/*.ts", "vitest.config.browser.ts"],
+  "exclude": []
+}

--- a/napi/parser/tsconfig.json
+++ b/napi/parser/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "compilerOptions": {
-    "module": "Preserve",
-    "moduleResolution": "Bundler",
-    "noEmit": true,
-    "target": "ESNext",
-    "allowImportingTsExtensions": true,
-    "noUnusedLocals": true,
-    "strict": false
-  }
+  "files": [],
+  "references": [{ "path": "./tsconfig.node.json" }, { "path": "./tsconfig.browser.json" }]
 }

--- a/napi/parser/tsconfig.node.json
+++ b/napi/parser/tsconfig.node.json
@@ -5,10 +5,10 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "target": "ESNext",
-    "strict": true,
+    "allowImportingTsExtensions": true,
+    "noUnusedLocals": true,
     "skipLibCheck": true,
-    "noUnusedLocals": true
+    "strict": false
   },
-  "include": ["scripts", "conformance/*.ts", "src-js", "test/**/*.ts"],
-  "exclude": ["test/**/fixtures"]
+  "exclude": ["test-browser", "vitest.config.browser.ts"]
 }

--- a/napi/transform/tsconfig.json
+++ b/napi/transform/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ESNext"],
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,


### PR DESCRIPTION
Replaces #20064 

The `dom` lib was implicitly being injected, this means stuff like `Token` and `Comment` were in the global scope, which was incorrect.


cc @overlookmotel 