### PR TITLE
docs(linter/plugins): move comment about "bivariance hack" into generated code

### DIFF
--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -3,6 +3,8 @@
 
 import type * as ESTree from "./types.d.ts";
 
+// To understand why we need the "Bivariance hack", see: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20219
+// For downsides, see: https://github.com/oxc-project/oxc/issues/18154#issuecomment-4012955607
 type BivarianceHackHandler<Handler extends (...args: any) => any> = {
   bivarianceHack(...args: Parameters<Handler>): ReturnType<Handler>;
 }["bivarianceHack"];

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -507,11 +507,12 @@ fn generate(codegen: &Codegen) -> Codes {
         }}
     ");
 
-    // See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20219 for why we need "Bivariance hack"
     #[rustfmt::skip]
     let visitor_type_oxlint = format!("
         import type * as ESTree from './types.d.ts';
 
+        // To understand why we need the \"Bivariance hack\", see: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20219
+        // For downsides, see: https://github.com/oxc-project/oxc/issues/18154#issuecomment-4012955607
         type BivarianceHackHandler<Handler extends (...args: any) => any> = {{
             bivarianceHack(...args: Parameters<Handler>): ReturnType<Handler>;
         }}[\"bivarianceHack\"];


### PR DESCRIPTION
Follow-on after #20065.

That PR added a comment about the "bivariance hack", but that comment was in the `ast_tools` codegen.

Move the comment into the generated code, as that's what people will be looking at when they ask themselves "what the hell is this thing?". Also add a link to [my comment](https://github.com/oxc-project/oxc/issues/18154#issuecomment-4012955607) about the shortcomings of the hack approach.