### PR TITLE
fix(oxfmt): Handle literalline for script-in-vue

### DIFF
--- a/apps/oxfmt/.gitignore
+++ b/apps/oxfmt/.gitignore
@@ -1,4 +1,4 @@
 /node_modules/
 /dist/
-/conformance/fixtures/prettier/
+/conformance/fixtures/
 *.node

--- a/apps/oxfmt/conformance/download-fixtures.js
+++ b/apps/oxfmt/conformance/download-fixtures.js
@@ -14,6 +14,11 @@ const sources = [
     repo: "prettier/prettier/tests/format",
     version: pkg.dependencies.prettier,
   },
+  {
+    name: "vue-vben-admin",
+    repo: "vbenjs/vue-vben-admin/packages",
+    version: "main",
+  },
   // {
   //   name: "plugin-svelte",
   //   repo: "sveltejs/prettier-plugin-svelte/tests",

--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-arrow-function.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-arrow-function.vue
@@ -1,0 +1,12 @@
+<script setup>
+watchEffect(() => {
+  const x = 1;
+});
+
+const fn = computed(() => {
+  return "hello";
+});
+</script>
+<template>
+  <div>{{ fn }}</div>
+</template>

--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-comment-only.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-comment-only.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>hello</div>
+</template>
+<script>
+// This file serves as a placeholder
+// with only comments in the script block
+</script>

--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-empty-switch.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-empty-switch.vue
@@ -1,0 +1,7 @@
+<script>
+switch (foo) {
+}
+</script>
+<template>
+  <div>hello</div>
+</template>

--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-template-literal.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-template-literal.vue
@@ -1,0 +1,9 @@
+<script setup>
+const a = `
+  hello
+  world
+`;
+</script>
+<template>
+  <div>{{ a }}</div>
+</template>

--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-trailing-comment.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/script-trailing-comment.vue
@@ -1,0 +1,12 @@
+<script setup>
+if (
+  a &&
+  b < c // trailing comment in multiline condition
+) {
+}
+
+const x = 1; // simple trailing comment
+</script>
+<template>
+  <div>hello</div>
+</template>

