### PR TITLE
perf(napi): remove `napi_build::setup()` from `oxc_napi` to avoid redundant rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,6 @@ name = "oxc_napi"
 version = "0.116.0"
 dependencies = [
  "napi",
- "napi-build",
  "napi-derive",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 categories.workspace = true
 edition.workspace = true
 homepage.workspace = true
-include = ["/src", "build.rs"]
+include = ["/src"]
 keywords.workspace = true
 license.workspace = true
 publish = true
@@ -30,9 +30,6 @@ oxc_syntax = { workspace = true }
 
 napi = { workspace = true }
 napi-derive = { workspace = true }
-
-[build-dependencies]
-napi-build = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["napi"]

--- a/crates/oxc_napi/build.rs
+++ b/crates/oxc_napi/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    napi_build::setup();
-}


### PR DESCRIPTION
## Summary

- Remove `napi_build::setup()` from `crates/oxc_napi/build.rs` (delete the file entirely) to prevent `oxc_napi` from being invalidated and recompiled on every sequential `napi build` invocation
- `napi_build::setup()` registers `cargo::rerun-if-env-changed=NAPI_TYPE_DEF_TMP_FOLDER`, but `@napi-rs/cli` sets a **different value** for this env var per package, causing `oxc_napi` + all dependents to rebuild for each of the 5 NAPI packages
- `oxc_napi` is a library crate — the linker args and env tracking are only needed in the leaf cdylib crates which already have their own `build.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)