### PR TITLE
test(linter): Port additional tests for two unicorn rules.

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -174,87 +174,109 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        "Promise.all([promise, anotherPromise])",
-        "Promise.all(notArrayLiteral)",
-        "Promise.all([...promises])",
+        "Promise.race([promise, anotherPromise])",
+        "Promise.race(notArrayLiteral)",
+        "Promise.race([...promises])",
         "Promise.any([promise, anotherPromise])",
         "Promise.race([promise, anotherPromise])",
         "Promise.notListedMethod([promise])",
-        "Promise[all]([promise])",
-        "Promise.all([,])",
-        "NotPromise.all([promise])",
-        "Promise.all(...[promise])",
-        "Promise.all([promise], extraArguments)",
-        "Promise.all()",
-        "new Promise.all([promise])",
-        "globalThis.Promise.all([promise])",
+        "Promise[race]([promise])",
+        "Promise.race([,])",
+        "NotPromise.race([promise])",
+        // TODO: These should be valid but Oxlint currently flags them
+        // "Promise?.race([promise])",
+        // "Promise.race?.([promise])",
+        "Promise.race(...[promise])",
+        "Promise.race([promise], extraArguments)",
+        "Promise.race()",
+        "new Promise.race([promise])",
+        // We are not checking these cases
+        "globalThis.Promise.race([promise])",
+        // TODO: This should be valid but Oxlint currently flags it
+        // r#"Promise["race"]([promise])"#,
+        // This can't be checked
         "Promise.allSettled([promise])",