--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -32,6 +32,7 @@ const categories: Category[] = [
     name: "js-in-vue",
     sources: [
       { dir: PRETTIER_FIXTURES_DIR, ext: ".vue" },
+      { dir: join(FIXTURES_DIR, "vue-vben-admin"), ext: ".vue" },
       { dir: join(EDGE_CASES_DIR, "js-in-vue") },
     ],
     optionSets: [
@@ -40,6 +41,8 @@ const categories: Category[] = [
     ],
     notes: {
       "vue/multiparser/lang-tsx.vue": "`lang=tsx` is not supported",
+      "effects/common-ui/src/components/api-component/api-component.vue":
+        "`<T = any,>() => {}` comma in generic param is removed even in .ts(x) file",
     },
   },
   {

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -1,6 +1,6 @@
 ## js-in-vue
 
-### Option 1: 94/95 (98.95%)
+### Option 1: 423/425 (99.53%)
 
 ```json
 {"printWidth":80}
@@ -8,9 +8,10 @@
 
 | File | Note |
 | :--- | :--- |
+| [effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
 | [vue/multiparser/lang-tsx.vue](diffs/js-in-vue/vue__multiparser__lang-tsx.vue.md) | `lang=tsx` is not supported |
 
-### Option 2: 94/95 (98.95%)
+### Option 2: 423/425 (99.53%)
 
 ```json
 {"printWidth":100,"vueIndentScriptAndStyle":true,"singleQuote":true}
@@ -18,6 +19,7 @@
 
 | File | Note |
 | :--- | :--- |
+| [effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
 | [vue/multiparser/lang-tsx.vue](diffs/js-in-vue/vue__multiparser__lang-tsx.vue.md) | `lang=tsx` is not supported |
 
 ## gql-in-js

--- a/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/effects__common-ui__src__components__api-component__api-component.vue.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/effects__common-ui__src__components__api-component__api-component.vue.md
@@ -1,0 +1,1245 @@
+# effects/common-ui/src/components/api-component/api-component.vue
+
+> `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file
+
+## Option 1
+
+`````json
+{"printWidth":80}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -274,9 +274,9 @@
+   getOptions: () => unref(getOptions),
+   /** 获取当前值 */
+   getValue: () => unref(modelValue),
+   /** 获取被包装的组件实例 */
+-  getComponentRef: <T = any,>() => componentRef.value as T,
++  getComponentRef: <T = any>() => componentRef.value as T,
+   /** 更新Api参数 */
+   updateParam(newParams: Record<string, any>) {
+     innerParams.value = newParams;
+   },
+
+`````
+
+### Actual (oxfmt)
+
+`````vue
+<script lang="ts" setup>
+import type { Component } from "vue";
+
+import type { AnyPromiseFunction } from "@vben/types";
+
+import { computed, nextTick, ref, unref, useAttrs, watch } from "vue";
+
+import { LoaderCircle } from "@vben/icons";
+
+import { cloneDeep, get, isEqual, isFunction } from "@vben-core/shared/utils";
+
+import { objectOmit } from "@vueuse/core";
+
+type OptionsItem = {
+  [name: string]: any;
+  children?: OptionsItem[];
+  disabled?: boolean;
+  label?: string;
+  value?: string;
+};
+
+interface Props {
+  /** 组件 */
+  component: Component;
+  /** 是否将value从数字转为string */
+  numberToString?: boolean;
+  /** 获取options数据的函数 */
+  api?: (arg?: any) => Promise<OptionsItem[] | Record<string, any>>;
+  /** 传递给api的参数 */
+  params?: Record<string, any>;
+  /** 从api返回的结果中提取options数组的字段名 */
+  resultField?: string;
+  /** label字段名 */
+  labelField?: string;
+  /** children字段名，需要层级数据的组件可用 */
+  childrenField?: string;
+  /** value字段名 */
+  valueField?: string;
+  /** disabled字段名 */
+  disabledField?: string;
+  /** 组件接收options数据的属性名 */
+  optionsPropName?: string;
+  /** 是否立即调用api */
+  immediate?: boolean;
+  /** 每次`visibleEvent`事件发生时都重新请求数据 */
+  alwaysLoad?: boolean;
+  /** 在api请求之前的回调函数 */
+  beforeFetch?: AnyPromiseFunction<any, any>;
+  /** 在api请求之后的回调函数 */
+  afterFetch?: AnyPromiseFunction<any, any>;
+  /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
+  options?: OptionsItem[];
+  /** 组件的插槽名称，用来显示一个"加载中"的图标 */
+  loadingSlot?: string;
+  /** 触发api请求的事件名 */
+  visibleEvent?: string;
+  /** 组件的v-model属性名，默认为modelValue。部分组件可能为value */
+  modelPropName?: string;
+  /**
+   * 自动选择
+   * - `first`：自动选择第一个选项
+   * - `last`：自动选择最后一个选项
+   * - `one`: 当请求的结果只有一个选项时，自动选择该选项
+   * - 函数：自定义选择逻辑，函数的参数为请求的结果数组，返回值为选择的选项
+   * - false：不自动选择(默认)
+   */
+  autoSelect?:
+    | "first"
+    | "last"
+    | "one"
+    | ((item: OptionsItem[]) => OptionsItem)
+    | false;
+}
+
+defineOptions({ name: "ApiComponent", inheritAttrs: false });
+
+const props = withDefaults(defineProps<Props>(), {
+  labelField: "label",
+  valueField: "value",
+  disabledField: "disabled",
+  childrenField: "",
+  optionsPropName: "options",
+  resultField: "",
+  visibleEvent: "",
+  numberToString: false,
+  params: () => ({}),
+  immediate: true,
+  alwaysLoad: false,
+  loadingSlot: "",
+  beforeFetch: undefined,
+  afterFetch: undefined,
+  modelPropName: "modelValue",
+  api: undefined,
+  autoSelect: false,
+  options: () => [],
+});
+
+const emit = defineEmits<{
+  optionsChange: [OptionsItem[]];
+}>();
+
+const modelValue = defineModel<any>({ default: undefined });
+
+const attrs = useAttrs();
+const innerParams = ref({});
+const refOptions = ref<OptionsItem[]>([]);
+const loading = ref(false);
+// 首次是否加载过了
+const isFirstLoaded = ref(false);
+// 标记是否有待处理的请求
+const hasPendingRequest = ref(false);
+
+const getOptions = computed(() => {
+  const {
+    labelField,
+    valueField,
+    disabledField,
+    childrenField,
+    numberToString,
+  } = props;
+
+  const refOptionsData = unref(refOptions);
+
+  function transformData(data: OptionsItem[]): OptionsItem[] {
+    return data.map((item) => {
+      const value = get(item, valueField);
+      const disabled = get(item, disabledField);
+      return {
+        ...objectOmit(item, [labelField, valueField, disabled, childrenField]),
+        label: get(item, labelField),
+        value: numberToString ? `${value}` : value,
+        disabled: get(item, disabledField),
+        ...(childrenField && item[childrenField]
+          ? { children: transformData(item[childrenField]) }
+          : {}),
+      };
+    });
+  }
+
+  const data: OptionsItem[] = transformData(refOptionsData);
+
+  return data.length > 0 ? data : props.options;
+});
+
+const bindProps = computed(() => {
+  return {
+    [props.modelPropName]: unref(modelValue),
+    [props.optionsPropName]: unref(getOptions),
+    [`onUpdate:${props.modelPropName}`]: (val: string) => {
+      modelValue.value = val;
+    },
+    ...objectOmit(attrs, [`onUpdate:${props.modelPropName}`]),
+    ...(props.visibleEvent
+      ? {
+          [props.visibleEvent]: handleFetchForVisible,
+        }
+      : {}),
+  };
+});
+
+async function fetchApi() {
+  const { api, beforeFetch, afterFetch, resultField } = props;
+
+  if (!api || !isFunction(api)) {
+    return;
+  }
+
+  // 如果正在加载，标记有待处理的请求并返回
+  if (loading.value) {
+    hasPendingRequest.value = true;
+    return;
+  }
+
+  refOptions.value = [];
+  try {
+    loading.value = true;
+    let finalParams = unref(mergedParams);
+    if (beforeFetch && isFunction(beforeFetch)) {
+      finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+    }
+    let res = await api(finalParams);
+    if (afterFetch && isFunction(afterFetch)) {
+      res = (await afterFetch(res)) || res;
+    }
+    isFirstLoaded.value = true;
+    if (Array.isArray(res)) {
+      refOptions.value = res;
+      emitChange();
+      return;
+    }
+    if (resultField) {
+      refOptions.value = get(res, resultField) || [];
+    }
+    emitChange();
+  } catch (error) {
+    console.warn(error);
+    // reset status
+    isFirstLoaded.value = false;
+  } finally {
+    loading.value = false;
+    // 如果有待处理的请求，立即触发新的请求
+    if (hasPendingRequest.value) {
+      hasPendingRequest.value = false;
+      // 使用 nextTick 确保状态更新完成后再触发新请求
+      await nextTick();
+      fetchApi();
+    }
+  }
+}
+
+async function handleFetchForVisible(visible: boolean) {
+  if (visible) {
+    if (props.alwaysLoad) {
+      await fetchApi();
+    } else if (!props.immediate && !unref(isFirstLoaded)) {
+      await fetchApi();
+    }
+  }
+}
+
+const mergedParams = computed(() => {
+  return {
+    ...props.params,
+    ...unref(innerParams),
+  };
+});
+
+watch(
+  mergedParams,
+  (value, oldValue) => {
+    if (isEqual(value, oldValue)) {
+      return;
+    }
+    fetchApi();
+  },
+  { deep: true, immediate: props.immediate },
+);
+
+function emitChange() {
+  if (
+    modelValue.value === undefined &&
+    props.autoSelect &&
+    unref(getOptions).length > 0
+  ) {
+    let firstOption;
+    if (isFunction(props.autoSelect)) {
+      firstOption = props.autoSelect(unref(getOptions));
+    } else {
+      switch (props.autoSelect) {
+        case "first": {
+          firstOption = unref(getOptions)[0];
+          break;
+        }
+        case "last": {
+          firstOption = unref(getOptions)[unref(getOptions).length - 1];
+          break;
+        }
+        case "one": {
+          if (unref(getOptions).length === 1) {
+            firstOption = unref(getOptions)[0];
+          }
+          break;
+        }
+      }
+    }
+
+    if (firstOption) modelValue.value = firstOption.value;
+  }
+  emit("optionsChange", unref(getOptions));
+}
+const componentRef = ref();
+defineExpose({
+  /** 获取options数据 */
+  getOptions: () => unref(getOptions),
+  /** 获取当前值 */
+  getValue: () => unref(modelValue),
+  /** 获取被包装的组件实例 */
+  getComponentRef: <T = any>() => componentRef.value as T,
+  /** 更新Api参数 */
+  updateParam(newParams: Record<string, any>) {
+    innerParams.value = newParams;
+  },
+});
+</script>
+<template>
+  <component
+    :is="component"
+    v-bind="bindProps"
+    :placeholder="$attrs.placeholder"
+    ref="componentRef"
+  >
+    <template v-for="item in Object.keys($slots)" #[item]="data">
+      <slot :name="item" v-bind="data || {}"></slot>
+    </template>
+    <template v-if="loadingSlot && loading" #[loadingSlot]>
+      <LoaderCircle class="animate-spin" />
+    </template>
+  </component>
+</template>
+
+`````
+
+### Expected (prettier)
+
+`````vue
+<script lang="ts" setup>
+import type { Component } from "vue";
+
+import type { AnyPromiseFunction } from "@vben/types";
+
+import { computed, nextTick, ref, unref, useAttrs, watch } from "vue";
+
+import { LoaderCircle } from "@vben/icons";
+
+import { cloneDeep, get, isEqual, isFunction } from "@vben-core/shared/utils";
+
+import { objectOmit } from "@vueuse/core";
+
+type OptionsItem = {
+  [name: string]: any;
+  children?: OptionsItem[];
+  disabled?: boolean;
+  label?: string;
+  value?: string;
+};
+
+interface Props {
+  /** 组件 */
+  component: Component;
+  /** 是否将value从数字转为string */
+  numberToString?: boolean;
+  /** 获取options数据的函数 */
+  api?: (arg?: any) => Promise<OptionsItem[] | Record<string, any>>;
+  /** 传递给api的参数 */
+  params?: Record<string, any>;
+  /** 从api返回的结果中提取options数组的字段名 */
+  resultField?: string;
+  /** label字段名 */
+  labelField?: string;
+  /** children字段名，需要层级数据的组件可用 */
+  childrenField?: string;
+  /** value字段名 */
+  valueField?: string;
+  /** disabled字段名 */
+  disabledField?: string;
+  /** 组件接收options数据的属性名 */
+  optionsPropName?: string;
+  /** 是否立即调用api */
+  immediate?: boolean;
+  /** 每次`visibleEvent`事件发生时都重新请求数据 */
+  alwaysLoad?: boolean;
+  /** 在api请求之前的回调函数 */
+  beforeFetch?: AnyPromiseFunction<any, any>;
+  /** 在api请求之后的回调函数 */
+  afterFetch?: AnyPromiseFunction<any, any>;
+  /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
+  options?: OptionsItem[];
+  /** 组件的插槽名称，用来显示一个"加载中"的图标 */
+  loadingSlot?: string;
+  /** 触发api请求的事件名 */
+  visibleEvent?: string;
+  /** 组件的v-model属性名，默认为modelValue。部分组件可能为value */
+  modelPropName?: string;
+  /**
+   * 自动选择
+   * - `first`：自动选择第一个选项
+   * - `last`：自动选择最后一个选项
+   * - `one`: 当请求的结果只有一个选项时，自动选择该选项
+   * - 函数：自定义选择逻辑，函数的参数为请求的结果数组，返回值为选择的选项
+   * - false：不自动选择(默认)
+   */
+  autoSelect?:
+    | "first"
+    | "last"
+    | "one"
+    | ((item: OptionsItem[]) => OptionsItem)
+    | false;
+}
+
+defineOptions({ name: "ApiComponent", inheritAttrs: false });
+
+const props = withDefaults(defineProps<Props>(), {
+  labelField: "label",
+  valueField: "value",
+  disabledField: "disabled",
+  childrenField: "",
+  optionsPropName: "options",
+  resultField: "",
+  visibleEvent: "",
+  numberToString: false,
+  params: () => ({}),
+  immediate: true,
+  alwaysLoad: false,
+  loadingSlot: "",
+  beforeFetch: undefined,
+  afterFetch: undefined,
+  modelPropName: "modelValue",
+  api: undefined,
+  autoSelect: false,
+  options: () => [],
+});
+
+const emit = defineEmits<{
+  optionsChange: [OptionsItem[]];
+}>();
+
+const modelValue = defineModel<any>({ default: undefined });
+
+const attrs = useAttrs();
+const innerParams = ref({});
+const refOptions = ref<OptionsItem[]>([]);
+const loading = ref(false);
+// 首次是否加载过了
+const isFirstLoaded = ref(false);
+// 标记是否有待处理的请求
+const hasPendingRequest = ref(false);
+
+const getOptions = computed(() => {
+  const {
+    labelField,
+    valueField,
+    disabledField,
+    childrenField,
+    numberToString,
+  } = props;
+
+  const refOptionsData = unref(refOptions);
+
+  function transformData(data: OptionsItem[]): OptionsItem[] {
+    return data.map((item) => {
+      const value = get(item, valueField);
+      const disabled = get(item, disabledField);
+      return {
+        ...objectOmit(item, [labelField, valueField, disabled, childrenField]),
+        label: get(item, labelField),
+        value: numberToString ? `${value}` : value,
+        disabled: get(item, disabledField),
+        ...(childrenField && item[childrenField]
+          ? { children: transformData(item[childrenField]) }
+          : {}),
+      };
+    });
+  }
+
+  const data: OptionsItem[] = transformData(refOptionsData);
+
+  return data.length > 0 ? data : props.options;
+});
+
+const bindProps = computed(() => {
+  return {
+    [props.modelPropName]: unref(modelValue),
+    [props.optionsPropName]: unref(getOptions),
+    [`onUpdate:${props.modelPropName}`]: (val: string) => {
+      modelValue.value = val;
+    },
+    ...objectOmit(attrs, [`onUpdate:${props.modelPropName}`]),
+    ...(props.visibleEvent
+      ? {
+          [props.visibleEvent]: handleFetchForVisible,
+        }
+      : {}),
+  };
+});
+
+async function fetchApi() {
+  const { api, beforeFetch, afterFetch, resultField } = props;
+
+  if (!api || !isFunction(api)) {
+    return;
+  }
+
+  // 如果正在加载，标记有待处理的请求并返回
+  if (loading.value) {
+    hasPendingRequest.value = true;
+    return;
+  }
+
+  refOptions.value = [];
+  try {
+    loading.value = true;
+    let finalParams = unref(mergedParams);
+    if (beforeFetch && isFunction(beforeFetch)) {
+      finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+    }
+    let res = await api(finalParams);
+    if (afterFetch && isFunction(afterFetch)) {
+      res = (await afterFetch(res)) || res;
+    }
+    isFirstLoaded.value = true;
+    if (Array.isArray(res)) {
+      refOptions.value = res;
+      emitChange();
+      return;
+    }
+    if (resultField) {
+      refOptions.value = get(res, resultField) || [];
+    }
+    emitChange();
+  } catch (error) {
+    console.warn(error);
+    // reset status
+    isFirstLoaded.value = false;
+  } finally {
+    loading.value = false;
+    // 如果有待处理的请求，立即触发新的请求
+    if (hasPendingRequest.value) {
+      hasPendingRequest.value = false;
+      // 使用 nextTick 确保状态更新完成后再触发新请求
+      await nextTick();
+      fetchApi();
+    }
+  }
+}
+
+async function handleFetchForVisible(visible: boolean) {
+  if (visible) {
+    if (props.alwaysLoad) {
+      await fetchApi();
+    } else if (!props.immediate && !unref(isFirstLoaded)) {
+      await fetchApi();
+    }
+  }
+}
+
+const mergedParams = computed(() => {
+  return {
+    ...props.params,
+    ...unref(innerParams),
+  };
+});
+
+watch(
+  mergedParams,
+  (value, oldValue) => {
+    if (isEqual(value, oldValue)) {
+      return;
+    }
+    fetchApi();
+  },
+  { deep: true, immediate: props.immediate },
+);
+
+function emitChange() {
+  if (
+    modelValue.value === undefined &&
+    props.autoSelect &&
+    unref(getOptions).length > 0
+  ) {
+    let firstOption;
+    if (isFunction(props.autoSelect)) {
+      firstOption = props.autoSelect(unref(getOptions));
+    } else {
+      switch (props.autoSelect) {
+        case "first": {
+          firstOption = unref(getOptions)[0];
+          break;
+        }
+        case "last": {
+          firstOption = unref(getOptions)[unref(getOptions).length - 1];
+          break;
+        }
+        case "one": {
+          if (unref(getOptions).length === 1) {
+            firstOption = unref(getOptions)[0];
+          }
+          break;
+        }
+      }
+    }
+
+    if (firstOption) modelValue.value = firstOption.value;
+  }
+  emit("optionsChange", unref(getOptions));
+}
+const componentRef = ref();
+defineExpose({
+  /** 获取options数据 */
+  getOptions: () => unref(getOptions),
+  /** 获取当前值 */
+  getValue: () => unref(modelValue),
+  /** 获取被包装的组件实例 */
+  getComponentRef: <T = any,>() => componentRef.value as T,
+  /** 更新Api参数 */
+  updateParam(newParams: Record<string, any>) {
+    innerParams.value = newParams;
+  },
+});
+</script>
+<template>
+  <component
+    :is="component"
+    v-bind="bindProps"
+    :placeholder="$attrs.placeholder"
+    ref="componentRef"
+  >
+    <template v-for="item in Object.keys($slots)" #[item]="data">
+      <slot :name="item" v-bind="data || {}"></slot>
+    </template>
+    <template v-if="loadingSlot && loading" #[loadingSlot]>
+      <LoaderCircle class="animate-spin" />
+    </template>
+  </component>
+</template>
+
+`````
+
+## Option 2
+
+`````json
+{"printWidth":100,"vueIndentScriptAndStyle":true,"singleQuote":true}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -259,9 +259,9 @@
+     getOptions: () => unref(getOptions),
+     /** 获取当前值 */
+     getValue: () => unref(modelValue),
+     /** 获取被包装的组件实例 */
+-    getComponentRef: <T = any,>() => componentRef.value as T,
++    getComponentRef: <T = any>() => componentRef.value as T,
+     /** 更新Api参数 */
+     updateParam(newParams: Record<string, any>) {
+       innerParams.value = newParams;
+     },
+
+`````
+
+### Actual (oxfmt)
+
+`````vue
+<script lang="ts" setup>
+  import type { Component } from 'vue';
+
+  import type { AnyPromiseFunction } from '@vben/types';
+
+  import { computed, nextTick, ref, unref, useAttrs, watch } from 'vue';
+
+  import { LoaderCircle } from '@vben/icons';
+
+  import { cloneDeep, get, isEqual, isFunction } from '@vben-core/shared/utils';
+
+  import { objectOmit } from '@vueuse/core';
+
+  type OptionsItem = {
+    [name: string]: any;
+    children?: OptionsItem[];
+    disabled?: boolean;
+    label?: string;
+    value?: string;
+  };
+
+  interface Props {
+    /** 组件 */
+    component: Component;
+    /** 是否将value从数字转为string */
+    numberToString?: boolean;
+    /** 获取options数据的函数 */
+    api?: (arg?: any) => Promise<OptionsItem[] | Record<string, any>>;
+    /** 传递给api的参数 */
+    params?: Record<string, any>;
+    /** 从api返回的结果中提取options数组的字段名 */
+    resultField?: string;
+    /** label字段名 */
+    labelField?: string;
+    /** children字段名，需要层级数据的组件可用 */
+    childrenField?: string;
+    /** value字段名 */
+    valueField?: string;
+    /** disabled字段名 */
+    disabledField?: string;
+    /** 组件接收options数据的属性名 */
+    optionsPropName?: string;
+    /** 是否立即调用api */
+    immediate?: boolean;
+    /** 每次`visibleEvent`事件发生时都重新请求数据 */
+    alwaysLoad?: boolean;
+    /** 在api请求之前的回调函数 */
+    beforeFetch?: AnyPromiseFunction<any, any>;
+    /** 在api请求之后的回调函数 */
+    afterFetch?: AnyPromiseFunction<any, any>;
+    /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
+    options?: OptionsItem[];
+    /** 组件的插槽名称，用来显示一个"加载中"的图标 */
+    loadingSlot?: string;
+    /** 触发api请求的事件名 */
+    visibleEvent?: string;
+    /** 组件的v-model属性名，默认为modelValue。部分组件可能为value */
+    modelPropName?: string;
+    /**
+     * 自动选择
+     * - `first`：自动选择第一个选项
+     * - `last`：自动选择最后一个选项
+     * - `one`: 当请求的结果只有一个选项时，自动选择该选项
+     * - 函数：自定义选择逻辑，函数的参数为请求的结果数组，返回值为选择的选项
+     * - false：不自动选择(默认)
+     */
+    autoSelect?: 'first' | 'last' | 'one' | ((item: OptionsItem[]) => OptionsItem) | false;
+  }
+
+  defineOptions({ name: 'ApiComponent', inheritAttrs: false });
+
+  const props = withDefaults(defineProps<Props>(), {
+    labelField: 'label',
+    valueField: 'value',
+    disabledField: 'disabled',
+    childrenField: '',
+    optionsPropName: 'options',
+    resultField: '',
+    visibleEvent: '',
+    numberToString: false,
+    params: () => ({}),
+    immediate: true,
+    alwaysLoad: false,
+    loadingSlot: '',
+    beforeFetch: undefined,
+    afterFetch: undefined,
+    modelPropName: 'modelValue',
+    api: undefined,
+    autoSelect: false,
+    options: () => [],
+  });
+
+  const emit = defineEmits<{
+    optionsChange: [OptionsItem[]];
+  }>();
+
+  const modelValue = defineModel<any>({ default: undefined });
+
+  const attrs = useAttrs();
+  const innerParams = ref({});
+  const refOptions = ref<OptionsItem[]>([]);
+  const loading = ref(false);
+  // 首次是否加载过了
+  const isFirstLoaded = ref(false);
+  // 标记是否有待处理的请求
+  const hasPendingRequest = ref(false);
+
+  const getOptions = computed(() => {
+    const { labelField, valueField, disabledField, childrenField, numberToString } = props;
+
+    const refOptionsData = unref(refOptions);
+
+    function transformData(data: OptionsItem[]): OptionsItem[] {
+      return data.map((item) => {
+        const value = get(item, valueField);
+        const disabled = get(item, disabledField);
+        return {
+          ...objectOmit(item, [labelField, valueField, disabled, childrenField]),
+          label: get(item, labelField),
+          value: numberToString ? `${value}` : value,
+          disabled: get(item, disabledField),
+          ...(childrenField && item[childrenField]
+            ? { children: transformData(item[childrenField]) }
+            : {}),
+        };
+      });
+    }
+
+    const data: OptionsItem[] = transformData(refOptionsData);
+
+    return data.length > 0 ? data : props.options;
+  });
+
+  const bindProps = computed(() => {
+    return {
+      [props.modelPropName]: unref(modelValue),
+      [props.optionsPropName]: unref(getOptions),
+      [`onUpdate:${props.modelPropName}`]: (val: string) => {
+        modelValue.value = val;
+      },
+      ...objectOmit(attrs, [`onUpdate:${props.modelPropName}`]),
+      ...(props.visibleEvent
+        ? {
+            [props.visibleEvent]: handleFetchForVisible,
+          }
+        : {}),
+    };
+  });
+
+  async function fetchApi() {
+    const { api, beforeFetch, afterFetch, resultField } = props;
+
+    if (!api || !isFunction(api)) {
+      return;
+    }
+
+    // 如果正在加载，标记有待处理的请求并返回
+    if (loading.value) {
+      hasPendingRequest.value = true;
+      return;
+    }
+
+    refOptions.value = [];
+    try {
+      loading.value = true;
+      let finalParams = unref(mergedParams);
+      if (beforeFetch && isFunction(beforeFetch)) {
+        finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+      }
+      let res = await api(finalParams);
+      if (afterFetch && isFunction(afterFetch)) {
+        res = (await afterFetch(res)) || res;
+      }
+      isFirstLoaded.value = true;
+      if (Array.isArray(res)) {
+        refOptions.value = res;
+        emitChange();
+        return;
+      }
+      if (resultField) {
+        refOptions.value = get(res, resultField) || [];
+      }
+      emitChange();
+    } catch (error) {
+      console.warn(error);
+      // reset status
+      isFirstLoaded.value = false;
+    } finally {
+      loading.value = false;
+      // 如果有待处理的请求，立即触发新的请求
+      if (hasPendingRequest.value) {
+        hasPendingRequest.value = false;
+        // 使用 nextTick 确保状态更新完成后再触发新请求
+        await nextTick();
+        fetchApi();
+      }
+    }
+  }
+
+  async function handleFetchForVisible(visible: boolean) {
+    if (visible) {
+      if (props.alwaysLoad) {
+        await fetchApi();
+      } else if (!props.immediate && !unref(isFirstLoaded)) {
+        await fetchApi();
+      }
+    }
+  }
+
+  const mergedParams = computed(() => {
+    return {
+      ...props.params,
+      ...unref(innerParams),
+    };
+  });
+
+  watch(
+    mergedParams,
+    (value, oldValue) => {
+      if (isEqual(value, oldValue)) {
+        return;
+      }
+      fetchApi();
+    },
+    { deep: true, immediate: props.immediate },
+  );
+
+  function emitChange() {
+    if (modelValue.value === undefined && props.autoSelect && unref(getOptions).length > 0) {
+      let firstOption;
+      if (isFunction(props.autoSelect)) {
+        firstOption = props.autoSelect(unref(getOptions));
+      } else {
+        switch (props.autoSelect) {
+          case 'first': {
+            firstOption = unref(getOptions)[0];
+            break;
+          }
+          case 'last': {
+            firstOption = unref(getOptions)[unref(getOptions).length - 1];
+            break;
+          }
+          case 'one': {
+            if (unref(getOptions).length === 1) {
+              firstOption = unref(getOptions)[0];
+            }
+            break;
+          }
+        }
+      }
+
+      if (firstOption) modelValue.value = firstOption.value;
+    }
+    emit('optionsChange', unref(getOptions));
+  }
+  const componentRef = ref();
+  defineExpose({
+    /** 获取options数据 */
+    getOptions: () => unref(getOptions),
+    /** 获取当前值 */
+    getValue: () => unref(modelValue),
+    /** 获取被包装的组件实例 */
+    getComponentRef: <T = any>() => componentRef.value as T,
+    /** 更新Api参数 */
+    updateParam(newParams: Record<string, any>) {
+      innerParams.value = newParams;
+    },
+  });
+</script>
+<template>
+  <component
+    :is="component"
+    v-bind="bindProps"
+    :placeholder="$attrs.placeholder"
+    ref="componentRef"
+  >
+    <template v-for="item in Object.keys($slots)" #[item]="data">
+      <slot :name="item" v-bind="data || {}"></slot>
+    </template>
+    <template v-if="loadingSlot && loading" #[loadingSlot]>
+      <LoaderCircle class="animate-spin" />
+    </template>
+  </component>
+</template>
+
+`````
+
+### Expected (prettier)
+
+`````vue
+<script lang="ts" setup>
+  import type { Component } from 'vue';
+
+  import type { AnyPromiseFunction } from '@vben/types';
+
+  import { computed, nextTick, ref, unref, useAttrs, watch } from 'vue';
+
+  import { LoaderCircle } from '@vben/icons';
+
+  import { cloneDeep, get, isEqual, isFunction } from '@vben-core/shared/utils';
+
+  import { objectOmit } from '@vueuse/core';
+
+  type OptionsItem = {
+    [name: string]: any;
+    children?: OptionsItem[];
+    disabled?: boolean;
+    label?: string;
+    value?: string;
+  };
+
+  interface Props {
+    /** 组件 */
+    component: Component;
+    /** 是否将value从数字转为string */
+    numberToString?: boolean;
+    /** 获取options数据的函数 */
+    api?: (arg?: any) => Promise<OptionsItem[] | Record<string, any>>;
+    /** 传递给api的参数 */
+    params?: Record<string, any>;
+    /** 从api返回的结果中提取options数组的字段名 */
+    resultField?: string;
+    /** label字段名 */
+    labelField?: string;
+    /** children字段名，需要层级数据的组件可用 */
+    childrenField?: string;
+    /** value字段名 */
+    valueField?: string;
+    /** disabled字段名 */
+    disabledField?: string;
+    /** 组件接收options数据的属性名 */
+    optionsPropName?: string;
+    /** 是否立即调用api */
+    immediate?: boolean;
+    /** 每次`visibleEvent`事件发生时都重新请求数据 */
+    alwaysLoad?: boolean;
+    /** 在api请求之前的回调函数 */
+    beforeFetch?: AnyPromiseFunction<any, any>;
+    /** 在api请求之后的回调函数 */
+    afterFetch?: AnyPromiseFunction<any, any>;
+    /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
+    options?: OptionsItem[];
+    /** 组件的插槽名称，用来显示一个"加载中"的图标 */
+    loadingSlot?: string;
+    /** 触发api请求的事件名 */
+    visibleEvent?: string;
+    /** 组件的v-model属性名，默认为modelValue。部分组件可能为value */
+    modelPropName?: string;
+    /**
+     * 自动选择
+     * - `first`：自动选择第一个选项
+     * - `last`：自动选择最后一个选项
+     * - `one`: 当请求的结果只有一个选项时，自动选择该选项
+     * - 函数：自定义选择逻辑，函数的参数为请求的结果数组，返回值为选择的选项
+     * - false：不自动选择(默认)
+     */
+    autoSelect?: 'first' | 'last' | 'one' | ((item: OptionsItem[]) => OptionsItem) | false;
+  }
+
+  defineOptions({ name: 'ApiComponent', inheritAttrs: false });
+
+  const props = withDefaults(defineProps<Props>(), {
+    labelField: 'label',
+    valueField: 'value',
+    disabledField: 'disabled',
+    childrenField: '',
+    optionsPropName: 'options',
+    resultField: '',
+    visibleEvent: '',
+    numberToString: false,
+    params: () => ({}),
+    immediate: true,
+    alwaysLoad: false,
+    loadingSlot: '',
+    beforeFetch: undefined,
+    afterFetch: undefined,
+    modelPropName: 'modelValue',
+    api: undefined,
+    autoSelect: false,
+    options: () => [],
+  });
+
+  const emit = defineEmits<{
+    optionsChange: [OptionsItem[]];
+  }>();
+
+  const modelValue = defineModel<any>({ default: undefined });
+
+  const attrs = useAttrs();
+  const innerParams = ref({});
+  const refOptions = ref<OptionsItem[]>([]);
+  const loading = ref(false);
+  // 首次是否加载过了
+  const isFirstLoaded = ref(false);
+  // 标记是否有待处理的请求
+  const hasPendingRequest = ref(false);
+
+  const getOptions = computed(() => {
+    const { labelField, valueField, disabledField, childrenField, numberToString } = props;
+
+    const refOptionsData = unref(refOptions);
+
+    function transformData(data: OptionsItem[]): OptionsItem[] {
+      return data.map((item) => {
+        const value = get(item, valueField);
+        const disabled = get(item, disabledField);
+        return {
+          ...objectOmit(item, [labelField, valueField, disabled, childrenField]),
+          label: get(item, labelField),
+          value: numberToString ? `${value}` : value,
+          disabled: get(item, disabledField),
+          ...(childrenField && item[childrenField]
+            ? { children: transformData(item[childrenField]) }
+            : {}),
+        };
+      });
+    }
+
+    const data: OptionsItem[] = transformData(refOptionsData);
+
+    return data.length > 0 ? data : props.options;
+  });
+
+  const bindProps = computed(() => {
+    return {
+      [props.modelPropName]: unref(modelValue),
+      [props.optionsPropName]: unref(getOptions),
+      [`onUpdate:${props.modelPropName}`]: (val: string) => {
+        modelValue.value = val;
+      },
+      ...objectOmit(attrs, [`onUpdate:${props.modelPropName}`]),
+      ...(props.visibleEvent
+        ? {
+            [props.visibleEvent]: handleFetchForVisible,
+          }
+        : {}),
+    };
+  });
+
+  async function fetchApi() {
+    const { api, beforeFetch, afterFetch, resultField } = props;
+
+    if (!api || !isFunction(api)) {
+      return;
+    }
+
+    // 如果正在加载，标记有待处理的请求并返回
+    if (loading.value) {
+      hasPendingRequest.value = true;
+      return;
+    }
+
+    refOptions.value = [];
+    try {
+      loading.value = true;
+      let finalParams = unref(mergedParams);
+      if (beforeFetch && isFunction(beforeFetch)) {
+        finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+      }
+      let res = await api(finalParams);
+      if (afterFetch && isFunction(afterFetch)) {
+        res = (await afterFetch(res)) || res;
+      }
+      isFirstLoaded.value = true;
+      if (Array.isArray(res)) {
+        refOptions.value = res;
+        emitChange();
+        return;
+      }
+      if (resultField) {
+        refOptions.value = get(res, resultField) || [];
+      }
+      emitChange();
+    } catch (error) {
+      console.warn(error);
+      // reset status
+      isFirstLoaded.value = false;
+    } finally {
+      loading.value = false;
+      // 如果有待处理的请求，立即触发新的请求
+      if (hasPendingRequest.value) {
+        hasPendingRequest.value = false;
+        // 使用 nextTick 确保状态更新完成后再触发新请求
+        await nextTick();
+        fetchApi();
+      }
+    }
+  }
+
+  async function handleFetchForVisible(visible: boolean) {
+    if (visible) {
+      if (props.alwaysLoad) {
+        await fetchApi();
+      } else if (!props.immediate && !unref(isFirstLoaded)) {
+        await fetchApi();
+      }
+    }
+  }
+
+  const mergedParams = computed(() => {
+    return {
+      ...props.params,
+      ...unref(innerParams),
+    };
+  });
+
+  watch(
+    mergedParams,
+    (value, oldValue) => {
+      if (isEqual(value, oldValue)) {
+        return;
+      }
+      fetchApi();
+    },
+    { deep: true, immediate: props.immediate },
+  );
+
+  function emitChange() {
+    if (modelValue.value === undefined && props.autoSelect && unref(getOptions).length > 0) {
+      let firstOption;
+      if (isFunction(props.autoSelect)) {
+        firstOption = props.autoSelect(unref(getOptions));
+      } else {
+        switch (props.autoSelect) {
+          case 'first': {
+            firstOption = unref(getOptions)[0];
+            break;
+          }
+          case 'last': {
+            firstOption = unref(getOptions)[unref(getOptions).length - 1];
+            break;
+          }
+          case 'one': {
+            if (unref(getOptions).length === 1) {
+              firstOption = unref(getOptions)[0];
+            }
+            break;
+          }
+        }
+      }
+
+      if (firstOption) modelValue.value = firstOption.value;
+    }
+    emit('optionsChange', unref(getOptions));
+  }
+  const componentRef = ref();
+  defineExpose({
+    /** 获取options数据 */
+    getOptions: () => unref(getOptions),
+    /** 获取当前值 */
+    getValue: () => unref(modelValue),
+    /** 获取被包装的组件实例 */
+    getComponentRef: <T = any,>() => componentRef.value as T,
+    /** 更新Api参数 */
+    updateParam(newParams: Record<string, any>) {
+      innerParams.value = newParams;
+    },
+  });
+</script>
+<template>
+  <component
+    :is="component"
+    v-bind="bindProps"
+    :placeholder="$attrs.placeholder"
+    ref="componentRef"
+  >
+    <template v-for="item in Object.keys($slots)" #[item]="data">
+      <slot :name="item" v-bind="data || {}"></slot>
+    </template>
+    <template v-if="loadingSlot && loading" #[loadingSlot]>
+      <LoaderCircle class="animate-spin" />
+    </template>
+  </component>
+</template>
+
+`````

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -7,16 +7,16 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::*;
 use oxc_formatter::{
     AstNode, AstNodes, FormatOptions, FormatVueBindingParams, FormatVueScriptGeneric, Formatter,
-    get_parse_options,
+    enable_jsx_source_type, get_parse_options,
 };
 use oxc_parser::{Parser, ParserReturn};
 use oxc_span::SourceType;
 
 use crate::{
     core::{
-        ExternalFormatter, FormatFileStrategy, FormatResult, JsFormatEmbeddedCb,
-        JsFormatEmbeddedDocCb, JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb,
-        ResolvedOptions, SourceFormatter, resolve_options_from_value,
+        ExternalFormatter, FormatFileStrategy, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb,
+        JsFormatFileCb, JsInitExternalFormatterCb, JsSortTailwindClassesCb, ResolvedOptions,
+        resolve_options_from_value,
     },
     prettier_compat::to_prettier_doc,
 };
@@ -85,8 +85,16 @@ pub fn run(
 // ---
 
 /// Full mode:
-/// - Format entire source as text
-/// - Return hardline-joined Doc string
+/// - Format entire source as IR
+/// - Convert IR to Prettier Doc
+///
+/// NOTE: Why we need to convert IR to Doc instead of just splitting by lines:
+/// A simple line-splitting approach might seem sufficient and can cover most cases,
+/// but it fails to handle newlines that appear within string, such as `TemplateLiteral`.
+///
+/// This is critical for `vueIndentScriptAndStyle: true`, (Prettier wraps the `<script>` content with `indent()`)
+/// `literalline` (used for template literal content) is not affected by `indent()`,
+/// while `hardline` (used for normal code) is.
 #[instrument(level = "debug", name = "oxfmt::text_to_doc::full", skip_all, fields(%source_ext))]
 fn run_full(
     source_ext: &str,
@@ -124,33 +132,60 @@ fn run_full(
         }
     }
 
+    let source_type = enable_jsx_source_type(
+        SourceType::from_extension(source_ext)
+            .expect("source_ext should be a valid JS/TS extension"),
+    );
+
     let strategy = FormatFileStrategy::OxcFormatter {
         path: format!("embedded.{source_ext}").into(),
-        source_type: SourceType::from_extension(source_ext)
-            .expect("source_ext should be a valid JS/TS extension"),
+        source_type,
     };
-    let mut resolved_options = resolve_options_from_value(options, &strategy, None)
+    let resolved_options = resolve_options_from_value(options, &strategy, None)
         .expect("`_oxfmtPluginOptionsJson` should contain valid config");
-    // Override filepath so external callbacks (e.g., Tailwind sorter) receive the parent
-    // file path (e.g., `App.vue`) instead of the dummy `embedded.ts` path.
-    resolved_options.set_filepath_override(parent_filepath);
-
-    let formatter = SourceFormatter::new(num_of_threads)
-        .with_external_formatter(Some(external_formatter.clone()));
-
-    let code = match tokio::task::block_in_place(|| {
-        formatter.format(&strategy, source_text, resolved_options)
-    }) {
-        FormatResult::Success { code, .. } => code,
-        FormatResult::Error(diagnostics) => {
-            debug!("`formatter.format()` failed: {diagnostics:?}");
-            external_formatter.cleanup();
-            return None;
-        }
+    let ResolvedOptions::OxcFormatter {
+        format_options,
+        mut external_options,
+        filepath_override,
+        ..
+    } = resolved_options
+    else {
+        unreachable!("OxcFormatter strategy should always resolve to OxcFormatter options");
     };
+
+    // Set filepath on external options for Prettier plugins and Tailwind sorter.
+    // Use the filepath override (parent filepath, e.g., `App.vue`) if available,
+    // otherwise fall back to the parent filepath from plugin options.
+    let filepath = filepath_override.as_deref().unwrap_or(&parent_filepath);
+    if let Value::Object(ref mut map) = external_options {
+        map.insert("filepath".to_string(), Value::String(filepath.to_string_lossy().to_string()));
+    }
+
+    let external_callbacks =
+        external_formatter.to_external_callbacks(&format_options, external_options);
+
+    let allocator = Allocator::default();
+    let ret =
+        Parser::new(&allocator, source_text, source_type).with_options(get_parse_options()).parse();
+    if !ret.errors.is_empty() {
+        debug!("`Parser::new().parse()` failed: {:?}", ret.errors);
+        external_formatter.cleanup();
+        return None;
+    }
+
+    let base_formatter = Formatter::new(&allocator, *format_options);
+    let formatted = tokio::task::block_in_place(|| {
+        base_formatter.format_with_external_callbacks(&ret.program, Some(external_callbacks))
+    });
+
+    let (elements, sorted_tailwind_classes) =
+        formatted.into_document().into_elements_and_tailwind_classes();
 
     external_formatter.cleanup();
-    Some(to_prettier_doc::printed_string_to_hardline_doc(&code))
+    Some(
+        to_prettier_doc::format_elements_to_prettier_doc(elements, &sorted_tailwind_classes)
+            .expect("Formatter IR to Prettier Doc conversion should not fail"),
+    )
 }
 
 // ---

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -169,16 +169,6 @@ impl ResolvedOptions {
             }
         }
     }
-
-    /// Set the filepath override for js-in-xxx flows.
-    /// See [`ResolvedOptions::OxcFormatter::filepath_override`] for details.
-    #[cfg(feature = "napi")]
-    pub fn set_filepath_override(&mut self, filepath: PathBuf) {
-        let ResolvedOptions::OxcFormatter { filepath_override, .. } = self else {
-            unreachable!("`filepath_override` is only applicable for `OxcFormatter` options");
-        };
-        *filepath_override = Some(filepath);
-    }
 }
 
 // ---

--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -13,33 +13,9 @@ use oxc_formatter::{
 // - caching interned elements
 // - reusing constant Doc structures like `{type: "line", hard: true}`
 
-/// Splits a printed string by newlines and joins with Prettier `hardline` docs.
-pub fn printed_string_to_hardline_doc(text: &str) -> Value {
-    // `lines()` will remove trailing newlines, but it is fine.
-    // For js-in-xxx fragments, do not need to preserve trailing newlines.
-    let lines: Vec<&str> = text.lines().collect();
-
-    if lines.len() <= 1 {
-        return Value::String(text.to_string());
-    }
-
-    let mut parts: Vec<Value> = Vec::with_capacity(lines.len() * 3);
-    for (i, line) in lines.iter().enumerate() {
-        if 0 < i {
-            // hardline = [{ type: "line", hard: true } + break-parent]
-            // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/document/builders/line.js#L27
-            parts.push(json!({"type": "line", "hard": true}));
-            parts.push(json!({"type": "break-parent"}));
-        }
-        parts.push(Value::String((*line).to_string()));
-    }
-
-    normalize_array(parts)
-}
-
 /// Converts `oxc_formatter` IR (`FormatElement` slice) into Prettier Doc.
 ///
-/// This is used for js-in-xxx fragment formatting
+/// This is used for js-in-xxx formatting (both full and fragment)
 /// where the IR must be returned to Prettier as an unresolved Doc (rather than a printed string)
 /// so that Prettier can handle line-wrapping in the parent context.
 pub fn format_elements_to_prettier_doc(
@@ -85,41 +61,165 @@ enum StartTagInfo {
     Labelled,
 }
 
+/// Simulates a subset of the `oxc_formatter` printer's runtime state.
+///
+/// Our IR (`FormatElement`) is designed to be consumed by its own printer,
+/// which applies several runtime optimizations
+/// (space deduplication, consecutive hardline merging, etc.).
+/// When converting this IR to Prettier `Doc` instead of printed text,
+/// we must replicate these same optimizations,
+/// otherwise the `Doc` would contain redundant spaces/lines that the printer would have suppressed.
+///
+/// Each field corresponds to a specific printer behavior in
+/// `crates/oxc_formatter/src/formatter/printer/mod.rs`.
+///
+/// NOTE: If the printer gains new runtime optimizations that affect output,
+/// this struct may need corresponding updates.
+/// The conformance tests will catch most divergences,
+/// but when debugging mismatches, compare against the printer's state machine.
+struct PrinterState {
+    /// Mirrors the printer's `pending_space` flag.
+    /// See: `PrinterState::pending_space` in `printer/mod.rs`
+    ///
+    /// Set by `Space`/`HardSpace` elements.
+    /// Consumed (flushed as `" "`) before the next visible content.
+    /// Boolean semantics naturally deduplicates consecutive spaces.
+    pending_space: bool,
+
+    /// Mirrors the printer's `line_width > 0` guard for hardline emission
+    /// and `has_empty_line` flag for empty line deduplication.
+    /// See: `Printer::print_line()` in printer/mod.rs
+    ///
+    /// When true, consecutive `Hard` lines are suppressed (the line is already broken).
+    /// `Empty` after a hardline emits only one additional `Hard` (the second newline).
+    ///
+    /// NOTE: Consecutive `Empty, Empty` won't fully collapse to a single empty line,
+    /// but such sequences don't occur in practice since the IR generators already
+    /// control line emission.
+    last_was_hardline: bool,
+}
+
+impl PrinterState {
+    fn new() -> Self {
+        Self { pending_space: false, last_was_hardline: false }
+    }
+
+    /// Flushes the pending space (if any) by appending `" "` to the current scope's children.
+    fn flush_pending_space(&mut self, stack: &mut [StackEntry]) -> Result<(), String> {
+        if self.pending_space {
+            concat_string(current_children_mut(stack)?, " ");
+            self.pending_space = false;
+        }
+        Ok(())
+    }
+}
+
 fn convert_elements(
     elements: &[FormatElement],
     state: &mut ConvertState,
 ) -> Result<Vec<Value>, String> {
     let mut stack: Vec<StackEntry> =
         vec![StackEntry { start_tag: None, start_info: None, children: vec![] }];
+    let mut printer = PrinterState::new();
 
     for element in elements {
         match element {
             FormatElement::Space | FormatElement::HardSpace => {
-                concat_string(current_children_mut(&mut stack)?, " ");
+                printer.pending_space = true;
+                printer.last_was_hardline = false;
             }
             FormatElement::Token { text } => {
+                printer.flush_pending_space(&mut stack)?;
                 concat_string(current_children_mut(&mut stack)?, text);
+                printer.last_was_hardline = false;
             }
             FormatElement::Text { text, .. } => {
+                printer.flush_pending_space(&mut stack)?;
                 push_text(current_children_mut(&mut stack)?, text);
+                printer.last_was_hardline = false;
             }
             FormatElement::Line(mode) => {
-                push_line(current_children_mut(&mut stack)?, *mode);
+                match mode {
+                    LineMode::SoftOrSpace => {
+                        // `SoftOrSpace` produces a space in flat mode, newline in expanded.
+                        // If `pending_space` is already set,
+                        // `SoftOrSpace` subsumes it (just like the printer's boolean idempotency).
+                        printer.pending_space = false;
+                        push_line(current_children_mut(&mut stack)?, *mode);
+                    }
+                    LineMode::Soft => {
+                        // Soft produces nothing in flat mode, newline in expanded.
+                        // Keep `pending_space` as-is (mirroring the printer).
+                        push_line(current_children_mut(&mut stack)?, *mode);
+                    }
+                    LineMode::Hard | LineMode::Empty => {
+                        printer.flush_pending_space(&mut stack)?;
+                        // Mimic the printer's `line_width > 0` guard and `has_empty_line` dedup:
+                        // - The printer only emits a newline when the line has content (`line_width > 0`).
+                        //   Consecutive `Hard, Hard` produces only one newline.
+                        // - For `Empty` after a hardline, only the second newline of `Empty` is emitted
+                        //   (the first is redundant since the line is already broken).
+                        if printer.last_was_hardline {
+                            if *mode == LineMode::Empty {
+                                push_line(current_children_mut(&mut stack)?, LineMode::Hard);
+                            }
+                            // `Hard` after `Hard` → skip (line already broken)
+                        } else {
+                            push_line(current_children_mut(&mut stack)?, *mode);
+                        }
+                    }
+                }
+                printer.last_was_hardline = matches!(mode, LineMode::Hard | LineMode::Empty);
             }
+            // `ExpandParent` is a directive (not visible content) — it forces the parent group
+            // to break. The printer treats it as a no-op (expansion is propagated at IR level).
+            // Neither `pending_space` nor `last_was_hardline` should be affected.
             FormatElement::ExpandParent => {
                 current_children_mut(&mut stack)?.push(json!({"type": "break-parent"}));
             }
             FormatElement::LineSuffixBoundary => {
+                printer.flush_pending_space(&mut stack)?;
                 current_children_mut(&mut stack)?.push(json!({"type": "line-suffix-boundary"}));
+                printer.last_was_hardline = false;
             }
             FormatElement::Tag(tag) => {
                 if tag.is_start() {
+                    // Flush pending space to the parent scope before opening a new tag.
+                    // The space belongs before the group/indent/conditional, not inside it.
+                    // If it were flushed inside (e.g. into a `ConditionalContent(Flat)`),
+                    // it could be lost when the group breaks.
+                    //
+                    // Exception: `LineSuffix` already contains a leading `Space` for separation.
+                    // Flushing the outer `pending_space` here would create a double space
+                    // (one from the flush + one from the LineSuffix's inner Space).
+                    // The printer avoids this via `line_width > 0` guard and boolean idempotency.
+                    // We discard the outer `pending_space` since the `LineSuffix`'s inner `Space` handles it.
+                    if printer.pending_space {
+                        if !matches!(tag, Tag::StartLineSuffix) {
+                            concat_string(current_children_mut(&mut stack)?, " ");
+                        }
+                        printer.pending_space = false;
+                    }
                     stack.push(StackEntry {
                         start_tag: Some(tag.clone()),
                         start_info: Some(extract_start_tag_info(tag)),
                         children: vec![],
                     });
                 } else {
+                    // For ConditionalContent, flush pending space into the closing scope's children
+                    // so it stays within the conditional branch (otherwise it leaks into expanded mode).
+                    // For all other tags (Indent, Group, Align, etc.), carry pending_space to the parent —
+                    // these wrappers are transparent for spacing, and flushing inside would cause
+                    // double-space bugs (e.g. `extends A, B  {` where indent's trailing " " + outer " ").
+                    if printer.pending_space
+                        && matches!(
+                            tag,
+                            Tag::EndConditionalContent | Tag::EndIndentIfGroupBreaks(_)
+                        )
+                    {
+                        concat_string(current_children_mut(&mut stack)?, " ");
+                        printer.pending_space = false;
+                    }
                     if stack.len() == 1 {
                         return Err(format!(
                             "Invalid formatter IR: found unmatched end tag `{tag:?}` while converting to Prettier Doc"
@@ -135,11 +235,43 @@ fn convert_elements(
                             "Invalid formatter IR: mismatched tags (start: `{start_tag:?}`, end: `{tag:?}`)"
                         ));
                     }
-                    let doc = build_doc(entry.start_info.as_ref(), entry.children);
+                    let is_line_suffix = matches!(entry.start_info, Some(StartTagInfo::LineSuffix));
+                    let mut doc = build_doc(entry.start_info.as_ref(), entry.children);
+
+                    // The formatter always prepends a `Space` inside `LineSuffix` for separation
+                    // from preceding code (e.g. `x = 1; // comment`).
+                    // The printer guards this with `line_width > 0`,
+                    // so the `Space` is suppressed when the line has no content yet.
+                    // When the parent scope has no preceding content (e.g. comment-only `<script>` blocks),
+                    // strip the leading space from the `lineSuffix` contents to avoid a spurious leading space.
+                    if is_line_suffix
+                        && current_children_mut(&mut stack)?.is_empty()
+                        && let Value::Object(ref mut map) = doc
+                        && let Some(contents) = map.get_mut("contents")
+                    {
+                        strip_leading_space(contents);
+                    }
+
                     current_children_mut(&mut stack)?.push(doc);
                 }
             }
             FormatElement::Interned(interned) => {
+                if printer.pending_space {
+                    // If the interned starts with a space-producing element,
+                    // don't flush — the inner conversion already emits a leading space.
+                    // This mirrors the printer's boolean idempotency (`Space + Space` = one space).
+                    if !matches!(
+                        interned.first(),
+                        Some(
+                            FormatElement::Space
+                                | FormatElement::HardSpace
+                                | FormatElement::Line(LineMode::SoftOrSpace)
+                        )
+                    ) {
+                        concat_string(current_children_mut(&mut stack)?, " ");
+                    }
+                    printer.pending_space = false;
+                }
                 let key = interned_cache_key(interned);
                 if let Some(cached) = state.interned_cache.get(&key) {
                     current_children_mut(&mut stack)?.extend(cached.iter().cloned());
@@ -148,15 +280,20 @@ fn convert_elements(
                     state.interned_cache.insert(key, converted.clone());
                     current_children_mut(&mut stack)?.extend(converted);
                 }
+                printer.last_was_hardline = false;
             }
             FormatElement::BestFitting(best_fitting) => {
+                printer.flush_pending_space(&mut stack)?;
                 let doc = convert_best_fitting(best_fitting, state)?;
                 current_children_mut(&mut stack)?.push(doc);
+                printer.last_was_hardline = false;
             }
             FormatElement::TailwindClass(index) => {
+                printer.flush_pending_space(&mut stack)?;
                 if let Some(class) = state.sorted_tailwind_classes.get(*index) {
                     concat_string(current_children_mut(&mut stack)?, class);
                 }
+                printer.last_was_hardline = false;
             }
         }
     }
@@ -289,7 +426,14 @@ fn build_doc(start_info: Option<&StartTagInfo>, children: Vec<Value>) -> Value {
 
     match info {
         StartTagInfo::Indent => {
-            json!({"type": "indent", "contents": normalize_array(children)})
+            // If the indent scope contains only hardlines and break-parents (no actual content),
+            // unwrap the indent wrapper. Otherwise Prettier applies indentation to the hardline,
+            // producing spurious leading spaces (e.g. empty `switch` body: `{\n  }` instead of `{\n}`).
+            if children_are_only_hardlines(&children) {
+                normalize_array(children)
+            } else {
+                json!({"type": "indent", "contents": normalize_array(children)})
+            }
         }
         StartTagInfo::Align(count) => {
             json!({"type": "align", "n": *count, "contents": normalize_array(children)})
@@ -391,6 +535,40 @@ fn group_id_string(id: GroupId) -> String {
     format!("G{}", u32::from(id))
 }
 
+/// Returns `true` if the children consist only of hardline docs and break-parent docs
+/// (i.e., no visible content that would benefit from indentation).
+fn children_are_only_hardlines(children: &[Value]) -> bool {
+    children.iter().all(|child| {
+        if let Value::Object(map) = child {
+            let ty = map.get("type").and_then(Value::as_str);
+            ty == Some("break-parent")
+                || (ty == Some("line") && map.get("hard") == Some(&Value::Bool(true)))
+        } else {
+            false
+        }
+    })
+}
+
+/// Strips a leading space character from a `Value`.
+/// Handles both plain strings (`" foo"` → `"foo"`) and arrays whose first element is a string.
+fn strip_leading_space(value: &mut Value) {
+    match value {
+        Value::String(s) => {
+            if s.starts_with(' ') {
+                s.remove(0);
+            }
+        }
+        Value::Array(arr) => {
+            if let Some(Value::String(s)) = arr.first_mut()
+                && s.starts_with(' ')
+            {
+                s.remove(0);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Concatenates a string onto the last element if it's also a string,
 /// otherwise pushes a new string value.
 fn concat_string(children: &mut Vec<Value>, s: &str) {
@@ -400,8 +578,6 @@ fn concat_string(children: &mut Vec<Value>, s: &str) {
         children.push(Value::String(s.to_string()));
     }
 }
-
-// ---
 
 /// Normalizes a `Vec<Value>` into a single `Value`:
 /// - Empty vec -> empty string

--- a/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/js-in-vue.test.ts.snap
@@ -31,3 +31,29 @@ exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ sor
 </template>
 "
 `;
+
+exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ template literal (no vueIndentScriptAndStyle) 1`] = `
+"<script setup>
+const a = \`
+  hello
+  world
+\`;
+</script>
+<template>
+  <div>{{ a }}</div>
+</template>
+"
+`;
+
+exports[`Format js-in-vue with prettier-plugin-oxfmt > should format .vue w/ template literal idempotently (vueIndentScriptAndStyle) 1`] = `
+"<script setup>
+  const a = \`
+  hello
+  world
+\`;
+</script>
+<template>
+  <div>{{ a }}</div>
+</template>
+"
+`;

--- a/apps/oxfmt/test/api/js-in-vue.test.ts
+++ b/apps/oxfmt/test/api/js-in-vue.test.ts
@@ -52,4 +52,55 @@ const cls = clsx("p-4 flex");
     expect(result.code).toMatchSnapshot();
     expect(result.errors).toStrictEqual([]);
   });
+
+  // https://github.com/oxc-project/oxc/issues/20084
+  it("should format .vue w/ template literal idempotently (vueIndentScriptAndStyle)", async () => {
+    const input = `
+<script setup>
+const a = \`
+  hello
+  world
+\`;
+</script>
+<template>
+  <div>{{ a }}</div>
+</template>
+`;
+    const result = await format("a.vue", input, {
+      vueIndentScriptAndStyle: true,
+    });
+
+    // Format again to verify idempotency
+    const result2 = await format("a.vue", result.code, {
+      vueIndentScriptAndStyle: true,
+    });
+
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+    expect(result2.code).toBe(result.code);
+    expect(result2.errors).toStrictEqual([]);
+  });
+
+  it("should format .vue w/ template literal (no vueIndentScriptAndStyle)", async () => {
+    const input = `
+<script setup>
+const a = \`
+  hello
+  world
+\`;
+</script>
+<template>
+  <div>{{ a }}</div>
+</template>
+`;
+    const result = await format("a.vue", input);
+
+    // Format again to verify idempotency
+    const result2 = await format("a.vue", result.code);
+
+    expect(result.code).toMatchSnapshot();
+    expect(result.errors).toStrictEqual([]);
+    expect(result2.code).toBe(result.code);
+    expect(result2.errors).toStrictEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #20084, closes #20085

Currently, in the context of `js-in-vue`, there are 2 types of code paths:

- Script block: `run_full()`
  - Converts a **string** formatted by `oxc_formatter` into Prettier's Doc format by splitting it into lines, joining with `hardline`
- Other cases: `run_fragment()`
  - Converts the **IR** formatted by `oxc_formatter` into Prettier's Doc format through an IR -> Doc implementation

The current issue can be described as a bug in the former.

As a result of simply splitting by lines, newlines within strings (newlines within `TemplateLiteral`s) are also treated as `hardline` (which are affected by parent indentation, it should be `literalline`), causing the nesting to deepen with each format.

To fix this, the former code path now also goes through an IR -> Doc conversion process.

Additionally, by doing this, the `printWidth` is also handled correctly.

In #20085, which involves re-converting a formatted string into an AST and then traversing it, was deemed undesirable.