### PR TITLE
refactor(ci): replace dorny/paths-filter with cargo tree-based change detection

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -1,0 +1,48 @@
+name: Check changes
+
+description: Detect whether a CI job should run based on changed files and crate dependencies.
+
+inputs:
+  packages:
+    required: false
+    description: Comma-separated crate names whose transitive deps (via cargo tree) to check (include mode)
+  exclude:
+    required: false
+    description: Comma-separated crate names to exclude (exclude mode); job runs unless ALL changes are in these dirs
+  paths:
+    required: false
+    description: Comma-separated additional paths that always trigger the job
+  token:
+    required: false
+    description: GitHub token for API access
+  pr-number:
+    required: false
+    description: Pull request number
+
+outputs:
+  changed:
+    description: Whether the job should run ("true" or "false")
+    value: ${{ steps.check.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check changes
+      id: check
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        GITHUB_PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        ARGS=""
+        if [ -n "${{ inputs.packages }}" ]; then
+          ARGS="$ARGS --packages ${{ inputs.packages }}"
+        fi
+        if [ -n "${{ inputs.exclude }}" ]; then
+          ARGS="$ARGS --exclude ${{ inputs.exclude }}"
+        fi
+        if [ -n "${{ inputs.paths }}" ]; then
+          ARGS="$ARGS --paths ${{ inputs.paths }}"
+        fi
+        SHOULD_RUN=$(node .github/scripts/check-changes.js $ARGS)
+        echo "changed=$SHOULD_RUN" >> $GITHUB_OUTPUT

--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -37,15 +37,15 @@ runs:
         INPUT_EXCLUDE: ${{ inputs.exclude }}
         INPUT_PATHS: ${{ inputs.paths }}
       run: |
-        ARGS=""
+        ARGS=()
         if [ -n "$INPUT_PACKAGES" ]; then
-          ARGS="$ARGS --packages $INPUT_PACKAGES"
+          ARGS+=("--packages" "$INPUT_PACKAGES")
         fi
         if [ -n "$INPUT_EXCLUDE" ]; then
-          ARGS="$ARGS --exclude $INPUT_EXCLUDE"
+          ARGS+=("--exclude" "$INPUT_EXCLUDE")
         fi
         if [ -n "$INPUT_PATHS" ]; then
-          ARGS="$ARGS --paths $INPUT_PATHS"
+          ARGS+=("--paths" "$INPUT_PATHS")
         fi
-        SHOULD_RUN=$(node .github/scripts/check-changes.js $ARGS)
+        SHOULD_RUN=$(node .github/scripts/check-changes.js "${ARGS[@]}")
         echo "changed=$SHOULD_RUN" >> $GITHUB_OUTPUT

--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -33,16 +33,19 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_PACKAGES: ${{ inputs.packages }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_PATHS: ${{ inputs.paths }}
       run: |
         ARGS=""
-        if [ -n "${{ inputs.packages }}" ]; then
-          ARGS="$ARGS --packages ${{ inputs.packages }}"
+        if [ -n "$INPUT_PACKAGES" ]; then
+          ARGS="$ARGS --packages $INPUT_PACKAGES"
         fi
-        if [ -n "${{ inputs.exclude }}" ]; then
-          ARGS="$ARGS --exclude ${{ inputs.exclude }}"
+        if [ -n "$INPUT_EXCLUDE" ]; then
+          ARGS="$ARGS --exclude $INPUT_EXCLUDE"
         fi
-        if [ -n "${{ inputs.paths }}" ]; then
-          ARGS="$ARGS --paths ${{ inputs.paths }}"
+        if [ -n "$INPUT_PATHS" ]; then
+          ARGS="$ARGS --paths $INPUT_PATHS"
         fi
         SHOULD_RUN=$(node .github/scripts/check-changes.js $ARGS)
         echo "changed=$SHOULD_RUN" >> $GITHUB_OUTPUT

--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -75,8 +75,8 @@ function shouldRunInclude(changedFiles, packages, paths) {
 }
 
 /**
- * Exclude mode: skip only if ALL changed files belong to excluded crate directories or paths.
- * No cargo tree — exclusion is intentionally shallow.
+ * Exclude mode: skip only if ALL changed files belong to excluded crate directories.
+ * Files matching `paths` always trigger the job. No cargo tree — exclusion is intentionally shallow.
  * @param {string[] | null} changedFiles
  * @param {string[]} excludeCrates - Crate names to exclude
  * @param {string[]} paths - Additional paths that always trigger the job

--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -106,9 +106,7 @@ function shouldRunExclude(changedFiles, excludeCrates, paths) {
   const excludePaths = excludeCrates.map((c) => `crates/${c}/`);
 
   // Skip only if EVERY changed file is inside an excluded crate directory
-  const allExcluded = changedFiles.every((file) =>
-    excludePaths.some((ep) => file.startsWith(ep)),
-  );
+  const allExcluded = changedFiles.every((file) => excludePaths.some((ep) => file.startsWith(ep)));
 
   if (allExcluded) {
     console.error(
@@ -153,9 +151,7 @@ async function main() {
     console.error("Error in change detection:", error);
     // On error, run as a fallback
     console.log("true");
-    console.error(
-      "::warning title=Change detection error::Error occurred, running as fallback",
-    );
+    console.error("::warning title=Change detection error::Error occurred, running as fallback");
     process.exit(0);
   }
 }

--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+// oxlint-disable no-console
+
+/**
+ * Generic change detection script for CI jobs.
+ *
+ * Include mode (default): checks if changes affect specified crates or their transitive dependencies.
+ *   node check-changes.js --packages oxc_minifier --paths tasks/minsize/
+ *
+ * Exclude mode: skips only if ALL changed files belong to excluded crate directories.
+ *   node check-changes.js --exclude oxc_linter,oxc_language_server --paths napi/,npm/
+ */
+
+const { getChangedFiles } = require("./get-changed-files.js");
+const { getCrateDependencies, checkFilesAffectCrates } = require("./utils.js");
+
+/**
+ * Parse CLI arguments into structured options.
+ * @returns {{ packages: string[], exclude: string[], paths: string[] }}
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = { packages: [], exclude: [], paths: [] };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--packages" && args[i + 1]) {
+      result.packages = args[++i].split(",").filter(Boolean);
+    } else if (arg === "--exclude" && args[i + 1]) {
+      result.exclude = args[++i].split(",").filter(Boolean);
+    } else if (arg === "--paths" && args[i + 1]) {
+      result.paths = args[++i].split(",").filter(Boolean);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Include mode: run if changes affect any of the specified crates (+ transitive deps) or paths.
+ * @param {string[] | null} changedFiles
+ * @param {string[]} packages - Root crate names
+ * @param {string[]} paths - Additional trigger paths
+ * @returns {boolean}
+ */
+function shouldRunInclude(changedFiles, packages, paths) {
+  if (changedFiles === null) {
+    console.error("No changed files list (manual trigger or error) - will run");
+    return true;
+  }
+
+  if (changedFiles.length === 0) {
+    console.error("No files changed - will skip");
+    return false;
+  }
+
+  // Resolve transitive dependencies via cargo tree
+  let allCrates;
+  try {
+    const deps = getCrateDependencies(packages);
+    allCrates = [...packages, ...deps];
+    console.error(`Checking crates (${allCrates.length}): ${allCrates.join(", ")}`);
+  } catch (error) {
+    console.error(`cargo tree failed: ${error.message} - will run as fallback`);
+    return true;
+  }
+
+  if (allCrates.length === 0) {
+    console.error("Warning: No crates resolved - will run as fallback");
+    return true;
+  }
+
+  return checkFilesAffectCrates(changedFiles, allCrates, paths);
+}
+
+/**
+ * Exclude mode: skip only if ALL changed files belong to excluded crate directories or paths.
+ * No cargo tree — exclusion is intentionally shallow.
+ * @param {string[] | null} changedFiles
+ * @param {string[]} excludeCrates - Crate names to exclude
+ * @param {string[]} paths - Additional paths that always trigger the job
+ * @returns {boolean}
+ */
+function shouldRunExclude(changedFiles, excludeCrates, paths) {
+  if (changedFiles === null) {
+    console.error("No changed files list (manual trigger or error) - will run");
+    return true;
+  }
+
+  if (changedFiles.length === 0) {
+    console.error("No files changed - will skip");
+    return false;
+  }
+
+  // Check always-trigger paths first
+  for (const file of changedFiles) {
+    for (const p of paths) {
+      if (file.startsWith(p)) {
+        console.error(`File ${file} matches always-trigger path ${p} - will run`);
+        return true;
+      }
+    }
+  }
+
+  const excludePaths = excludeCrates.map((c) => `crates/${c}/`);
+
+  // Skip only if EVERY changed file is inside an excluded crate directory
+  const allExcluded = changedFiles.every((file) =>
+    excludePaths.some((ep) => file.startsWith(ep)),
+  );
+
+  if (allExcluded) {
+    console.error(
+      `All ${changedFiles.length} changed files are in excluded crates (${excludeCrates.join(", ")}) - will skip`,
+    );
+    return false;
+  }
+
+  console.error("Changes found outside excluded crates - will run");
+  return true;
+}
+
+async function main() {
+  try {
+    const opts = parseArgs();
+
+    if (opts.packages.length === 0 && opts.exclude.length === 0) {
+      console.error("Error: must specify --packages or --exclude");
+      console.log("true");
+      process.exit(0);
+    }
+
+    const changedFiles = await getChangedFiles();
+
+    let shouldRun;
+    if (opts.exclude.length > 0) {
+      shouldRun = shouldRunExclude(changedFiles, opts.exclude, opts.paths);
+    } else {
+      shouldRun = shouldRunInclude(changedFiles, opts.packages, opts.paths);
+    }
+
+    console.log(shouldRun ? "true" : "false");
+
+    if (shouldRun) {
+      console.error("::notice title=Change detection::Will run this job");
+    } else {
+      console.error("::notice title=Change detection::Will skip this job");
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error("Error in change detection:", error);
+    // On error, run as a fallback
+    console.log("true");
+    console.error(
+      "::warning title=Change detection error::Error occurred, running as fallback",
+    );
+    process.exit(0);
+  }
+}
+
+void main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,8 +332,8 @@ jobs:
       - uses: ./.github/actions/check-changes
         id: filter
         with:
-          packages: oxc_minifier
-          paths: tasks/minsize/
+          packages: oxc_minsize
+          paths: .github/workflows/ci.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 
@@ -357,8 +357,8 @@ jobs:
       - uses: ./.github/actions/check-changes
         id: filter
         with:
-          packages: oxc_parser,oxc_minifier
-          paths: tasks/track_memory_allocations/
+          packages: oxc_track_memory_allocations
+          paths: .github/workflows/ci.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 
@@ -412,7 +412,7 @@ jobs:
         id: filter
         with:
           packages: oxc_linter
-          paths: tasks/linter_codegen/
+          paths: tasks/linter_codegen/,.github/workflows/ci.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,27 +143,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          filters: |
-            src:
-              - '!crates/oxc_linter/**'
+          exclude: oxc_linter
+          paths: napi/,npm/,apps/,pnpm-lock.yaml,package.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: wasi
           save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
       - name: Build
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         run: |
           rustup target add wasm32-wasip1-threads
           pnpm run build-wasm-dev
           git diff --exit-code # Must commit everything
       - name: Test wasi in browser
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         working-directory: napi/parser
         run: |
           rm -rf *.wasm
@@ -179,28 +180,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          predicate-quantifier: "every"
-          filters: |
-            src:
-              - '!crates/oxc_linter/**'
-              - '!crates/oxc_language_server/**'
-              - '!editors/**'
+          exclude: oxc_linter,oxc_language_server
+          paths: napi/,npm/,apps/,tasks/e2e/,pnpm-lock.yaml,package.json,editors/
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: napi
           save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
       - uses: ./.github/actions/clone-submodules
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           babel: false
           prettier: false
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         name: Run tests in workspace
         env:
           RUN_RAW_RANGE_TESTS: "true"
@@ -209,11 +208,11 @@ jobs:
           rustup target add wasm32-wasip1-threads
           pnpm run build-test
           pnpm run test
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         name: Run e2e tests
         working-directory: tasks/e2e
         run: pnpm run test
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         run: |
           git diff --exit-code # Must commit everything
 
@@ -225,28 +224,26 @@ jobs:
       - name: Enable long paths on Windows
         run: git config --system core.longpaths true
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          predicate-quantifier: "every"
-          filters: |
-            src:
-              - '!crates/oxc_linter/**'
-              - '!crates/oxc_language_server/**'
-              - '!editors/**'
+          exclude: oxc_linter,oxc_language_server
+          paths: napi/,npm/,apps/,tasks/e2e/,pnpm-lock.yaml,package.json,editors/
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: napi
           save-cache: ${{ github.ref_name == 'main' }}
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
       - uses: ./.github/actions/clone-submodules
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           babel: false
           prettier: false
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         name: Run tests in workspace
         env:
           RUN_RAW_RANGE_TESTS: "true"
@@ -254,13 +251,13 @@ jobs:
           rustup target add wasm32-wasip1-threads
           pnpm run build-test
           pnpm run test
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         name: Run e2e tests
         run: |
           pnpm install --frozen-lockfile
           pnpm run test
         working-directory: tasks/e2e
-      - if: steps.filter.outputs.src == 'true'
+      - if: steps.filter.outputs.changed == 'true'
         run: |
           git diff --exit-code # Must commit everything
 
@@ -332,24 +329,22 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          filters: |
-            src:
-              - '.github/workflows/ci.yml'
-              - 'crates/oxc_minifier/**'
-              - 'crates/oxc_codegen/**'
-              - 'tasks/minsize/**'
+          packages: oxc_minifier
+          paths: tasks/minsize/
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
 
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: minsize
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Check minification size
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         run: |
           cargo minsize
           git diff --exit-code
@@ -359,29 +354,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          filters: |
-            src:
-              - '.github/workflows/ci.yml'
-              - 'crates/oxc_ast/**'
-              - 'crates/oxc_data_structures/**'
-              - 'crates/oxc_parser/**'
-              - 'crates/oxc_minifier/**'
-              - 'crates/oxc_mangler/**'
-              - 'crates/oxc_allocator/**'
-              - 'crates/oxc_semantic/**'
-              - 'tasks/track_memory_allocations/**'
+          packages: oxc_parser,oxc_minifier
+          paths: tasks/track_memory_allocations/
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
 
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: allocs
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Check allocations
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         run: |
           cargo allocs
           git diff --exit-code ||
@@ -420,24 +408,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: ./.github/actions/check-changes
         id: filter
         with:
-          filters: |
-            src:
-              - '.github/workflows/ci.yml'
-              - 'crates/oxc_linter/**'
-              - 'tasks/linter_codegen/**'
+          packages: oxc_linter
+          paths: tasks/linter_codegen/
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
 
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         with:
           components: rustfmt
           cache-key: lintgen
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Check linter changes
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.changed == 'true'
         run: |
           cargo lintgen
           git diff --exit-code ||

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -46,6 +46,7 @@ jobs:
         id: filter
         with:
           packages: oxc_allocator,oxc_ast,oxc_data_structures,oxc_parser,oxc_transformer
+          paths: .github/workflows/miri.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -42,12 +42,21 @@ jobs:
       - name: Checkout
         uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
 
+      - uses: ./.github/actions/check-changes
+        id: filter
+        with:
+          packages: oxc_allocator,oxc_ast,oxc_data_structures,oxc_parser,oxc_transformer
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+
       - uses: oxc-project/setup-rust@704e1648ce532a12b4d6fb98db0ba10afa3ae879 # v1.0.13
+        if: steps.filter.outputs.changed == 'true'
         with:
           cache-key: miri
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Install Miri
+        if: steps.filter.outputs.changed == 'true'
         run: |
           rustup toolchain install "${MIRI_TOOLCHAIN}" --component miri
           cargo +"${MIRI_TOOLCHAIN}" miri setup
@@ -55,6 +64,7 @@ jobs:
       # `--lib --bins --tests` omits doctests, which Miri can't run
       # https://github.com/oxc-project/oxc/pull/11092
       - name: Test with Miri
+        if: steps.filter.outputs.changed == 'true'
         run: |
           cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
           cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests -p oxc_parser -p oxc_transformer


### PR DESCRIPTION
## Summary

- Replace `dorny/paths-filter` in 6 CI jobs with a unified `check-changes.js` script that uses `cargo tree` to resolve transitive dependencies, fixing silent CI skips when upstream crates change
- Add a reusable `check-changes` composite action to eliminate boilerplate across jobs
- Add change detection to Miri workflow to skip expensive steps when unrelated code changes

### Key improvements over old `dorny/paths-filter`

- **Transitive dependency tracking**: uses `cargo tree` so e.g. `oxc_parser` changes correctly trigger minification checks
- **Task crate resolution**: uses actual task crates (`oxc_minsize`, `oxc_track_memory_allocations`) instead of library crates, catching dev-dependencies like `oxc_codegen` that `cargo tree -e normal` on `oxc_minifier` alone would miss
- **Self-validation**: `.github/workflows/ci.yml` and `.github/workflows/miri.yml` are included in trigger paths so workflow edits exercise the affected jobs

### Modes

**Include mode** (`--packages`): resolves transitive deps via `cargo tree`, runs if changes affect any dep crate or additional paths.

**Exclude mode** (`--exclude`): skips only if ALL changed files are in excluded crate directories (intentionally shallow — no `cargo tree`).

### Jobs updated
`test-wasm32-wasip1-threads`, `test-napi`, `test-napi-windows`, `minification`, `allocs`, `lintgen`, `miri`

### Jobs intentionally unchanged
`conformance` (already uses `cargo tree`), `benchmark` (already uses `cargo tree`), `ast_changes` (uses auto-generated watch list), `test-ubuntu` (primary gate, runs everything), `typos`/`lint` (always run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)