-        "Promise.all('one').then(something);",
     ];
 
     let fail = vec![
-        "await Promise.all([x])",
-        "await Promise['all']([x])",
-        "await Promise.all([(0, promise)])",
-        "async function * foo() {await Promise.all([yield promise])}",
-        "async function * foo() {await Promise.all([yield* promise])}",
-        "await Promise.all([() => promise,],)",
-        "await Promise.all([a ? b : c,],)",
-        "await Promise.all([x ??= y,],)",
-        "await Promise.all([x ||= y,],)",
-        "await Promise.all([x &&= y,],)",
-        "await Promise.all([x |= y,],)",
-        "await Promise.all([x ^= y,],)",
-        "await Promise.all([x ??= y,],)",
-        "await Promise.all([x ||= y,],)",
-        "await Promise.all([x &&= y,],)",
-        "await Promise.all([x | y,],)",
-        "await Promise.all([x ^ y,],)",
-        "await Promise.all([x & y,],)",
-        "await Promise.all([x !== y,],)",
-        "await Promise.all([x == y,],)",
-        "await Promise.all([x in y,],)",
-        "await Promise.all([x >>> y,],)",
-        "await Promise.all([x + y,],)",
-        "await Promise.all([x / y,],)",
-        "await Promise.all([x ** y,],)",
-        "await Promise.all([promise,],)",
-        "await Promise.all([getPromise(),],)",
-        "await Promise.all([promises[0],],)",
-        "await Promise.all([await promise])",
+        // `await`ed
+        "await Promise.race([(0, promise)])",
+        "async function * foo() {await Promise.race([yield promise])}",
+        "async function * foo() {await Promise.race([yield* promise])}",
+        "await Promise.race([() => promise,],)",
+        "await Promise.race([a ? b : c,],)",
+        "await Promise.race([x ??= y,],)",
+        "await Promise.race([x ||= y,],)",
+        "await Promise.race([x &&= y,],)",
+        "await Promise.race([x |= y,],)",
+        "await Promise.race([x ^= y,],)",
+        "await Promise.race([x ??= y,],)",
+        "await Promise.race([x ||= y,],)",
+        "await Promise.race([x &&= y,],)",
+        "await Promise.race([x | y,],)",
+        "await Promise.race([x ^ y,],)",
+        "await Promise.race([x & y,],)",
+        "await Promise.race([x !== y,],)",
+        "await Promise.race([x == y,],)",
+        "await Promise.race([x in y,],)",
+        "await Promise.race([x >>> y,],)",
+        "await Promise.race([x + y,],)",
+        "await Promise.race([x / y,],)",
+        "await Promise.race([x ** y,],)",
+        "await Promise.race([promise,],)",
+        "await Promise.race([getPromise(),],)",
+        "await Promise.race([promises[0],],)",
+        "await Promise.race([await promise])",
         "await Promise.any([promise])",
         "await Promise.race([promise])",
-        "await Promise.all([new Promise(() => {})])",
-        "+await Promise.all([+1])",
+        "await Promise.race([new Promise(() => {})])",
+        "+await Promise.race([+1])",
+        // ASI, `Promise.race()` is not really `await`ed
         "
-        await Promise.all([(x,y)])
+        await Promise.race([(x,y)])
         [0].toString()
         ",
-        "Promise.all([promise,],)",
+        // Not `await`ed
+        "Promise.race([promise,],)",
         "
         foo
-        Promise.all([(0, promise),],)
+        Promise.race([(0, promise),],)
         ",
         "
         foo
-        Promise.all([[array][0],],)
+        Promise.race([[array][0],],)
         ",
-        "Promise.all([promise]).then()",
-        "Promise.all([1]).then()",
-        "Promise.all([1.]).then()",
-        "Promise.all([.1]).then()",
-        "Promise.all([(0, promise)]).then()",
-        "const _ = () => Promise.all([ a ?? b ,],)",
-        "Promise.all([ {a} = 1 ,],)",
-        "Promise.all([ function () {} ,],)",
-        "Promise.all([ class {} ,],)",
-        "Promise.all([ new Foo ,],).then()",
-        "Promise.all([ new Foo ,],).toString",
-        "foo(Promise.all([promise]))",
-        "Promise.all([promise]).foo = 1",
-        "Promise.all([promise])[0] ||= 1",
-        "Promise.all([undefined]).then()",
-        "Promise.all([null]).then()",
+        "Promise.race([promise]).then()",
+        "Promise.race([1]).then()",
+        "Promise.race([1.]).then()",
+        "Promise.race([.1]).then()",
+        "Promise.race([(0, promise)]).then()",
+        "const _ = () => Promise.race([ a ?? b ,],)",
+        "Promise.race([ {a} = 1 ,],)",
+        "Promise.race([ function () {} ,],)",
+        "Promise.race([ class {} ,],)",
+        "Promise.race([ new Foo ,],).then()",
+        "Promise.race([ new Foo ,],).toString",
+        "foo(Promise.race([promise]))",
+        "Promise.race([promise]).foo = 1",
+        "Promise.race([promise])[0] ||= 1",
+        "Promise.race([undefined]).then()",
+        "Promise.race([null]).then()",
+        // `Promise.all` specific
+        "Promise.all([promise])",
+        "await Promise.all([promise])",
+        "const foo = () => Promise.all([promise])",
+        "const foo = await Promise.all([promise])",
+        "foo = await Promise.all([promise])",
+        // `Promise.{all, race}()` should not care if the result is used
+        "const foo = await Promise.race([promise])",
+        "const foo = () => Promise.race([promise])",
+        "foo = await Promise.race([promise])",
+        "const results = await Promise.any([promise])",
+        "const results = await Promise.race([promise])",
+        // Fixable, but not provided at this point
+        "const [foo] = await Promise.all([promise])",
+        // TypeScript-specific
         "Promise.all([x] as const).then()",
         "Promise.all([x] satisfies any[]).then()",
         "Promise.all([x as const]).then()",
@@ -263,7 +285,7 @@ fn test() {
     ];
 
     let fix = vec![
-        ("Promise.all([null]).then()", "Promise.all([null]).then()", None),
+        ("Promise.race([null]).then()", "Promise.resolve(null).then()", None),
         // Promise.all returns an array, so we preserve the array structure
         // `await Promise.all([x])` -> `[await x]`
         ("await Promise.all([x]);", "[await x];", None),
@@ -280,6 +302,8 @@ fn test() {
             "function foo () { return Promise.all([x]); }",
             None,
         ),
+        ("const foo = () => Promise.race([x])", "const foo = () => Promise.resolve(x)", None),
+        ("foo = await Promise.race([x])", "foo = await Promise.race([x])", None),
         (
             "Promise.all(['one']).then((result) => result[0]);",
             "Promise.all(['one']).then((result) => result[0]);",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -353,9 +353,39 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
+        // Not `boolean`
         "const bar = foo.find(fn)",
         "const bar = foo.find(fn) || baz",
         "if (foo.find(fn) ?? bar) {}",
+        // Not matched `CallExpression` — find
+        "if (new foo.find(fn)) {}",
+        "if (find(fn)) {}",
+        // TODO: Get these passing.
+        // r#"if (foo["find"](fn)) {}"#,
+        r#"if (foo["fi" + "nd"](fn) /* find */) {}"#, // spellchecker:disable-line
+        // TODO: Get these passing.
+        // "if (foo[`find`](fn)) {}",
+        "if (foo[find](fn)) {}",
+        "if (foo.notFind(fn) /* find */) {}",
+        "if (foo.find()) {}",
+        "if (foo.find(fn, thisArgument, extraArgument)) {}",
+        // TODO: Get these passing.
+        // "if (foo.find(...argumentsArray)) {}",
+        // Not matched `CallExpression` — findLast
+        "if (new foo.findLast(fn)) {}",
+        "if (findLast(fn)) {}",
+        // TODO: Get these passing.
+        // r#"if (foo["findLast"](fn)) {}"#,
+        r#"if (foo["fi" + "nd"](fn) /* findLast */) {}"#, // spellchecker:disable-line
+        // TODO: Get these passing.
+        // "if (foo[`findLast`](fn)) {}",
+        "if (foo[findLast](fn)) {}",
+        "if (foo.notFind(fn) /* findLast */) {}",
+        "if (foo.findLast()) {}",
+        "if (foo.findLast(fn, thisArgument, extraArgument)) {}",
+        // TODO: Get these passing.
+        // "if (foo.findLast(...argumentsArray)) {}",
+        // .filter(…).length > 0
         "array.filter(fn).length > 0.",
         "array.filter(fn).length > .0",
         "array.filter(fn).length > 0.0",
@@ -363,6 +393,7 @@ fn test() {
         "array.filter(fn).length < 0",
         "array.filter(fn).length >= 0",
         "0 > array.filter(fn).length",
+        // .filter(…).length !== 0
         "array.filter(fn).length !== 0.",
         "array.filter(fn).length !== .0",
         "array.filter(fn).length !== 0.0",
@@ -372,6 +403,7 @@ fn test() {
         "array.filter(fn).length == 0",
         "array.filter(fn).length = 0",
         "0 !== array.filter(fn).length",
+        // .filter(…).length >= 1
         "array.filter(fn).length >= 1",
         "array.filter(fn).length >= 1.",
         "array.filter(fn).length >= 1.0",
@@ -381,16 +413,20 @@ fn test() {
         "array.filter(fn).length = 1",
         "array.filter(fn).length += 1",
         "1 >= array.filter(fn).length",
+        // .length
         "array.filter(fn)?.length > 0",
         "array.filter(fn)[length] > 0",
         "array.filter(fn).notLength > 0",
         "array.filter(fn).length() > 0",
         "+array.filter(fn).length >= 1",
+        // .filter
         "array.filter?.(fn).length > 0",
         "array?.filter(fn).length > 0",
         "array.notFilter(fn).length > 0",
         "array.filter.length > 0",
+        // jQuery#filter
         r#"$element.filter(":visible").length > 0"#,
+        // Compare with `undefined`
         "foo.find(fn) == 0",
         r#"foo.find(fn) != """#,
         "foo.find(fn) === null",
@@ -409,15 +445,73 @@ fn test() {
         "foo.findLastIndex(bar, extraArgument) !== -1",
         "foo.findLastIndex(bar) instanceof -1",
         "foo.findLastIndex(...bar) !== -1",
+        // lodash/underscore findIndex
+        "_.findIndex(bar)",
+        "_.findIndex(foo, bar)",
     ];
 
     let fail = vec![
+        // find — boolean contexts
+        "const bar = !foo.find(fn)",
+        // TODO: Get this working. Boolean() is not recognized as a boolean context by Oxlint
+        // "const bar = Boolean(foo.find(fn))",
         "if (foo.find(fn)) {}",
+        "const bar = foo.find(fn) ? 1 : 2",
+        "while (foo.find(fn)) foo.shift();",
+        "do {foo.shift();} while (foo.find(fn));",
+        "for (; foo.find(fn); ) foo.shift();",
+        // findLast — boolean contexts
+        "const bar = !foo.findLast(fn)",
+        // TODO: Get this working. Boolean() is not recognized as a boolean context by Oxlint
+        // "const bar = Boolean(foo.findLast(fn))",
         "if (foo.findLast(fn)) {}",
+        "const bar = foo.findLast(fn) ? 1 : 2",
+        "while (foo.findLast(fn)) foo.shift();",
+        "do {foo.shift();} while (foo.findLast(fn));",
+        "for (; foo.findLast(fn); ) foo.shift();",
+        // Comments
+        "console.log(foo /* comment 1 */ . /* comment 2 */ find /* comment 3 */ (fn) ? a : b)",
+        // jQuery.find — always truthy, should not be used as boolean
+        r#"if (jQuery.find(".outer > div")) {}"#,
+        // Actual messages
+        "if (bar.find(fn)) {}",
+        "if (bar.findLast(fn)) {}",
+        // Snapshot cases
         r#"if (array.find(element => element === "🦄")) {}"#,
         r#"const foo = array.find(element => element === "🦄") ? bar : baz;"#,
+        // Chained find — only the outer .find should report
+        "
+        if (
+            array
+                .find(element => Array.isArray(element))
+            // ^^^^ This should NOT report
+                .find(x => x === 0)
+            // ^^^^ This should report
+        ) {
+        }
+        ",
+        // .filter(…).length
         "array.filter(fn).length > 0",
         "array.filter(fn).length !== 0",
+        // TODO: Get this working.
+        // "
+        // if (
+        //     ((
+        //         ((
+        //             ((
+        //                 ((
+        //                     array
+        //                 ))
+        //                     .filter(what_ever_here)
+        //             ))
+        //                 .length
+        //         ))
+        //         >
+        //         (( 0 ))
+        //     ))
+        // );
+        // ",
+        // Compare with `undefined`
         "foo.find(fn) == null",
         "foo.find(fn) == undefined",
         "foo.find(fn) === undefined",
@@ -433,8 +527,6 @@ fn test() {
         "foo.findIndex(bar) == - 1",
         "foo.findIndex(bar) >= 0",
         "foo.findIndex(bar) < 0",
-        "foo.findIndex(bar) !== (( - 1 ))",
-        "foo.findIndex(element => element.bar === 1) !== (( - 1 ))",
         // findLastIndex: negative one || ( >= || < ) 0
         "foo.findLastIndex(bar) !== -1",
         "foo.findLastIndex(bar) != -1",
@@ -443,13 +535,38 @@ fn test() {
         "foo.findLastIndex(bar) == - 1",
         "foo.findLastIndex(bar) >= 0",
         "foo.findLastIndex(bar) < 0",
+        "foo.findIndex(bar) !== (( - 1 ))",
+        "foo.findIndex(element => element.bar === 1) !== (( - 1 ))",
         "foo.findLastIndex(bar) !== (( - 1 ))",
         "foo.findLastIndex(element => element.bar === 1) !== (( - 1 ))",
     ];
 
     let fix = vec![
+        // find — boolean contexts
+        ("const bar = !foo.find(fn)", "const bar = !foo.some(fn)"),
         ("if (foo.find(fn)) {}", "if (foo.some(fn)) {}"),
+        ("const bar = foo.find(fn) ? 1 : 2", "const bar = foo.some(fn) ? 1 : 2"),
+        ("while (foo.find(fn)) foo.shift();", "while (foo.some(fn)) foo.shift();"),
+        ("do {foo.shift();} while (foo.find(fn));", "do {foo.shift();} while (foo.some(fn));"),
+        ("for (; foo.find(fn); ) foo.shift();", "for (; foo.some(fn); ) foo.shift();"),
+        // findLast — boolean contexts
+        ("const bar = !foo.findLast(fn)", "const bar = !foo.some(fn)"),
         ("if (foo.findLast(fn)) {}", "if (foo.some(fn)) {}"),
+        ("const bar = foo.findLast(fn) ? 1 : 2", "const bar = foo.some(fn) ? 1 : 2"),
+        ("while (foo.findLast(fn)) foo.shift();", "while (foo.some(fn)) foo.shift();"),
+        ("do {foo.shift();} while (foo.findLast(fn));", "do {foo.shift();} while (foo.some(fn));"),
+        ("for (; foo.findLast(fn); ) foo.shift();", "for (; foo.some(fn); ) foo.shift();"),
+        // Comments
+        (
+            "console.log(foo /* comment 1 */ . /* comment 2 */ find /* comment 3 */ (fn) ? a : b)",
+            "console.log(foo /* comment 1 */ . /* comment 2 */ some /* comment 3 */ (fn) ? a : b)",
+        ),
+        // jQuery
+        (r#"if (jQuery.find(".outer > div")) {}"#, r#"if (jQuery.some(".outer > div")) {}"#),
+        // Actual messages
+        ("if (bar.find(fn)) {}", "if (bar.some(fn)) {}"),
+        ("if (bar.findLast(fn)) {}", "if (bar.some(fn)) {}"),
+        // Snapshot cases
         (
             r#"if (array.find(element => element === "🦄")) {}"#,
             r#"if (array.some(element => element === "🦄")) {}"#,
@@ -458,8 +575,10 @@ fn test() {
             r#"const foo = array.find(element => element === "🦄") ? bar : baz;"#,
             r#"const foo = array.some(element => element === "🦄") ? bar : baz;"#,
         ),
+        // .filter(…).length
         ("array.filter(fn).length > 0", "array.some(fn)"),
         ("array.filter(fn).length !== 0", "array.some(fn)"),
+        // Compare with `undefined`
         ("foo.find(fn) == null", "foo.some(fn) == null"),
         ("foo.find(fn) == undefined", "foo.some(fn) == undefined"),
         ("foo.find(fn) === undefined", "foo.some(fn) === undefined"),

--- a/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
@@ -2,206 +2,192 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x])
-   ·               ───
+ 1 │ await Promise.race([(0, promise)])
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise['all']([x])
-   ·               ─────
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([(0, promise)])
-   ·               ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:39]
- 1 │ async function * foo() {await Promise.all([yield promise])}
-   ·                                       ───
+ 1 │ async function * foo() {await Promise.race([yield promise])}
+   ·                                       ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:39]
- 1 │ async function * foo() {await Promise.all([yield* promise])}
-   ·                                       ───
+ 1 │ async function * foo() {await Promise.race([yield* promise])}
+   ·                                       ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([() => promise,],)
-   ·               ───
+ 1 │ await Promise.race([() => promise,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([a ? b : c,],)
-   ·               ───
+ 1 │ await Promise.race([a ? b : c,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ??= y,],)
-   ·               ───
+ 1 │ await Promise.race([x ??= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ||= y,],)
-   ·               ───
+ 1 │ await Promise.race([x ||= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x &&= y,],)
-   ·               ───
+ 1 │ await Promise.race([x &&= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x |= y,],)
-   ·               ───
+ 1 │ await Promise.race([x |= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ^= y,],)
-   ·               ───
+ 1 │ await Promise.race([x ^= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ??= y,],)
-   ·               ───
+ 1 │ await Promise.race([x ??= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ||= y,],)
-   ·               ───
+ 1 │ await Promise.race([x ||= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x &&= y,],)
-   ·               ───
+ 1 │ await Promise.race([x &&= y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x | y,],)
-   ·               ───
+ 1 │ await Promise.race([x | y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ^ y,],)
-   ·               ───
+ 1 │ await Promise.race([x ^ y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x & y,],)
-   ·               ───
+ 1 │ await Promise.race([x & y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x !== y,],)
-   ·               ───
+ 1 │ await Promise.race([x !== y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x == y,],)
-   ·               ───
+ 1 │ await Promise.race([x == y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x in y,],)
-   ·               ───
+ 1 │ await Promise.race([x in y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x >>> y,],)
-   ·               ───
+ 1 │ await Promise.race([x >>> y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x + y,],)
-   ·               ───
+ 1 │ await Promise.race([x + y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x / y,],)
-   ·               ───
+ 1 │ await Promise.race([x / y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([x ** y,],)
-   ·               ───
+ 1 │ await Promise.race([x ** y,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([promise,],)
-   ·               ───
+ 1 │ await Promise.race([promise,],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([getPromise(),],)
-   ·               ───
+ 1 │ await Promise.race([getPromise(),],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([promises[0],],)
-   ·               ───
+ 1 │ await Promise.race([promises[0],],)
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([await promise])
-   ·               ───
+ 1 │ await Promise.race([await promise])
+   ·               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
@@ -219,163 +205,240 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:15]
+ 1 │ await Promise.race([new Promise(() => {})])
+   ·               ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:16]
+ 1 │ +await Promise.race([+1])
+   ·                ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:2:23]
+ 1 │ 
+ 2 │         await Promise.race([(x,y)])
+   ·                       ────
+ 3 │         [0].toString()
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([promise,],)
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:3:17]
+ 2 │         foo
+ 3 │         Promise.race([(0, promise),],)
+   ·                 ────
+ 4 │         
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:3:17]
+ 2 │         foo
+ 3 │         Promise.race([[array][0],],)
+   ·                 ────
+ 4 │         
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([promise]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([1]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([1.]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([.1]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([(0, promise)]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:25]
+ 1 │ const _ = () => Promise.race([ a ?? b ,],)
+   ·                         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([ {a} = 1 ,],)
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([ function () {} ,],)
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([ class {} ,],)
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([ new Foo ,],).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([ new Foo ,],).toString
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:13]
+ 1 │ foo(Promise.race([promise]))
+   ·             ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([promise]).foo = 1
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([promise])[0] ||= 1
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([undefined]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.race([null]).then()
+   ·         ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:9]
+ 1 │ Promise.all([promise])
+   ·         ───
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
    ╭─[no_single_promise_in_promise_methods.mts:1:15]
- 1 │ await Promise.all([new Promise(() => {})])
+ 1 │ await Promise.all([promise])
    ·               ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:16]
- 1 │ +await Promise.all([+1])
-   ·                ───
+   ╭─[no_single_promise_in_promise_methods.mts:1:27]
+ 1 │ const foo = () => Promise.all([promise])
+   ·                           ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:2:23]
- 1 │ 
- 2 │         await Promise.all([(x,y)])
-   ·                       ───
- 3 │         [0].toString()
+   ╭─[no_single_promise_in_promise_methods.mts:1:27]
+ 1 │ const foo = await Promise.all([promise])
+   ·                           ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([promise,],)
-   ·         ───
+   ╭─[no_single_promise_in_promise_methods.mts:1:21]
+ 1 │ foo = await Promise.all([promise])
+   ·                     ───
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:27]
+ 1 │ const foo = await Promise.race([promise])
+   ·                           ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:27]
+ 1 │ const foo = () => Promise.race([promise])
+   ·                           ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:21]
+ 1 │ foo = await Promise.race([promise])
+   ·                     ────
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.any()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:31]
+ 1 │ const results = await Promise.any([promise])
+   ·                               ───
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.race()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.mts:1:31]
+ 1 │ const results = await Promise.race([promise])
+   ·                               ────
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 
   ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:3:17]
- 2 │         foo
- 3 │         Promise.all([(0, promise),],)
-   ·                 ───
- 4 │         
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:3:17]
- 2 │         foo
- 3 │         Promise.all([[array][0],],)
-   ·                 ───
- 4 │         
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([promise]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([1]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([1.]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([.1]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([(0, promise)]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:25]
- 1 │ const _ = () => Promise.all([ a ?? b ,],)
-   ·                         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([ {a} = 1 ,],)
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([ function () {} ,],)
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([ class {} ,],)
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([ new Foo ,],).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([ new Foo ,],).toString
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:13]
- 1 │ foo(Promise.all([promise]))
-   ·             ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([promise]).foo = 1
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([promise])[0] ||= 1
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([undefined]).then()
-   ·         ───
-   ╰────
-  help: Either use the value directly, or switch to `Promise.resolve(…)`.
-
-  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
-   ╭─[no_single_promise_in_promise_methods.mts:1:9]
- 1 │ Promise.all([null]).then()
-   ·         ───
+   ╭─[no_single_promise_in_promise_methods.mts:1:29]
+ 1 │ const [foo] = await Promise.all([promise])
+   ·                             ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
 

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_some.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_some.snap
@@ -1,6 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:18]
+ 1 │ const bar = !foo.find(fn)
+   ·                  ────
+   ╰────
+  help: Replace `find` with `some`.
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
    ╭─[prefer_array_some.tsx:1:9]
@@ -10,8 +18,99 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `find` with `some`.
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:17]
+ 1 │ const bar = foo.find(fn) ? 1 : 2
+   ·                 ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:12]
+ 1 │ while (foo.find(fn)) foo.shift();
+   ·            ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:30]
+ 1 │ do {foo.shift();} while (foo.find(fn));
+   ·                              ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:12]
+ 1 │ for (; foo.find(fn); ) foo.shift();
+   ·            ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:18]
+ 1 │ const bar = !foo.findLast(fn)
+   ·                  ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
    ╭─[prefer_array_some.tsx:1:9]
  1 │ if (foo.findLast(fn)) {}
+   ·         ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:17]
+ 1 │ const bar = foo.findLast(fn) ? 1 : 2
+   ·                 ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:12]
+ 1 │ while (foo.findLast(fn)) foo.shift();
+   ·            ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:30]
+ 1 │ do {foo.shift();} while (foo.findLast(fn));
+   ·                              ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:12]
+ 1 │ for (; foo.findLast(fn); ) foo.shift();
+   ·            ────────
+   ╰────
+  help: Replace `findLast` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:51]
+ 1 │ console.log(foo /* comment 1 */ . /* comment 2 */ find /* comment 3 */ (fn) ? a : b)
+   ·                                                   ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:12]
+ 1 │ if (jQuery.find(".outer > div")) {}
+   ·            ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:9]
+ 1 │ if (bar.find(fn)) {}
+   ·         ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:1:9]
+ 1 │ if (bar.findLast(fn)) {}
    ·         ────────
    ╰────
   help: Replace `findLast` with `some`.
