### PR TITLE
fix(linter/plugins): add license notice to `oxlint-plugin-eslint` package

### DIFF
--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -136,6 +136,16 @@ export default defineConfig([
     ...pluginEslintPkgConfig,
     entry: { index: "src-js/plugin-eslint/index.ts" },
     format: "esm",
+    banner: {
+      js: [
+        "/**",
+        " * ESLint's rules code copied from https://github.com/eslint/eslint",
+        " *",
+        " * License: MIT",
+        " * https://github.com/eslint/eslint/blob/a0d1a3772679d3d74bb860fc65b5b58678acd452/LICENSE",
+        " */",
+      ].join("\n"),
+    },
   },
   {
     ...pluginEslintPkgConfig,


### PR DESCRIPTION
`oxlint-plugin-eslint` package bundles all of ESLint's rules. Add a license header crediting ESLint for the code, and linking to the MIT license.