### PR TITLE
refactor(linter/plugins): remove dead code

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -19,12 +19,6 @@ import {
   VISITOR_CFG,
 } from "./visitor.ts";
 
-// Lazy implementation
-/*
-import { TOKEN } from '../../dist/src-js/raw-transfer/lazy-common.js';
-import { walkProgram } from '../generated/walk.js';
-*/
-
 import { walkProgram, ancestors } from "../generated/walk.js";
 
 import type { AfterHook, BufferWithArrays } from "./types.ts";
@@ -237,21 +231,6 @@ export function lintFileImpl(
     }
 
     debugAssert(ancestors.length === 0, "`ancestors` should be empty after walking AST");
-
-    // Lazy implementation
-    /*
-    const sourceIsAscii = sourceText.length === sourceByteLen;
-    const ast = {
-      buffer,
-      sourceText,
-      sourceByteLen,
-      sourceIsAscii,
-      nodes: new Map(),
-      token: TOKEN,
-    };
-
-    walkProgram(programPos, ast, compiledVisitor);
-    */
   }
 
   // Run `after` hooks

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -1,11 +1,3 @@
-// Lazy implementation
-/*
-// Visitor object returned by a `Rule`'s `create` function.
-export interface Visitor {
-  [key: string]: VisitFn;
-}
-*/
-
 import type { Span } from "./location.ts";
 import type { Token } from "./tokens.ts";
 


### PR DESCRIPTION
We had pieces of commented-out code related to an alternative implementation of linter plugins using lazy deserialization. This code is now very out of date, and so largely pointless. Remove it.