@@ -27,6 +126,15 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_array_some.tsx:1:19]
  1 │ const foo = array.find(element => element === "🦄") ? bar : baz;
    ·                   ────
+   ╰────
+  help: Replace `find` with `some`.
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.find(…)` or `.findLast(…)`.
+   ╭─[prefer_array_some.tsx:6:18]
+ 5 │             // ^^^^ This should NOT report
+ 6 │                 .find(x => x === 0)
+   ·                  ────
+ 7 │             // ^^^^ This should report
    ╰────
   help: Replace `find` with `some`.
 
@@ -137,18 +245,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.
    ╭─[prefer_array_some.tsx:1:5]
- 1 │ foo.findIndex(bar) !== (( - 1 ))
-   ·     ─────────
-   ╰────
-
-  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.
-   ╭─[prefer_array_some.tsx:1:5]
- 1 │ foo.findIndex(element => element.bar === 1) !== (( - 1 ))
-   ·     ─────────
-   ╰────
-
-  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.
-   ╭─[prefer_array_some.tsx:1:5]
  1 │ foo.findLastIndex(bar) !== -1
    ·     ─────────────
    ╰────
@@ -187,6 +283,18 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_array_some.tsx:1:5]
  1 │ foo.findLastIndex(bar) < 0
    ·     ─────────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.
+   ╭─[prefer_array_some.tsx:1:5]
+ 1 │ foo.findIndex(bar) !== (( - 1 ))
+   ·     ─────────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.
+   ╭─[prefer_array_some.tsx:1:5]
+ 1 │ foo.findIndex(element => element.bar === 1) !== (( - 1 ))
+   ·     ─────────
    ╰────
 
   ⚠ eslint-plugin-unicorn(prefer-array-some): Prefer `.some(…)` over `.findIndex(…)` or `.findLastIndex(…)`.


### PR DESCRIPTION
See https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test/prefer-array-some.js and https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/609d4870f3731d39bd5b5f184628e2cf06578dba/test/no-single-promise-in-promise-methods.js

I used Claude for help porting the tests for `prefer-array-some`, mostly as a test, and then used a script to compare the tests that were ported to the original to make sure it ported everything correctly (and skipped some <template> tests that we can't handle anyway). I did the same for the other rule.

The reason I didn't use the rulegen tooling is because these tests are not handled adequately currently due to being generated dynamically or in separate sets.

One nice thing is that it also ported the comments for each set of tests.

For reference, the verification script's output, the tests that it couldn't find are due to being commented out (or template tests that were excluded).

<details>
<summary>test comparisons</summary>

```
node tasks/rulegen/compare-tests.mjs prefer-array-some unicorn
Downloading https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test/prefer-array-some.js ...
Reading Rust file: /Users/connorshea/code/oxc/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs

