### PR TITLE
chore(linter,formatter): Add dev build commands to Justfile for oxlint and oxfmt.

### DIFF
--- a/justfile
+++ b/justfile
@@ -154,10 +154,15 @@ watch-oxlint *args='':
   just watch 'cargo run -p oxlint -- --disable-nested-config {{args}}'
 
 # oxlint release build for node.js
-# After building, you can run the built version of oxlint with
-# `node apps/oxlint/dist/cli.js`
+# After building, you can run oxlint with `node <oxc-root>/apps/oxlint/dist/cli.js`
 oxlint-node:
   pnpm -C apps/oxlint run build
+
+# oxlint dev build, for testing with Node.js locally.
+# This will lack some functionality but build faster, as it skips `--release` and the allocator feature.
+# After building, you can run oxlint with `node <oxc-root>/apps/oxlint/dist/cli.js`
+oxlint-node-dev:
+  pnpm -C apps/oxlint run build-dev
 
 watch-oxlint-node *args='':
   just watch 'pnpm run -C apps/oxlint build-dev && node apps/oxlint/dist/cli.js --disable-nested-config {{args}}'
@@ -203,8 +208,15 @@ watch-oxfmt *args='':
   just watch 'cargo run -p oxfmt -- {{args}}'
 
 # Build oxfmt in release build
+# After building, you can run oxfmt with `node <oxc-root>/apps/oxfmt/dist/cli.js`
 oxfmt-node:
   pnpm -C apps/oxfmt run build
+
+# oxfmt dev build, for testing with Node.js locally.
+# This will lack some functionality but build faster.
+# After building, you can run oxfmt with `node <oxc-root>/apps/oxfmt/dist/cli.js`
+oxfmt-node-dev:
+  pnpm -C apps/oxfmt run build-dev
 
 watch-oxfmt-node *args='':
   just watch 'pnpm run -C apps/oxfmt build-dev && node apps/oxfmt/dist/cli.js {{args}}'

--- a/justfile
+++ b/justfile
@@ -159,7 +159,8 @@ oxlint-node:
   pnpm -C apps/oxlint run build
 
 # oxlint dev build, for testing with Node.js locally.
-# This will lack some functionality but build faster, as it skips `--release` and the allocator feature.
+# This uses a non-release Rust build without the `allocator` feature (no mimalloc) and sets DEBUG options for the JS bundle,
+# which mainly affects build time, performance, and debug assertions rather than available linting functionality.
 # After building, you can run oxlint with `node <oxc-root>/apps/oxlint/dist/cli.js`
 oxlint-node-dev:
   pnpm -C apps/oxlint run build-dev

--- a/justfile
+++ b/justfile
@@ -213,7 +213,7 @@ oxfmt-node:
   pnpm -C apps/oxfmt run build
 
 # oxfmt dev build, for testing with Node.js locally.
-# This will lack some functionality but build faster.
+# This builds faster than the release build and may differ in performance or behavior.
 # After building, you can run oxfmt with `node <oxc-root>/apps/oxfmt/dist/cli.js`
 oxfmt-node-dev:
   pnpm -C apps/oxfmt run build-dev


### PR DESCRIPTION
These build significantly faster for me while letting me still test the app locally. I remember discussing these a while ago, but we never added anything to the Justfile for easily using them.

I'm not sure if there are any downsides to this beyond potential edge-case differences from the release build, but I figure it's probably worth considering?