### PR TITLE
fix(linter): merge `env` from extended config files

### DIFF
--- a/apps/oxlint/fixtures/cli/extends_env/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/extends_env/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "categories": { "correctness": "off"},
+  "env": {
+    "node": true
+  },
+  "rules": {
+    "no-undef": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/extends_env/extends/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/extends_env/extends/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["../.oxlintrc.json"],
+  "rules": {
+    "no-undef": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/extends_env/extends/test.js
+++ b/apps/oxlint/fixtures/cli/extends_env/extends/test.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/apps/oxlint/fixtures/cli/extends_env/overrides_extends/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/extends_env/overrides_extends/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../.oxlintrc.json"],
+  "env": {
+    "node": false
+  },
+  "rules": {
+    "no-undef": "error"
+  }
+}

--- a/apps/oxlint/fixtures/cli/extends_env/overrides_extends/test.js
+++ b/apps/oxlint/fixtures/cli/extends_env/overrides_extends/test.js
@@ -1,0 +1,2 @@
+// only this file should report, because we override the extends env
+console.log('a');

--- a/apps/oxlint/fixtures/cli/extends_env/test.js
+++ b/apps/oxlint/fixtures/cli/extends_env/test.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1284,6 +1284,12 @@ mod test {
     }
 
     #[test]
+    fn test_extends_env() {
+        let args = &[];
+        Tester::new().with_cwd("fixtures/cli/extends_env".into()).test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_nested_config_multi_file_analysis_imports() {
         let args = &["issue_10054"];
         Tester::new().with_cwd("fixtures/cli".into()).test_and_snapshot(args);

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_env_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_env_@oxlint.snap
@@ -1,0 +1,21 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/cli/extends_env
+----------
+
+  x eslint(no-undef): 'console' is not defined.
+   ,-[overrides_extends/test.js:2:1]
+ 1 | // only this file should report, because we override the extends env
+ 2 | console.log('a');
+   : ^^^^^^^
+   `----
+  help: Either define 'console' or remove the reference to it. If 'console' is a global variable, add it to the 'globals' configuration.
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 3 files using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -376,8 +376,12 @@ impl Oxlintrc {
             .collect::<Vec<_>>();
 
         let settings = self.settings.clone();
-        let env = self.env.clone();
-        let globals = self.globals.clone();
+
+        let mut globals = OxlintGlobals::default();
+        other.env.override_globals(&mut globals);
+        other.globals.override_globals(&mut globals);
+        self.env.override_globals(&mut globals);
+        self.globals.override_globals(&mut globals);
 
         let mut overrides = other.overrides;
         overrides.extend(self.overrides.clone());
@@ -407,7 +411,7 @@ impl Oxlintrc {
             categories,
             rules: OxlintRules::new(rules),
             settings,
-            env,
+            env: OxlintEnv::default(), // env does not merge directly, it is used to override globals
             globals,
             overrides,
             options,


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/20087
✅ ~POC: need to check if everything is fine, specially with `globals`~