### PR TITLE
fix(ci): allow longpaths for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     name: Test Windows
     runs-on: windows-latest
     steps:
+      - run: git config --system core.longpaths true
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
       # Unsung heroes of the internet, who led me here to speed up Windows' slowness:
       # https://github.com/actions/cache/issues/752#issuecomment-1847036770

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -130,6 +130,9 @@ jobs:
       run:
         shell: bash
     steps:
+      - if: ${{ contains(matrix.os, 'windows') }}
+        run: git config --system core.longpaths true
+
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
 
       - name: Install cross

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -129,6 +129,9 @@ jobs:
               pnpm build --target riscv64gc-unknown-linux-musl -x
 
     steps:
+      - if: ${{ contains(matrix.os, 'windows') }}
+        run: git config --system core.longpaths true
+
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6


### PR DESCRIPTION
After https://github.com/oxc-project/oxc/pull/20044 the paths are too long for windows git.
The windows CI is failing because of this: https://github.com/oxc-project/oxc/actions/runs/22763163089/job/66024371179

Solution found in https://stackoverflow.com/a/22575737/7387397
Should work again: https://github.com/oxc-project/oxc/actions/runs/22764481037/job/66028823796?pr=20075