### PR TITLE
feat(oxlint): Add Bitbucket Code Insights output formatter

### DIFF
--- a/.agents/skills/migrate-oxlint/SKILL.md
+++ b/.agents/skills/migrate-oxlint/SKILL.md
@@ -152,7 +152,7 @@ Additional oxlint options:
 - Disable comments work: `// eslint-disable` and `// eslint-disable-next-line` comments are supported by oxlint. Use `--replace-eslint-comments` to convert them to `// oxlint-disable` if desired.
 - List available rules: Run `npx oxlint@latest --rules` to see all supported rules.
 - Schema support: Add `"$schema": "./node_modules/oxlint/configuration_schema.json"` to `.oxlintrc.json` for editor autocompletion.
-- Output formats: `default`, `stylish`, `json`, `github`, `gitlab`, `junit`, `checkstyle`, `unix`
+- Output formats: `default`, `stylish`, `json`, `github`, `gitlab`, `bitbucket`, `junit`, `checkstyle`, `unix`
 
 ## References
 

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -244,7 +244,7 @@ pub struct WarningOptions {
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
     /// Use a specific output format. Possible values:
-    /// `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+    /// `bitbucket`, `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
     #[bpaf(long, short, fallback_with(default_output_format), hide_usage)]
     pub format: OutputFormat,
 }

