### PR TITLE
test(linter): update the rulegen test path for vue rules.

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1440,7 +1440,7 @@ fn main() {
         RuleKind::Node => format!("{NODE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Promise => format!("{PROMISE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Vitest => format!("{VITEST_TEST_PATH}/{kebab_rule_name}.test.ts"),
-        RuleKind::Vue => format!("{VUE_TEST_PATH}/{kebab_rule_name}.js"),
+        RuleKind::Vue => format!("{VUE_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Oxc => String::new(),
     };
     let rule_src_path = match rule_kind {


### PR DESCRIPTION
All eslint-plugin-vue tests were moved. See https://github.com/vuejs/eslint-plugin-vue/commit/b5d8f141a4aeba1e1c363be2042a4da680159ecb#diff-ed2e8d689a406c52dde510ab3fdf139e22e8a24154b51bc7f2025eefe961d58c