### PR TITLE
feat(linter): add `no-array-method-for-side-effect` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3817,6 +3817,12 @@ impl RuleRunner for crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpr
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::oxc::no_array_method_for_side_effect::NoArrayMethodForSideEffect {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::oxc::no_async_await::NoAsyncAwait {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -354,6 +354,7 @@ pub use crate::rules::oxc::erasing_op::ErasingOp as OxcErasingOp;
 pub use crate::rules::oxc::misrefactored_assign_op::MisrefactoredAssignOp as OxcMisrefactoredAssignOp;
 pub use crate::rules::oxc::missing_throw::MissingThrow as OxcMissingThrow;
 pub use crate::rules::oxc::no_accumulating_spread::NoAccumulatingSpread as OxcNoAccumulatingSpread;
+pub use crate::rules::oxc::no_array_method_for_side_effect::NoArrayMethodForSideEffect as OxcNoArrayMethodForSideEffect;
 pub use crate::rules::oxc::no_async_await::NoAsyncAwait as OxcNoAsyncAwait;
 pub use crate::rules::oxc::no_async_endpoint_handlers::NoAsyncEndpointHandlers as OxcNoAsyncEndpointHandlers;
 pub use crate::rules::oxc::no_barrel_file::NoBarrelFile as OxcNoBarrelFile;
@@ -1306,6 +1307,7 @@ pub enum RuleEnum {
     OxcMisrefactoredAssignOp(OxcMisrefactoredAssignOp),
     OxcMissingThrow(OxcMissingThrow),
     OxcNoAccumulatingSpread(OxcNoAccumulatingSpread),
+    OxcNoArrayMethodForSideEffect(OxcNoArrayMethodForSideEffect),
     OxcNoAsyncAwait(OxcNoAsyncAwait),
     OxcNoAsyncEndpointHandlers(OxcNoAsyncEndpointHandlers),
     OxcNoBarrelFile(OxcNoBarrelFile),
@@ -2084,7 +2086,8 @@ const OXC_ERASING_OP_ID: usize = OXC_DOUBLE_COMPARISONS_ID + 1usize;
 const OXC_MISREFACTORED_ASSIGN_OP_ID: usize = OXC_ERASING_OP_ID + 1usize;
 const OXC_MISSING_THROW_ID: usize = OXC_MISREFACTORED_ASSIGN_OP_ID + 1usize;
 const OXC_NO_ACCUMULATING_SPREAD_ID: usize = OXC_MISSING_THROW_ID + 1usize;
-const OXC_NO_ASYNC_AWAIT_ID: usize = OXC_NO_ACCUMULATING_SPREAD_ID + 1usize;
+const OXC_NO_ARRAY_METHOD_FOR_SIDE_EFFECT_ID: usize = OXC_NO_ACCUMULATING_SPREAD_ID + 1usize;
+const OXC_NO_ASYNC_AWAIT_ID: usize = OXC_NO_ARRAY_METHOD_FOR_SIDE_EFFECT_ID + 1usize;
 const OXC_NO_ASYNC_ENDPOINT_HANDLERS_ID: usize = OXC_NO_ASYNC_AWAIT_ID + 1usize;
 const OXC_NO_BARREL_FILE_ID: usize = OXC_NO_ASYNC_ENDPOINT_HANDLERS_ID + 1usize;
 const OXC_NO_CONST_ENUM_ID: usize = OXC_NO_BARREL_FILE_ID + 1usize;
@@ -2891,6 +2894,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OXC_MISREFACTORED_ASSIGN_OP_ID,
             Self::OxcMissingThrow(_) => OXC_MISSING_THROW_ID,
             Self::OxcNoAccumulatingSpread(_) => OXC_NO_ACCUMULATING_SPREAD_ID,
+            Self::OxcNoArrayMethodForSideEffect(_) => OXC_NO_ARRAY_METHOD_FOR_SIDE_EFFECT_ID,
             Self::OxcNoAsyncAwait(_) => OXC_NO_ASYNC_AWAIT_ID,
             Self::OxcNoAsyncEndpointHandlers(_) => OXC_NO_ASYNC_ENDPOINT_HANDLERS_ID,
             Self::OxcNoBarrelFile(_) => OXC_NO_BARREL_FILE_ID,
@@ -3687,6 +3691,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::NAME,
             Self::OxcMissingThrow(_) => OxcMissingThrow::NAME,
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::NAME,
+            Self::OxcNoArrayMethodForSideEffect(_) => OxcNoArrayMethodForSideEffect::NAME,
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::NAME,
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::NAME,
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::NAME,
@@ -4525,6 +4530,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::CATEGORY,
             Self::OxcMissingThrow(_) => OxcMissingThrow::CATEGORY,
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::CATEGORY,
+            Self::OxcNoArrayMethodForSideEffect(_) => OxcNoArrayMethodForSideEffect::CATEGORY,
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::CATEGORY,
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::CATEGORY,
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::CATEGORY,
@@ -5326,6 +5332,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::FIX,
             Self::OxcMissingThrow(_) => OxcMissingThrow::FIX,
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::FIX,
+            Self::OxcNoArrayMethodForSideEffect(_) => OxcNoArrayMethodForSideEffect::FIX,
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::FIX,
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::FIX,
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::FIX,
@@ -6307,6 +6314,9 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::documentation(),
             Self::OxcMissingThrow(_) => OxcMissingThrow::documentation(),
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::documentation(),
+            Self::OxcNoArrayMethodForSideEffect(_) => {
+                OxcNoArrayMethodForSideEffect::documentation()
+            }
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::documentation(),
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::documentation(),
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::documentation(),
@@ -8131,6 +8141,10 @@ impl RuleEnum {
                 .or_else(|| OxcMissingThrow::schema(generator)),
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::config_schema(generator)
                 .or_else(|| OxcNoAccumulatingSpread::schema(generator)),
+            Self::OxcNoArrayMethodForSideEffect(_) => {
+                OxcNoArrayMethodForSideEffect::config_schema(generator)
+                    .or_else(|| OxcNoArrayMethodForSideEffect::schema(generator))
+            }
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::config_schema(generator)
                 .or_else(|| OxcNoAsyncAwait::schema(generator)),
             Self::OxcNoAsyncEndpointHandlers(_) => {
@@ -9006,6 +9020,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => "oxc",
             Self::OxcMissingThrow(_) => "oxc",
             Self::OxcNoAccumulatingSpread(_) => "oxc",
+            Self::OxcNoArrayMethodForSideEffect(_) => "oxc",
             Self::OxcNoAsyncAwait(_) => "oxc",
             Self::OxcNoAsyncEndpointHandlers(_) => "oxc",
             Self::OxcNoBarrelFile(_) => "oxc",
@@ -11029,6 +11044,9 @@ impl RuleEnum {
             Self::OxcNoAccumulatingSpread(_) => Ok(Self::OxcNoAccumulatingSpread(
                 OxcNoAccumulatingSpread::from_configuration(value)?,
             )),
+            Self::OxcNoArrayMethodForSideEffect(_) => Ok(Self::OxcNoArrayMethodForSideEffect(
+                OxcNoArrayMethodForSideEffect::from_configuration(value)?,
+            )),
             Self::OxcNoAsyncAwait(_) => {
                 Ok(Self::OxcNoAsyncAwait(OxcNoAsyncAwait::from_configuration(value)?))
             }
@@ -11947,6 +11965,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.to_configuration(),
             Self::OxcMissingThrow(rule) => rule.to_configuration(),
             Self::OxcNoAccumulatingSpread(rule) => rule.to_configuration(),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.to_configuration(),
             Self::OxcNoAsyncAwait(rule) => rule.to_configuration(),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.to_configuration(),
             Self::OxcNoBarrelFile(rule) => rule.to_configuration(),
@@ -12649,6 +12668,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.run(node, ctx),
             Self::OxcMissingThrow(rule) => rule.run(node, ctx),
             Self::OxcNoAccumulatingSpread(rule) => rule.run(node, ctx),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.run(node, ctx),
             Self::OxcNoAsyncAwait(rule) => rule.run(node, ctx),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.run(node, ctx),
             Self::OxcNoBarrelFile(rule) => rule.run(node, ctx),
@@ -13349,6 +13369,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.run_once(ctx),
             Self::OxcMissingThrow(rule) => rule.run_once(ctx),
             Self::OxcNoAccumulatingSpread(rule) => rule.run_once(ctx),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.run_once(ctx),
             Self::OxcNoAsyncAwait(rule) => rule.run_once(ctx),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.run_once(ctx),
             Self::OxcNoBarrelFile(rule) => rule.run_once(ctx),
@@ -14145,6 +14166,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcMissingThrow(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcNoAccumulatingSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcNoAsyncAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::OxcNoBarrelFile(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14849,6 +14871,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.should_run(ctx),
             Self::OxcMissingThrow(rule) => rule.should_run(ctx),
             Self::OxcNoAccumulatingSpread(rule) => rule.should_run(ctx),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.should_run(ctx),
             Self::OxcNoAsyncAwait(rule) => rule.should_run(ctx),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.should_run(ctx),
             Self::OxcNoBarrelFile(rule) => rule.should_run(ctx),
@@ -15825,6 +15848,9 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::IS_TSGOLINT_RULE,
             Self::OxcMissingThrow(_) => OxcMissingThrow::IS_TSGOLINT_RULE,
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::IS_TSGOLINT_RULE,
+            Self::OxcNoArrayMethodForSideEffect(_) => {
+                OxcNoArrayMethodForSideEffect::IS_TSGOLINT_RULE
+            }
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::IS_TSGOLINT_RULE,
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::IS_TSGOLINT_RULE,
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::IS_TSGOLINT_RULE,
@@ -16704,6 +16730,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(_) => OxcMisrefactoredAssignOp::HAS_CONFIG,
             Self::OxcMissingThrow(_) => OxcMissingThrow::HAS_CONFIG,
             Self::OxcNoAccumulatingSpread(_) => OxcNoAccumulatingSpread::HAS_CONFIG,
+            Self::OxcNoArrayMethodForSideEffect(_) => OxcNoArrayMethodForSideEffect::HAS_CONFIG,
             Self::OxcNoAsyncAwait(_) => OxcNoAsyncAwait::HAS_CONFIG,
             Self::OxcNoAsyncEndpointHandlers(_) => OxcNoAsyncEndpointHandlers::HAS_CONFIG,
             Self::OxcNoBarrelFile(_) => OxcNoBarrelFile::HAS_CONFIG,
@@ -17412,6 +17439,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.types_info(),
             Self::OxcMissingThrow(rule) => rule.types_info(),
             Self::OxcNoAccumulatingSpread(rule) => rule.types_info(),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.types_info(),
             Self::OxcNoAsyncAwait(rule) => rule.types_info(),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.types_info(),
             Self::OxcNoBarrelFile(rule) => rule.types_info(),
@@ -18112,6 +18140,7 @@ impl RuleEnum {
             Self::OxcMisrefactoredAssignOp(rule) => rule.run_info(),
             Self::OxcMissingThrow(rule) => rule.run_info(),
             Self::OxcNoAccumulatingSpread(rule) => rule.run_info(),
+            Self::OxcNoArrayMethodForSideEffect(rule) => rule.run_info(),
             Self::OxcNoAsyncAwait(rule) => rule.run_info(),
             Self::OxcNoAsyncEndpointHandlers(rule) => rule.run_info(),
             Self::OxcNoBarrelFile(rule) => rule.run_info(),
@@ -18926,6 +18955,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::OxcMisrefactoredAssignOp(OxcMisrefactoredAssignOp::default()),
         RuleEnum::OxcMissingThrow(OxcMissingThrow::default()),
         RuleEnum::OxcNoAccumulatingSpread(OxcNoAccumulatingSpread::default()),
+        RuleEnum::OxcNoArrayMethodForSideEffect(OxcNoArrayMethodForSideEffect::default()),
         RuleEnum::OxcNoAsyncAwait(OxcNoAsyncAwait::default()),
         RuleEnum::OxcNoAsyncEndpointHandlers(OxcNoAsyncEndpointHandlers::default()),
         RuleEnum::OxcNoBarrelFile(OxcNoBarrelFile::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -620,6 +620,7 @@ pub(crate) mod oxc {
     pub mod misrefactored_assign_op;
     pub mod missing_throw;
     pub mod no_accumulating_spread;
+    pub mod no_array_method_for_side_effect;
     pub mod no_async_await;
     pub mod no_async_endpoint_handlers;
     pub mod no_barrel_file;

--- a/crates/oxc_linter/src/rules/oxc/no_array_method_for_side_effect.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_array_method_for_side_effect.rs
@@ -1,0 +1,214 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNode;
+use oxc_span::Span;
+
+use crate::{context::LintContext, rule::Rule};
+
+fn no_array_method_for_side_effect_diagnostic(method_name: &str, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Array.prototype.{method_name}() called without using its return value"
+    ))
+    .with_help(format!(
+        "`.{method_name}()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects."
+    ))
+    .with_label(span)
+}
+
+/// Methods on `Array.prototype` whose return value is almost always meaningful.
+/// Calling these as expression statements (discarding the result) is a code smell.
+const TARGET_METHODS: [&str; 16] = [
+    "every",
+    "filter",
+    "find",
+    "findIndex",
+    "findLast",
+    "findLastIndex",
+    "flat",
+    "flatMap",
+    "map",
+    "reduce",
+    "reduceRight",
+    "some",
+    "toReversed",
+    "toSorted",
+    "toSpliced",
+    "with",
+];
+
+#[derive(Debug, Default, Clone)]
+pub struct NoArrayMethodForSideEffect;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows calling array methods like `map()`, `filter()`, `toSorted()`, or
+    /// `reduce()` without using the return value.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Methods such as `Array.prototype.map()` and `Array.prototype.toSorted()`
+    /// return a new value. Calling them as a bare expression statement means the
+    /// result is discarded, which is almost always a mistake. If you only need
+    /// the side effects of the callback, use `forEach()` instead. If you intended
+    /// to use the new value, assign it to a variable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// array.toSorted();
+    ///
+    /// array.map((item) => {
+    ///   console.log(item + 1);
+    /// });
+    ///
+    /// array.filter(Boolean);
+    ///
+    /// array.reduce((acc, item) => acc + item, 0);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const sorted = array.toSorted();
+    ///
+    /// const incremented = array.map((item) => {
+    ///   console.log(++item);
+    ///   return item;
+    /// });
+    ///
+    /// array.forEach((item) => {
+    ///   console.log(item + 1);
+    /// });
+    ///
+    /// const filtered = array.filter(Boolean);
+    ///
+    /// const sum = array.reduce((acc, item) => acc + item, 0);
+    /// ```
+    NoArrayMethodForSideEffect,
+    oxc,
+    correctness
+);
+
+impl Rule for NoArrayMethodForSideEffect {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let mut ancestors = ctx
+            .nodes()
+            .ancestors(node.id())
+            .filter(|a| !matches!(a.kind(), AstKind::ChainExpression(_)));
+        let Some(parent) = ancestors.next() else { return };
+
+        if !matches!(parent.kind(), AstKind::ExpressionStatement(_)) {
+            return;
+        }
+
+        // The callee must be a member expression like `array.map(...)`.
+        let callee = call_expr.callee.get_inner_expression();
+        let member_expr = callee.as_member_expression().or_else(|| {
+            if let oxc_ast::ast::Expression::ChainExpression(chain) = callee {
+                chain.expression.as_member_expression()
+            } else {
+                None
+            }
+        });
+        let Some(member_expr) = member_expr else {
+            return;
+        };
+
+        let Some((_span, method_name)) = member_expr.static_property_info() else {
+            return;
+        };
+
+        if !TARGET_METHODS.contains(&method_name) {
+            return;
+        }
+
+        ctx.diagnostic(no_array_method_for_side_effect_diagnostic(method_name, call_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Return value is used — assigned to a variable
+        ("const sorted = array.toSorted();", None),
+        ("const mapped = array.map(x => x + 1);", None),
+        ("const filtered = array.filter(Boolean);", None),
+        ("const found = array.find(x => x > 0);", None),
+        ("const idx = array.findIndex(x => x > 0);", None),
+        ("const foundLast = array.findLast(x => x > 0);", None),
+        ("const idxLast = array.findLastIndex(x => x > 0);", None),
+        ("const flatMapped = array.flatMap(x => [x, x]);", None),
+        ("const flattened = array.flat();", None),
+        ("const sum = array.reduce((a, b) => a + b, 0);", None),
+        ("const sum = array.reduceRight((a, b) => a + b, 0);", None),
+        ("const allPositive = array.every(x => x > 0);", None),
+        ("const hasPositive = array.some(x => x > 0);", None),
+        ("const reversed = array.toReversed();", None),
+        ("const spliced = array.toSpliced(0, 1);", None),
+        ("const replaced = array.with(0, 'a');", None),
+        // Used in boolean context
+        ("if (array.every(x => x > 0)) {}", None),
+        ("while (array.some(x => x > 0)) {}", None),
+        // Used as argument
+        ("console.log(array.map(x => x + 1));", None),
+        ("foo(array.filter(Boolean));", None),
+        // Used in return
+        ("function f() { return array.map(x => x + 1); }", None),
+        // forEach is fine — it is designed for side effects
+        ("array.forEach(x => console.log(x));", None),
+        // Mutating methods are fine as expression statements
+        ("array.sort();", None),
+        ("array.reverse();", None),
+        ("array.splice(0, 1);", None),
+        ("array.fill(0);", None),
+        ("array.copyWithin(0, 1);", None),
+        // Non-array methods
+        ("foo.bar();", None),
+        ("foo.customMethod();", None),
+        // Used in ternary
+        ("const x = cond ? array.map(fn) : [];", None),
+        // Used in logical expression
+        ("const x = array.find(fn) || 'default';", None),
+        // Chained — final method is forEach so result is not discarded
+        ("array.map(fn).forEach(x => console.log(x));", None),
+    ];
+
+    let fail = vec![
+        // Basic expression statement — return value discarded
+        ("array.toSorted();", None),
+        ("array.map(x => x + 1);", None),
+        ("array.map((item) => { console.log(item + 1); });", None),
+        ("array.filter(Boolean);", None),
+        ("array.find(x => x > 0);", None),
+        ("array.findIndex(x => x > 0);", None),
+        ("array.findLast(x => x > 0);", None),
+        ("array.findLastIndex(x => x > 0);", None),
+        ("array.flat();", None),
+        ("array.flatMap(x => [x, x]);", None),
+        ("array.reduce((a, b) => a + b, 0);", None),
+        ("array.reduceRight((a, b) => a + b, 0);", None),
+        ("array.every(x => x > 0);", None),
+        ("array.some(x => x > 0);", None),
+        ("array.toReversed();", None),
+        ("array.toSpliced(0, 1);", None),
+        ("array.with(0, 'a');", None),
+        // Optional chaining — still unused
+        ("array?.map(x => x + 1);", None),
+        ("array?.filter(Boolean);", None),
+        // Deeply nested member expression
+        ("foo.bar.baz.map(x => x + 1);", None),
+        // Chained — final result still discarded
+        ("array.filter(Boolean).map(fn);", None),
+    ];
+
+    Tester::new(NoArrayMethodForSideEffect::NAME, NoArrayMethodForSideEffect::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/oxc_no_array_method_for_side_effect.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_array_method_for_side_effect.snap
@@ -1,0 +1,150 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.toSorted() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.toSorted();
+   · ────────────────
+   ╰────
+  help: `.toSorted()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.map() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.map(x => x + 1);
+   · ─────────────────────
+   ╰────
+  help: `.map()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.map() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.map((item) => { console.log(item + 1); });
+   · ───────────────────────────────────────────────
+   ╰────
+  help: `.map()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.filter() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.filter(Boolean);
+   · ─────────────────────
+   ╰────
+  help: `.filter()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.find() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.find(x => x > 0);
+   · ──────────────────────
+   ╰────
+  help: `.find()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.findIndex() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.findIndex(x => x > 0);
+   · ───────────────────────────
+   ╰────
+  help: `.findIndex()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.findLast() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.findLast(x => x > 0);
+   · ──────────────────────────
+   ╰────
+  help: `.findLast()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.findLastIndex() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.findLastIndex(x => x > 0);
+   · ───────────────────────────────
+   ╰────
+  help: `.findLastIndex()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.flat() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.flat();
+   · ────────────
+   ╰────
+  help: `.flat()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.flatMap() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.flatMap(x => [x, x]);
+   · ──────────────────────────
+   ╰────
+  help: `.flatMap()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.reduce() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.reduce((a, b) => a + b, 0);
+   · ────────────────────────────────
+   ╰────
+  help: `.reduce()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.reduceRight() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.reduceRight((a, b) => a + b, 0);
+   · ─────────────────────────────────────
+   ╰────
+  help: `.reduceRight()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.every() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.every(x => x > 0);
+   · ───────────────────────
+   ╰────
+  help: `.every()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.some() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.some(x => x > 0);
+   · ──────────────────────
+   ╰────
+  help: `.some()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.toReversed() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.toReversed();
+   · ──────────────────
+   ╰────
+  help: `.toReversed()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.toSpliced() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.toSpliced(0, 1);
+   · ─────────────────────
+   ╰────
+  help: `.toSpliced()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.with() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.with(0, 'a');
+   · ──────────────────
+   ╰────
+  help: `.with()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.map() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array?.map(x => x + 1);
+   · ──────────────────────
+   ╰────
+  help: `.map()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.filter() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array?.filter(Boolean);
+   · ──────────────────────
+   ╰────
+  help: `.filter()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.map() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ foo.bar.baz.map(x => x + 1);
+   · ───────────────────────────
+   ╰────
+  help: `.map()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.
+
+  ⚠ oxc(no-array-method-for-side-effect): Array.prototype.map() called without using its return value
+   ╭─[no_array_method_for_side_effect.tsx:1:1]
+ 1 │ array.filter(Boolean).map(fn);
+   · ─────────────────────────────
+   ╰────
+  help: `.map()` returns a new value. Either assign the result to a variable or use `.forEach()` for side effects.


### PR DESCRIPTION
This pull request introduces a new rule which ensures methods like `Array#toSorted()` are not actually used without using their return value. I created this because I just found out that some time ago I search-and-replaced all occurrences of `Array#sort()` with `Array#toSorted()` without adjusting the code logic.

This code is heavily based on the `eslint/no-new` rule and was created with help of Opus 4.6.