### PR TITLE
refactor(apps, napi, tasks): remove `noUnusedLocals` from tsconfigs

### DIFF
--- a/apps/oxfmt/tsconfig.json
+++ b/apps/oxfmt/tsconfig.json
@@ -6,8 +6,7 @@
     "noEmit": true,
     "target": "ESNext",
     "strict": true,
-    "skipLibCheck": true,
-    "noUnusedLocals": true
+    "skipLibCheck": true
   },
   "include": ["scripts", "conformance/*.ts", "src-js", "test/**/*.ts"],
   "exclude": ["test/**/fixtures"]

--- a/apps/oxlint/src-js/visitor.test-d.ts
+++ b/apps/oxlint/src-js/visitor.test-d.ts
@@ -4,25 +4,23 @@ import type { Node, CallExpression } from "./generated/types.d.ts";
 
 // Empty visitor object is allowed
 const emptyVisitor = {};
-export type _Empty = ExpectTrue<ExpectExtends<VisitorObject, typeof emptyVisitor>>;
+type _Empty = ExpectTrue<ExpectExtends<VisitorObject, typeof emptyVisitor>>;
 
 // Specific node visitors have a stricter type for the parameter
 const callExpressionVisitor = {
   CallExpression: (_node: CallExpression) => {},
 };
-export type _CallExpr = ExpectTrue<ExpectExtends<VisitorObject, typeof callExpressionVisitor>>;
+type _CallExpr = ExpectTrue<ExpectExtends<VisitorObject, typeof callExpressionVisitor>>;
 
 const callExpressionExitVisitor = {
   "CallExpression:exit": (_node: CallExpression) => {},
 };
-export type _CallExprExit = ExpectTrue<
-  ExpectExtends<VisitorObject, typeof callExpressionExitVisitor>
->;
+type _CallExprExit = ExpectTrue<ExpectExtends<VisitorObject, typeof callExpressionExitVisitor>>;
 
 const debuggerStatementWrongTypeVisitor = {
   DebuggerStatement: (_node: CallExpression) => {},
 };
-export type _DebuggerStmtWrongType = ExpectFalse<
+type _DebuggerStmtWrongType = ExpectFalse<
   ExpectExtends<VisitorObject, typeof debuggerStatementWrongTypeVisitor>
 >;
 
@@ -31,13 +29,13 @@ const selectorsVisitor = {
   "FunctionExpression > Identifier": (_node: Node) => {},
   ":matches(FunctionExpression, FunctionDeclaration)": (_node: Node) => {},
 };
-export type _Selectors = ExpectTrue<ExpectExtends<VisitorObject, typeof selectorsVisitor>>;
+type _Selectors = ExpectTrue<ExpectExtends<VisitorObject, typeof selectorsVisitor>>;
 
 // Visitor functions can omit the node parameter
 const callExpressionNoParamVisitor = {
   CallExpression: () => {},
 };
-export type _CallExprNoParam = ExpectTrue<
+type _CallExprNoParam = ExpectTrue<
   ExpectExtends<VisitorObject, typeof callExpressionNoParamVisitor>
 >;
 
@@ -47,7 +45,7 @@ export type _CallExprNoParam = ExpectTrue<
 const callExpressionUndefinedVisitor = {
   CallExpression: undefined,
 };
-export type _CallExprUndefined = ExpectTrue<
+type _CallExprUndefined = ExpectTrue<
   ExpectExtends<VisitorObject, typeof callExpressionUndefinedVisitor>
 >;
 
@@ -55,14 +53,14 @@ export type _CallExprUndefined = ExpectTrue<
 const invalidNullVisitor = {
   CallExpression: null,
 };
-export type _InvalidNull = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidNullVisitor>>;
+type _InvalidNull = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidNullVisitor>>;
 
 const invalidObjectVisitor = {
   CallExpression: {},
 };
-export type _InvalidObject = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidObjectVisitor>>;
+type _InvalidObject = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidObjectVisitor>>;
 
 const invalidStringVisitor = {
   CallExpression: "oh dear",
 };
-export type _InvalidString = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidStringVisitor>>;
+type _InvalidString = ExpectFalse<ExpectExtends<VisitorObject, typeof invalidStringVisitor>>;

--- a/apps/oxlint/tsconfig.json
+++ b/apps/oxlint/tsconfig.json
@@ -7,8 +7,7 @@
     "target": "ESNext",
     "allowImportingTsExtensions": true,
     "strict": true,
-    "skipLibCheck": true,
-    "noUnusedLocals": true
+    "skipLibCheck": true
   },
   "exclude": ["node_modules", "fixtures", "test/fixtures/*/files", "conformance/submodules"]
 }

--- a/napi/minify/tsconfig.json
+++ b/napi/minify/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "target": "ESNext",
-    "noUnusedLocals": true
+    "target": "ESNext"
   }
 }

--- a/napi/parser/tsconfig.node.json
+++ b/napi/parser/tsconfig.node.json
@@ -6,7 +6,6 @@
     "noEmit": true,
     "target": "ESNext",
     "allowImportingTsExtensions": true,
-    "noUnusedLocals": true,
     "skipLibCheck": true,
     "strict": false
   },

--- a/napi/transform/tsconfig.json
+++ b/napi/transform/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "target": "ESNext",
-    "noUnusedLocals": true
+    "target": "ESNext"
   }
 }

--- a/tasks/e2e/tsconfig.json
+++ b/tasks/e2e/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "module": "esnext",
-    "noUnusedLocals": true,
     "strict": false
   }
 }


### PR DESCRIPTION
Remove `noUnusedLocals` option from `tsconfig.json` files. It's redundant, as Oxlint `no-unused-vars` covers this for us.

It's an annoyance to have `noUnusedLocals` enabled, as in VS Code TypeScript complains about unused vars, even if they're prefixed with `_`.

Removing this option allows simplifying type tests added in #20066. Only reason these types had to be exported was to stop TS complaining that they were unused.