### PR TITLE
fix(linter/plugins): define `RegExp.escape` for tsc

### DIFF
--- a/apps/oxlint/src-js/globals.d.ts
+++ b/apps/oxlint/src-js/globals.d.ts
@@ -5,3 +5,9 @@ declare const DEBUG: boolean;
 
 // `true` if is build for conformance testing
 declare const CONFORMANCE: boolean;
+
+// `RegExp.escape` is not yet in TypeScript's lib types (available from ES2025).
+// TODO: Remove this once TypeScript ships it.
+interface RegExpConstructor {
+  escape(this: void, str: string): string;
+}


### PR DESCRIPTION
Fix a couple of errors that get flagged by TypeScript in VS Code, because it doesn't recognise `RegExp.escape`. Oxlint's typecheck doesn't flag it (presumably tsgo is aware of this new addition to the language), but it's still annoying having red squiggles in VS Code. This PR fixes that.