### PR TITLE
fix(ci): install CA certificates on FreeBSD for Cargo 1.94

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -221,7 +221,7 @@ jobs:
           environment_variables: "DEBUG RUSTUP_IO_THREADS"
           shell: bash
           run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake
+            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"
@@ -506,7 +506,7 @@ jobs:
           environment_variables: "DEBUG RUSTUP_IO_THREADS"
           shell: bash
           run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake
+            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -184,7 +184,7 @@ jobs:
           environment_variables: "DEBUG RUSTUP_IO_THREADS"
           shell: bash
           run: |
-            sudo pkg install -y -f curl libnghttp2 node22 npm cmake
+            sudo pkg install -y -f curl libnghttp2 node22 npm cmake ca_root_nss
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"


### PR DESCRIPTION
## Summary
- Cargo 1.94.0 changed its TLS behavior and can no longer verify SSL certificates for `index.crates.io` on the FreeBSD CI VM without an explicit CA bundle
- Install `ca_root_nss` package (Mozilla's CA certificates) in all three FreeBSD `pkg install` commands across `release_apps.yml` and `reusable_release_napi.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)