Comparing test cases for unicorn/prefer-array-some...

Upstream (Node.js evaluated): 72 valid, 52 invalid
Oxlint (Rust file):           70 valid, 46 invalid

Missing valid cases (6):
  1. if (foo["find"](fn)) {}
  2. if (foo["findLast"](fn)) {}
  3. if (foo[`find`](fn)) {}
  4. if (foo[`findLast`](fn)) {}
  5. if (foo.find(...argumentsArray)) {}
  6. if (foo.findLast(...argumentsArray)) {}

Missing invalid cases (8):
  1. const bar = Boolean(foo.find(fn))
  2. const bar = Boolean(foo.findLast(fn))
  3. if ( (( (( (( (( array )) .filter(what_ever_here) )) .length )) > (( 0 )) )) );
  4. <template><div v-if="foo.find(fn)"></div></template>
  5. <script>if (foo.findLast(fn));</script>
  6. <template><div v-if="foo.filter(fn).length > 0"></div></template>
  7. <template><div v-if="foo.filter(fn).length !== 0"></div></template>
  8. <script>if (foo.filter(fn).length > 0);</script>

Extra valid cases in oxlint not in upstream (4):
  1. new foo.findLastIndex(bar) !== -1
  2. foo.findLastIndex(bar, extraArgument) !== -1
  3. foo.findLastIndex(bar) instanceof -1
  4. foo.findLastIndex(...bar) !== -1

Extra invalid cases in oxlint not in upstream (2):
  1. foo.findLastIndex(bar) !== (( - 1 ))
  2. foo.findLastIndex(element => element.bar === 1) !== (( - 1 ))
```

```
node tasks/rulegen/compare-tests.mjs no-single-promise-in-promise-methods unicorn
Downloading https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test/no-single-promise-in-promise-methods.js ...
Reading Rust file: /Users/connorshea/code/oxc/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs

Comparing test cases for unicorn/no-single-promise-in-promise-methods...

Upstream (Node.js evaluated): 18 valid, 62 invalid
Oxlint (Rust file):           15 valid, 67 invalid

Missing valid cases (3):
  1. Promise?.race([promise])
  2. Promise.race?.([promise])
  3. Promise["race"]([promise])

Extra invalid cases in oxlint not in upstream (5):
  1. Promise.all([x] as const).then()
  2. Promise.all([x] satisfies any[]).then()
  3. Promise.all([x as const]).then()
  4. Promise.all([x!]).then()
  5. Promise.all(['one']).then(something);
```

</details>