### PR TITLE
fix(linter/plugins): fix types for `walkProgram` and `walkProgramWithCfg`

### DIFF
--- a/apps/oxlint/src-js/generated/walk.d.ts
+++ b/apps/oxlint/src-js/generated/walk.d.ts
@@ -2,10 +2,9 @@
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/estree_visit.rs`.
 
 import type { Node, Program } from "./types.d.ts";
+import type { VisitFn, EnterExit } from "../plugins/visitor.ts";
 
-type VisitFn = ((node: Node) => void) | null;
-type EnterExitVisitor = { enter: VisitFn; exit: VisitFn } | null;
-type CompiledVisitors = (VisitFn | EnterExitVisitor)[];
+type CompiledVisitors = (VisitFn | EnterExit | null)[];
 
 export declare function walkProgram(program: Program, visitors: CompiledVisitors): void;
 export declare const ancestors: Node[];

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -17,9 +17,8 @@ import {
 import { ancestors } from "../generated/walk.js";
 import { debugAssert, debugAssertIsFunction } from "../utils/asserts.ts";
 
-import type { CfgVisitFn, EnterExit } from "./visitor.ts";
+import type { CfgVisitFn, EnterExit, VisitFn } from "./visitor.ts";
 import type { Node, Program } from "../generated/types.d.ts";
-import type { CompiledVisitors } from "../generated/walk.js";
 
 /**
  * Offset added to type IDs for exit visits to distinguish them from enter visits.
@@ -89,7 +88,10 @@ export function resetCfgWalk(): void {
  * @param ast - AST
  * @param visitors - Visitors array
  */
-export function walkProgramWithCfg(ast: Program, visitors: CompiledVisitors): void {
+export function walkProgramWithCfg(
+  ast: Program,
+  visitors: (VisitFn | EnterExit | CfgVisitFn | null)[],
+): void {
   // Get the steps that need to be run to walk the AST
   prepareSteps(ast);
 

--- a/napi/parser/src-js/generated/visit/walk.d.ts
+++ b/napi/parser/src-js/generated/visit/walk.d.ts
@@ -3,8 +3,8 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type VisitFn = ((node: ESTree.Node) => void) | null;
-type EnterExitVisitor = { enter: VisitFn; exit: VisitFn } | null;
-type CompiledVisitors = (VisitFn | EnterExitVisitor)[];
+type VisitFn = (node: ESTree.Node) => void;
+type EnterExit = { enter: VisitFn; exit: VisitFn };
+type CompiledVisitors = (VisitFn | EnterExit | null)[];
 
 export declare function walkProgram(program: ESTree.Program, visitors: CompiledVisitors): void;

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -535,9 +535,9 @@ fn generate(codegen: &Codegen) -> Codes {
     let walk_dts_parser = "
         import type * as ESTree from '@oxc-project/types';
 
-        type VisitFn = ((node: ESTree.Node) => void) | null;
-        type EnterExitVisitor = { enter: VisitFn; exit: VisitFn } | null;
-        type CompiledVisitors = (VisitFn | EnterExitVisitor)[];
+        type VisitFn = (node: ESTree.Node) => void;
+        type EnterExit = { enter: VisitFn; exit: VisitFn };
+        type CompiledVisitors = (VisitFn | EnterExit | null)[];
 
         export declare function walkProgram(program: ESTree.Program, visitors: CompiledVisitors): void;
     ".to_string();
@@ -550,10 +550,9 @@ fn generate(codegen: &Codegen) -> Codes {
     #[rustfmt::skip]
     let walk_dts_oxlint = "
         import type { Node, Program } from './types.d.ts';
+        import type { VisitFn, EnterExit } from '../plugins/visitor.ts';
 
-        type VisitFn = ((node: Node) => void) | null;
-        type EnterExitVisitor = { enter: VisitFn; exit: VisitFn } | null;
-        type CompiledVisitors = (VisitFn | EnterExitVisitor)[];
+        type CompiledVisitors = (VisitFn | EnterExit | null)[];
 
         export declare function walkProgram(program: Program, visitors: CompiledVisitors): void;
         export declare const ancestors: Node[];


### PR DESCRIPTION
Fix a mistake in our (internal) types: `walkProgramWithCfg` was missing that elements can be `CfgVisitFn`.

Also refactor the types for `walkProgram`, importing the original `VisitFn` and `EnterExit` types from where they're defined.