### PR TITLE
fix(linter): check `globals` entry for `no-undef`, only check es2026 globals for `no-extend-native` and `no-constant-binary-expression`

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -260,10 +260,29 @@ impl<'a> LintContext<'a> {
     /// Checks if a given variable named is defined as a global variable in the current environment.
     ///
     /// Example:
-    /// - `env_contains_var("Date")` returns `true` because it is a global builtin in all environments.
-    /// - `env_contains_var("HTMLElement")` returns `true` only if the `browser` environment is enabled.
-    /// - `env_contains_var("globalThis")` returns `true` only if the `es2020` environment or higher is enabled.
-    pub fn env_contains_var(&self, var: &str) -> bool {
+    /// - `is_global_defined("Date")` returns `true` because it is a global builtin in all environments.
+    /// - `is_global_defined("HTMLElement")` returns `true` only if the `browser` environment is enabled.
+    /// - `is_global_defined("globalThis")` returns `true` only if the `es2020` environment or higher is enabled.
+    /// - `is_global_defined("myGlobalVar")` returns `true` only if it is defined in the `globals` section as a non "off" value.
+    pub fn is_global_defined(&self, var: &str) -> bool {
+        if !self.scoping().root_unresolved_references().contains_key(var) {
+            return false;
+        }
+        if self.globals().is_enabled(var) {
+            return true;
+        }
+        self.env_contains_var(var)
+    }
+
+    pub fn is_ecma_script_global(&self, var: &str) -> bool {
+        if !self.scoping().root_unresolved_references().contains_key(var) {
+            return false;
+        }
+
+        GLOBALS["es2026"].contains_key(var) || GLOBALS["builtin"].contains_key(var)
+    }
+
+    fn env_contains_var(&self, var: &str) -> bool {
         if GLOBALS["builtin"].contains_key(var) {
             return true;
         }

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -350,8 +350,7 @@ impl NoConstantBinaryExpression {
             | Expression::RegExpLiteral(_) => true,
             Expression::NewExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
-                    return ctx.env_contains_var(ident.name.as_str())
-                        && ctx.scoping().root_unresolved_references().contains_key(&ident.name);
+                    return ctx.is_ecma_script_global(&ident.name);
                 }
                 false
             }

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -90,7 +90,7 @@ impl Rule for NoExtendNative {
                 let reference = symbols.get_reference(reference_id);
                 let name = ctx.semantic().reference_name(reference);
                 // If the referenced name does not appear to be a global object, skip it.
-                if !ctx.env_contains_var(name) {
+                if !ctx.is_ecma_script_global(name) {
                     continue;
                 }
                 // If the referenced name is explicitly allowed, skip it.

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -73,11 +73,7 @@ impl Rule for NoUndef {
 
                 let name = ctx.semantic().reference_name(reference);
 
-                if ctx.env_contains_var(name) {
-                    continue;
-                }
-
-                if ctx.globals().is_enabled(name) {
+                if ctx.is_global_defined(name) {
                     continue;
                 }
 
@@ -152,6 +148,13 @@ fn test() {
         ("var a; ({b: a} = {});", None, None),
         ("var obj; [obj.a, obj.b] = [0, 1];", None, None),
         ("URLSearchParams;", None, Some(serde_json::json!({"env": { "browser": true }}))),
+        (
+            "URLSearchParams;",
+            None,
+            Some(
+                serde_json::json!({"env": { "browser": false }, "globals": { "URLSearchParams": "readonly" }}),
+            ),
+        ),
         ("Intl;", None, Some(serde_json::json!({"env": { "browser": true }}))),
         ("IntersectionObserver;", None, Some(serde_json::json!({"env": { "browser": true }}))),
         ("Credential;", None, Some(serde_json::json!({"env": { "browser": true }}))),


### PR DESCRIPTION
These 3 rules are the only one which did not checked for "globals" and only lookedup the envs.  
In the future PR I want to remove env from the lint context. It should be resolved into "globals" before.

Added one test case where we already tested the "globals" option