### PR TITLE
refactor(ci): use ReFS dev drive with increased size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
       - uses: samypr100/setup-dev-drive@30f0f98ae5636b2b6501e181dfb3631b9974818d # v4.0.0
         with:
           workspace-copy: true
-          drive-size: 8GB
-          drive-format: NTFS
+          drive-size: 12GB
+          drive-format: ReFS
           env-mapping: |
             CARGO_HOME,{{ DEV_DRIVE }}/.cargo
             RUSTUP_HOME,{{ DEV_DRIVE }}/.rustup


### PR DESCRIPTION
## Summary

- Switch Windows CI dev drive format from NTFS to ReFS for better performance
- Increase dev drive size from 8GB to 12GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)