### PR TITLE
perf(napi): unify build-test profile to coverage for cache sharing

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -11,7 +11,7 @@
     "build-dev": "pnpm run build-napi && pnpm run build-js",
     "build-test": "pnpm run build-napi-test && pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
-    "build-napi-test": "pnpm run build-napi",
+    "build-napi-test": "pnpm run build-napi --profile coverage",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.js",
     "test": "vitest --dir test run",

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -27,7 +27,7 @@
     "build-test": "pnpm run build-napi-test && cross-env DEBUG=true pnpm run build-js",
     "build-conformance": "pnpm run build-napi-test && cross-env CONFORMANCE=true pnpm run build-js",
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
-    "build-napi-test": "pnpm run build-napi --features testing",
+    "build-napi-test": "pnpm run build-napi --features testing --profile coverage",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
     "build-js": "node scripts/build.ts",
     "generate-config-types": "node scripts/generate-config-types.ts",

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "build-dev": "napi build --esm --platform",
-    "build-test": "pnpm run build-dev",
+    "build-test": "pnpm run build-dev --profile coverage",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build-dev": "napi build --esm --platform",
-    "build-test": "pnpm run build-dev",
+    "build-test": "pnpm run build-dev --profile coverage",
     "build": "pnpm run build-dev --features allocator --release",
     "postbuild": "publint",
     "postbuild-dev": "node scripts/patch.js",


### PR DESCRIPTION
## Summary

- All NAPI `build-test` scripts now use `--profile coverage`, matching what `napi/parser` already used.
- Previously, `napi/parser` used `--profile coverage` while `napi/minify`, `napi/transform`, `apps/oxfmt`, and `apps/oxlint` used the default `dev` profile.

### Why this matters

`pnpm run build-test` runs 5 sequential `napi build` invocations (`--workspace-concurrency=1`). Each calls `cargo build` independently. Cargo's fingerprint system includes the **profile** — so artifacts compiled with one profile cannot be reused by another.

**Before:** The first package (minify) compiles all shared deps in `dev` profile. Then parser uses `coverage` profile, which writes to a completely separate target directory (`target/coverage/` vs `target/debug/`). Zero cache sharing between them. Subsequent `dev` packages reuse minify's cache but not parser's.

**After:** All packages use `coverage` profile. The first package compiles shared deps once in `target/coverage/`, and all subsequent packages reuse those artifacts incrementally.

From CI build logs, parser's `coverage` profile build took 27s (full recompile) vs ~5s if it could have reused the previous build's artifacts. Estimated savings: **~15-20s** on the Test NAPI critical path.