### PR TITLE
feat(linter): Implement `react/no-clone-element` rule.

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2500,6 +2500,12 @@ impl RuleRunner for crate::rules::react::no_children_prop::NoChildrenProp {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::react::no_clone_element::NoCloneElement {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::no_danger::NoDanger {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -408,6 +408,7 @@ pub use crate::rules::react::jsx_props_no_spread_multi::JsxPropsNoSpreadMulti as
 pub use crate::rules::react::jsx_props_no_spreading::JsxPropsNoSpreading as ReactJsxPropsNoSpreading;
 pub use crate::rules::react::no_array_index_key::NoArrayIndexKey as ReactNoArrayIndexKey;
 pub use crate::rules::react::no_children_prop::NoChildrenProp as ReactNoChildrenProp;
+pub use crate::rules::react::no_clone_element::NoCloneElement as ReactNoCloneElement;
 pub use crate::rules::react::no_danger::NoDanger as ReactNoDanger;
 pub use crate::rules::react::no_danger_with_children::NoDangerWithChildren as ReactNoDangerWithChildren;
 pub use crate::rules::react::no_did_mount_set_state::NoDidMountSetState as ReactNoDidMountSetState;
@@ -1107,6 +1108,7 @@ pub enum RuleEnum {
     ReactJsxPropsNoSpreading(ReactJsxPropsNoSpreading),
     ReactNoArrayIndexKey(ReactNoArrayIndexKey),
     ReactNoChildrenProp(ReactNoChildrenProp),
+    ReactNoCloneElement(ReactNoCloneElement),
     ReactNoDanger(ReactNoDanger),
     ReactNoDangerWithChildren(ReactNoDangerWithChildren),
     ReactNoDidMountSetState(ReactNoDidMountSetState),
@@ -1853,7 +1855,8 @@ const REACT_JSX_PROPS_NO_SPREAD_MULTI_ID: usize = REACT_JSX_PASCAL_CASE_ID + 1us
 const REACT_JSX_PROPS_NO_SPREADING_ID: usize = REACT_JSX_PROPS_NO_SPREAD_MULTI_ID + 1usize;
 const REACT_NO_ARRAY_INDEX_KEY_ID: usize = REACT_JSX_PROPS_NO_SPREADING_ID + 1usize;
 const REACT_NO_CHILDREN_PROP_ID: usize = REACT_NO_ARRAY_INDEX_KEY_ID + 1usize;
-const REACT_NO_DANGER_ID: usize = REACT_NO_CHILDREN_PROP_ID + 1usize;
+const REACT_NO_CLONE_ELEMENT_ID: usize = REACT_NO_CHILDREN_PROP_ID + 1usize;
+const REACT_NO_DANGER_ID: usize = REACT_NO_CLONE_ELEMENT_ID + 1usize;
 const REACT_NO_DANGER_WITH_CHILDREN_ID: usize = REACT_NO_DANGER_ID + 1usize;
 const REACT_NO_DID_MOUNT_SET_STATE_ID: usize = REACT_NO_DANGER_WITH_CHILDREN_ID + 1usize;
 const REACT_NO_DIRECT_MUTATION_STATE_ID: usize = REACT_NO_DID_MOUNT_SET_STATE_ID + 1usize;
@@ -2662,6 +2665,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => REACT_JSX_PROPS_NO_SPREADING_ID,
             Self::ReactNoArrayIndexKey(_) => REACT_NO_ARRAY_INDEX_KEY_ID,
             Self::ReactNoChildrenProp(_) => REACT_NO_CHILDREN_PROP_ID,
+            Self::ReactNoCloneElement(_) => REACT_NO_CLONE_ELEMENT_ID,
             Self::ReactNoDanger(_) => REACT_NO_DANGER_ID,
             Self::ReactNoDangerWithChildren(_) => REACT_NO_DANGER_WITH_CHILDREN_ID,
             Self::ReactNoDidMountSetState(_) => REACT_NO_DID_MOUNT_SET_STATE_ID,
@@ -3465,6 +3469,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::NAME,
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::NAME,
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::NAME,
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::NAME,
             Self::ReactNoDanger(_) => ReactNoDanger::NAME,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::NAME,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::NAME,
@@ -4288,6 +4293,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::CATEGORY,
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::CATEGORY,
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::CATEGORY,
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::CATEGORY,
             Self::ReactNoDanger(_) => ReactNoDanger::CATEGORY,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::CATEGORY,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::CATEGORY,
@@ -5106,6 +5112,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::FIX,
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::FIX,
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::FIX,
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::FIX,
             Self::ReactNoDanger(_) => ReactNoDanger::FIX,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::FIX,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::FIX,
@@ -6002,6 +6009,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::documentation(),
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::documentation(),
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::documentation(),
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::documentation(),
             Self::ReactNoDanger(_) => ReactNoDanger::documentation(),
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::documentation(),
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::documentation(),
@@ -7545,6 +7553,8 @@ impl RuleEnum {
                 .or_else(|| ReactNoArrayIndexKey::schema(generator)),
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::config_schema(generator)
                 .or_else(|| ReactNoChildrenProp::schema(generator)),
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::config_schema(generator)
+                .or_else(|| ReactNoCloneElement::schema(generator)),
             Self::ReactNoDanger(_) => {
                 ReactNoDanger::config_schema(generator).or_else(|| ReactNoDanger::schema(generator))
             }
@@ -8816,6 +8826,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => "react",
             Self::ReactNoArrayIndexKey(_) => "react",
             Self::ReactNoChildrenProp(_) => "react",
+            Self::ReactNoCloneElement(_) => "react",
             Self::ReactNoDanger(_) => "react",
             Self::ReactNoDangerWithChildren(_) => "react",
             Self::ReactNoDidMountSetState(_) => "react",
@@ -10388,6 +10399,9 @@ impl RuleEnum {
             Self::ReactNoChildrenProp(_) => {
                 Ok(Self::ReactNoChildrenProp(ReactNoChildrenProp::from_configuration(value)?))
             }
+            Self::ReactNoCloneElement(_) => {
+                Ok(Self::ReactNoCloneElement(ReactNoCloneElement::from_configuration(value)?))
+            }
             Self::ReactNoDanger(_) => {
                 Ok(Self::ReactNoDanger(ReactNoDanger::from_configuration(value)?))
             }
@@ -11761,6 +11775,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.to_configuration(),
             Self::ReactNoArrayIndexKey(rule) => rule.to_configuration(),
             Self::ReactNoChildrenProp(rule) => rule.to_configuration(),
+            Self::ReactNoCloneElement(rule) => rule.to_configuration(),
             Self::ReactNoDanger(rule) => rule.to_configuration(),
             Self::ReactNoDangerWithChildren(rule) => rule.to_configuration(),
             Self::ReactNoDidMountSetState(rule) => rule.to_configuration(),
@@ -12464,6 +12479,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.run(node, ctx),
             Self::ReactNoArrayIndexKey(rule) => rule.run(node, ctx),
             Self::ReactNoChildrenProp(rule) => rule.run(node, ctx),
+            Self::ReactNoCloneElement(rule) => rule.run(node, ctx),
             Self::ReactNoDanger(rule) => rule.run(node, ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run(node, ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run(node, ctx),
@@ -13165,6 +13181,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.run_once(ctx),
             Self::ReactNoArrayIndexKey(rule) => rule.run_once(ctx),
             Self::ReactNoChildrenProp(rule) => rule.run_once(ctx),
+            Self::ReactNoCloneElement(rule) => rule.run_once(ctx),
             Self::ReactNoDanger(rule) => rule.run_once(ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run_once(ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run_once(ctx),
@@ -13936,6 +13953,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoArrayIndexKey(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoChildrenProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactNoCloneElement(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDanger(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactNoDidMountSetState(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14667,6 +14685,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.should_run(ctx),
             Self::ReactNoArrayIndexKey(rule) => rule.should_run(ctx),
             Self::ReactNoChildrenProp(rule) => rule.should_run(ctx),
+            Self::ReactNoCloneElement(rule) => rule.should_run(ctx),
             Self::ReactNoDanger(rule) => rule.should_run(ctx),
             Self::ReactNoDangerWithChildren(rule) => rule.should_run(ctx),
             Self::ReactNoDidMountSetState(rule) => rule.should_run(ctx),
@@ -15532,6 +15551,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::IS_TSGOLINT_RULE,
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::IS_TSGOLINT_RULE,
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::IS_TSGOLINT_RULE,
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::IS_TSGOLINT_RULE,
             Self::ReactNoDanger(_) => ReactNoDanger::IS_TSGOLINT_RULE,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::IS_TSGOLINT_RULE,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::IS_TSGOLINT_RULE,
@@ -16470,6 +16490,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(_) => ReactJsxPropsNoSpreading::HAS_CONFIG,
             Self::ReactNoArrayIndexKey(_) => ReactNoArrayIndexKey::HAS_CONFIG,
             Self::ReactNoChildrenProp(_) => ReactNoChildrenProp::HAS_CONFIG,
+            Self::ReactNoCloneElement(_) => ReactNoCloneElement::HAS_CONFIG,
             Self::ReactNoDanger(_) => ReactNoDanger::HAS_CONFIG,
             Self::ReactNoDangerWithChildren(_) => ReactNoDangerWithChildren::HAS_CONFIG,
             Self::ReactNoDidMountSetState(_) => ReactNoDidMountSetState::HAS_CONFIG,
@@ -17233,6 +17254,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.types_info(),
             Self::ReactNoArrayIndexKey(rule) => rule.types_info(),
             Self::ReactNoChildrenProp(rule) => rule.types_info(),
+            Self::ReactNoCloneElement(rule) => rule.types_info(),
             Self::ReactNoDanger(rule) => rule.types_info(),
             Self::ReactNoDangerWithChildren(rule) => rule.types_info(),
             Self::ReactNoDidMountSetState(rule) => rule.types_info(),
@@ -17934,6 +17956,7 @@ impl RuleEnum {
             Self::ReactJsxPropsNoSpreading(rule) => rule.run_info(),
             Self::ReactNoArrayIndexKey(rule) => rule.run_info(),
             Self::ReactNoChildrenProp(rule) => rule.run_info(),
+            Self::ReactNoCloneElement(rule) => rule.run_info(),
             Self::ReactNoDanger(rule) => rule.run_info(),
             Self::ReactNoDangerWithChildren(rule) => rule.run_info(),
             Self::ReactNoDidMountSetState(rule) => rule.run_info(),
@@ -18723,6 +18746,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactJsxPropsNoSpreading(ReactJsxPropsNoSpreading::default()),
         RuleEnum::ReactNoArrayIndexKey(ReactNoArrayIndexKey::default()),
         RuleEnum::ReactNoChildrenProp(ReactNoChildrenProp::default()),
+        RuleEnum::ReactNoCloneElement(ReactNoCloneElement::default()),
         RuleEnum::ReactNoDanger(ReactNoDanger::default()),
         RuleEnum::ReactNoDangerWithChildren(ReactNoDangerWithChildren::default()),
         RuleEnum::ReactNoDidMountSetState(ReactNoDidMountSetState::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -408,6 +408,7 @@ pub(crate) mod react {
     pub mod jsx_props_no_spreading;
     pub mod no_array_index_key;
     pub mod no_children_prop;
+    pub mod no_clone_element;
     pub mod no_danger;
     pub mod no_danger_with_children;
     pub mod no_did_mount_set_state;

--- a/crates/oxc_linter/src/rules/react/no_clone_element.rs
+++ b/crates/oxc_linter/src/rules/react/no_clone_element.rs
@@ -1,0 +1,143 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_import_from_module};
+
+fn no_clone_element_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`React.cloneElement` should not be used.")
+        .with_help("`React.cloneElement` is uncommon and leads to fragile React components.")
+        .with_label(span)
+        .with_note("https://react.dev/reference/react/cloneElement#alternatives")
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoCloneElement;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents the usage of `React.cloneElement`, which is considered an anti-pattern in React.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// It is recommended not to use `React.cloneElement` because it can lead to code that is
+    /// harder to follow and understand. It is generally uncommon and fragile, and there are various
+    /// alternatives recommended by
+    /// [the React documentation](https://react.dev/reference/react/cloneElement#alternatives).
+    ///
+    /// Note that this rule is based on [`@eslint-react/no-clone-element`](https://www.eslint-react.xyz/docs/rules/no-clone-element)
+    /// from `@eslint-react`, not a rule from `eslint-plugin-react`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// import { cloneElement } from "react";
+    ///
+    /// function List({ children }) {
+    ///   const [selectedIndex, setSelectedIndex] = useState(0);
+    ///   return (
+    ///     <div className="List">
+    ///       {Children.map(children, (child, index) =>
+    ///         cloneElement(child, {
+    ///           isHighlighted: index === selectedIndex
+    ///         })
+    ///       )}
+    ///     </div>
+    ///   );
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// // Using a map with a `renderItem` function prop instead.
+    /// function List({ items, renderItem }) {
+    ///   const [selectedIndex, setSelectedIndex] = useState(0);
+    ///   return (
+    ///     <div className="List">
+    ///       {items.map((item, index) => {
+    ///         const isHighlighted = index === selectedIndex;
+    ///         return renderItem(item, isHighlighted);
+    ///       })}
+    ///     </div>
+    ///   );
+    /// }
+    /// ```
+    NoCloneElement,
+    react,
+    restriction,
+    none,
+);
+
+impl Rule for NoCloneElement {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        // import { cloneElement } from 'react';
+        // cloneElement(...) / (cloneElement)(...)
+        if let Expression::Identifier(ident) = call_expr.callee.get_inner_expression()
+            && ident.name == "cloneElement"
+            && is_import_from_module(ident, "react", ctx)
+        {
+            ctx.diagnostic(no_clone_element_diagnostic(ident.span));
+            return;
+        }
+
+        // import React from 'react';
+        // React.cloneElement(...) / React?.cloneElement(...) / React["cloneElement"](...)
+        if let Some(member_expr) = call_expr.callee.get_inner_expression().get_member_expr()
+            && let Some(name) = member_expr.static_property_name()
+            && name == "cloneElement"
+            && let Expression::Identifier(ident) = member_expr.object()
+            && is_import_from_module(ident, "react", ctx)
+        {
+            ctx.diagnostic(no_clone_element_diagnostic(call_expr.callee.span()));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "/* import { cloneElement } from 'react'; */",
+        "// import { cloneElement } from 'react';",
+        "import { cloneElement } from 'react'; // cloneElement() in a comment.",
+        "import { cloneElement } from 'react'; /* cloneElement() in a comment. */",
+        "import { cloneElement } from 'something-else'; const clonedElement = cloneElement(<div />);",
+        "import React from 'something-else'; const clonedElement = React.cloneElement(<div />);",
+        "const cloneElement = () => {}; const clonedElement = cloneElement(<div />);",
+    ];
+
+    let fail = vec![
+        r#"import { cloneElement } from "react";
+           const clonedElement = cloneElement(
+             <Row title="Cabbage">Hello</Row>,
+             { isHighlighted: true },
+             "Goodbye",
+           );"#,
+        r#"import { cloneElement } from "react";
+           function Component() {
+             const element = <div />;
+             return cloneElement(element, { isHighlighted: true });
+           }"#,
+        "import React, { cloneElement } from 'react';
+         const element = <div />;
+         const clonedElement = cloneElement(element);",
+        "import React from 'react';
+         const element = <div />;
+         const clonedElement = React.cloneElement(element);",
+        "import React from 'react'; const clonedElement = React.cloneElement(<div />);",
+        "import Aliased from 'react'; const clonedElement = Aliased.cloneElement(<div />);",
+        "import { cloneElement } from 'react'; const clonedElement = (cloneElement)(<div />);",
+        r#"import React from 'react'; const clonedElement = React["cloneElement"](<div />);"#,
+        "import React from 'react'; const clonedElement = React?.cloneElement(<div />);",
+    ];
+
+    Tester::new(NoCloneElement::NAME, NoCloneElement::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_no_clone_element.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_clone_element.snap
@@ -1,0 +1,81 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:2:34]
+ 1 │ import { cloneElement } from "react";
+ 2 │            const clonedElement = cloneElement(
+   ·                                  ────────────
+ 3 │              <Row title="Cabbage">Hello</Row>,
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:4:21]
+ 3 │              const element = <div />;
+ 4 │              return cloneElement(element, { isHighlighted: true });
+   ·                     ────────────
+ 5 │            }
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:3:32]
+ 2 │          const element = <div />;
+ 3 │          const clonedElement = cloneElement(element);
+   ·                                ────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:3:32]
+ 2 │          const element = <div />;
+ 3 │          const clonedElement = React.cloneElement(element);
+   ·                                ──────────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:1:50]
+ 1 │ import React from 'react'; const clonedElement = React.cloneElement(<div />);
+   ·                                                  ──────────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:1:52]
+ 1 │ import Aliased from 'react'; const clonedElement = Aliased.cloneElement(<div />);
+   ·                                                    ────────────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:1:62]
+ 1 │ import { cloneElement } from 'react'; const clonedElement = (cloneElement)(<div />);
+   ·                                                              ────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:1:50]
+ 1 │ import React from 'react'; const clonedElement = React["cloneElement"](<div />);
+   ·                                                  ─────────────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives
+
+  ⚠ eslint-plugin-react(no-clone-element): `React.cloneElement` should not be used.
+   ╭─[no_clone_element.tsx:1:50]
+ 1 │ import React from 'react'; const clonedElement = React?.cloneElement(<div />);
+   ·                                                  ───────────────────
+   ╰────
+  help: `React.cloneElement` is uncommon and leads to fragile React components.
+  note: https://react.dev/reference/react/cloneElement#alternatives


### PR DESCRIPTION
AI Disclosure: All code in this PR was written by me (docs, diagnostics, tests), excluding the `run` method which I used Claude Code for help with.

Fixes #20105. Part of #1022, arguably.

This is based on the rule from `@eslint-react/eslint-plugin`: https://www.eslint-react.xyz/docs/rules/no-clone-element

You can read about `React.cloneElement` in [the React docs](https://react.dev/reference/react/cloneElement).

This intentionally does not handle `require` imports currently. They are supported in the original rule, but I'm not sure they're worth the extra complexity here and almost none of our other react rules handle them either. It also does not handle import aliases like `import { cloneElement as foobar } from 'react';`.