--- a/apps/oxlint/src/output_formatter/bitbucket.rs
+++ b/apps/oxlint/src/output_formatter/bitbucket.rs
@@ -1,0 +1,323 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+#[cfg(windows)]
+use cow_utils::CowUtils;
+
+use serde::Serialize;
+
+use oxc_diagnostics::{
+    Error, Severity,
+    reporter::{DiagnosticReporter, DiagnosticResult, Info},
+};
+
+use crate::output_formatter::InternalFormatter;
+
+#[derive(Debug, Default)]
+pub struct BitbucketOutputFormatter;
+
+/// Severity levels accepted by the Bitbucket Code Insights Annotations API.
+///
+/// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-reports/#api-group-reports>
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+#[expect(dead_code)]
+enum BitbucketSeverity {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+/// Annotation types accepted by the Bitbucket Code Insights Annotations API.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[expect(dead_code)]
+enum BitbucketAnnotationType {
+    Bug,
+    CodeSmell,
+    Vulnerability,
+}
+
+/// A single Bitbucket Code Insights annotation entry.
+///
+/// Matches the schema required by the bulk create/update annotations endpoint:
+/// `POST /repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{reportId}/annotations`
+#[derive(Debug, Serialize)]
+struct BitbucketAnnotationJson {
+    external_id: String,
+    summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<String>,
+    annotation_type: BitbucketAnnotationType,
+    severity: BitbucketSeverity,
+    path: String,
+    line: usize,
+}
+
+impl InternalFormatter for BitbucketOutputFormatter {
+    fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
+        Box::new(BitbucketReporter::default())
+    }
+}
+
+/// Find the git repository root by walking up from the current directory.
+/// Returns `None` if no `.git` directory is found.
+fn find_git_root() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_git_root_from(&cwd)
+}
+
+/// Find the git repository root by walking up from the given path.
+fn find_git_root_from(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// Get the path prefix from CWD to the git repository root.
+/// This prefix should be prepended to CWD-relative paths to make them repo-relative.
+///
+/// For example, if git root is `/repo` and CWD is `/repo/packages/foo`,
+/// this returns `Some("packages/foo")`.
+fn get_repo_path_prefix() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let git_root = find_git_root()?;
+
+    let relative = cwd.strip_prefix(&git_root).ok()?;
+    if relative.as_os_str().is_empty() {
+        return None;
+    }
+
+    Some(relative.to_path_buf())
+}
+
+/// Renders reports as a Bitbucket Code Insights annotations array.
+///
+/// The output JSON array can be sent directly to the Bitbucket bulk annotations endpoint:
+/// `POST /repositories/{workspace}/{repo_slug}/commit/{commit}/reports/{reportId}/annotations`
+///
+/// Note that, due to syntactic restrictions of JSON arrays, this reporter waits until all
+/// diagnostics have been reported before writing them to the output stream.
+struct BitbucketReporter {
+    diagnostics: Vec<Error>,
+    /// Path prefix to prepend to CWD-relative paths to make them repo-relative.
+    /// `None` if CWD is the git root or if we're not in a git repository.
+    repo_path_prefix: Option<PathBuf>,
+}
+
+impl BitbucketReporter {
+    fn default() -> Self {
+        Self { diagnostics: Vec::new(), repo_path_prefix: get_repo_path_prefix() }
+    }
+}
+
+impl DiagnosticReporter for BitbucketReporter {
+    fn finish(&mut self, _: &DiagnosticResult) -> Option<String> {
+        Some(format_bitbucket(&mut self.diagnostics, self.repo_path_prefix.as_deref()))
+    }
+
+    fn render_error(&mut self, error: Error) -> Option<String> {
+        self.diagnostics.push(error);
+        None
+    }
+}
+
+fn format_bitbucket(diagnostics: &mut Vec<Error>, repo_path_prefix: Option<&Path>) -> String {
+    let annotations = diagnostics.drain(..).map(|error| {
+        let Info { start, filename, message, severity, rule_id, .. } = Info::new(&error);
+
+        let (annotation_type, bitbucket_severity) = match severity {
+            Severity::Error => (BitbucketAnnotationType::Bug, BitbucketSeverity::High),
+            Severity::Warning => (BitbucketAnnotationType::CodeSmell, BitbucketSeverity::Medium),
+            Severity::Advice => (BitbucketAnnotationType::CodeSmell, BitbucketSeverity::Low),
+        };
+
+        let external_id = {
+            let mut hasher = DefaultHasher::new();
+            start.line.hash(&mut hasher);
+            filename.hash(&mut hasher);
+            message.hash(&mut hasher);
+            rule_id.hash(&mut hasher);
+            format!("oxlint-{:x}", hasher.finish())
+        };
+
+        let path = match repo_path_prefix {
+            Some(prefix) => {
+                // Normalize path separators to forward slashes on Windows.
+                #[cfg(windows)]
+                {
+                    let combined = prefix.join(&filename);
+                    combined.to_string_lossy().cow_replace('\\', "/").into_owned()
+                }
+                #[cfg(not(windows))]
+                {
+                    prefix.join(&filename).to_string_lossy().to_string()
+                }
+            }
+            None => filename,
+        };
+
+        BitbucketAnnotationJson {
+            external_id,
+            summary: message,
+            details: rule_id,
+            annotation_type,
+            severity: bitbucket_severity,
+            path,
+            line: start.line,
+        }
+    });
+
+    serde_json::to_string_pretty(&annotations.collect::<Vec<_>>()).expect("Failed to serialize")
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::{Path, PathBuf};
+
+    use oxc_diagnostics::{
+        Error, NamedSource, OxcDiagnostic,
+        reporter::{DiagnosticReporter, DiagnosticResult},
+    };
+    use oxc_span::Span;
+
+    use super::{BitbucketReporter, find_git_root_from, format_bitbucket};
+
+    #[test]
+    fn reporter() {
+        let mut reporter = BitbucketReporter::default();
+
+        let error = OxcDiagnostic::warn("error message")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("test.ts", "debugger;"));
+
+        let first_result = reporter.render_error(error);
+
+        // reporter keeps it in memory
+        assert!(first_result.is_none());
+
+        // reporter gives results when finishing
+        let second_result = reporter.finish(&DiagnosticResult::default());
+
+        assert!(second_result.is_some());
+        let json: serde_json::Value = serde_json::from_str(&second_result.unwrap()).unwrap();
+        let array = json.as_array().unwrap();
+        assert_eq!(array.len(), 1);
+        let value = array[0].as_object().unwrap();
+        assert!(value["external_id"].as_str().unwrap().starts_with("oxlint-"));
+        assert_eq!(value["summary"], "error message");
+        assert_eq!(value["annotation_type"], "CODE_SMELL");
+        assert_eq!(value["severity"], "MEDIUM");
+        let location_path = value["path"].as_str().unwrap();
+        assert!(
+            location_path.ends_with("test.ts"),
+            "path '{location_path}' should end with test.ts"
+        );
+        assert_eq!(value["line"], 1);
+    }
+
+    #[test]
+    fn reporter_with_error_severity() {
+        let mut reporter = BitbucketReporter { diagnostics: Vec::new(), repo_path_prefix: None };
+
+        let error = OxcDiagnostic::error("critical error")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("example.js", "eval('x');"));
+
+        reporter.render_error(error);
+        let result = reporter.finish(&DiagnosticResult::default()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let value = &json[0];
+        assert_eq!(value["annotation_type"], "BUG");
+        assert_eq!(value["severity"], "HIGH");
+        assert_eq!(value["path"], "example.js");
+    }
+
+    #[test]
+    fn find_git_root_from_current_dir() {
+        let cwd = std::env::current_dir().unwrap();
+        let git_root = find_git_root_from(&cwd);
+        assert!(git_root.is_some());
+        assert!(git_root.unwrap().join(".git").exists());
+    }
+
+    #[test]
+    fn find_git_root_from_nonexistent() {
+        let path = PathBuf::from("/");
+        let git_root = find_git_root_from(&path);
+        assert!(git_root.is_none() || *git_root.unwrap() == *"/");
+    }
+
+    #[test]
+    fn format_bitbucket_with_prefix() {
+        let error = OxcDiagnostic::warn("test error")
+            .with_label(Span::new(0, 5))
+            .with_source_code(NamedSource::new("example.js", "const x = 1;"));
+
+        let mut diagnostics: Vec<Error> = vec![error];
+
+        let result = format_bitbucket(&mut diagnostics, Some(Path::new("packages/foo")));
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let path = json[0]["path"].as_str().unwrap();
+        assert_eq!(path, "packages/foo/example.js");
+    }
+
+    #[test]
+    fn format_bitbucket_without_prefix() {
+        let error = OxcDiagnostic::warn("test error")
+            .with_label(Span::new(0, 5))
+            .with_source_code(NamedSource::new("example.js", "const x = 1;"));
+
+        let mut diagnostics: Vec<Error> = vec![error];
+
+        let result = format_bitbucket(&mut diagnostics, None);
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let path = json[0]["path"].as_str().unwrap();
+        assert_eq!(path, "example.js");
+    }
+
+    #[test]
+    fn format_bitbucket_external_id_uniqueness() {
+        // Two identical errors should produce the same external_id (deterministic hashing)
+        let error1 = OxcDiagnostic::warn("duplicate")
+            .with_label(Span::new(0, 5))
+            .with_source_code(NamedSource::new("file.js", "const x = 1;"));
+        let error2 = OxcDiagnostic::warn("duplicate")
+            .with_label(Span::new(0, 5))
+            .with_source_code(NamedSource::new("file.js", "const x = 1;"));
+
+        let mut d1: Vec<Error> = vec![error1];
+        let mut d2: Vec<Error> = vec![error2];
+
+        let r1 = format_bitbucket(&mut d1, None);
+        let r2 = format_bitbucket(&mut d2, None);
+
+        let j1: serde_json::Value = serde_json::from_str(&r1).unwrap();
+        let j2: serde_json::Value = serde_json::from_str(&r2).unwrap();
+
+        assert_eq!(j1[0]["external_id"], j2[0]["external_id"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn format_bitbucket_windows_normalization() {
+        let error = OxcDiagnostic::warn("test error")
+            .with_label(Span::new(0, 5))
+            .with_source_code(NamedSource::new("example.js", "const x = 1;"));
+
+        let mut diagnostics: Vec<Error> = vec![error];
+
+        // Windows-style prefix with backslashes should be normalized to forward slashes
+        let result = format_bitbucket(&mut diagnostics, Some(Path::new(r"packages\foo")));
+        let json: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let path = json[0]["path"].as_str().unwrap();
+        assert_eq!(path, "packages/foo/example.js");
+    }
+}

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -1,3 +1,4 @@
+mod bitbucket;
 mod checkstyle;
 mod default;
 mod github;
@@ -11,6 +12,7 @@ mod xml_utils;
 use std::str::FromStr;
 use std::time::Duration;
 
+use bitbucket::BitbucketOutputFormatter;
 use checkstyle::CheckStyleOutputFormatter;
 use github::GithubOutputFormatter;
 use gitlab::GitlabOutputFormatter;
@@ -30,6 +32,7 @@ pub enum OutputFormat {
     /// <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message>
     Github,
     Gitlab,
+    Bitbucket,
     Json,
     Unix,
     Checkstyle,
@@ -48,6 +51,7 @@ impl FromStr for OutputFormat {
             "checkstyle" => Ok(Self::Checkstyle),
             "github" => Ok(Self::Github),
             "gitlab" => Ok(Self::Gitlab),
+            "bitbucket" => Ok(Self::Bitbucket),
             "stylish" => Ok(Self::Stylish),
             "junit" => Ok(Self::JUnit),
             _ => Err(format!("'{s}' is not a known format")),
@@ -102,6 +106,7 @@ impl OutputFormatter {
             OutputFormat::Checkstyle => Box::<CheckStyleOutputFormatter>::default(),
             OutputFormat::Github => Box::new(GithubOutputFormatter),
             OutputFormat::Gitlab => Box::<GitlabOutputFormatter>::default(),
+            OutputFormat::Bitbucket => Box::new(BitbucketOutputFormatter),
             OutputFormat::Unix => Box::<UnixOutputFormatter>::default(),
             OutputFormat::Default => Box::new(DefaultOutputFormatter),
             OutputFormat::Stylish => Box::<StylishOutputFormatter>::default(),
@@ -145,9 +150,11 @@ mod test {
             formats.push("json");
         }
 
-        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        // Exclude `gitlab` and `bitbucket` on big-endian systems because
+        // hash-based identifiers (fingerprint / external_id) differ there
         if cfg!(not(target_endian = "big")) {
             formats.push("gitlab");
+            formats.push("bitbucket");
         }
 
         for fmt in &formats {
@@ -169,9 +176,11 @@ mod test {
             formats.push("json");
         }
 
-        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        // Exclude `gitlab` and `bitbucket` on big-endian systems because
+        // hash-based identifiers (fingerprint / external_id) differ there
         if cfg!(not(target_endian = "big")) {
             formats.push("gitlab");
+            formats.push("bitbucket");
         }
 
         for fmt in &formats {
@@ -196,9 +205,11 @@ mod test {
             formats.push("json");
         }
 
-        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        // Exclude `gitlab` and `bitbucket` on big-endian systems because
+        // hash-based identifiers (fingerprint / external_id) differ there
         if cfg!(not(target_endian = "big")) {
             formats.push("gitlab");
+            formats.push("bitbucket");
         }
 
         for fmt in &formats {
@@ -221,9 +232,11 @@ mod test {
             formats.push("json");
         }
 
-        // Exclude `gitlab` on big-endian systems because fingerprints differ there
+        // Exclude `gitlab` and `bitbucket` on big-endian systems because
+        // hash-based identifiers (fingerprint / external_id) differ there
         if cfg!(not(target_endian = "big")) {
             formats.push("gitlab");
+            formats.push("bitbucket");
         }
 
         for fmt in &formats {

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,35 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=bitbucket --report-unused-disable-directives disable-directive.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+[
+  {
+    "external_id": "oxlint-e5bb99862a04a6a5",
+    "summary": "Unused eslint-disable directive (no problems were reported).",
+    "annotation_type": "CODE_SMELL",
+    "severity": "MEDIUM",
+    "path": "apps/oxlint/disable-directive.js",
+    "line": 9
+  },
+  {
+    "external_id": "oxlint-bd12fdeac615e7f5",
+    "summary": "Unused eslint-disable directive (no problems were reported).",
+    "annotation_type": "CODE_SMELL",
+    "severity": "MEDIUM",
+    "path": "apps/oxlint/disable-directive.js",
+    "line": 12
+  },
+  {
+    "external_id": "oxlint-9718e601f3f712eb",
+    "summary": "Unused eslint-disable directive (no problems were reported).",
+    "annotation_type": "CODE_SMELL",
+    "severity": "MEDIUM",
+    "path": "apps/oxlint/disable-directive.js",
+    "line": 15
+  }
+]----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=bitbucket ok.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+[]----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket parser-error.js@oxlint.snap
@@ -1,0 +1,19 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=bitbucket parser-error.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+[
+  {
+    "external_id": "oxlint-f50f23f6e0a3d4dd",
+    "summary": "Expected `;` but found `:`",
+    "annotation_type": "BUG",
+    "severity": "HIGH",
+    "path": "apps/oxlint/parser-error.js",
+    "line": 3
+  }
+]----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=bitbucket test.js@oxlint.snap
@@ -1,0 +1,38 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=bitbucket test.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+[
+  {
+    "external_id": "oxlint-7765f70321217d",
+    "summary": "`debugger` statement is not allowed",
+    "details": "eslint(no-debugger)",
+    "annotation_type": "BUG",
+    "severity": "HIGH",
+    "path": "apps/oxlint/test.js",
+    "line": 5
+  },
+  {
+    "external_id": "oxlint-7d16105a507dfcf1",
+    "summary": "Function 'foo' is declared but never used.",
+    "details": "eslint(no-unused-vars)",
+    "annotation_type": "CODE_SMELL",
+    "severity": "MEDIUM",
+    "path": "apps/oxlint/test.js",
+    "line": 1
+  },
+  {
+    "external_id": "oxlint-9b0babde6f2aa6f1",
+    "summary": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.",
+    "details": "eslint(no-unused-vars)",
+    "annotation_type": "CODE_SMELL",
+    "severity": "MEDIUM",
+    "path": "apps/oxlint/test.js",
+    "line": 1
+  }
+]----------
+CLI result: LintFoundErrors
+----------

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -118,7 +118,7 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format. Possible values: `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+  Use a specific output format. Possible values: `bitbucket`, `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -73,8 +73,9 @@ Handle Warnings
                               your project
 
 Output
-    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
-                              `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+    -f, --format=ARG          Use a specific output format. Possible values: `bitbucket`,
+                              `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`,
+                              `stylish`, `unix`
 
 Miscellaneous
         --silent              Do not display any diagnostics


### PR DESCRIPTION
## Summary
Adds a new Bitbucket output formatter for oxlint that emits diagnostics as Bitbucket Code Insights annotations (bulk annotations JSON) so CI can upload reports to Bitbucket.

## Why
Enable Bitbucket Code Insights integration by producing the exact annotation payload expected by [Bitbucket reports endpoints](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-reports/#api-group-reports). This lets CI workflows surface linter issues directly in Bitbucket's UI.

## What changed
- Added: [bitbucket.rs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — implements `BitbucketOutputFormatter`, `BitbucketReporter`, and serialization types.
- Mapping: Maps Severity → Bitbucket `annotation_type`/`severity` (`Error`→`BUG/HIGH`, `Warning`→`CODE_SMELL`/`MEDIUM`, `Advice`→`CODE_SMELL`/`LOW`).
- Repo paths: Detects git repo root and prepends repo-relative prefix (handles Windows path normalization).
- Deterministic IDs: Generates stable `external_id` per diagnostic using a deterministic hash.
- Tests: Unit tests covering serialization, path prefixing, `severity` mappings, and `external_id` determinism.

## Compatibility / Migration
Non-breaking — new formatter only; existing formatters unaffected. To use, select the bitbucket formatter when running oxlint in CI and POST the resulting JSON to Bitbucket Code Insights annotations endpoint.