### PR TITLE
fix(linter/plugins): include common chunks in `oxlint-plugin-eslint` package

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -141,6 +141,9 @@ export default defineConfig([
     ...pluginEslintPkgConfig,
     entry: pluginEslintRulesEntries,
     format: "commonjs",
+    outputOptions: {
+      chunkFileNames: "common/[name].cjs",
+    },
   },
 ]);
 

--- a/npm/oxlint-plugin-eslint/package.json
+++ b/npm/oxlint-plugin-eslint/package.json
@@ -23,6 +23,7 @@
   "files": [
     "index.js",
     "rules",
+    "common",
     "README.md"
   ],
   "type": "module",


### PR DESCRIPTION
Common chunks were not included in `files` key of `package.json` in `npm/oxlint-plugin-eslint`, so the package would have been broken when published. Fix that.