### PR TITLE
feat(oxlint,oxfmt): add `--config-dir` flag

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -146,6 +146,16 @@ pub struct ConfigOptions {
     /// Path to the configuration file
     #[bpaf(short, long, argument("PATH"))]
     pub config: Option<PathBuf>,
+
+    /// Base directory for resolving relative paths in the configuration file.
+    ///
+    /// When a config file is stored in a different location than the project root
+    /// (e.g., in a cache directory), use this flag to specify where relative paths
+    /// in the config should be resolved from.
+    ///
+    /// If not provided, relative paths are resolved from the config file's parent directory.
+    #[bpaf(long("config-dir"), argument("DIR"), hide_usage)]
+    pub config_dir: Option<PathBuf>,
 }
 
 /// Ignore Options

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -75,6 +75,7 @@ impl FormatRunner {
             &cwd,
             oxfmtrc_path.as_deref(),
             editorconfig_path.as_deref(),
+            config_options.config_dir.as_deref(),
         ) {
             Ok(r) => r,
             Err(err) => {

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -200,6 +200,7 @@ impl ConfigResolver {
         cwd: &Path,
         oxfmtrc_path: Option<&Path>,
         editorconfig_path: Option<&Path>,
+        config_dir_override: Option<&Path>,
     ) -> Result<Self, String> {
         // Read and parse config file, or use empty JSON if not found
         let json_string = match oxfmtrc_path {
@@ -219,8 +220,11 @@ impl ConfigResolver {
         // Parse as raw JSON value
         let raw_config: Value =
             serde_json::from_str(&json_string).map_err(|err| err.to_string())?;
-        // Store the config directory for override path resolution
-        let config_dir = oxfmtrc_path.and_then(|p| p.parent().map(Path::to_path_buf));
+        // Store the config directory for override path resolution.
+        // If config_dir_override is provided, use it instead of deriving from the config file path.
+        let config_dir = config_dir_override
+            .map(Path::to_path_buf)
+            .or_else(|| oxfmtrc_path.and_then(|p| p.parent().map(Path::to_path_buf)));
 
         let editorconfig = match editorconfig_path {
             Some(path) => {

--- a/apps/oxfmt/src/lsp/options.rs
+++ b/apps/oxfmt/src/lsp/options.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 #[serde(rename_all = "camelCase")]
 pub struct FormatOptions {
     pub config_path: Option<String>,
+    pub config_dir: Option<String>,
 }
 
 impl<'de> Deserialize<'de> for FormatOptions {
@@ -29,6 +30,9 @@ impl TryFrom<Value> for FormatOptions {
             config_path: object
                 .get("fmt.configPath")
                 .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
+            config_dir: object
+                .get("fmt.configDir")
+                .and_then(|config_dir| serde_json::from_value::<String>(config_dir.clone()).ok()),
         })
     }
 }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -46,14 +46,17 @@ impl ServerFormatterBuilder {
         debug!("root_path = {:?}", root_path.display());
 
         // Build `ConfigResolver` from config paths
-        let (config_resolver, ignore_patterns) =
-            match Self::build_config_resolver(&root_path, options.config_path.as_ref(), options.config_dir.as_ref()) {
-                Ok((resolver, patterns)) => (resolver, patterns),
-                Err(err) => {
-                    warn!("Failed to build config resolver: {err}, falling back to default config");
-                    Self::default_config_resolver()
-                }
-            };
+        let (config_resolver, ignore_patterns) = match Self::build_config_resolver(
+            &root_path,
+            options.config_path.as_ref(),
+            options.config_dir.as_ref(),
+        ) {
+            Ok((resolver, patterns)) => (resolver, patterns),
+            Err(err) => {
+                warn!("Failed to build config resolver: {err}, falling back to default config");
+                Self::default_config_resolver()
+            }
+        };
 
         let gitignore_glob = match Self::create_ignore_globs(&root_path, &ignore_patterns) {
             Ok(glob) => Some(glob),

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -47,7 +47,7 @@ impl ServerFormatterBuilder {
 
         // Build `ConfigResolver` from config paths
         let (config_resolver, ignore_patterns) =
-            match Self::build_config_resolver(&root_path, options.config_path.as_ref()) {
+            match Self::build_config_resolver(&root_path, options.config_path.as_ref(), options.config_dir.as_ref()) {
                 Ok((resolver, patterns)) => (resolver, patterns),
                 Err(err) => {
                     warn!("Failed to build config resolver: {err}, falling back to default config");
@@ -108,15 +108,18 @@ impl ServerFormatterBuilder {
     fn build_config_resolver(
         root_path: &Path,
         config_path: Option<&String>,
+        config_dir: Option<&String>,
     ) -> Result<(ConfigResolver, Vec<String>), String> {
         let oxfmtrc_path =
             resolve_oxfmtrc_path(root_path, config_path.filter(|s| !s.is_empty()).map(Path::new));
         let editorconfig_path = resolve_editorconfig_path(root_path);
+        let config_dir_path = config_dir.filter(|s| !s.is_empty()).map(PathBuf::from);
 
         let mut resolver = ConfigResolver::from_config_paths(
             root_path,
             oxfmtrc_path.as_deref(),
             editorconfig_path.as_deref(),
+            config_dir_path.as_deref(),
         )?;
 
         // Validate config and cache options, returns ignore patterns
@@ -127,7 +130,7 @@ impl ServerFormatterBuilder {
 
     /// Create a default `ConfigResolver` when config loading fails.
     fn default_config_resolver() -> (ConfigResolver, Vec<String>) {
-        let mut resolver = ConfigResolver::from_config_paths(Path::new("."), None, None)
+        let mut resolver = ConfigResolver::from_config_paths(Path::new("."), None, None, None)
             .expect("Default ConfigResolver should never fail");
         let ignore_patterns = resolver
             .build_and_validate()

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -57,6 +57,7 @@ impl StdinRunner {
             &cwd,
             oxfmtrc_path.as_deref(),
             editorconfig_path.as_deref(),
+            config_options.config_dir.as_deref(),
         ) {
             Ok(r) => r,
             Err(err) => {

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -123,6 +123,16 @@ pub struct BasicOptions {
     #[bpaf(long, short, argument("./.oxlintrc.json"))]
     pub config: Option<PathBuf>,
 
+    /// Base directory for resolving relative paths in the configuration file.
+    ///
+    /// When a config file is stored in a different location than the project root
+    /// (e.g., in a cache directory), use this flag to specify where relative paths
+    /// in the config (such as plugin paths or ignore patterns) should be resolved from.
+    ///
+    /// If not provided, relative paths are resolved from the config file's parent directory.
+    #[bpaf(long("config-dir"), argument("DIR"), hide_usage)]
+    pub config_dir: Option<PathBuf>,
+
     /// TypeScript `tsconfig.json` path for reading path alias and project references for import plugin.
     /// If not provided, will look for `tsconfig.json` in the current working directory.
     #[bpaf(argument("./tsconfig.json"), hide_usage)]

--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -494,19 +494,28 @@ impl<'a> ConfigLoader<'a> {
         &self,
         cwd: &Path,
         config_path: Option<&PathBuf>,
+        config_dir: Option<&Path>,
     ) -> Result<Oxlintrc, OxcDiagnostic> {
-        if let Some(config_path) = config_path {
+        let mut config = if let Some(config_path) = config_path {
             let full_path = cwd.join(config_path);
             if is_js_config_path(&full_path) {
-                return self.load_root_js_config(&full_path);
+                self.load_root_js_config(&full_path)?
+            } else {
+                Oxlintrc::from_file(&full_path)?
             }
-            return Oxlintrc::from_file(&full_path);
+        } else {
+            match self.try_load_config_from_dir(cwd)? {
+                Some(config) => config,
+                None => Oxlintrc::default(),
+            }
+        };
+
+        if let Some(dir) = config_dir {
+            config.path = dir.join("oxlint.config.json");
+            config.set_config_dir(dir);
         }
 
-        match self.try_load_config_from_dir(cwd)? {
-            Some(config) => Ok(config),
-            None => Ok(Oxlintrc::default()),
-        }
+        Ok(config)
     }
 
     /// Load root config by searching up parent directories.
@@ -524,28 +533,36 @@ impl<'a> ConfigLoader<'a> {
         &self,
         cwd: &Path,
         config_path: Option<&PathBuf>,
+        config_dir: Option<&Path>,
     ) -> Result<Oxlintrc, OxcDiagnostic> {
         // If an explicit config path is provided, use it directly
-        if let Some(config_path) = config_path {
+        let mut config = if let Some(config_path) = config_path {
             let full_path = cwd.join(config_path);
             if is_js_config_path(&full_path) {
-                return self.load_root_js_config(&full_path);
+                self.load_root_js_config(&full_path)?
+            } else {
+                Oxlintrc::from_file(&full_path)?
             }
-            return Oxlintrc::from_file(&full_path);
+        } else {
+            // Search up the directory tree for a config file
+            let mut found = None;
+            let mut current = Some(cwd);
+            while let Some(dir) = current {
+                if let Some(config) = self.try_load_config_from_dir(dir)? {
+                    found = Some(config);
+                    break;
+                }
+                current = dir.parent();
+            }
+            found.unwrap_or_default()
+        };
+
+        if let Some(dir) = config_dir {
+            config.path = dir.join("oxlint.config.json");
+            config.set_config_dir(dir);
         }
 
-        // Search up the directory tree for a config file
-        let mut current = Some(cwd);
-        while let Some(dir) = current {
-            if let Some(config) = self.try_load_config_from_dir(dir)? {
-                return Ok(config);
-            }
-            // Move to parent directory
-            current = dir.parent();
-        }
-
-        // No config found in any ancestor directory
-        Ok(Oxlintrc::default())
+        Ok(config)
     }
 
     fn load_root_js_config(&self, path: &Path) -> Result<Oxlintrc, OxcDiagnostic> {
@@ -589,10 +606,11 @@ impl<'a> ConfigLoader<'a> {
         &mut self,
         cwd: &Path,
         config_path: Option<&PathBuf>,
+        config_dir: Option<&Path>,
         paths: &[Arc<OsStr>],
         search_for_nested_configs: bool,
     ) -> Result<LoadedConfigs, CliConfigLoadError> {
-        let oxlintrc = match self.load_root_config(cwd, config_path) {
+        let oxlintrc = match self.load_root_config(cwd, config_path, config_dir) {
             Ok(config) => config,
             Err(err) => return Err(CliConfigLoadError::RootConfig(err)),
         };
@@ -796,17 +814,17 @@ mod test {
 
         // Test case 1: Invalid path that should fail
         let invalid_config = PathBuf::from("child/../../fixtures/cli/linter/eslintrc.json");
-        let result = loader.load_root_config(&cwd, Some(&invalid_config));
+        let result = loader.load_root_config(&cwd, Some(&invalid_config), None);
         assert!(result.is_err(), "Expected config lookup to fail with invalid path");
 
         // Test case 2: Valid path that should pass
         let valid_config = PathBuf::from("fixtures/cli/linter/eslintrc.json");
-        let result = loader.load_root_config(&cwd, Some(&valid_config));
+        let result = loader.load_root_config(&cwd, Some(&valid_config), None);
         assert!(result.is_ok(), "Expected config lookup to succeed with valid path");
 
         // Test case 3: Valid path using parent directory (..) syntax that should pass
         let valid_parent_config = PathBuf::from("fixtures/cli/linter/../linter/eslintrc.json");
-        let result = loader.load_root_config(&cwd, Some(&valid_parent_config));
+        let result = loader.load_root_config(&cwd, Some(&valid_parent_config), None);
         assert!(result.is_ok(), "Expected config lookup to succeed with parent directory syntax");
 
         // Verify the resolved path is correct
@@ -829,7 +847,7 @@ mod test {
         // Uses fixture: ancestor_search/apps/app1 -> should find ancestor_search/.oxlintrc.json
         let nested_dir = cwd.join("apps/oxlint/fixtures/cli/ancestor_search/apps/app1");
         if nested_dir.exists() {
-            let result = loader.load_root_config_with_ancestor_search(&nested_dir, None);
+            let result = loader.load_root_config_with_ancestor_search(&nested_dir, None, None);
             assert!(result.is_ok(), "Expected ancestor search to find config or return default");
 
             // Verify the config was actually found (not just default)
@@ -846,13 +864,13 @@ mod test {
         // Uses dedicated fixture with .oxlintrc.json
         let valid_config =
             PathBuf::from("fixtures/cli/ancestor_search_explicit_config/.oxlintrc.json");
-        let result = loader.load_root_config_with_ancestor_search(&cwd, Some(&valid_config));
+        let result = loader.load_root_config_with_ancestor_search(&cwd, Some(&valid_config), None);
         assert!(result.is_ok(), "Expected config lookup to succeed with explicit path");
 
         // Test case 3: When no config exists in any ancestor, should return default
         let temp_dir = std::env::temp_dir().join("oxc_test_no_config");
         std::fs::create_dir_all(&temp_dir).expect("Failed to create temporary test directory");
-        let result = loader.load_root_config_with_ancestor_search(&temp_dir, None);
+        let result = loader.load_root_config_with_ancestor_search(&temp_dir, None, None);
         assert!(result.is_ok(), "Expected default config when no config found");
         std::fs::remove_dir_all(&temp_dir).expect("Failed to cleanup temporary test directory");
     }
@@ -935,7 +953,7 @@ mod test {
         let loader = loader.with_js_config_loader(Some(&js_loader));
 
         let config = loader
-            .load_root_config(root_dir.path(), Some(&PathBuf::from("oxlint.config.ts")))
+            .load_root_config(root_dir.path(), Some(&PathBuf::from("oxlint.config.ts")), None)
             .unwrap();
 
         assert_eq!(config.options.type_aware, Some(true));
@@ -960,7 +978,7 @@ mod test {
         let loader = loader.with_js_config_loader(Some(&js_loader));
 
         let config = loader
-            .load_root_config(root_dir.path(), Some(&PathBuf::from("oxlint.config.ts")))
+            .load_root_config(root_dir.path(), Some(&PathBuf::from("oxlint.config.ts")), None)
             .unwrap();
 
         assert_eq!(config.options.type_check, Some(true));
@@ -1126,7 +1144,7 @@ mod test {
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
-        let result = loader.load_root_config(root_dir.path(), None);
+        let result = loader.load_root_config(root_dir.path(), None, None);
         assert!(result.is_ok(), "Expected .oxlintrc.jsonc to be discovered and loaded");
         let config = result.unwrap();
         assert!(
@@ -1147,7 +1165,7 @@ mod test {
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
-        let result = loader.load_root_config(root_dir.path(), None);
+        let result = loader.load_root_config(root_dir.path(), None, None);
         assert!(
             result.is_err(),
             "Expected an error when both .oxlintrc.json and .oxlintrc.jsonc exist"
@@ -1163,7 +1181,7 @@ mod test {
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
-        let result = loader.load_root_config(root_dir.path(), None);
+        let result = loader.load_root_config(root_dir.path(), None, None);
         assert!(result.is_err(), "Expected an error when both JSON and TS configs exist");
     }
 
@@ -1177,7 +1195,7 @@ mod test {
         let mut external_plugin_store = ExternalPluginStore::new(false);
         let loader = ConfigLoader::new(None, &mut external_plugin_store, &[], None);
 
-        let result = loader.load_root_config(root_dir.path(), None);
+        let result = loader.load_root_config(root_dir.path(), None, None);
         assert!(result.is_err(), "Expected an error when both JSONC and TS configs exist");
     }
 }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -214,6 +214,7 @@ impl CliRunner {
             config_loader.load_root_and_nested(
                 &self.cwd,
                 basic_options.config.as_ref(),
+                basic_options.config_dir.as_deref(),
                 &paths,
                 search_for_nested_configs,
             )

--- a/apps/oxlint/src/lsp/options.rs
+++ b/apps/oxlint/src/lsp/options.rs
@@ -28,6 +28,8 @@ pub struct LintOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ts_config_path: Option<String>,
     pub unused_disable_directives: Option<UnusedDisableDirectives>,
     pub type_aware: Option<bool>,
@@ -109,6 +111,9 @@ impl TryFrom<Value> for LintOptions {
             config_path: object
                 .get("configPath")
                 .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),
+            config_dir: object
+                .get("configDir")
+                .and_then(|config_dir| serde_json::from_value::<String>(config_dir.clone()).ok()),
             ts_config_path: object
                 .get("tsConfigPath")
                 .and_then(|config_path| serde_json::from_value::<String>(config_path.clone()).ok()),

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -105,6 +105,7 @@ impl ServerLinterBuilder {
         };
 
         let config_path = options.config_path.as_ref().filter(|p| !p.is_empty()).map(PathBuf::from);
+        let config_dir = options.config_dir.as_ref().filter(|p| !p.is_empty()).map(PathBuf::from);
         let loader = ConfigLoader::new(
             external_linter,
             &mut external_plugin_store,
@@ -115,7 +116,7 @@ impl ServerLinterBuilder {
         let loader = loader.with_js_config_loader(self.js_config_loader.as_ref());
 
         let oxlintrc =
-            match loader.load_root_config_with_ancestor_search(&root_path, config_path.as_ref()) {
+            match loader.load_root_config_with_ancestor_search(&root_path, config_path.as_ref(), config_dir.as_deref()) {
                 Ok(config) => config,
                 Err(e) => {
                     warn!("Failed to load config: {e}");
@@ -812,6 +813,7 @@ impl ServerLinter {
 
     fn needs_restart(old_options: &LSPLintOptions, new_options: &LSPLintOptions) -> bool {
         old_options.config_path != new_options.config_path
+            || old_options.config_dir != new_options.config_dir
             || old_options.ts_config_path != new_options.ts_config_path
             || old_options.use_nested_configs() != new_options.use_nested_configs()
             || old_options.fix_kind != new_options.fix_kind

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -115,14 +115,17 @@ impl ServerLinterBuilder {
         #[cfg(feature = "napi")]
         let loader = loader.with_js_config_loader(self.js_config_loader.as_ref());
 
-        let oxlintrc =
-            match loader.load_root_config_with_ancestor_search(&root_path, config_path.as_ref(), config_dir.as_deref()) {
-                Ok(config) => config,
-                Err(e) => {
-                    warn!("Failed to load config: {e}");
-                    Oxlintrc::default()
-                }
-            };
+        let oxlintrc = match loader.load_root_config_with_ancestor_search(
+            &root_path,
+            config_path.as_ref(),
+            config_dir.as_deref(),
+        ) {
+            Ok(config) => config,
+            Err(e) => {
+                warn!("Failed to load config: {e}");
+                Oxlintrc::default()
+            }
+        };
 
         let base_patterns = oxlintrc.ignore_patterns.clone();
 


### PR DESCRIPTION
## Summary

- Add `--config-dir <DIR>` CLI flag to both oxlint and oxfmt
- When a config file is stored in a different location than the project root (e.g., in a cache directory), relative paths in the config (plugin paths, ignore patterns, overrides) should still resolve from the project root
- If not provided, behavior is unchanged — relative paths resolve from the config file's parent directory
- Also exposed via LSP options (`configDir` for oxlint, `fmt.configDir` for oxfmt)

### oxlint changes
- `BasicOptions`: new `--config-dir` argument
- `ConfigLoader::load_root_config()` / `load_root_config_with_ancestor_search()` / `load_root_and_nested()`: accept optional `config_dir` parameter, override `Oxlintrc.path` and call `set_config_dir()` when provided
- LSP `LintOptions`: new `config_dir` field, threaded through to config loading

### oxfmt changes
- `ConfigOptions`: new `--config-dir` argument
- `ConfigResolver::from_config_paths()`: accept optional `config_dir_override` parameter
- LSP `FormatOptions`: new `config_dir` field, threaded through to `build_config_resolver()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)