### PR TITLE
fix(codegen): print decorators for FormalParameterRest

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -816,6 +816,7 @@ impl Gen for FormalParameter<'_> {
 impl Gen for FormalParameterRest<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
+        p.print_decorators(&self.decorators, ctx);
         self.rest.print(p, ctx);
         if let Some(type_annotation) = &self.type_annotation {
             p.print_colon();

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -12,6 +12,7 @@ use crate::tester::{
 fn cases() {
     test_same_ignore_parse_errors("class C {\n\t@foo static accessor A = @bar class {};\n}\n");
     test_same_ignore_parse_errors("function foo(@foo x = @bar class {}) {}\n");
+    test_same_ignore_parse_errors("function foo(@foo ...rest) {}\n");
 }
 
 #[test]


### PR DESCRIPTION
FormalParameterRest was missing decorator printing, so decorators on
rest parameters (e.g. `@foo ...rest`) were silently dropped during
code generation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>