### PR TITLE
fix(linter/capitalized_comments): use JS-style regexes for `ignorePattern`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,6 +2034,7 @@ dependencies = [
  "papaya",
  "phf",
  "rayon",
+ "regress",
  "rust-lapper",
  "rustc-hash",
  "self_cell",
@@ -2889,6 +2890,16 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ pico-args = "0.5.0" # Minimal argument parser
 prettyplease = "0.2.37" # Rust code formatting
 project-root = "0.2.2" # Project root detection
 rayon = "1.11.0" # Data parallelism
+regress = "0.10.5" # JavaScript-compatible regular expressions
 ropey = "1.6.1" # Rope text structure
 rust-lapper = "1.2.0" # Interval tree
 saphyr = "0.0.6" # YAML parser

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -63,6 +63,7 @@ nodejs-built-in-modules = { workspace = true }
 papaya = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }
+regress = { workspace = true }
 rust-lapper = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, features = ["indexmap2", "regex"] }

--- a/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
@@ -1,4 +1,4 @@
-use lazy_regex::{Regex, RegexBuilder};
+use regress::{Flags as RegexFlags, Regex};
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -91,8 +91,15 @@ impl CommentConfigJson {
     fn into_comment_config(self, base: &CommentConfigJson) -> CommentConfig {
         let pattern = self.ignore_pattern.as_ref().or(base.ignore_pattern.as_ref());
         CommentConfig {
-            ignore_pattern: pattern
-                .and_then(|p| RegexBuilder::new(&format!(r"^\s*(?:{p})")).build().ok()),
+            ignore_pattern: pattern.and_then(|p| {
+                // We use `regress` crate for compatibility with JS regexes.
+                // ESlint: `const regExp = RegExp(`^\\s*(?:${ignorePatternStr})`, "u");`
+                Regex::with_flags(
+                    &format!(r"^\s*(?:{p})"),
+                    RegexFlags { unicode: true, ..Default::default() },
+                )
+                .ok()
+            }),
             ignore_inline_comments: self
                 .ignore_inline_comments
                 .or(base.ignore_inline_comments)
@@ -214,7 +221,7 @@ impl Rule for CapitalizedComments {
 
             // Check ignorePattern (using normalized text, like ESLint)
             if let Some(ref pattern) = config.ignore_pattern
-                && pattern.is_match(&normalized)
+                && pattern.find(&normalized).is_some()
             {
                 continue;
             }
@@ -696,6 +703,32 @@ fn test() {
                 serde_json::json!(["always", { "line": { "ignorePattern": "lineCommentIgnorePattern" }, "block": { "ignorePattern": "blockCommentIgnorePattern" }}]),
             ),
         ),
+        // `[[]` is valid JS regex syntax (character class containing literal `[`)
+        // but invalid in Rust's `regex` crate (nested character class).
+        // Using `regress` crate ensures JS-compatible regex parsing.
+        ("// [foo] bar", Some(serde_json::json!(["always", { "ignorePattern": "[[]" }]))),
+        // `.` matches full Unicode code points (including astral characters like emoji)
+        (
+            {
+                const _: () = assert!('😀'.len_utf8() == 4);
+                const _: () = assert!('😀'.len_utf16() == 2);
+                "// 😀x"
+            },
+            Some(serde_json::json!(["always", { "ignorePattern": ".x" }])),
+        ),
+        // Unicode property escapes require the `u` flag
+        (
+            "// lowercase ignored by unicode property escape",
+            Some(serde_json::json!(["always", { "ignorePattern": "\\p{Script=Latin}" }])),
+        ),
+        // Positive lookahead: `foo(?=bar)` matches `foo` only when followed by `bar`
+        ("// foobar", Some(serde_json::json!(["always", { "ignorePattern": "foo(?=bar)" }]))),
+        // Negative lookahead: `foo(?!bar)` matches `foo` only when NOT followed by `bar`
+        ("// foobaz", Some(serde_json::json!(["always", { "ignorePattern": "foo(?!bar)" }]))),
+        // Positive lookbehind: `f(?<=f)oo` matches because after consuming `f`, lookbehind confirms it
+        ("// foo", Some(serde_json::json!(["always", { "ignorePattern": "f(?<=f)oo" }]))),
+        // Negative lookbehind: `f(?<!x)oo` matches because char behind is `f`, not `x`
+        ("// foo", Some(serde_json::json!(["always", { "ignorePattern": "f(?<!x)oo" }]))),
     ];
 
     let fail = vec![
@@ -885,6 +918,24 @@ fn test() {
         ),
         ("// should fail. https://github.com", Some(serde_json::json!(["always"]))),
         ("// Should fail. https://github.com", Some(serde_json::json!(["never"]))),
+        // `[[]` matches literal `[`, but comment doesn't contain `[`
+        ("// no bracket here", Some(serde_json::json!(["always", { "ignorePattern": "[[]" }]))),
+        // `.` matches one code point; comment starts with `a` which matches `.`,
+        // but then `x` doesn't match `b`, so `.x` fails
+        ("// ab", Some(serde_json::json!(["always", { "ignorePattern": ".x" }]))),
+        // `\p{Script=Greek}` doesn't match Latin characters
+        (
+            "// lowercase",
+            Some(serde_json::json!(["always", { "ignorePattern": "\\p{Script=Greek}" }])),
+        ),
+        // Positive lookahead: `foo(?=bar)` doesn't match `foo` when followed by `baz`
+        ("// foobaz", Some(serde_json::json!(["always", { "ignorePattern": "foo(?=bar)" }]))),
+        // Negative lookahead: `foo(?!bar)` doesn't match `foo` when followed by `bar`
+        ("// foobar", Some(serde_json::json!(["always", { "ignorePattern": "foo(?!bar)" }]))),
+        // Positive lookbehind: `f(?<=x)oo` doesn't match because lookbehind sees `f`, not `x`
+        ("// foo", Some(serde_json::json!(["always", { "ignorePattern": "f(?<=x)oo" }]))),
+        // Negative lookbehind: `f(?<!f)oo` doesn't match because char behind IS `f`
+        ("// foo", Some(serde_json::json!(["always", { "ignorePattern": "f(?<!f)oo" }]))),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/eslint_capitalized_comments.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_capitalized_comments.snap
@@ -456,3 +456,52 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────
    ╰────
   help: Change the first letter of the comment to lowercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // no bracket here
+   · ──────────────────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // ab
+   · ─────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // lowercase
+   · ────────────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // foobaz
+   · ─────────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // foobar
+   · ─────────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // foo
+   · ──────
+   ╰────
+  help: Change the first letter of the comment to uppercase
+
+  ⚠ eslint(capitalized-comments): Comments should not begin with a lowercase letter
+   ╭─[capitalized_comments.tsx:1:1]
+ 1 │ // foo
+   · ──────
+   ╰────
+  help: Change the first letter of the comment to uppercase


### PR DESCRIPTION
Fixes #20112.

This PR switches the regex engine used by `capitalized_comments` rule to [regress](https://crates.io/crates/regress), which provides JS-compatible regexes.

In NodeJS repo, all 1700 errors disappear.

As noted in #20112, I'm not sure if this is the direction we should take or not. Another option is to keep using `regex` crate, but produce better errors.