### PR TITLE
feat(linter): add Angular plugin with 48 rules ported from angular-eslint

### DIFF
--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -603,7 +603,7 @@ mod test {
             serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::TYPESCRIPT | LintPlugins::UNICORN));
         let config: Oxlintrc =
-            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue"] }"#).unwrap();
+            serde_json::from_str(r#"{ "plugins": ["typescript", "unicorn", "react", "oxc", "import", "jsdoc", "jest", "vitest", "jsx-a11y", "nextjs", "react-perf", "promise", "node", "vue", "angular"] }"#).unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::all()));
 
         let config: Oxlintrc =

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -94,6 +94,8 @@ bitflags! {
         const NODE = 1 << 12;
         /// `eslint-plugin-vue`
         const VUE = 1 << 13;
+        /// Angular 20 linting rules
+        const ANGULAR = 1 << 14;
     }
 }
 
@@ -129,6 +131,12 @@ impl LintPlugins {
     pub fn has_import(self) -> bool {
         self.contains(LintPlugins::IMPORT)
     }
+
+    /// Returns `true` if the Angular plugin is enabled.
+    #[inline]
+    pub fn has_angular(self) -> bool {
+        self.contains(LintPlugins::ANGULAR)
+    }
 }
 
 impl TryFrom<&str> for LintPlugins {
@@ -158,6 +166,7 @@ impl TryFrom<&str> for LintPlugins {
             "promise" => Ok(LintPlugins::PROMISE),
             "node" => Ok(LintPlugins::NODE),
             "vue" => Ok(LintPlugins::VUE),
+            "angular" => Ok(LintPlugins::ANGULAR),
             // "eslint" is not really a plugin, so it's 'empty'. This has the added benefit of
             // making it the default value.
             "eslint" => Ok(LintPlugins::ESLINT),
@@ -183,6 +192,7 @@ impl From<LintPlugins> for &'static str {
             LintPlugins::PROMISE => "promise",
             LintPlugins::NODE => "node",
             LintPlugins::VUE => "vue",
+            LintPlugins::ANGULAR => "angular",
             _ => "",
         }
     }
@@ -254,6 +264,7 @@ impl JsonSchema for LintPlugins {
             Promise,
             Node,
             Vue,
+            Angular,
         }
 
         let enum_schema = r#gen.subschema_for::<LintPluginOptionsSchema>();

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -480,6 +480,11 @@ impl<'a> ContextHost<'a> {
             self.frameworks.set(FrameworkFlags::Jest, jest_like);
         }
 
+        if self.plugins().has_angular() {
+            let angular_like = frameworks::has_angular_imports(self.module_record());
+            self.frameworks.set(FrameworkFlags::Angular, angular_like);
+        }
+
         self
     }
 

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -69,6 +69,11 @@ impl FrameworkFlags {
     pub const fn is_jest(self) -> bool {
         self.contains(Self::Jest)
     }
+
+    #[inline]
+    pub const fn is_angular(self) -> bool {
+        self.contains(Self::Angular)
+    }
 }
 
 /// <https://jestjs.io/docs/configuration#testmatch-arraystring>
@@ -94,6 +99,14 @@ pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
 
 pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
     module_record.import_entries.iter().any(|entry| entry.module_request.name() == "@jest/globals")
+}
+
+/// Check if a file has Angular-related imports from `@angular/*` packages.
+pub fn has_angular_imports(module_record: &ModuleRecord) -> bool {
+    module_record.import_entries.iter().any(|entry| {
+        let name = entry.module_request.name();
+        name.starts_with("@angular/")
+    })
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4434,3 +4434,298 @@ impl RuleRunner for crate::rules::vue::valid_define_props::ValidDefineProps {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
+
+impl RuleRunner for crate::rules::angular::no_host_metadata_property::NoHostMetadataProperty {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_control_flow::PreferControlFlow {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_output_readonly::PreferOutputReadonly {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::PropertyDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_signals::PreferSignals {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_standalone::PreferStandalone {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::component_class_suffix::ComponentClassSuffix {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::component_selector::ComponentSelector {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::directive_class_suffix::DirectiveClassSuffix {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::directive_selector::DirectiveSelector {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::contextual_lifecycle::ContextualLifecycle {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_empty_lifecycle_method::NoEmptyLifecycleMethod {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_lifecycle_call::NoLifecycleCall {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::sort_lifecycle_methods::SortLifecycleMethods {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::use_lifecycle_interface::UseLifecycleInterface {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_inject::PreferInject {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_on_push_component_change_detection::PreferOnPushComponentChangeDetection {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::use_injectable_provided_in::UseInjectableProvidedIn {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_input_rename::NoInputRename {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_inputs_metadata_property::NoInputsMetadataProperty {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_output_native::NoOutputNative {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::PropertyDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_output_on_prefix::NoOutputOnPrefix {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::PropertyDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_output_rename::NoOutputRename {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_outputs_metadata_property::NoOutputsMetadataProperty {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_pipe_impure::NoPipeImpure {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::pipe_prefix::PipePrefix {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::use_pipe_transform_interface::UsePipeTransformInterface {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::relative_url_prefix::RelativeUrlPrefix {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::use_component_selector::UseComponentSelector {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::use_component_view_encapsulation::UseComponentViewEncapsulation
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_attribute_decorator::NoAttributeDecorator {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::component_max_inline_declarations::ComponentMaxInlineDeclarations
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::computed_must_return::ComputedMustReturn {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::consistent_component_styles::ConsistentComponentStyles {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::contextual_decorator::ContextualDecorator {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_async_lifecycle_method::NoAsyncLifecycleMethod {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::MethodDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_conflicting_lifecycle::NoConflictingLifecycle {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::no_duplicates_in_metadata_arrays::NoDuplicatesInMetadataArrays
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_forward_ref::NoForwardRef {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::no_implicit_take_until_destroyed::NoImplicitTakeUntilDestroyed
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_input_prefix::NoInputPrefix {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::no_queries_metadata_property::NoQueriesMetadataProperty {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::prefer_host_metadata_property::PreferHostMetadataProperty
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_output_emitter_ref::PreferOutputEmitterRef {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::prefer_signal_model::PreferSignalModel {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Class]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner
+    for crate::rules::angular::require_lifecycle_on_prototype::RequireLifecycleOnPrototype
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::PropertyDefinition]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::require_localize_metadata::RequireLocalizeMetadata {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::runtime_localize::RuntimeLocalize {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TaggedTemplateExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::angular::sort_keys_in_type_decorator::SortKeysInTypeDecorator {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::Decorator]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -8,6 +8,54 @@
     clippy::missing_errors_doc,
     clippy::match_same_arms
 )]
+pub use crate::rules::angular::component_class_suffix::ComponentClassSuffix as AngularComponentClassSuffix;
+pub use crate::rules::angular::component_max_inline_declarations::ComponentMaxInlineDeclarations as AngularComponentMaxInlineDeclarations;
+pub use crate::rules::angular::component_selector::ComponentSelector as AngularComponentSelector;
+pub use crate::rules::angular::computed_must_return::ComputedMustReturn as AngularComputedMustReturn;
+pub use crate::rules::angular::consistent_component_styles::ConsistentComponentStyles as AngularConsistentComponentStyles;
+pub use crate::rules::angular::contextual_decorator::ContextualDecorator as AngularContextualDecorator;
+pub use crate::rules::angular::contextual_lifecycle::ContextualLifecycle as AngularContextualLifecycle;
+pub use crate::rules::angular::directive_class_suffix::DirectiveClassSuffix as AngularDirectiveClassSuffix;
+pub use crate::rules::angular::directive_selector::DirectiveSelector as AngularDirectiveSelector;
+pub use crate::rules::angular::no_async_lifecycle_method::NoAsyncLifecycleMethod as AngularNoAsyncLifecycleMethod;
+pub use crate::rules::angular::no_attribute_decorator::NoAttributeDecorator as AngularNoAttributeDecorator;
+pub use crate::rules::angular::no_conflicting_lifecycle::NoConflictingLifecycle as AngularNoConflictingLifecycle;
+pub use crate::rules::angular::no_duplicates_in_metadata_arrays::NoDuplicatesInMetadataArrays as AngularNoDuplicatesInMetadataArrays;
+pub use crate::rules::angular::no_empty_lifecycle_method::NoEmptyLifecycleMethod as AngularNoEmptyLifecycleMethod;
+pub use crate::rules::angular::no_forward_ref::NoForwardRef as AngularNoForwardRef;
+pub use crate::rules::angular::no_host_metadata_property::NoHostMetadataProperty as AngularNoHostMetadataProperty;
+pub use crate::rules::angular::no_implicit_take_until_destroyed::NoImplicitTakeUntilDestroyed as AngularNoImplicitTakeUntilDestroyed;
+pub use crate::rules::angular::no_input_prefix::NoInputPrefix as AngularNoInputPrefix;
+pub use crate::rules::angular::no_input_rename::NoInputRename as AngularNoInputRename;
+pub use crate::rules::angular::no_inputs_metadata_property::NoInputsMetadataProperty as AngularNoInputsMetadataProperty;
+pub use crate::rules::angular::no_lifecycle_call::NoLifecycleCall as AngularNoLifecycleCall;
+pub use crate::rules::angular::no_output_native::NoOutputNative as AngularNoOutputNative;
+pub use crate::rules::angular::no_output_on_prefix::NoOutputOnPrefix as AngularNoOutputOnPrefix;
+pub use crate::rules::angular::no_output_rename::NoOutputRename as AngularNoOutputRename;
+pub use crate::rules::angular::no_outputs_metadata_property::NoOutputsMetadataProperty as AngularNoOutputsMetadataProperty;
+pub use crate::rules::angular::no_pipe_impure::NoPipeImpure as AngularNoPipeImpure;
+pub use crate::rules::angular::no_queries_metadata_property::NoQueriesMetadataProperty as AngularNoQueriesMetadataProperty;
+pub use crate::rules::angular::pipe_prefix::PipePrefix as AngularPipePrefix;
+pub use crate::rules::angular::prefer_control_flow::PreferControlFlow as AngularPreferControlFlow;
+pub use crate::rules::angular::prefer_host_metadata_property::PreferHostMetadataProperty as AngularPreferHostMetadataProperty;
+pub use crate::rules::angular::prefer_inject::PreferInject as AngularPreferInject;
+pub use crate::rules::angular::prefer_on_push_component_change_detection::PreferOnPushComponentChangeDetection as AngularPreferOnPushComponentChangeDetection;
+pub use crate::rules::angular::prefer_output_emitter_ref::PreferOutputEmitterRef as AngularPreferOutputEmitterRef;
+pub use crate::rules::angular::prefer_output_readonly::PreferOutputReadonly as AngularPreferOutputReadonly;
+pub use crate::rules::angular::prefer_signal_model::PreferSignalModel as AngularPreferSignalModel;
+pub use crate::rules::angular::prefer_signals::PreferSignals as AngularPreferSignals;
+pub use crate::rules::angular::prefer_standalone::PreferStandalone as AngularPreferStandalone;
+pub use crate::rules::angular::relative_url_prefix::RelativeUrlPrefix as AngularRelativeUrlPrefix;
+pub use crate::rules::angular::require_lifecycle_on_prototype::RequireLifecycleOnPrototype as AngularRequireLifecycleOnPrototype;
+pub use crate::rules::angular::require_localize_metadata::RequireLocalizeMetadata as AngularRequireLocalizeMetadata;
+pub use crate::rules::angular::runtime_localize::RuntimeLocalize as AngularRuntimeLocalize;
+pub use crate::rules::angular::sort_keys_in_type_decorator::SortKeysInTypeDecorator as AngularSortKeysInTypeDecorator;
+pub use crate::rules::angular::sort_lifecycle_methods::SortLifecycleMethods as AngularSortLifecycleMethods;
+pub use crate::rules::angular::use_component_selector::UseComponentSelector as AngularUseComponentSelector;
+pub use crate::rules::angular::use_component_view_encapsulation::UseComponentViewEncapsulation as AngularUseComponentViewEncapsulation;
+pub use crate::rules::angular::use_injectable_provided_in::UseInjectableProvidedIn as AngularUseInjectableProvidedIn;
+pub use crate::rules::angular::use_lifecycle_interface::UseLifecycleInterface as AngularUseLifecycleInterface;
+pub use crate::rules::angular::use_pipe_transform_interface::UsePipeTransformInterface as AngularUsePipeTransformInterface;
 pub use crate::rules::eslint::accessor_pairs::AccessorPairs as EslintAccessorPairs;
 pub use crate::rules::eslint::array_callback_return::ArrayCallbackReturn as EslintArrayCallbackReturn;
 pub use crate::rules::eslint::arrow_body_style::ArrowBodyStyle as EslintArrowBodyStyle;
@@ -1413,6 +1461,54 @@ pub enum RuleEnum {
     VueRequireTypedRef(VueRequireTypedRef),
     VueValidDefineEmits(VueValidDefineEmits),
     VueValidDefineProps(VueValidDefineProps),
+    AngularNoHostMetadataProperty(AngularNoHostMetadataProperty),
+    AngularPreferControlFlow(AngularPreferControlFlow),
+    AngularPreferOutputReadonly(AngularPreferOutputReadonly),
+    AngularPreferSignals(AngularPreferSignals),
+    AngularPreferStandalone(AngularPreferStandalone),
+    AngularComponentClassSuffix(AngularComponentClassSuffix),
+    AngularComponentSelector(AngularComponentSelector),
+    AngularDirectiveClassSuffix(AngularDirectiveClassSuffix),
+    AngularDirectiveSelector(AngularDirectiveSelector),
+    AngularContextualLifecycle(AngularContextualLifecycle),
+    AngularNoEmptyLifecycleMethod(AngularNoEmptyLifecycleMethod),
+    AngularNoLifecycleCall(AngularNoLifecycleCall),
+    AngularSortLifecycleMethods(AngularSortLifecycleMethods),
+    AngularUseLifecycleInterface(AngularUseLifecycleInterface),
+    AngularPreferInject(AngularPreferInject),
+    AngularPreferOnPushComponentChangeDetection(AngularPreferOnPushComponentChangeDetection),
+    AngularUseInjectableProvidedIn(AngularUseInjectableProvidedIn),
+    AngularNoInputRename(AngularNoInputRename),
+    AngularNoInputsMetadataProperty(AngularNoInputsMetadataProperty),
+    AngularNoOutputNative(AngularNoOutputNative),
+    AngularNoOutputOnPrefix(AngularNoOutputOnPrefix),
+    AngularNoOutputRename(AngularNoOutputRename),
+    AngularNoOutputsMetadataProperty(AngularNoOutputsMetadataProperty),
+    AngularNoPipeImpure(AngularNoPipeImpure),
+    AngularPipePrefix(AngularPipePrefix),
+    AngularUsePipeTransformInterface(AngularUsePipeTransformInterface),
+    AngularRelativeUrlPrefix(AngularRelativeUrlPrefix),
+    AngularUseComponentSelector(AngularUseComponentSelector),
+    AngularUseComponentViewEncapsulation(AngularUseComponentViewEncapsulation),
+    AngularNoAttributeDecorator(AngularNoAttributeDecorator),
+    AngularComponentMaxInlineDeclarations(AngularComponentMaxInlineDeclarations),
+    AngularComputedMustReturn(AngularComputedMustReturn),
+    AngularConsistentComponentStyles(AngularConsistentComponentStyles),
+    AngularContextualDecorator(AngularContextualDecorator),
+    AngularNoAsyncLifecycleMethod(AngularNoAsyncLifecycleMethod),
+    AngularNoConflictingLifecycle(AngularNoConflictingLifecycle),
+    AngularNoDuplicatesInMetadataArrays(AngularNoDuplicatesInMetadataArrays),
+    AngularNoForwardRef(AngularNoForwardRef),
+    AngularNoImplicitTakeUntilDestroyed(AngularNoImplicitTakeUntilDestroyed),
+    AngularNoInputPrefix(AngularNoInputPrefix),
+    AngularNoQueriesMetadataProperty(AngularNoQueriesMetadataProperty),
+    AngularPreferHostMetadataProperty(AngularPreferHostMetadataProperty),
+    AngularPreferOutputEmitterRef(AngularPreferOutputEmitterRef),
+    AngularPreferSignalModel(AngularPreferSignalModel),
+    AngularRequireLifecycleOnPrototype(AngularRequireLifecycleOnPrototype),
+    AngularRequireLocalizeMetadata(AngularRequireLocalizeMetadata),
+    AngularRuntimeLocalize(AngularRuntimeLocalize),
+    AngularSortKeysInTypeDecorator(AngularSortKeysInTypeDecorator),
 }
 const IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID: usize = 0usize;
 const IMPORT_DEFAULT_ID: usize = IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID + 1usize;
@@ -2193,6 +2289,64 @@ const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1us
 const VUE_REQUIRE_TYPED_REF_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
 const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_REQUIRE_TYPED_REF_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
+const ANGULAR_NO_HOST_METADATA_PROPERTY_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
+const ANGULAR_PREFER_CONTROL_FLOW_ID: usize = ANGULAR_NO_HOST_METADATA_PROPERTY_ID + 1usize;
+const ANGULAR_PREFER_OUTPUT_READONLY_ID: usize = ANGULAR_PREFER_CONTROL_FLOW_ID + 1usize;
+const ANGULAR_PREFER_SIGNALS_ID: usize = ANGULAR_PREFER_OUTPUT_READONLY_ID + 1usize;
+const ANGULAR_PREFER_STANDALONE_ID: usize = ANGULAR_PREFER_SIGNALS_ID + 1usize;
+const ANGULAR_COMPONENT_CLASS_SUFFIX_ID: usize = ANGULAR_PREFER_STANDALONE_ID + 1usize;
+const ANGULAR_COMPONENT_SELECTOR_ID: usize = ANGULAR_COMPONENT_CLASS_SUFFIX_ID + 1usize;
+const ANGULAR_DIRECTIVE_CLASS_SUFFIX_ID: usize = ANGULAR_COMPONENT_SELECTOR_ID + 1usize;
+const ANGULAR_DIRECTIVE_SELECTOR_ID: usize = ANGULAR_DIRECTIVE_CLASS_SUFFIX_ID + 1usize;
+const ANGULAR_CONTEXTUAL_LIFECYCLE_ID: usize = ANGULAR_DIRECTIVE_SELECTOR_ID + 1usize;
+const ANGULAR_NO_EMPTY_LIFECYCLE_METHOD_ID: usize = ANGULAR_CONTEXTUAL_LIFECYCLE_ID + 1usize;
+const ANGULAR_NO_LIFECYCLE_CALL_ID: usize = ANGULAR_NO_EMPTY_LIFECYCLE_METHOD_ID + 1usize;
+const ANGULAR_SORT_LIFECYCLE_METHODS_ID: usize = ANGULAR_NO_LIFECYCLE_CALL_ID + 1usize;
+const ANGULAR_USE_LIFECYCLE_INTERFACE_ID: usize = ANGULAR_SORT_LIFECYCLE_METHODS_ID + 1usize;
+const ANGULAR_PREFER_INJECT_ID: usize = ANGULAR_USE_LIFECYCLE_INTERFACE_ID + 1usize;
+const ANGULAR_PREFER_ON_PUSH_COMPONENT_CHANGE_DETECTION_ID: usize =
+    ANGULAR_PREFER_INJECT_ID + 1usize;
+const ANGULAR_USE_INJECTABLE_PROVIDED_IN_ID: usize =
+    ANGULAR_PREFER_ON_PUSH_COMPONENT_CHANGE_DETECTION_ID + 1usize;
+const ANGULAR_NO_INPUT_RENAME_ID: usize = ANGULAR_USE_INJECTABLE_PROVIDED_IN_ID + 1usize;
+const ANGULAR_NO_INPUTS_METADATA_PROPERTY_ID: usize = ANGULAR_NO_INPUT_RENAME_ID + 1usize;
+const ANGULAR_NO_OUTPUT_NATIVE_ID: usize = ANGULAR_NO_INPUTS_METADATA_PROPERTY_ID + 1usize;
+const ANGULAR_NO_OUTPUT_ON_PREFIX_ID: usize = ANGULAR_NO_OUTPUT_NATIVE_ID + 1usize;
+const ANGULAR_NO_OUTPUT_RENAME_ID: usize = ANGULAR_NO_OUTPUT_ON_PREFIX_ID + 1usize;
+const ANGULAR_NO_OUTPUTS_METADATA_PROPERTY_ID: usize = ANGULAR_NO_OUTPUT_RENAME_ID + 1usize;
+const ANGULAR_NO_PIPE_IMPURE_ID: usize = ANGULAR_NO_OUTPUTS_METADATA_PROPERTY_ID + 1usize;
+const ANGULAR_PIPE_PREFIX_ID: usize = ANGULAR_NO_PIPE_IMPURE_ID + 1usize;
+const ANGULAR_USE_PIPE_TRANSFORM_INTERFACE_ID: usize = ANGULAR_PIPE_PREFIX_ID + 1usize;
+const ANGULAR_RELATIVE_URL_PREFIX_ID: usize = ANGULAR_USE_PIPE_TRANSFORM_INTERFACE_ID + 1usize;
+const ANGULAR_USE_COMPONENT_SELECTOR_ID: usize = ANGULAR_RELATIVE_URL_PREFIX_ID + 1usize;
+const ANGULAR_USE_COMPONENT_VIEW_ENCAPSULATION_ID: usize =
+    ANGULAR_USE_COMPONENT_SELECTOR_ID + 1usize;
+const ANGULAR_NO_ATTRIBUTE_DECORATOR_ID: usize =
+    ANGULAR_USE_COMPONENT_VIEW_ENCAPSULATION_ID + 1usize;
+const ANGULAR_COMPONENT_MAX_INLINE_DECLARATIONS_ID: usize =
+    ANGULAR_NO_ATTRIBUTE_DECORATOR_ID + 1usize;
+const ANGULAR_COMPUTED_MUST_RETURN_ID: usize =
+    ANGULAR_COMPONENT_MAX_INLINE_DECLARATIONS_ID + 1usize;
+const ANGULAR_CONSISTENT_COMPONENT_STYLES_ID: usize = ANGULAR_COMPUTED_MUST_RETURN_ID + 1usize;
+const ANGULAR_CONTEXTUAL_DECORATOR_ID: usize = ANGULAR_CONSISTENT_COMPONENT_STYLES_ID + 1usize;
+const ANGULAR_NO_ASYNC_LIFECYCLE_METHOD_ID: usize = ANGULAR_CONTEXTUAL_DECORATOR_ID + 1usize;
+const ANGULAR_NO_CONFLICTING_LIFECYCLE_ID: usize = ANGULAR_NO_ASYNC_LIFECYCLE_METHOD_ID + 1usize;
+const ANGULAR_NO_DUPLICATES_IN_METADATA_ARRAYS_ID: usize =
+    ANGULAR_NO_CONFLICTING_LIFECYCLE_ID + 1usize;
+const ANGULAR_NO_FORWARD_REF_ID: usize = ANGULAR_NO_DUPLICATES_IN_METADATA_ARRAYS_ID + 1usize;
+const ANGULAR_NO_IMPLICIT_TAKE_UNTIL_DESTROYED_ID: usize = ANGULAR_NO_FORWARD_REF_ID + 1usize;
+const ANGULAR_NO_INPUT_PREFIX_ID: usize = ANGULAR_NO_IMPLICIT_TAKE_UNTIL_DESTROYED_ID + 1usize;
+const ANGULAR_NO_QUERIES_METADATA_PROPERTY_ID: usize = ANGULAR_NO_INPUT_PREFIX_ID + 1usize;
+const ANGULAR_PREFER_HOST_METADATA_PROPERTY_ID: usize =
+    ANGULAR_NO_QUERIES_METADATA_PROPERTY_ID + 1usize;
+const ANGULAR_PREFER_OUTPUT_EMITTER_REF_ID: usize =
+    ANGULAR_PREFER_HOST_METADATA_PROPERTY_ID + 1usize;
+const ANGULAR_PREFER_SIGNAL_MODEL_ID: usize = ANGULAR_PREFER_OUTPUT_EMITTER_REF_ID + 1usize;
+const ANGULAR_REQUIRE_LIFECYCLE_ON_PROTOTYPE_ID: usize = ANGULAR_PREFER_SIGNAL_MODEL_ID + 1usize;
+const ANGULAR_REQUIRE_LOCALIZE_METADATA_ID: usize =
+    ANGULAR_REQUIRE_LIFECYCLE_ON_PROTOTYPE_ID + 1usize;
+const ANGULAR_RUNTIME_LOCALIZE_ID: usize = ANGULAR_REQUIRE_LOCALIZE_METADATA_ID + 1usize;
+const ANGULAR_SORT_KEYS_IN_TYPE_DECORATOR_ID: usize = ANGULAR_RUNTIME_LOCALIZE_ID + 1usize;
 impl RuleEnum {
     pub fn id(&self) -> usize {
         match self {
@@ -3000,6 +3154,66 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VUE_REQUIRE_TYPED_REF_ID,
             Self::VueValidDefineEmits(_) => VUE_VALID_DEFINE_EMITS_ID,
             Self::VueValidDefineProps(_) => VUE_VALID_DEFINE_PROPS_ID,
+            Self::AngularNoHostMetadataProperty(_) => ANGULAR_NO_HOST_METADATA_PROPERTY_ID,
+            Self::AngularPreferControlFlow(_) => ANGULAR_PREFER_CONTROL_FLOW_ID,
+            Self::AngularPreferOutputReadonly(_) => ANGULAR_PREFER_OUTPUT_READONLY_ID,
+            Self::AngularPreferSignals(_) => ANGULAR_PREFER_SIGNALS_ID,
+            Self::AngularPreferStandalone(_) => ANGULAR_PREFER_STANDALONE_ID,
+            Self::AngularComponentClassSuffix(_) => ANGULAR_COMPONENT_CLASS_SUFFIX_ID,
+            Self::AngularComponentSelector(_) => ANGULAR_COMPONENT_SELECTOR_ID,
+            Self::AngularDirectiveClassSuffix(_) => ANGULAR_DIRECTIVE_CLASS_SUFFIX_ID,
+            Self::AngularDirectiveSelector(_) => ANGULAR_DIRECTIVE_SELECTOR_ID,
+            Self::AngularContextualLifecycle(_) => ANGULAR_CONTEXTUAL_LIFECYCLE_ID,
+            Self::AngularNoEmptyLifecycleMethod(_) => ANGULAR_NO_EMPTY_LIFECYCLE_METHOD_ID,
+            Self::AngularNoLifecycleCall(_) => ANGULAR_NO_LIFECYCLE_CALL_ID,
+            Self::AngularSortLifecycleMethods(_) => ANGULAR_SORT_LIFECYCLE_METHODS_ID,
+            Self::AngularUseLifecycleInterface(_) => ANGULAR_USE_LIFECYCLE_INTERFACE_ID,
+            Self::AngularPreferInject(_) => ANGULAR_PREFER_INJECT_ID,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                ANGULAR_PREFER_ON_PUSH_COMPONENT_CHANGE_DETECTION_ID
+            }
+            Self::AngularUseInjectableProvidedIn(_) => ANGULAR_USE_INJECTABLE_PROVIDED_IN_ID,
+            Self::AngularNoInputRename(_) => ANGULAR_NO_INPUT_RENAME_ID,
+            Self::AngularNoInputsMetadataProperty(_) => ANGULAR_NO_INPUTS_METADATA_PROPERTY_ID,
+            Self::AngularNoOutputNative(_) => ANGULAR_NO_OUTPUT_NATIVE_ID,
+            Self::AngularNoOutputOnPrefix(_) => ANGULAR_NO_OUTPUT_ON_PREFIX_ID,
+            Self::AngularNoOutputRename(_) => ANGULAR_NO_OUTPUT_RENAME_ID,
+            Self::AngularNoOutputsMetadataProperty(_) => ANGULAR_NO_OUTPUTS_METADATA_PROPERTY_ID,
+            Self::AngularNoPipeImpure(_) => ANGULAR_NO_PIPE_IMPURE_ID,
+            Self::AngularPipePrefix(_) => ANGULAR_PIPE_PREFIX_ID,
+            Self::AngularUsePipeTransformInterface(_) => ANGULAR_USE_PIPE_TRANSFORM_INTERFACE_ID,
+            Self::AngularRelativeUrlPrefix(_) => ANGULAR_RELATIVE_URL_PREFIX_ID,
+            Self::AngularUseComponentSelector(_) => ANGULAR_USE_COMPONENT_SELECTOR_ID,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                ANGULAR_USE_COMPONENT_VIEW_ENCAPSULATION_ID
+            }
+            Self::AngularNoAttributeDecorator(_) => ANGULAR_NO_ATTRIBUTE_DECORATOR_ID,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                ANGULAR_COMPONENT_MAX_INLINE_DECLARATIONS_ID
+            }
+            Self::AngularComputedMustReturn(_) => ANGULAR_COMPUTED_MUST_RETURN_ID,
+            Self::AngularConsistentComponentStyles(_) => ANGULAR_CONSISTENT_COMPONENT_STYLES_ID,
+            Self::AngularContextualDecorator(_) => ANGULAR_CONTEXTUAL_DECORATOR_ID,
+            Self::AngularNoAsyncLifecycleMethod(_) => ANGULAR_NO_ASYNC_LIFECYCLE_METHOD_ID,
+            Self::AngularNoConflictingLifecycle(_) => ANGULAR_NO_CONFLICTING_LIFECYCLE_ID,
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                ANGULAR_NO_DUPLICATES_IN_METADATA_ARRAYS_ID
+            }
+            Self::AngularNoForwardRef(_) => ANGULAR_NO_FORWARD_REF_ID,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                ANGULAR_NO_IMPLICIT_TAKE_UNTIL_DESTROYED_ID
+            }
+            Self::AngularNoInputPrefix(_) => ANGULAR_NO_INPUT_PREFIX_ID,
+            Self::AngularNoQueriesMetadataProperty(_) => ANGULAR_NO_QUERIES_METADATA_PROPERTY_ID,
+            Self::AngularPreferHostMetadataProperty(_) => ANGULAR_PREFER_HOST_METADATA_PROPERTY_ID,
+            Self::AngularPreferOutputEmitterRef(_) => ANGULAR_PREFER_OUTPUT_EMITTER_REF_ID,
+            Self::AngularPreferSignalModel(_) => ANGULAR_PREFER_SIGNAL_MODEL_ID,
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                ANGULAR_REQUIRE_LIFECYCLE_ON_PROTOTYPE_ID
+            }
+            Self::AngularRequireLocalizeMetadata(_) => ANGULAR_REQUIRE_LOCALIZE_METADATA_ID,
+            Self::AngularRuntimeLocalize(_) => ANGULAR_RUNTIME_LOCALIZE_ID,
+            Self::AngularSortKeysInTypeDecorator(_) => ANGULAR_SORT_KEYS_IN_TYPE_DECORATOR_ID,
         }
     }
     pub fn name(&self) -> &'static str {
@@ -3796,6 +4010,64 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::NAME,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::NAME,
             Self::VueValidDefineProps(_) => VueValidDefineProps::NAME,
+            Self::AngularNoHostMetadataProperty(_) => AngularNoHostMetadataProperty::NAME,
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::NAME,
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::NAME,
+            Self::AngularPreferSignals(_) => AngularPreferSignals::NAME,
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::NAME,
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::NAME,
+            Self::AngularComponentSelector(_) => AngularComponentSelector::NAME,
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::NAME,
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::NAME,
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::NAME,
+            Self::AngularNoEmptyLifecycleMethod(_) => AngularNoEmptyLifecycleMethod::NAME,
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::NAME,
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::NAME,
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::NAME,
+            Self::AngularPreferInject(_) => AngularPreferInject::NAME,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::NAME
+            }
+            Self::AngularUseInjectableProvidedIn(_) => AngularUseInjectableProvidedIn::NAME,
+            Self::AngularNoInputRename(_) => AngularNoInputRename::NAME,
+            Self::AngularNoInputsMetadataProperty(_) => AngularNoInputsMetadataProperty::NAME,
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::NAME,
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::NAME,
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::NAME,
+            Self::AngularNoOutputsMetadataProperty(_) => AngularNoOutputsMetadataProperty::NAME,
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::NAME,
+            Self::AngularPipePrefix(_) => AngularPipePrefix::NAME,
+            Self::AngularUsePipeTransformInterface(_) => AngularUsePipeTransformInterface::NAME,
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::NAME,
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::NAME,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::NAME
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::NAME,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::NAME
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::NAME,
+            Self::AngularConsistentComponentStyles(_) => AngularConsistentComponentStyles::NAME,
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::NAME,
+            Self::AngularNoAsyncLifecycleMethod(_) => AngularNoAsyncLifecycleMethod::NAME,
+            Self::AngularNoConflictingLifecycle(_) => AngularNoConflictingLifecycle::NAME,
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::NAME
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::NAME,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::NAME
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::NAME,
+            Self::AngularNoQueriesMetadataProperty(_) => AngularNoQueriesMetadataProperty::NAME,
+            Self::AngularPreferHostMetadataProperty(_) => AngularPreferHostMetadataProperty::NAME,
+            Self::AngularPreferOutputEmitterRef(_) => AngularPreferOutputEmitterRef::NAME,
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::NAME,
+            Self::AngularRequireLifecycleOnPrototype(_) => AngularRequireLifecycleOnPrototype::NAME,
+            Self::AngularRequireLocalizeMetadata(_) => AngularRequireLocalizeMetadata::NAME,
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::NAME,
+            Self::AngularSortKeysInTypeDecorator(_) => AngularSortKeysInTypeDecorator::NAME,
         }
     }
     pub fn category(&self) -> RuleCategory {
@@ -4638,6 +4910,68 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::CATEGORY,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::CATEGORY,
             Self::VueValidDefineProps(_) => VueValidDefineProps::CATEGORY,
+            Self::AngularNoHostMetadataProperty(_) => AngularNoHostMetadataProperty::CATEGORY,
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::CATEGORY,
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::CATEGORY,
+            Self::AngularPreferSignals(_) => AngularPreferSignals::CATEGORY,
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::CATEGORY,
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::CATEGORY,
+            Self::AngularComponentSelector(_) => AngularComponentSelector::CATEGORY,
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::CATEGORY,
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::CATEGORY,
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::CATEGORY,
+            Self::AngularNoEmptyLifecycleMethod(_) => AngularNoEmptyLifecycleMethod::CATEGORY,
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::CATEGORY,
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::CATEGORY,
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::CATEGORY,
+            Self::AngularPreferInject(_) => AngularPreferInject::CATEGORY,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::CATEGORY
+            }
+            Self::AngularUseInjectableProvidedIn(_) => AngularUseInjectableProvidedIn::CATEGORY,
+            Self::AngularNoInputRename(_) => AngularNoInputRename::CATEGORY,
+            Self::AngularNoInputsMetadataProperty(_) => AngularNoInputsMetadataProperty::CATEGORY,
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::CATEGORY,
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::CATEGORY,
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::CATEGORY,
+            Self::AngularNoOutputsMetadataProperty(_) => AngularNoOutputsMetadataProperty::CATEGORY,
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::CATEGORY,
+            Self::AngularPipePrefix(_) => AngularPipePrefix::CATEGORY,
+            Self::AngularUsePipeTransformInterface(_) => AngularUsePipeTransformInterface::CATEGORY,
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::CATEGORY,
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::CATEGORY,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::CATEGORY
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::CATEGORY,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::CATEGORY
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::CATEGORY,
+            Self::AngularConsistentComponentStyles(_) => AngularConsistentComponentStyles::CATEGORY,
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::CATEGORY,
+            Self::AngularNoAsyncLifecycleMethod(_) => AngularNoAsyncLifecycleMethod::CATEGORY,
+            Self::AngularNoConflictingLifecycle(_) => AngularNoConflictingLifecycle::CATEGORY,
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::CATEGORY
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::CATEGORY,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::CATEGORY
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::CATEGORY,
+            Self::AngularNoQueriesMetadataProperty(_) => AngularNoQueriesMetadataProperty::CATEGORY,
+            Self::AngularPreferHostMetadataProperty(_) => {
+                AngularPreferHostMetadataProperty::CATEGORY
+            }
+            Self::AngularPreferOutputEmitterRef(_) => AngularPreferOutputEmitterRef::CATEGORY,
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::CATEGORY,
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                AngularRequireLifecycleOnPrototype::CATEGORY
+            }
+            Self::AngularRequireLocalizeMetadata(_) => AngularRequireLocalizeMetadata::CATEGORY,
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::CATEGORY,
+            Self::AngularSortKeysInTypeDecorator(_) => AngularSortKeysInTypeDecorator::CATEGORY,
         }
     }
     #[doc = r" This [`Rule`]'s auto-fix capabilities."]
@@ -5435,6 +5769,64 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::FIX,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::FIX,
             Self::VueValidDefineProps(_) => VueValidDefineProps::FIX,
+            Self::AngularNoHostMetadataProperty(_) => AngularNoHostMetadataProperty::FIX,
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::FIX,
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::FIX,
+            Self::AngularPreferSignals(_) => AngularPreferSignals::FIX,
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::FIX,
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::FIX,
+            Self::AngularComponentSelector(_) => AngularComponentSelector::FIX,
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::FIX,
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::FIX,
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::FIX,
+            Self::AngularNoEmptyLifecycleMethod(_) => AngularNoEmptyLifecycleMethod::FIX,
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::FIX,
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::FIX,
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::FIX,
+            Self::AngularPreferInject(_) => AngularPreferInject::FIX,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::FIX
+            }
+            Self::AngularUseInjectableProvidedIn(_) => AngularUseInjectableProvidedIn::FIX,
+            Self::AngularNoInputRename(_) => AngularNoInputRename::FIX,
+            Self::AngularNoInputsMetadataProperty(_) => AngularNoInputsMetadataProperty::FIX,
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::FIX,
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::FIX,
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::FIX,
+            Self::AngularNoOutputsMetadataProperty(_) => AngularNoOutputsMetadataProperty::FIX,
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::FIX,
+            Self::AngularPipePrefix(_) => AngularPipePrefix::FIX,
+            Self::AngularUsePipeTransformInterface(_) => AngularUsePipeTransformInterface::FIX,
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::FIX,
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::FIX,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::FIX
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::FIX,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::FIX
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::FIX,
+            Self::AngularConsistentComponentStyles(_) => AngularConsistentComponentStyles::FIX,
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::FIX,
+            Self::AngularNoAsyncLifecycleMethod(_) => AngularNoAsyncLifecycleMethod::FIX,
+            Self::AngularNoConflictingLifecycle(_) => AngularNoConflictingLifecycle::FIX,
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::FIX
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::FIX,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::FIX
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::FIX,
+            Self::AngularNoQueriesMetadataProperty(_) => AngularNoQueriesMetadataProperty::FIX,
+            Self::AngularPreferHostMetadataProperty(_) => AngularPreferHostMetadataProperty::FIX,
+            Self::AngularPreferOutputEmitterRef(_) => AngularPreferOutputEmitterRef::FIX,
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::FIX,
+            Self::AngularRequireLifecycleOnPrototype(_) => AngularRequireLifecycleOnPrototype::FIX,
+            Self::AngularRequireLocalizeMetadata(_) => AngularRequireLocalizeMetadata::FIX,
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::FIX,
+            Self::AngularSortKeysInTypeDecorator(_) => AngularSortKeysInTypeDecorator::FIX,
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -6430,6 +6822,94 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::documentation(),
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::documentation(),
             Self::VueValidDefineProps(_) => VueValidDefineProps::documentation(),
+            Self::AngularNoHostMetadataProperty(_) => {
+                AngularNoHostMetadataProperty::documentation()
+            }
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::documentation(),
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::documentation(),
+            Self::AngularPreferSignals(_) => AngularPreferSignals::documentation(),
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::documentation(),
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::documentation(),
+            Self::AngularComponentSelector(_) => AngularComponentSelector::documentation(),
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::documentation(),
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::documentation(),
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::documentation(),
+            Self::AngularNoEmptyLifecycleMethod(_) => {
+                AngularNoEmptyLifecycleMethod::documentation()
+            }
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::documentation(),
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::documentation(),
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::documentation(),
+            Self::AngularPreferInject(_) => AngularPreferInject::documentation(),
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::documentation()
+            }
+            Self::AngularUseInjectableProvidedIn(_) => {
+                AngularUseInjectableProvidedIn::documentation()
+            }
+            Self::AngularNoInputRename(_) => AngularNoInputRename::documentation(),
+            Self::AngularNoInputsMetadataProperty(_) => {
+                AngularNoInputsMetadataProperty::documentation()
+            }
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::documentation(),
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::documentation(),
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::documentation(),
+            Self::AngularNoOutputsMetadataProperty(_) => {
+                AngularNoOutputsMetadataProperty::documentation()
+            }
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::documentation(),
+            Self::AngularPipePrefix(_) => AngularPipePrefix::documentation(),
+            Self::AngularUsePipeTransformInterface(_) => {
+                AngularUsePipeTransformInterface::documentation()
+            }
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::documentation(),
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::documentation(),
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::documentation()
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::documentation(),
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::documentation()
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::documentation(),
+            Self::AngularConsistentComponentStyles(_) => {
+                AngularConsistentComponentStyles::documentation()
+            }
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::documentation(),
+            Self::AngularNoAsyncLifecycleMethod(_) => {
+                AngularNoAsyncLifecycleMethod::documentation()
+            }
+            Self::AngularNoConflictingLifecycle(_) => {
+                AngularNoConflictingLifecycle::documentation()
+            }
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::documentation()
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::documentation(),
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::documentation()
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::documentation(),
+            Self::AngularNoQueriesMetadataProperty(_) => {
+                AngularNoQueriesMetadataProperty::documentation()
+            }
+            Self::AngularPreferHostMetadataProperty(_) => {
+                AngularPreferHostMetadataProperty::documentation()
+            }
+            Self::AngularPreferOutputEmitterRef(_) => {
+                AngularPreferOutputEmitterRef::documentation()
+            }
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::documentation(),
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                AngularRequireLifecycleOnPrototype::documentation()
+            }
+            Self::AngularRequireLocalizeMetadata(_) => {
+                AngularRequireLocalizeMetadata::documentation()
+            }
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::documentation(),
+            Self::AngularSortKeysInTypeDecorator(_) => {
+                AngularSortKeysInTypeDecorator::documentation()
+            }
         }
     }
     #[cfg(feature = "ruledocs")]
@@ -8411,6 +8891,162 @@ impl RuleEnum {
                 .or_else(|| VueValidDefineEmits::schema(generator)),
             Self::VueValidDefineProps(_) => VueValidDefineProps::config_schema(generator)
                 .or_else(|| VueValidDefineProps::schema(generator)),
+            Self::AngularNoHostMetadataProperty(_) => {
+                AngularNoHostMetadataProperty::config_schema(generator)
+                    .or_else(|| AngularNoHostMetadataProperty::schema(generator))
+            }
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::config_schema(generator)
+                .or_else(|| AngularPreferControlFlow::schema(generator)),
+            Self::AngularPreferOutputReadonly(_) => {
+                AngularPreferOutputReadonly::config_schema(generator)
+                    .or_else(|| AngularPreferOutputReadonly::schema(generator))
+            }
+            Self::AngularPreferSignals(_) => AngularPreferSignals::config_schema(generator)
+                .or_else(|| AngularPreferSignals::schema(generator)),
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::config_schema(generator)
+                .or_else(|| AngularPreferStandalone::schema(generator)),
+            Self::AngularComponentClassSuffix(_) => {
+                AngularComponentClassSuffix::config_schema(generator)
+                    .or_else(|| AngularComponentClassSuffix::schema(generator))
+            }
+            Self::AngularComponentSelector(_) => AngularComponentSelector::config_schema(generator)
+                .or_else(|| AngularComponentSelector::schema(generator)),
+            Self::AngularDirectiveClassSuffix(_) => {
+                AngularDirectiveClassSuffix::config_schema(generator)
+                    .or_else(|| AngularDirectiveClassSuffix::schema(generator))
+            }
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::config_schema(generator)
+                .or_else(|| AngularDirectiveSelector::schema(generator)),
+            Self::AngularContextualLifecycle(_) => {
+                AngularContextualLifecycle::config_schema(generator)
+                    .or_else(|| AngularContextualLifecycle::schema(generator))
+            }
+            Self::AngularNoEmptyLifecycleMethod(_) => {
+                AngularNoEmptyLifecycleMethod::config_schema(generator)
+                    .or_else(|| AngularNoEmptyLifecycleMethod::schema(generator))
+            }
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::config_schema(generator)
+                .or_else(|| AngularNoLifecycleCall::schema(generator)),
+            Self::AngularSortLifecycleMethods(_) => {
+                AngularSortLifecycleMethods::config_schema(generator)
+                    .or_else(|| AngularSortLifecycleMethods::schema(generator))
+            }
+            Self::AngularUseLifecycleInterface(_) => {
+                AngularUseLifecycleInterface::config_schema(generator)
+                    .or_else(|| AngularUseLifecycleInterface::schema(generator))
+            }
+            Self::AngularPreferInject(_) => AngularPreferInject::config_schema(generator)
+                .or_else(|| AngularPreferInject::schema(generator)),
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::config_schema(generator)
+                    .or_else(|| AngularPreferOnPushComponentChangeDetection::schema(generator))
+            }
+            Self::AngularUseInjectableProvidedIn(_) => {
+                AngularUseInjectableProvidedIn::config_schema(generator)
+                    .or_else(|| AngularUseInjectableProvidedIn::schema(generator))
+            }
+            Self::AngularNoInputRename(_) => AngularNoInputRename::config_schema(generator)
+                .or_else(|| AngularNoInputRename::schema(generator)),
+            Self::AngularNoInputsMetadataProperty(_) => {
+                AngularNoInputsMetadataProperty::config_schema(generator)
+                    .or_else(|| AngularNoInputsMetadataProperty::schema(generator))
+            }
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::config_schema(generator)
+                .or_else(|| AngularNoOutputNative::schema(generator)),
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::config_schema(generator)
+                .or_else(|| AngularNoOutputOnPrefix::schema(generator)),
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::config_schema(generator)
+                .or_else(|| AngularNoOutputRename::schema(generator)),
+            Self::AngularNoOutputsMetadataProperty(_) => {
+                AngularNoOutputsMetadataProperty::config_schema(generator)
+                    .or_else(|| AngularNoOutputsMetadataProperty::schema(generator))
+            }
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::config_schema(generator)
+                .or_else(|| AngularNoPipeImpure::schema(generator)),
+            Self::AngularPipePrefix(_) => AngularPipePrefix::config_schema(generator)
+                .or_else(|| AngularPipePrefix::schema(generator)),
+            Self::AngularUsePipeTransformInterface(_) => {
+                AngularUsePipeTransformInterface::config_schema(generator)
+                    .or_else(|| AngularUsePipeTransformInterface::schema(generator))
+            }
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::config_schema(generator)
+                .or_else(|| AngularRelativeUrlPrefix::schema(generator)),
+            Self::AngularUseComponentSelector(_) => {
+                AngularUseComponentSelector::config_schema(generator)
+                    .or_else(|| AngularUseComponentSelector::schema(generator))
+            }
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::config_schema(generator)
+                    .or_else(|| AngularUseComponentViewEncapsulation::schema(generator))
+            }
+            Self::AngularNoAttributeDecorator(_) => {
+                AngularNoAttributeDecorator::config_schema(generator)
+                    .or_else(|| AngularNoAttributeDecorator::schema(generator))
+            }
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::config_schema(generator)
+                    .or_else(|| AngularComponentMaxInlineDeclarations::schema(generator))
+            }
+            Self::AngularComputedMustReturn(_) => {
+                AngularComputedMustReturn::config_schema(generator)
+                    .or_else(|| AngularComputedMustReturn::schema(generator))
+            }
+            Self::AngularConsistentComponentStyles(_) => {
+                AngularConsistentComponentStyles::config_schema(generator)
+                    .or_else(|| AngularConsistentComponentStyles::schema(generator))
+            }
+            Self::AngularContextualDecorator(_) => {
+                AngularContextualDecorator::config_schema(generator)
+                    .or_else(|| AngularContextualDecorator::schema(generator))
+            }
+            Self::AngularNoAsyncLifecycleMethod(_) => {
+                AngularNoAsyncLifecycleMethod::config_schema(generator)
+                    .or_else(|| AngularNoAsyncLifecycleMethod::schema(generator))
+            }
+            Self::AngularNoConflictingLifecycle(_) => {
+                AngularNoConflictingLifecycle::config_schema(generator)
+                    .or_else(|| AngularNoConflictingLifecycle::schema(generator))
+            }
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::config_schema(generator)
+                    .or_else(|| AngularNoDuplicatesInMetadataArrays::schema(generator))
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::config_schema(generator)
+                .or_else(|| AngularNoForwardRef::schema(generator)),
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::config_schema(generator)
+                    .or_else(|| AngularNoImplicitTakeUntilDestroyed::schema(generator))
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::config_schema(generator)
+                .or_else(|| AngularNoInputPrefix::schema(generator)),
+            Self::AngularNoQueriesMetadataProperty(_) => {
+                AngularNoQueriesMetadataProperty::config_schema(generator)
+                    .or_else(|| AngularNoQueriesMetadataProperty::schema(generator))
+            }
+            Self::AngularPreferHostMetadataProperty(_) => {
+                AngularPreferHostMetadataProperty::config_schema(generator)
+                    .or_else(|| AngularPreferHostMetadataProperty::schema(generator))
+            }
+            Self::AngularPreferOutputEmitterRef(_) => {
+                AngularPreferOutputEmitterRef::config_schema(generator)
+                    .or_else(|| AngularPreferOutputEmitterRef::schema(generator))
+            }
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::config_schema(generator)
+                .or_else(|| AngularPreferSignalModel::schema(generator)),
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                AngularRequireLifecycleOnPrototype::config_schema(generator)
+                    .or_else(|| AngularRequireLifecycleOnPrototype::schema(generator))
+            }
+            Self::AngularRequireLocalizeMetadata(_) => {
+                AngularRequireLocalizeMetadata::config_schema(generator)
+                    .or_else(|| AngularRequireLocalizeMetadata::schema(generator))
+            }
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::config_schema(generator)
+                .or_else(|| AngularRuntimeLocalize::schema(generator)),
+            Self::AngularSortKeysInTypeDecorator(_) => {
+                AngularSortKeysInTypeDecorator::config_schema(generator)
+                    .or_else(|| AngularSortKeysInTypeDecorator::schema(generator))
+            }
         }
     }
     pub fn plugin_name(&self) -> &'static str {
@@ -9111,6 +9747,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => "vue",
             Self::VueValidDefineEmits(_) => "vue",
             Self::VueValidDefineProps(_) => "vue",
+            Self::AngularNoHostMetadataProperty(_) => "angular",
+            Self::AngularPreferControlFlow(_) => "angular",
+            Self::AngularPreferOutputReadonly(_) => "angular",
+            Self::AngularPreferSignals(_) => "angular",
+            Self::AngularPreferStandalone(_) => "angular",
+            Self::AngularComponentClassSuffix(_) => "angular",
+            Self::AngularComponentSelector(_) => "angular",
+            Self::AngularDirectiveClassSuffix(_) => "angular",
+            Self::AngularDirectiveSelector(_) => "angular",
+            Self::AngularContextualLifecycle(_) => "angular",
+            Self::AngularNoEmptyLifecycleMethod(_) => "angular",
+            Self::AngularNoLifecycleCall(_) => "angular",
+            Self::AngularSortLifecycleMethods(_) => "angular",
+            Self::AngularUseLifecycleInterface(_) => "angular",
+            Self::AngularPreferInject(_) => "angular",
+            Self::AngularPreferOnPushComponentChangeDetection(_) => "angular",
+            Self::AngularUseInjectableProvidedIn(_) => "angular",
+            Self::AngularNoInputRename(_) => "angular",
+            Self::AngularNoInputsMetadataProperty(_) => "angular",
+            Self::AngularNoOutputNative(_) => "angular",
+            Self::AngularNoOutputOnPrefix(_) => "angular",
+            Self::AngularNoOutputRename(_) => "angular",
+            Self::AngularNoOutputsMetadataProperty(_) => "angular",
+            Self::AngularNoPipeImpure(_) => "angular",
+            Self::AngularPipePrefix(_) => "angular",
+            Self::AngularUsePipeTransformInterface(_) => "angular",
+            Self::AngularRelativeUrlPrefix(_) => "angular",
+            Self::AngularUseComponentSelector(_) => "angular",
+            Self::AngularUseComponentViewEncapsulation(_) => "angular",
+            Self::AngularNoAttributeDecorator(_) => "angular",
+            Self::AngularComponentMaxInlineDeclarations(_) => "angular",
+            Self::AngularComputedMustReturn(_) => "angular",
+            Self::AngularConsistentComponentStyles(_) => "angular",
+            Self::AngularContextualDecorator(_) => "angular",
+            Self::AngularNoAsyncLifecycleMethod(_) => "angular",
+            Self::AngularNoConflictingLifecycle(_) => "angular",
+            Self::AngularNoDuplicatesInMetadataArrays(_) => "angular",
+            Self::AngularNoForwardRef(_) => "angular",
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => "angular",
+            Self::AngularNoInputPrefix(_) => "angular",
+            Self::AngularNoQueriesMetadataProperty(_) => "angular",
+            Self::AngularPreferHostMetadataProperty(_) => "angular",
+            Self::AngularPreferOutputEmitterRef(_) => "angular",
+            Self::AngularPreferSignalModel(_) => "angular",
+            Self::AngularRequireLifecycleOnPrototype(_) => "angular",
+            Self::AngularRequireLocalizeMetadata(_) => "angular",
+            Self::AngularRuntimeLocalize(_) => "angular",
+            Self::AngularSortKeysInTypeDecorator(_) => "angular",
         }
     }
     pub fn from_configuration(
@@ -11350,6 +12034,172 @@ impl RuleEnum {
             Self::VueValidDefineProps(_) => {
                 Ok(Self::VueValidDefineProps(VueValidDefineProps::from_configuration(value)?))
             }
+            Self::AngularNoHostMetadataProperty(_) => Ok(Self::AngularNoHostMetadataProperty(
+                AngularNoHostMetadataProperty::from_configuration(value)?,
+            )),
+            Self::AngularPreferControlFlow(_) => Ok(Self::AngularPreferControlFlow(
+                AngularPreferControlFlow::from_configuration(value)?,
+            )),
+            Self::AngularPreferOutputReadonly(_) => Ok(Self::AngularPreferOutputReadonly(
+                AngularPreferOutputReadonly::from_configuration(value)?,
+            )),
+            Self::AngularPreferSignals(_) => {
+                Ok(Self::AngularPreferSignals(AngularPreferSignals::from_configuration(value)?))
+            }
+            Self::AngularPreferStandalone(_) => Ok(Self::AngularPreferStandalone(
+                AngularPreferStandalone::from_configuration(value)?,
+            )),
+            Self::AngularComponentClassSuffix(_) => Ok(Self::AngularComponentClassSuffix(
+                AngularComponentClassSuffix::from_configuration(value)?,
+            )),
+            Self::AngularComponentSelector(_) => Ok(Self::AngularComponentSelector(
+                AngularComponentSelector::from_configuration(value)?,
+            )),
+            Self::AngularDirectiveClassSuffix(_) => Ok(Self::AngularDirectiveClassSuffix(
+                AngularDirectiveClassSuffix::from_configuration(value)?,
+            )),
+            Self::AngularDirectiveSelector(_) => Ok(Self::AngularDirectiveSelector(
+                AngularDirectiveSelector::from_configuration(value)?,
+            )),
+            Self::AngularContextualLifecycle(_) => Ok(Self::AngularContextualLifecycle(
+                AngularContextualLifecycle::from_configuration(value)?,
+            )),
+            Self::AngularNoEmptyLifecycleMethod(_) => Ok(Self::AngularNoEmptyLifecycleMethod(
+                AngularNoEmptyLifecycleMethod::from_configuration(value)?,
+            )),
+            Self::AngularNoLifecycleCall(_) => {
+                Ok(Self::AngularNoLifecycleCall(AngularNoLifecycleCall::from_configuration(value)?))
+            }
+            Self::AngularSortLifecycleMethods(_) => Ok(Self::AngularSortLifecycleMethods(
+                AngularSortLifecycleMethods::from_configuration(value)?,
+            )),
+            Self::AngularUseLifecycleInterface(_) => Ok(Self::AngularUseLifecycleInterface(
+                AngularUseLifecycleInterface::from_configuration(value)?,
+            )),
+            Self::AngularPreferInject(_) => {
+                Ok(Self::AngularPreferInject(AngularPreferInject::from_configuration(value)?))
+            }
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                Ok(Self::AngularPreferOnPushComponentChangeDetection(
+                    AngularPreferOnPushComponentChangeDetection::from_configuration(value)?,
+                ))
+            }
+            Self::AngularUseInjectableProvidedIn(_) => Ok(Self::AngularUseInjectableProvidedIn(
+                AngularUseInjectableProvidedIn::from_configuration(value)?,
+            )),
+            Self::AngularNoInputRename(_) => {
+                Ok(Self::AngularNoInputRename(AngularNoInputRename::from_configuration(value)?))
+            }
+            Self::AngularNoInputsMetadataProperty(_) => Ok(Self::AngularNoInputsMetadataProperty(
+                AngularNoInputsMetadataProperty::from_configuration(value)?,
+            )),
+            Self::AngularNoOutputNative(_) => {
+                Ok(Self::AngularNoOutputNative(AngularNoOutputNative::from_configuration(value)?))
+            }
+            Self::AngularNoOutputOnPrefix(_) => Ok(Self::AngularNoOutputOnPrefix(
+                AngularNoOutputOnPrefix::from_configuration(value)?,
+            )),
+            Self::AngularNoOutputRename(_) => {
+                Ok(Self::AngularNoOutputRename(AngularNoOutputRename::from_configuration(value)?))
+            }
+            Self::AngularNoOutputsMetadataProperty(_) => {
+                Ok(Self::AngularNoOutputsMetadataProperty(
+                    AngularNoOutputsMetadataProperty::from_configuration(value)?,
+                ))
+            }
+            Self::AngularNoPipeImpure(_) => {
+                Ok(Self::AngularNoPipeImpure(AngularNoPipeImpure::from_configuration(value)?))
+            }
+            Self::AngularPipePrefix(_) => {
+                Ok(Self::AngularPipePrefix(AngularPipePrefix::from_configuration(value)?))
+            }
+            Self::AngularUsePipeTransformInterface(_) => {
+                Ok(Self::AngularUsePipeTransformInterface(
+                    AngularUsePipeTransformInterface::from_configuration(value)?,
+                ))
+            }
+            Self::AngularRelativeUrlPrefix(_) => Ok(Self::AngularRelativeUrlPrefix(
+                AngularRelativeUrlPrefix::from_configuration(value)?,
+            )),
+            Self::AngularUseComponentSelector(_) => Ok(Self::AngularUseComponentSelector(
+                AngularUseComponentSelector::from_configuration(value)?,
+            )),
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                Ok(Self::AngularUseComponentViewEncapsulation(
+                    AngularUseComponentViewEncapsulation::from_configuration(value)?,
+                ))
+            }
+            Self::AngularNoAttributeDecorator(_) => Ok(Self::AngularNoAttributeDecorator(
+                AngularNoAttributeDecorator::from_configuration(value)?,
+            )),
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                Ok(Self::AngularComponentMaxInlineDeclarations(
+                    AngularComponentMaxInlineDeclarations::from_configuration(value)?,
+                ))
+            }
+            Self::AngularComputedMustReturn(_) => Ok(Self::AngularComputedMustReturn(
+                AngularComputedMustReturn::from_configuration(value)?,
+            )),
+            Self::AngularConsistentComponentStyles(_) => {
+                Ok(Self::AngularConsistentComponentStyles(
+                    AngularConsistentComponentStyles::from_configuration(value)?,
+                ))
+            }
+            Self::AngularContextualDecorator(_) => Ok(Self::AngularContextualDecorator(
+                AngularContextualDecorator::from_configuration(value)?,
+            )),
+            Self::AngularNoAsyncLifecycleMethod(_) => Ok(Self::AngularNoAsyncLifecycleMethod(
+                AngularNoAsyncLifecycleMethod::from_configuration(value)?,
+            )),
+            Self::AngularNoConflictingLifecycle(_) => Ok(Self::AngularNoConflictingLifecycle(
+                AngularNoConflictingLifecycle::from_configuration(value)?,
+            )),
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                Ok(Self::AngularNoDuplicatesInMetadataArrays(
+                    AngularNoDuplicatesInMetadataArrays::from_configuration(value)?,
+                ))
+            }
+            Self::AngularNoForwardRef(_) => {
+                Ok(Self::AngularNoForwardRef(AngularNoForwardRef::from_configuration(value)?))
+            }
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                Ok(Self::AngularNoImplicitTakeUntilDestroyed(
+                    AngularNoImplicitTakeUntilDestroyed::from_configuration(value)?,
+                ))
+            }
+            Self::AngularNoInputPrefix(_) => {
+                Ok(Self::AngularNoInputPrefix(AngularNoInputPrefix::from_configuration(value)?))
+            }
+            Self::AngularNoQueriesMetadataProperty(_) => {
+                Ok(Self::AngularNoQueriesMetadataProperty(
+                    AngularNoQueriesMetadataProperty::from_configuration(value)?,
+                ))
+            }
+            Self::AngularPreferHostMetadataProperty(_) => {
+                Ok(Self::AngularPreferHostMetadataProperty(
+                    AngularPreferHostMetadataProperty::from_configuration(value)?,
+                ))
+            }
+            Self::AngularPreferOutputEmitterRef(_) => Ok(Self::AngularPreferOutputEmitterRef(
+                AngularPreferOutputEmitterRef::from_configuration(value)?,
+            )),
+            Self::AngularPreferSignalModel(_) => Ok(Self::AngularPreferSignalModel(
+                AngularPreferSignalModel::from_configuration(value)?,
+            )),
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                Ok(Self::AngularRequireLifecycleOnPrototype(
+                    AngularRequireLifecycleOnPrototype::from_configuration(value)?,
+                ))
+            }
+            Self::AngularRequireLocalizeMetadata(_) => Ok(Self::AngularRequireLocalizeMetadata(
+                AngularRequireLocalizeMetadata::from_configuration(value)?,
+            )),
+            Self::AngularRuntimeLocalize(_) => {
+                Ok(Self::AngularRuntimeLocalize(AngularRuntimeLocalize::from_configuration(value)?))
+            }
+            Self::AngularSortKeysInTypeDecorator(_) => Ok(Self::AngularSortKeysInTypeDecorator(
+                AngularSortKeysInTypeDecorator::from_configuration(value)?,
+            )),
         }
     }
     pub fn to_configuration(&self) -> Option<Result<serde_json::Value, serde_json::Error>> {
@@ -12054,6 +12904,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.to_configuration(),
             Self::VueValidDefineEmits(rule) => rule.to_configuration(),
             Self::VueValidDefineProps(rule) => rule.to_configuration(),
+            Self::AngularNoHostMetadataProperty(rule) => rule.to_configuration(),
+            Self::AngularPreferControlFlow(rule) => rule.to_configuration(),
+            Self::AngularPreferOutputReadonly(rule) => rule.to_configuration(),
+            Self::AngularPreferSignals(rule) => rule.to_configuration(),
+            Self::AngularPreferStandalone(rule) => rule.to_configuration(),
+            Self::AngularComponentClassSuffix(rule) => rule.to_configuration(),
+            Self::AngularComponentSelector(rule) => rule.to_configuration(),
+            Self::AngularDirectiveClassSuffix(rule) => rule.to_configuration(),
+            Self::AngularDirectiveSelector(rule) => rule.to_configuration(),
+            Self::AngularContextualLifecycle(rule) => rule.to_configuration(),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.to_configuration(),
+            Self::AngularNoLifecycleCall(rule) => rule.to_configuration(),
+            Self::AngularSortLifecycleMethods(rule) => rule.to_configuration(),
+            Self::AngularUseLifecycleInterface(rule) => rule.to_configuration(),
+            Self::AngularPreferInject(rule) => rule.to_configuration(),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.to_configuration(),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.to_configuration(),
+            Self::AngularNoInputRename(rule) => rule.to_configuration(),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.to_configuration(),
+            Self::AngularNoOutputNative(rule) => rule.to_configuration(),
+            Self::AngularNoOutputOnPrefix(rule) => rule.to_configuration(),
+            Self::AngularNoOutputRename(rule) => rule.to_configuration(),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.to_configuration(),
+            Self::AngularNoPipeImpure(rule) => rule.to_configuration(),
+            Self::AngularPipePrefix(rule) => rule.to_configuration(),
+            Self::AngularUsePipeTransformInterface(rule) => rule.to_configuration(),
+            Self::AngularRelativeUrlPrefix(rule) => rule.to_configuration(),
+            Self::AngularUseComponentSelector(rule) => rule.to_configuration(),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.to_configuration(),
+            Self::AngularNoAttributeDecorator(rule) => rule.to_configuration(),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.to_configuration(),
+            Self::AngularComputedMustReturn(rule) => rule.to_configuration(),
+            Self::AngularConsistentComponentStyles(rule) => rule.to_configuration(),
+            Self::AngularContextualDecorator(rule) => rule.to_configuration(),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.to_configuration(),
+            Self::AngularNoConflictingLifecycle(rule) => rule.to_configuration(),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.to_configuration(),
+            Self::AngularNoForwardRef(rule) => rule.to_configuration(),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.to_configuration(),
+            Self::AngularNoInputPrefix(rule) => rule.to_configuration(),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.to_configuration(),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.to_configuration(),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.to_configuration(),
+            Self::AngularPreferSignalModel(rule) => rule.to_configuration(),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.to_configuration(),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.to_configuration(),
+            Self::AngularRuntimeLocalize(rule) => rule.to_configuration(),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.to_configuration(),
         }
     }
     pub(crate) fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -12754,6 +13652,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.run(node, ctx),
             Self::VueValidDefineEmits(rule) => rule.run(node, ctx),
             Self::VueValidDefineProps(rule) => rule.run(node, ctx),
+            Self::AngularNoHostMetadataProperty(rule) => rule.run(node, ctx),
+            Self::AngularPreferControlFlow(rule) => rule.run(node, ctx),
+            Self::AngularPreferOutputReadonly(rule) => rule.run(node, ctx),
+            Self::AngularPreferSignals(rule) => rule.run(node, ctx),
+            Self::AngularPreferStandalone(rule) => rule.run(node, ctx),
+            Self::AngularComponentClassSuffix(rule) => rule.run(node, ctx),
+            Self::AngularComponentSelector(rule) => rule.run(node, ctx),
+            Self::AngularDirectiveClassSuffix(rule) => rule.run(node, ctx),
+            Self::AngularDirectiveSelector(rule) => rule.run(node, ctx),
+            Self::AngularContextualLifecycle(rule) => rule.run(node, ctx),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.run(node, ctx),
+            Self::AngularNoLifecycleCall(rule) => rule.run(node, ctx),
+            Self::AngularSortLifecycleMethods(rule) => rule.run(node, ctx),
+            Self::AngularUseLifecycleInterface(rule) => rule.run(node, ctx),
+            Self::AngularPreferInject(rule) => rule.run(node, ctx),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.run(node, ctx),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.run(node, ctx),
+            Self::AngularNoInputRename(rule) => rule.run(node, ctx),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.run(node, ctx),
+            Self::AngularNoOutputNative(rule) => rule.run(node, ctx),
+            Self::AngularNoOutputOnPrefix(rule) => rule.run(node, ctx),
+            Self::AngularNoOutputRename(rule) => rule.run(node, ctx),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.run(node, ctx),
+            Self::AngularNoPipeImpure(rule) => rule.run(node, ctx),
+            Self::AngularPipePrefix(rule) => rule.run(node, ctx),
+            Self::AngularUsePipeTransformInterface(rule) => rule.run(node, ctx),
+            Self::AngularRelativeUrlPrefix(rule) => rule.run(node, ctx),
+            Self::AngularUseComponentSelector(rule) => rule.run(node, ctx),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.run(node, ctx),
+            Self::AngularNoAttributeDecorator(rule) => rule.run(node, ctx),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.run(node, ctx),
+            Self::AngularComputedMustReturn(rule) => rule.run(node, ctx),
+            Self::AngularConsistentComponentStyles(rule) => rule.run(node, ctx),
+            Self::AngularContextualDecorator(rule) => rule.run(node, ctx),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.run(node, ctx),
+            Self::AngularNoConflictingLifecycle(rule) => rule.run(node, ctx),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.run(node, ctx),
+            Self::AngularNoForwardRef(rule) => rule.run(node, ctx),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.run(node, ctx),
+            Self::AngularNoInputPrefix(rule) => rule.run(node, ctx),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.run(node, ctx),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.run(node, ctx),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.run(node, ctx),
+            Self::AngularPreferSignalModel(rule) => rule.run(node, ctx),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.run(node, ctx),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.run(node, ctx),
+            Self::AngularRuntimeLocalize(rule) => rule.run(node, ctx),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.run(node, ctx),
         }
     }
     pub(crate) fn run_once(&self, ctx: &LintContext<'_>) {
@@ -13454,6 +14400,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.run_once(ctx),
             Self::VueValidDefineEmits(rule) => rule.run_once(ctx),
             Self::VueValidDefineProps(rule) => rule.run_once(ctx),
+            Self::AngularNoHostMetadataProperty(rule) => rule.run_once(ctx),
+            Self::AngularPreferControlFlow(rule) => rule.run_once(ctx),
+            Self::AngularPreferOutputReadonly(rule) => rule.run_once(ctx),
+            Self::AngularPreferSignals(rule) => rule.run_once(ctx),
+            Self::AngularPreferStandalone(rule) => rule.run_once(ctx),
+            Self::AngularComponentClassSuffix(rule) => rule.run_once(ctx),
+            Self::AngularComponentSelector(rule) => rule.run_once(ctx),
+            Self::AngularDirectiveClassSuffix(rule) => rule.run_once(ctx),
+            Self::AngularDirectiveSelector(rule) => rule.run_once(ctx),
+            Self::AngularContextualLifecycle(rule) => rule.run_once(ctx),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.run_once(ctx),
+            Self::AngularNoLifecycleCall(rule) => rule.run_once(ctx),
+            Self::AngularSortLifecycleMethods(rule) => rule.run_once(ctx),
+            Self::AngularUseLifecycleInterface(rule) => rule.run_once(ctx),
+            Self::AngularPreferInject(rule) => rule.run_once(ctx),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.run_once(ctx),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.run_once(ctx),
+            Self::AngularNoInputRename(rule) => rule.run_once(ctx),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.run_once(ctx),
+            Self::AngularNoOutputNative(rule) => rule.run_once(ctx),
+            Self::AngularNoOutputOnPrefix(rule) => rule.run_once(ctx),
+            Self::AngularNoOutputRename(rule) => rule.run_once(ctx),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.run_once(ctx),
+            Self::AngularNoPipeImpure(rule) => rule.run_once(ctx),
+            Self::AngularPipePrefix(rule) => rule.run_once(ctx),
+            Self::AngularUsePipeTransformInterface(rule) => rule.run_once(ctx),
+            Self::AngularRelativeUrlPrefix(rule) => rule.run_once(ctx),
+            Self::AngularUseComponentSelector(rule) => rule.run_once(ctx),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.run_once(ctx),
+            Self::AngularNoAttributeDecorator(rule) => rule.run_once(ctx),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.run_once(ctx),
+            Self::AngularComputedMustReturn(rule) => rule.run_once(ctx),
+            Self::AngularConsistentComponentStyles(rule) => rule.run_once(ctx),
+            Self::AngularContextualDecorator(rule) => rule.run_once(ctx),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.run_once(ctx),
+            Self::AngularNoConflictingLifecycle(rule) => rule.run_once(ctx),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.run_once(ctx),
+            Self::AngularNoForwardRef(rule) => rule.run_once(ctx),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.run_once(ctx),
+            Self::AngularNoInputPrefix(rule) => rule.run_once(ctx),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.run_once(ctx),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.run_once(ctx),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.run_once(ctx),
+            Self::AngularPreferSignalModel(rule) => rule.run_once(ctx),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.run_once(ctx),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.run_once(ctx),
+            Self::AngularRuntimeLocalize(rule) => rule.run_once(ctx),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.run_once(ctx),
         }
     }
     pub(crate) fn run_on_jest_node<'a, 'c>(
@@ -14254,6 +15248,64 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineEmits(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueValidDefineProps(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoHostMetadataProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferControlFlow(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferOutputReadonly(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferSignals(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferStandalone(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularComponentClassSuffix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularComponentSelector(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularDirectiveClassSuffix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularDirectiveSelector(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularContextualLifecycle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoLifecycleCall(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularSortLifecycleMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularUseLifecycleInterface(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferInject(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::AngularUseInjectableProvidedIn(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoInputRename(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoOutputNative(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoOutputOnPrefix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoOutputRename(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoPipeImpure(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPipePrefix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularUsePipeTransformInterface(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularRelativeUrlPrefix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularUseComponentSelector(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularUseComponentViewEncapsulation(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::AngularNoAttributeDecorator(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularComponentMaxInlineDeclarations(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::AngularComputedMustReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularConsistentComponentStyles(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularContextualDecorator(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoConflictingLifecycle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::AngularNoForwardRef(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => {
+                rule.run_on_jest_node(jest_node, ctx)
+            }
+            Self::AngularNoInputPrefix(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularPreferSignalModel(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularRuntimeLocalize(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.run_on_jest_node(jest_node, ctx),
         }
     }
     pub(crate) fn should_run(&self, ctx: &ContextHost) -> bool {
@@ -14954,6 +16006,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.should_run(ctx),
             Self::VueValidDefineEmits(rule) => rule.should_run(ctx),
             Self::VueValidDefineProps(rule) => rule.should_run(ctx),
+            Self::AngularNoHostMetadataProperty(rule) => rule.should_run(ctx),
+            Self::AngularPreferControlFlow(rule) => rule.should_run(ctx),
+            Self::AngularPreferOutputReadonly(rule) => rule.should_run(ctx),
+            Self::AngularPreferSignals(rule) => rule.should_run(ctx),
+            Self::AngularPreferStandalone(rule) => rule.should_run(ctx),
+            Self::AngularComponentClassSuffix(rule) => rule.should_run(ctx),
+            Self::AngularComponentSelector(rule) => rule.should_run(ctx),
+            Self::AngularDirectiveClassSuffix(rule) => rule.should_run(ctx),
+            Self::AngularDirectiveSelector(rule) => rule.should_run(ctx),
+            Self::AngularContextualLifecycle(rule) => rule.should_run(ctx),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.should_run(ctx),
+            Self::AngularNoLifecycleCall(rule) => rule.should_run(ctx),
+            Self::AngularSortLifecycleMethods(rule) => rule.should_run(ctx),
+            Self::AngularUseLifecycleInterface(rule) => rule.should_run(ctx),
+            Self::AngularPreferInject(rule) => rule.should_run(ctx),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.should_run(ctx),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.should_run(ctx),
+            Self::AngularNoInputRename(rule) => rule.should_run(ctx),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.should_run(ctx),
+            Self::AngularNoOutputNative(rule) => rule.should_run(ctx),
+            Self::AngularNoOutputOnPrefix(rule) => rule.should_run(ctx),
+            Self::AngularNoOutputRename(rule) => rule.should_run(ctx),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.should_run(ctx),
+            Self::AngularNoPipeImpure(rule) => rule.should_run(ctx),
+            Self::AngularPipePrefix(rule) => rule.should_run(ctx),
+            Self::AngularUsePipeTransformInterface(rule) => rule.should_run(ctx),
+            Self::AngularRelativeUrlPrefix(rule) => rule.should_run(ctx),
+            Self::AngularUseComponentSelector(rule) => rule.should_run(ctx),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.should_run(ctx),
+            Self::AngularNoAttributeDecorator(rule) => rule.should_run(ctx),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.should_run(ctx),
+            Self::AngularComputedMustReturn(rule) => rule.should_run(ctx),
+            Self::AngularConsistentComponentStyles(rule) => rule.should_run(ctx),
+            Self::AngularContextualDecorator(rule) => rule.should_run(ctx),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.should_run(ctx),
+            Self::AngularNoConflictingLifecycle(rule) => rule.should_run(ctx),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.should_run(ctx),
+            Self::AngularNoForwardRef(rule) => rule.should_run(ctx),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.should_run(ctx),
+            Self::AngularNoInputPrefix(rule) => rule.should_run(ctx),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.should_run(ctx),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.should_run(ctx),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.should_run(ctx),
+            Self::AngularPreferSignalModel(rule) => rule.should_run(ctx),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.should_run(ctx),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.should_run(ctx),
+            Self::AngularRuntimeLocalize(rule) => rule.should_run(ctx),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.should_run(ctx),
         }
     }
     pub fn is_tsgolint_rule(&self) -> bool {
@@ -15948,6 +17048,94 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::IS_TSGOLINT_RULE,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::IS_TSGOLINT_RULE,
             Self::VueValidDefineProps(_) => VueValidDefineProps::IS_TSGOLINT_RULE,
+            Self::AngularNoHostMetadataProperty(_) => {
+                AngularNoHostMetadataProperty::IS_TSGOLINT_RULE
+            }
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::IS_TSGOLINT_RULE,
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::IS_TSGOLINT_RULE,
+            Self::AngularPreferSignals(_) => AngularPreferSignals::IS_TSGOLINT_RULE,
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::IS_TSGOLINT_RULE,
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::IS_TSGOLINT_RULE,
+            Self::AngularComponentSelector(_) => AngularComponentSelector::IS_TSGOLINT_RULE,
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::IS_TSGOLINT_RULE,
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::IS_TSGOLINT_RULE,
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::IS_TSGOLINT_RULE,
+            Self::AngularNoEmptyLifecycleMethod(_) => {
+                AngularNoEmptyLifecycleMethod::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::IS_TSGOLINT_RULE,
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::IS_TSGOLINT_RULE,
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::IS_TSGOLINT_RULE,
+            Self::AngularPreferInject(_) => AngularPreferInject::IS_TSGOLINT_RULE,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::IS_TSGOLINT_RULE
+            }
+            Self::AngularUseInjectableProvidedIn(_) => {
+                AngularUseInjectableProvidedIn::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoInputRename(_) => AngularNoInputRename::IS_TSGOLINT_RULE,
+            Self::AngularNoInputsMetadataProperty(_) => {
+                AngularNoInputsMetadataProperty::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::IS_TSGOLINT_RULE,
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::IS_TSGOLINT_RULE,
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::IS_TSGOLINT_RULE,
+            Self::AngularNoOutputsMetadataProperty(_) => {
+                AngularNoOutputsMetadataProperty::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::IS_TSGOLINT_RULE,
+            Self::AngularPipePrefix(_) => AngularPipePrefix::IS_TSGOLINT_RULE,
+            Self::AngularUsePipeTransformInterface(_) => {
+                AngularUsePipeTransformInterface::IS_TSGOLINT_RULE
+            }
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::IS_TSGOLINT_RULE,
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::IS_TSGOLINT_RULE,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::IS_TSGOLINT_RULE,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::IS_TSGOLINT_RULE
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::IS_TSGOLINT_RULE,
+            Self::AngularConsistentComponentStyles(_) => {
+                AngularConsistentComponentStyles::IS_TSGOLINT_RULE
+            }
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::IS_TSGOLINT_RULE,
+            Self::AngularNoAsyncLifecycleMethod(_) => {
+                AngularNoAsyncLifecycleMethod::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoConflictingLifecycle(_) => {
+                AngularNoConflictingLifecycle::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::IS_TSGOLINT_RULE,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::IS_TSGOLINT_RULE
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::IS_TSGOLINT_RULE,
+            Self::AngularNoQueriesMetadataProperty(_) => {
+                AngularNoQueriesMetadataProperty::IS_TSGOLINT_RULE
+            }
+            Self::AngularPreferHostMetadataProperty(_) => {
+                AngularPreferHostMetadataProperty::IS_TSGOLINT_RULE
+            }
+            Self::AngularPreferOutputEmitterRef(_) => {
+                AngularPreferOutputEmitterRef::IS_TSGOLINT_RULE
+            }
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::IS_TSGOLINT_RULE,
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                AngularRequireLifecycleOnPrototype::IS_TSGOLINT_RULE
+            }
+            Self::AngularRequireLocalizeMetadata(_) => {
+                AngularRequireLocalizeMetadata::IS_TSGOLINT_RULE
+            }
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::IS_TSGOLINT_RULE,
+            Self::AngularSortKeysInTypeDecorator(_) => {
+                AngularSortKeysInTypeDecorator::IS_TSGOLINT_RULE
+            }
         }
     }
     #[doc = r" Whether this rule declares a configuration type."]
@@ -16817,6 +18005,76 @@ impl RuleEnum {
             Self::VueRequireTypedRef(_) => VueRequireTypedRef::HAS_CONFIG,
             Self::VueValidDefineEmits(_) => VueValidDefineEmits::HAS_CONFIG,
             Self::VueValidDefineProps(_) => VueValidDefineProps::HAS_CONFIG,
+            Self::AngularNoHostMetadataProperty(_) => AngularNoHostMetadataProperty::HAS_CONFIG,
+            Self::AngularPreferControlFlow(_) => AngularPreferControlFlow::HAS_CONFIG,
+            Self::AngularPreferOutputReadonly(_) => AngularPreferOutputReadonly::HAS_CONFIG,
+            Self::AngularPreferSignals(_) => AngularPreferSignals::HAS_CONFIG,
+            Self::AngularPreferStandalone(_) => AngularPreferStandalone::HAS_CONFIG,
+            Self::AngularComponentClassSuffix(_) => AngularComponentClassSuffix::HAS_CONFIG,
+            Self::AngularComponentSelector(_) => AngularComponentSelector::HAS_CONFIG,
+            Self::AngularDirectiveClassSuffix(_) => AngularDirectiveClassSuffix::HAS_CONFIG,
+            Self::AngularDirectiveSelector(_) => AngularDirectiveSelector::HAS_CONFIG,
+            Self::AngularContextualLifecycle(_) => AngularContextualLifecycle::HAS_CONFIG,
+            Self::AngularNoEmptyLifecycleMethod(_) => AngularNoEmptyLifecycleMethod::HAS_CONFIG,
+            Self::AngularNoLifecycleCall(_) => AngularNoLifecycleCall::HAS_CONFIG,
+            Self::AngularSortLifecycleMethods(_) => AngularSortLifecycleMethods::HAS_CONFIG,
+            Self::AngularUseLifecycleInterface(_) => AngularUseLifecycleInterface::HAS_CONFIG,
+            Self::AngularPreferInject(_) => AngularPreferInject::HAS_CONFIG,
+            Self::AngularPreferOnPushComponentChangeDetection(_) => {
+                AngularPreferOnPushComponentChangeDetection::HAS_CONFIG
+            }
+            Self::AngularUseInjectableProvidedIn(_) => AngularUseInjectableProvidedIn::HAS_CONFIG,
+            Self::AngularNoInputRename(_) => AngularNoInputRename::HAS_CONFIG,
+            Self::AngularNoInputsMetadataProperty(_) => AngularNoInputsMetadataProperty::HAS_CONFIG,
+            Self::AngularNoOutputNative(_) => AngularNoOutputNative::HAS_CONFIG,
+            Self::AngularNoOutputOnPrefix(_) => AngularNoOutputOnPrefix::HAS_CONFIG,
+            Self::AngularNoOutputRename(_) => AngularNoOutputRename::HAS_CONFIG,
+            Self::AngularNoOutputsMetadataProperty(_) => {
+                AngularNoOutputsMetadataProperty::HAS_CONFIG
+            }
+            Self::AngularNoPipeImpure(_) => AngularNoPipeImpure::HAS_CONFIG,
+            Self::AngularPipePrefix(_) => AngularPipePrefix::HAS_CONFIG,
+            Self::AngularUsePipeTransformInterface(_) => {
+                AngularUsePipeTransformInterface::HAS_CONFIG
+            }
+            Self::AngularRelativeUrlPrefix(_) => AngularRelativeUrlPrefix::HAS_CONFIG,
+            Self::AngularUseComponentSelector(_) => AngularUseComponentSelector::HAS_CONFIG,
+            Self::AngularUseComponentViewEncapsulation(_) => {
+                AngularUseComponentViewEncapsulation::HAS_CONFIG
+            }
+            Self::AngularNoAttributeDecorator(_) => AngularNoAttributeDecorator::HAS_CONFIG,
+            Self::AngularComponentMaxInlineDeclarations(_) => {
+                AngularComponentMaxInlineDeclarations::HAS_CONFIG
+            }
+            Self::AngularComputedMustReturn(_) => AngularComputedMustReturn::HAS_CONFIG,
+            Self::AngularConsistentComponentStyles(_) => {
+                AngularConsistentComponentStyles::HAS_CONFIG
+            }
+            Self::AngularContextualDecorator(_) => AngularContextualDecorator::HAS_CONFIG,
+            Self::AngularNoAsyncLifecycleMethod(_) => AngularNoAsyncLifecycleMethod::HAS_CONFIG,
+            Self::AngularNoConflictingLifecycle(_) => AngularNoConflictingLifecycle::HAS_CONFIG,
+            Self::AngularNoDuplicatesInMetadataArrays(_) => {
+                AngularNoDuplicatesInMetadataArrays::HAS_CONFIG
+            }
+            Self::AngularNoForwardRef(_) => AngularNoForwardRef::HAS_CONFIG,
+            Self::AngularNoImplicitTakeUntilDestroyed(_) => {
+                AngularNoImplicitTakeUntilDestroyed::HAS_CONFIG
+            }
+            Self::AngularNoInputPrefix(_) => AngularNoInputPrefix::HAS_CONFIG,
+            Self::AngularNoQueriesMetadataProperty(_) => {
+                AngularNoQueriesMetadataProperty::HAS_CONFIG
+            }
+            Self::AngularPreferHostMetadataProperty(_) => {
+                AngularPreferHostMetadataProperty::HAS_CONFIG
+            }
+            Self::AngularPreferOutputEmitterRef(_) => AngularPreferOutputEmitterRef::HAS_CONFIG,
+            Self::AngularPreferSignalModel(_) => AngularPreferSignalModel::HAS_CONFIG,
+            Self::AngularRequireLifecycleOnPrototype(_) => {
+                AngularRequireLifecycleOnPrototype::HAS_CONFIG
+            }
+            Self::AngularRequireLocalizeMetadata(_) => AngularRequireLocalizeMetadata::HAS_CONFIG,
+            Self::AngularRuntimeLocalize(_) => AngularRuntimeLocalize::HAS_CONFIG,
+            Self::AngularSortKeysInTypeDecorator(_) => AngularSortKeysInTypeDecorator::HAS_CONFIG,
         }
     }
     pub fn types_info(&self) -> Option<&'static AstTypesBitset> {
@@ -17517,6 +18775,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.types_info(),
             Self::VueValidDefineEmits(rule) => rule.types_info(),
             Self::VueValidDefineProps(rule) => rule.types_info(),
+            Self::AngularNoHostMetadataProperty(rule) => rule.types_info(),
+            Self::AngularPreferControlFlow(rule) => rule.types_info(),
+            Self::AngularPreferOutputReadonly(rule) => rule.types_info(),
+            Self::AngularPreferSignals(rule) => rule.types_info(),
+            Self::AngularPreferStandalone(rule) => rule.types_info(),
+            Self::AngularComponentClassSuffix(rule) => rule.types_info(),
+            Self::AngularComponentSelector(rule) => rule.types_info(),
+            Self::AngularDirectiveClassSuffix(rule) => rule.types_info(),
+            Self::AngularDirectiveSelector(rule) => rule.types_info(),
+            Self::AngularContextualLifecycle(rule) => rule.types_info(),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.types_info(),
+            Self::AngularNoLifecycleCall(rule) => rule.types_info(),
+            Self::AngularSortLifecycleMethods(rule) => rule.types_info(),
+            Self::AngularUseLifecycleInterface(rule) => rule.types_info(),
+            Self::AngularPreferInject(rule) => rule.types_info(),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.types_info(),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.types_info(),
+            Self::AngularNoInputRename(rule) => rule.types_info(),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.types_info(),
+            Self::AngularNoOutputNative(rule) => rule.types_info(),
+            Self::AngularNoOutputOnPrefix(rule) => rule.types_info(),
+            Self::AngularNoOutputRename(rule) => rule.types_info(),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.types_info(),
+            Self::AngularNoPipeImpure(rule) => rule.types_info(),
+            Self::AngularPipePrefix(rule) => rule.types_info(),
+            Self::AngularUsePipeTransformInterface(rule) => rule.types_info(),
+            Self::AngularRelativeUrlPrefix(rule) => rule.types_info(),
+            Self::AngularUseComponentSelector(rule) => rule.types_info(),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.types_info(),
+            Self::AngularNoAttributeDecorator(rule) => rule.types_info(),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.types_info(),
+            Self::AngularComputedMustReturn(rule) => rule.types_info(),
+            Self::AngularConsistentComponentStyles(rule) => rule.types_info(),
+            Self::AngularContextualDecorator(rule) => rule.types_info(),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.types_info(),
+            Self::AngularNoConflictingLifecycle(rule) => rule.types_info(),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.types_info(),
+            Self::AngularNoForwardRef(rule) => rule.types_info(),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.types_info(),
+            Self::AngularNoInputPrefix(rule) => rule.types_info(),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.types_info(),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.types_info(),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.types_info(),
+            Self::AngularPreferSignalModel(rule) => rule.types_info(),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.types_info(),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.types_info(),
+            Self::AngularRuntimeLocalize(rule) => rule.types_info(),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.types_info(),
         }
     }
     pub fn run_info(&self) -> RuleRunFunctionsImplemented {
@@ -18217,6 +19523,54 @@ impl RuleEnum {
             Self::VueRequireTypedRef(rule) => rule.run_info(),
             Self::VueValidDefineEmits(rule) => rule.run_info(),
             Self::VueValidDefineProps(rule) => rule.run_info(),
+            Self::AngularNoHostMetadataProperty(rule) => rule.run_info(),
+            Self::AngularPreferControlFlow(rule) => rule.run_info(),
+            Self::AngularPreferOutputReadonly(rule) => rule.run_info(),
+            Self::AngularPreferSignals(rule) => rule.run_info(),
+            Self::AngularPreferStandalone(rule) => rule.run_info(),
+            Self::AngularComponentClassSuffix(rule) => rule.run_info(),
+            Self::AngularComponentSelector(rule) => rule.run_info(),
+            Self::AngularDirectiveClassSuffix(rule) => rule.run_info(),
+            Self::AngularDirectiveSelector(rule) => rule.run_info(),
+            Self::AngularContextualLifecycle(rule) => rule.run_info(),
+            Self::AngularNoEmptyLifecycleMethod(rule) => rule.run_info(),
+            Self::AngularNoLifecycleCall(rule) => rule.run_info(),
+            Self::AngularSortLifecycleMethods(rule) => rule.run_info(),
+            Self::AngularUseLifecycleInterface(rule) => rule.run_info(),
+            Self::AngularPreferInject(rule) => rule.run_info(),
+            Self::AngularPreferOnPushComponentChangeDetection(rule) => rule.run_info(),
+            Self::AngularUseInjectableProvidedIn(rule) => rule.run_info(),
+            Self::AngularNoInputRename(rule) => rule.run_info(),
+            Self::AngularNoInputsMetadataProperty(rule) => rule.run_info(),
+            Self::AngularNoOutputNative(rule) => rule.run_info(),
+            Self::AngularNoOutputOnPrefix(rule) => rule.run_info(),
+            Self::AngularNoOutputRename(rule) => rule.run_info(),
+            Self::AngularNoOutputsMetadataProperty(rule) => rule.run_info(),
+            Self::AngularNoPipeImpure(rule) => rule.run_info(),
+            Self::AngularPipePrefix(rule) => rule.run_info(),
+            Self::AngularUsePipeTransformInterface(rule) => rule.run_info(),
+            Self::AngularRelativeUrlPrefix(rule) => rule.run_info(),
+            Self::AngularUseComponentSelector(rule) => rule.run_info(),
+            Self::AngularUseComponentViewEncapsulation(rule) => rule.run_info(),
+            Self::AngularNoAttributeDecorator(rule) => rule.run_info(),
+            Self::AngularComponentMaxInlineDeclarations(rule) => rule.run_info(),
+            Self::AngularComputedMustReturn(rule) => rule.run_info(),
+            Self::AngularConsistentComponentStyles(rule) => rule.run_info(),
+            Self::AngularContextualDecorator(rule) => rule.run_info(),
+            Self::AngularNoAsyncLifecycleMethod(rule) => rule.run_info(),
+            Self::AngularNoConflictingLifecycle(rule) => rule.run_info(),
+            Self::AngularNoDuplicatesInMetadataArrays(rule) => rule.run_info(),
+            Self::AngularNoForwardRef(rule) => rule.run_info(),
+            Self::AngularNoImplicitTakeUntilDestroyed(rule) => rule.run_info(),
+            Self::AngularNoInputPrefix(rule) => rule.run_info(),
+            Self::AngularNoQueriesMetadataProperty(rule) => rule.run_info(),
+            Self::AngularPreferHostMetadataProperty(rule) => rule.run_info(),
+            Self::AngularPreferOutputEmitterRef(rule) => rule.run_info(),
+            Self::AngularPreferSignalModel(rule) => rule.run_info(),
+            Self::AngularRequireLifecycleOnPrototype(rule) => rule.run_info(),
+            Self::AngularRequireLocalizeMetadata(rule) => rule.run_info(),
+            Self::AngularRuntimeLocalize(rule) => rule.run_info(),
+            Self::AngularSortKeysInTypeDecorator(rule) => rule.run_info(),
         }
     }
 }
@@ -19035,5 +20389,63 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueRequireTypedRef(VueRequireTypedRef::default()),
         RuleEnum::VueValidDefineEmits(VueValidDefineEmits::default()),
         RuleEnum::VueValidDefineProps(VueValidDefineProps::default()),
+        RuleEnum::AngularNoHostMetadataProperty(AngularNoHostMetadataProperty::default()),
+        RuleEnum::AngularPreferControlFlow(AngularPreferControlFlow::default()),
+        RuleEnum::AngularPreferOutputReadonly(AngularPreferOutputReadonly::default()),
+        RuleEnum::AngularPreferSignals(AngularPreferSignals::default()),
+        RuleEnum::AngularPreferStandalone(AngularPreferStandalone::default()),
+        RuleEnum::AngularComponentClassSuffix(AngularComponentClassSuffix::default()),
+        RuleEnum::AngularComponentSelector(AngularComponentSelector::default()),
+        RuleEnum::AngularDirectiveClassSuffix(AngularDirectiveClassSuffix::default()),
+        RuleEnum::AngularDirectiveSelector(AngularDirectiveSelector::default()),
+        RuleEnum::AngularContextualLifecycle(AngularContextualLifecycle::default()),
+        RuleEnum::AngularNoEmptyLifecycleMethod(AngularNoEmptyLifecycleMethod::default()),
+        RuleEnum::AngularNoLifecycleCall(AngularNoLifecycleCall::default()),
+        RuleEnum::AngularSortLifecycleMethods(AngularSortLifecycleMethods::default()),
+        RuleEnum::AngularUseLifecycleInterface(AngularUseLifecycleInterface::default()),
+        RuleEnum::AngularPreferInject(AngularPreferInject::default()),
+        RuleEnum::AngularPreferOnPushComponentChangeDetection(
+            AngularPreferOnPushComponentChangeDetection::default(),
+        ),
+        RuleEnum::AngularUseInjectableProvidedIn(AngularUseInjectableProvidedIn::default()),
+        RuleEnum::AngularNoInputRename(AngularNoInputRename::default()),
+        RuleEnum::AngularNoInputsMetadataProperty(AngularNoInputsMetadataProperty::default()),
+        RuleEnum::AngularNoOutputNative(AngularNoOutputNative::default()),
+        RuleEnum::AngularNoOutputOnPrefix(AngularNoOutputOnPrefix::default()),
+        RuleEnum::AngularNoOutputRename(AngularNoOutputRename::default()),
+        RuleEnum::AngularNoOutputsMetadataProperty(AngularNoOutputsMetadataProperty::default()),
+        RuleEnum::AngularNoPipeImpure(AngularNoPipeImpure::default()),
+        RuleEnum::AngularPipePrefix(AngularPipePrefix::default()),
+        RuleEnum::AngularUsePipeTransformInterface(AngularUsePipeTransformInterface::default()),
+        RuleEnum::AngularRelativeUrlPrefix(AngularRelativeUrlPrefix::default()),
+        RuleEnum::AngularUseComponentSelector(AngularUseComponentSelector::default()),
+        RuleEnum::AngularUseComponentViewEncapsulation(
+            AngularUseComponentViewEncapsulation::default(),
+        ),
+        RuleEnum::AngularNoAttributeDecorator(AngularNoAttributeDecorator::default()),
+        RuleEnum::AngularComponentMaxInlineDeclarations(
+            AngularComponentMaxInlineDeclarations::default(),
+        ),
+        RuleEnum::AngularComputedMustReturn(AngularComputedMustReturn::default()),
+        RuleEnum::AngularConsistentComponentStyles(AngularConsistentComponentStyles::default()),
+        RuleEnum::AngularContextualDecorator(AngularContextualDecorator::default()),
+        RuleEnum::AngularNoAsyncLifecycleMethod(AngularNoAsyncLifecycleMethod::default()),
+        RuleEnum::AngularNoConflictingLifecycle(AngularNoConflictingLifecycle::default()),
+        RuleEnum::AngularNoDuplicatesInMetadataArrays(
+            AngularNoDuplicatesInMetadataArrays::default(),
+        ),
+        RuleEnum::AngularNoForwardRef(AngularNoForwardRef::default()),
+        RuleEnum::AngularNoImplicitTakeUntilDestroyed(
+            AngularNoImplicitTakeUntilDestroyed::default(),
+        ),
+        RuleEnum::AngularNoInputPrefix(AngularNoInputPrefix::default()),
+        RuleEnum::AngularNoQueriesMetadataProperty(AngularNoQueriesMetadataProperty::default()),
+        RuleEnum::AngularPreferHostMetadataProperty(AngularPreferHostMetadataProperty::default()),
+        RuleEnum::AngularPreferOutputEmitterRef(AngularPreferOutputEmitterRef::default()),
+        RuleEnum::AngularPreferSignalModel(AngularPreferSignalModel::default()),
+        RuleEnum::AngularRequireLifecycleOnPrototype(AngularRequireLifecycleOnPrototype::default()),
+        RuleEnum::AngularRequireLocalizeMetadata(AngularRequireLocalizeMetadata::default()),
+        RuleEnum::AngularRuntimeLocalize(AngularRuntimeLocalize::default()),
+        RuleEnum::AngularSortKeysInTypeDecorator(AngularSortKeysInTypeDecorator::default()),
     ]
 });

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -746,6 +746,76 @@ pub(crate) mod vue {
     pub mod valid_define_props;
 }
 
+/// Angular 20 linting rules
+/// <https://angular.dev/guide/signals>
+pub(crate) mod angular {
+    // Phase 1: Original rules
+    pub mod no_host_metadata_property;
+    pub mod prefer_control_flow;
+    pub mod prefer_output_readonly;
+    pub mod prefer_signals;
+    pub mod prefer_standalone;
+
+    // Phase 2.5: Naming convention rules
+    pub mod component_class_suffix;
+    pub mod component_selector;
+    pub mod directive_class_suffix;
+    pub mod directive_selector;
+
+    // Phase 2.6: Lifecycle rules
+    pub mod contextual_lifecycle;
+    pub mod no_empty_lifecycle_method;
+    pub mod no_lifecycle_call;
+    pub mod sort_lifecycle_methods;
+    pub mod use_lifecycle_interface;
+
+    // Phase 2.7: Modern DI & Performance rules
+    pub mod prefer_inject;
+    pub mod prefer_on_push_component_change_detection;
+    pub mod use_injectable_provided_in;
+
+    // Phase 2.8: Input/Output rules
+    pub mod no_input_rename;
+    pub mod no_inputs_metadata_property;
+    pub mod no_output_native;
+    pub mod no_output_on_prefix;
+    pub mod no_output_rename;
+    pub mod no_outputs_metadata_property;
+
+    // Phase 2.9: Pipe rules
+    pub mod no_pipe_impure;
+    pub mod pipe_prefix;
+    pub mod use_pipe_transform_interface;
+
+    // Phase 2.10: Component architecture rules
+    pub mod relative_url_prefix;
+    pub mod use_component_selector;
+    pub mod use_component_view_encapsulation;
+
+    // Phase 2.11: Additional rules
+    pub mod no_attribute_decorator;
+
+    // Phase 3: Additional rules for angular-eslint parity
+    pub mod component_max_inline_declarations;
+    pub mod computed_must_return;
+    pub mod consistent_component_styles;
+    pub mod contextual_decorator;
+    pub mod no_async_lifecycle_method;
+    pub mod no_conflicting_lifecycle;
+    pub mod no_duplicates_in_metadata_arrays;
+    pub mod no_forward_ref;
+    pub mod no_implicit_take_until_destroyed;
+    pub mod no_input_prefix;
+    pub mod no_queries_metadata_property;
+    pub mod prefer_host_metadata_property;
+    pub mod prefer_output_emitter_ref;
+    pub mod prefer_signal_model;
+    pub mod require_lifecycle_on_prototype;
+    pub mod require_localize_metadata;
+    pub mod runtime_localize;
+    pub mod sort_keys_in_type_decorator;
+}
+
 // Re-export RuleEnum, RULES, and all rule type aliases from generated code
 pub use crate::generated::rules_enum::*;
 

--- a/crates/oxc_linter/src/rules/angular/README.md
+++ b/crates/oxc_linter/src/rules/angular/README.md
@@ -1,0 +1,239 @@
+# Angular Plugin for Oxlint
+
+This plugin provides Angular-specific linting rules for oxlint, ported from [angular-eslint](https://github.com/angular-eslint/angular-eslint).
+
+## Implementation Status
+
+The Angular plugin implements **48 rules** covering component/directive conventions, lifecycle methods, signals, inputs/outputs, pipes, and more. This represents near-complete parity with angular-eslint's TypeScript rules.
+
+## Implemented Rules
+
+### Component/Directive Rules
+
+| Rule                                        | Category    | Description                                                           |
+| ------------------------------------------- | ----------- | --------------------------------------------------------------------- |
+| `component-class-suffix`                    | correctness | Ensures component classes end with 'Component' or a custom suffix     |
+| `component-max-inline-declarations`         | style       | Enforces maximum lines for inline template/styles/animations          |
+| `component-selector`                        | correctness | Validates component selector naming conventions (prefix, style, type) |
+| `consistent-component-styles`               | style       | Enforces consistent usage of `styles`/`styleUrl`/`styleUrls`          |
+| `directive-class-suffix`                    | correctness | Ensures directive classes end with 'Directive' or a custom suffix     |
+| `directive-selector`                        | correctness | Validates directive selector naming conventions                       |
+| `no-host-metadata-property`                 | style       | Disallows `host` metadata property in decorators                      |
+| `prefer-host-metadata-property`             | style       | Prefers `host` metadata over `@HostBinding`/`@HostListener`           |
+| `prefer-on-push-component-change-detection` | style       | Enforces OnPush change detection strategy                             |
+| `prefer-standalone`                         | style       | Enforces standalone components (Angular 14+)                          |
+| `relative-url-prefix`                       | correctness | Ensures relative URLs start with `./` or `../`                        |
+| `use-component-selector`                    | correctness | Ensures components have a selector defined                            |
+| `use-component-view-encapsulation`          | style       | Disallows ViewEncapsulation.None                                      |
+
+### Lifecycle Rules
+
+| Rule                             | Category    | Description                                           |
+| -------------------------------- | ----------- | ----------------------------------------------------- |
+| `contextual-lifecycle`           | correctness | Ensures lifecycle methods match the decorator context |
+| `no-async-lifecycle-method`      | correctness | Disallows async lifecycle methods                     |
+| `no-conflicting-lifecycle`       | correctness | Disallows implementing both DoCheck and OnChanges     |
+| `no-empty-lifecycle-method`      | correctness | Disallows empty lifecycle methods                     |
+| `no-lifecycle-call`              | correctness | Disallows explicit lifecycle method calls             |
+| `require-lifecycle-on-prototype` | correctness | Ensures lifecycle methods on prototype, not instance  |
+| `sort-lifecycle-methods`         | style       | Ensures lifecycle methods are in canonical order      |
+| `use-lifecycle-interface`        | correctness | Ensures lifecycle interface implementation            |
+
+### Signal Rules
+
+| Rule                        | Category    | Description                                   |
+| --------------------------- | ----------- | --------------------------------------------- |
+| `computed-must-return`      | correctness | Ensures `computed()` signals return a value   |
+| `prefer-output-emitter-ref` | style       | Prefers `output()` over `@Output()` decorator |
+| `prefer-signal-model`       | style       | Suggests `model()` for input/output pairs     |
+| `prefer-signals`            | style       | Enforces signal-based APIs over decorators    |
+
+### Input/Output Rules
+
+| Rule                           | Category    | Description                             |
+| ------------------------------ | ----------- | --------------------------------------- |
+| `no-input-prefix`              | style       | Disallows certain input name prefixes   |
+| `no-input-rename`              | correctness | Disallows input aliasing                |
+| `no-inputs-metadata-property`  | style       | Disallows `inputs` metadata property    |
+| `no-output-native`             | correctness | Disallows native event names as outputs |
+| `no-output-on-prefix`          | style       | Disallows "on" prefix for outputs       |
+| `no-output-rename`             | correctness | Disallows output aliasing               |
+| `no-outputs-metadata-property` | style       | Disallows `outputs` metadata property   |
+| `prefer-output-readonly`       | correctness | Enforces readonly on outputs            |
+
+### Pipe Rules
+
+| Rule                           | Category    | Description                                    |
+| ------------------------------ | ----------- | ---------------------------------------------- |
+| `no-pipe-impure`               | style       | Disallows impure pipes                         |
+| `pipe-prefix`                  | style       | Enforces pipe name prefix conventions          |
+| `use-pipe-transform-interface` | correctness | Ensures PipeTransform interface implementation |
+
+### Decorator Rules
+
+| Rule                               | Category    | Description                                           |
+| ---------------------------------- | ----------- | ----------------------------------------------------- |
+| `contextual-decorator`             | correctness | Ensures decorators used in appropriate class contexts |
+| `no-attribute-decorator`           | style       | Disallows `@Attribute` decorator                      |
+| `no-duplicates-in-metadata-arrays` | correctness | Disallows duplicates in metadata arrays               |
+| `no-queries-metadata-property`     | style       | Disallows `queries` metadata property                 |
+| `sort-keys-in-type-decorator`      | style       | Orders decorator properties consistently              |
+
+### Dependency Injection Rules
+
+| Rule                         | Category    | Description                                   |
+| ---------------------------- | ----------- | --------------------------------------------- |
+| `no-forward-ref`             | style       | Disallows `forwardRef()` usage                |
+| `prefer-inject`              | style       | Prefers `inject()` over constructor injection |
+| `use-injectable-provided-in` | correctness | Ensures `providedIn` in `@Injectable`         |
+
+### Localization Rules
+
+| Rule                        | Category | Description                              |
+| --------------------------- | -------- | ---------------------------------------- |
+| `require-localize-metadata` | pedantic | Ensures `$localize` has metadata         |
+| `runtime-localize`          | pedantic | Prevents `$localize` at module load time |
+
+### Other Rules
+
+| Rule                               | Category    | Description                                    |
+| ---------------------------------- | ----------- | ---------------------------------------------- |
+| `no-implicit-take-until-destroyed` | correctness | Requires DestroyRef for `takeUntilDestroyed()` |
+| `prefer-control-flow`              | style       | Enforces `@if`/`@for`/`@switch` syntax         |
+
+## Rules Not Implemented
+
+The following angular-eslint rules are **not implemented** due to requiring TypeScript type information:
+
+| Rule                   | Reason                                                          |
+| ---------------------- | --------------------------------------------------------------- |
+| `no-developer-preview` | Requires JSDoc/type analysis to detect `@developerPreview` tags |
+| `no-experimental`      | Requires JSDoc/type analysis to detect `@experimental` tags     |
+| `no-uncalled-signals`  | Requires type information to detect Signal types                |
+
+These rules cannot be implemented without full TypeScript semantic analysis capabilities.
+
+## Known Limitations
+
+### General Limitations
+
+1. **No type information**: Oxlint operates on AST only, without TypeScript's type checker. Rules requiring type inference cannot be implemented.
+
+2. **No auto-fix**: Most rules do not support automatic fixing yet. Angular-eslint provides auto-fix for many rules.
+
+### Rule-Specific Limitations
+
+#### `component-selector` / `directive-selector`
+
+- **Complex compound selectors** (e.g., `app-[custom]`, `button[appHighlight]`) are not fully supported
+  - **Why**: Angular-eslint uses `CssSelector.parse()` from `@angular-eslint/bundled-angular-compiler` which contains Angular's full CSS selector parser. This parser handles all CSS selector syntax including attribute selectors, pseudo-classes, and compound selectors. Oxlint uses a simpler regex-based approach that handles common cases (element selectors, attribute selectors) but cannot parse arbitrary CSS selector combinations.
+- **Multiple selector configurations in array format** not supported
+  - **Why**: The angular-eslint rule supports passing an array of selector configurations (different prefixes/types per selector). The oxlint implementation only supports a single configuration object.
+
+#### `require-lifecycle-on-prototype`
+
+- Only detects PropertyDefinition patterns (`ngOnInit = () => {}`)
+- Does not detect AssignmentExpression patterns (`this.ngOnInit = () => {}` in constructor)
+  - **Why**: Angular-eslint uses ESLint's selector query system which can match AST patterns declaratively (e.g., `AssignmentExpression > MemberExpression[property.name=ngOnInit]`). Oxlint uses a visitor pattern that processes nodes individually. Detecting constructor assignments requires traversing into constructor bodies and matching specific assignment patterns, which is more complex to implement correctly and was deferred.
+
+## Usage
+
+To enable Angular rules in oxlint, add them to your configuration:
+
+```json
+{
+  "rules": {
+    "angular/component-class-suffix": "error",
+    "angular/prefer-standalone": "warn",
+    "angular/use-lifecycle-interface": "error"
+  }
+}
+```
+
+Or enable all Angular rules:
+
+```json
+{
+  "plugins": ["angular"]
+}
+```
+
+## Configuration Examples
+
+### Component Selector Validation
+
+```json
+{
+  "rules": {
+    "angular/component-selector": [
+      "error",
+      {
+        "type": "element",
+        "prefix": "app",
+        "style": "kebab-case"
+      }
+    ]
+  }
+}
+```
+
+### Directive Selector Validation
+
+```json
+{
+  "rules": {
+    "angular/directive-selector": [
+      "error",
+      {
+        "type": "attribute",
+        "prefix": "app",
+        "style": "camelCase"
+      }
+    ]
+  }
+}
+```
+
+### Custom Class Suffixes
+
+```json
+{
+  "rules": {
+    "angular/component-class-suffix": [
+      "error",
+      {
+        "suffixes": ["Component", "Page", "View"]
+      }
+    ]
+  }
+}
+```
+
+### Input Prefix Restrictions
+
+```json
+{
+  "rules": {
+    "angular/no-input-prefix": [
+      "error",
+      {
+        "prefixes": ["on", "is", "can"]
+      }
+    ]
+  }
+}
+```
+
+## Contributing
+
+When adding new Angular rules:
+
+1. Create the rule file in `crates/oxc_linter/src/rules/angular/`
+2. Register the rule in `crates/oxc_linter/src/rules/angular.rs`
+3. Add comprehensive test cases (pass and fail)
+4. Update this README with the rule documentation
+
+## Reference
+
+- [angular-eslint](https://github.com/angular-eslint/angular-eslint) - Original ESLint implementation
+- [Angular Style Guide](https://angular.io/guide/styleguide) - Official Angular style guidelines

--- a/crates/oxc_linter/src/rules/angular/component_class_suffix.rs
+++ b/crates/oxc_linter/src/rules/angular/component_class_suffix.rs
@@ -1,0 +1,272 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_decorator_identifier, get_decorator_name, is_angular_core_import},
+};
+
+fn component_class_suffix_diagnostic(span: Span, suffixes: &[String]) -> OxcDiagnostic {
+    let suffix_list = suffixes.join(", ");
+    OxcDiagnostic::warn(format!(
+        "Component class names should end with one of these suffixes: {suffix_list}"
+    ))
+    .with_help(
+        "Rename the class to include a valid suffix (e.g., 'ExampleComponent'). \
+        Note: As of Angular v20, this naming convention is no longer officially recommended.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ComponentClassSuffixConfig {
+    #[serde(default = "default_suffixes")]
+    suffixes: Vec<String>,
+}
+
+fn default_suffixes() -> Vec<String> {
+    vec!["Component".to_string()]
+}
+
+impl Default for ComponentClassSuffixConfig {
+    fn default() -> Self {
+        Self { suffixes: default_suffixes() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentClassSuffix {
+    suffixes: Vec<String>,
+}
+
+impl Default for ComponentClassSuffix {
+    fn default() -> Self {
+        Self { suffixes: default_suffixes() }
+    }
+}
+
+impl From<ComponentClassSuffixConfig> for ComponentClassSuffix {
+    fn from(config: ComponentClassSuffixConfig) -> Self {
+        Self { suffixes: config.suffixes }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that component class names end with a specific suffix (default: "Component").
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using a consistent suffix for component classes:
+    /// - Makes it easy to identify components in the codebase
+    /// - Follows Angular naming conventions
+    /// - Improves code readability and maintainability
+    ///
+    /// **Note:** As of Angular v20, this naming convention is no longer officially
+    /// recommended by the Angular team, but many teams still find it useful for
+    /// consistency.
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/component-class-suffix": ["error", { "suffixes": ["Component", "View"] }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class Example {}  // Missing "Component" suffix
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ComponentClassSuffix,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for ComponentClassSuffix {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<ComponentClassSuffixConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class_from_decorator(node, ctx) else {
+            return;
+        };
+
+        // Get the class name
+        let Some(class_name) = class.id.as_ref().map(|id| id.name.as_str()) else {
+            return;
+        };
+
+        // Check if the class name ends with any of the configured suffixes
+        let has_valid_suffix = self.suffixes.iter().any(|suffix| class_name.ends_with(suffix));
+
+        if !has_valid_suffix {
+            let span = class.id.as_ref().map_or(decorator.span, |id| id.span);
+            ctx.diagnostic(component_class_suffix_diagnostic(span, &self.suffixes));
+        }
+    }
+}
+
+fn get_parent_class_from_decorator<'a, 'b>(
+    node: &'b crate::AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Default suffix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Custom suffix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestView {}
+            ",
+            Some(serde_json::json!([{ "suffixes": ["View", "Component"] }])),
+        ),
+        // Non-Angular Component
+        (
+            r"
+            import { Component } from 'other-lib';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class Test {}
+            ",
+            None,
+        ),
+        // Not a component (Directive)
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appTest]'
+            })
+            class TestDirective {}
+            ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // Missing Component suffix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class Test {}
+            ",
+            None,
+        ),
+        // Wrong suffix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComp {}
+            ",
+            None,
+        ),
+        // Custom suffixes - not matching
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestPage {}
+            ",
+            Some(serde_json::json!([{ "suffixes": ["Component", "View"] }])),
+        ),
+    ];
+
+    Tester::new(ComponentClassSuffix::NAME, ComponentClassSuffix::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/component_max_inline_declarations.rs
+++ b/crates/oxc_linter/src/rules/angular/component_max_inline_declarations.rs
@@ -1,0 +1,416 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        is_angular_core_import,
+    },
+};
+
+fn component_max_inline_declarations_diagnostic(
+    span: Span,
+    property: &str,
+    actual: usize,
+    max: usize,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Inline `{property}` has too many lines ({actual}). Maximum allowed is {max}."
+    ))
+    .with_help(format!(
+        "Extract the inline {property} to a separate file. For templates use `templateUrl`, \
+        for styles use `styleUrl` or `styleUrls`."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ComponentMaxInlineDeclarationsConfig {
+    /// Maximum lines for inline template (default: 3)
+    #[serde(default = "default_template")]
+    template: usize,
+    /// Maximum lines for inline styles (default: 3)
+    #[serde(default = "default_styles")]
+    styles: usize,
+    /// Maximum lines for inline animations (default: 15)
+    #[serde(default = "default_animations")]
+    animations: usize,
+}
+
+fn default_template() -> usize {
+    3
+}
+
+fn default_styles() -> usize {
+    3
+}
+
+fn default_animations() -> usize {
+    15
+}
+
+impl Default for ComponentMaxInlineDeclarationsConfig {
+    fn default() -> Self {
+        Self {
+            template: default_template(),
+            styles: default_styles(),
+            animations: default_animations(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[expect(clippy::struct_field_names)]
+pub struct ComponentMaxInlineDeclarations {
+    template_max: usize,
+    styles_max: usize,
+    animations_max: usize,
+}
+
+impl Default for ComponentMaxInlineDeclarations {
+    fn default() -> Self {
+        Self {
+            template_max: default_template(),
+            styles_max: default_styles(),
+            animations_max: default_animations(),
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a maximum number of lines for inline templates, styles, and animations in components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Large inline templates, styles, or animations make components harder to read and maintain.
+    /// When these become too long, they should be extracted to separate files:
+    /// - Templates: Use `templateUrl` instead of `template`
+    /// - Styles: Use `styleUrl` or `styleUrls` instead of `styles`
+    /// - Animations: Consider extracting to a separate animations file
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/component-max-inline-declarations": ["error", {
+    ///     "template": 3,
+    ///     "styles": 3,
+    ///     "animations": 15
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (with default config):
+    /// ```typescript
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: `
+    ///     <div>Line 1</div>
+    ///     <div>Line 2</div>
+    ///     <div>Line 3</div>
+    ///     <div>Line 4</div>
+    ///   `
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   templateUrl: './example.component.html'
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ComponentMaxInlineDeclarations,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for ComponentMaxInlineDeclarations {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        let config: ComponentMaxInlineDeclarationsConfig =
+            serde_json::from_value(config_value.clone())?;
+        Ok(Self {
+            template_max: config.template,
+            styles_max: config.styles,
+            animations_max: config.animations,
+        })
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check template
+        if let Some((span, line_count)) = get_property_line_count(metadata, "template")
+            && line_count > self.template_max {
+                ctx.diagnostic(component_max_inline_declarations_diagnostic(
+                    span,
+                    "template",
+                    line_count,
+                    self.template_max,
+                ));
+            }
+
+        // Check styles array
+        if let Some((span, line_count)) = get_styles_line_count(metadata)
+            && line_count > self.styles_max {
+                ctx.diagnostic(component_max_inline_declarations_diagnostic(
+                    span,
+                    "styles",
+                    line_count,
+                    self.styles_max,
+                ));
+            }
+
+        // Check animations
+        if let Some((span, line_count)) = get_property_line_count(metadata, "animations")
+            && line_count > self.animations_max {
+                ctx.diagnostic(component_max_inline_declarations_diagnostic(
+                    span,
+                    "animations",
+                    line_count,
+                    self.animations_max,
+                ));
+            }
+    }
+}
+
+fn get_property_line_count(
+    metadata: &oxc_ast::ast::ObjectExpression<'_>,
+    property_name: &str,
+) -> Option<(Span, usize)> {
+    for prop in &metadata.properties {
+        if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+            let prop_name = match &obj_prop.key {
+                oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+                oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+                _ => None,
+            };
+
+            if prop_name == Some(property_name) {
+                let line_count = count_lines_in_expression(&obj_prop.value);
+                return Some((obj_prop.span, line_count));
+            }
+        }
+    }
+    None
+}
+
+fn get_styles_line_count(metadata: &oxc_ast::ast::ObjectExpression<'_>) -> Option<(Span, usize)> {
+    for prop in &metadata.properties {
+        if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+            let prop_name = match &obj_prop.key {
+                oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+                oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+                _ => None,
+            };
+
+            if prop_name == Some("styles") {
+                // styles can be an array or a single string
+                // For arrays, SUM the lines of all elements (not max)
+                let line_count = match &obj_prop.value {
+                    oxc_ast::ast::Expression::ArrayExpression(array) => array
+                        .elements
+                        .iter()
+                        .filter_map(|el| el.as_expression().map(count_lines_in_expression))
+                        .sum(),
+                    expr => count_lines_in_expression(expr),
+                };
+                return Some((obj_prop.span, line_count));
+            }
+        }
+    }
+    None
+}
+
+fn count_lines_in_expression(expr: &oxc_ast::ast::Expression<'_>) -> usize {
+    match expr {
+        oxc_ast::ast::Expression::StringLiteral(lit) => count_lines(&lit.value),
+        oxc_ast::ast::Expression::TemplateLiteral(lit) => {
+            // Count lines in the template literal
+            lit.quasis.iter().map(|quasi| count_lines(&quasi.value.raw)).sum()
+        }
+        oxc_ast::ast::Expression::ArrayExpression(array) => {
+            // For arrays (like animations), count total lines
+            array
+                .elements
+                .iter()
+                .filter_map(|el| el.as_expression().map(count_lines_in_expression))
+                .sum()
+        }
+        _ => 0,
+    }
+}
+
+fn count_lines(s: &str) -> usize {
+    // Count newlines + 1 for the content
+    let newline_count = s.chars().filter(|&c| c == '\n').count();
+    if s.is_empty() { 0 } else { newline_count + 1 }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using templateUrl
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                templateUrl: './test.component.html'
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Short inline template
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '<div>Short</div>'
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Template within limit (3 lines)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: `<div>Line 1</div>
+<div>Line 2</div>
+<div>Line 3</div>`
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Custom higher limit
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: `
+                    <div>Line 1</div>
+                    <div>Line 2</div>
+                    <div>Line 3</div>
+                    <div>Line 4</div>
+                    <div>Line 5</div>
+                `
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "template": 10 }])),
+        ),
+    ];
+
+    let fail = vec![
+        // Template exceeds default limit
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: `
+                    <div>Line 1</div>
+                    <div>Line 2</div>
+                    <div>Line 3</div>
+                    <div>Line 4</div>
+                    <div>Line 5</div>
+                `
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Styles exceed limit
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: [`
+                    .class1 { color: red; }
+                    .class2 { color: blue; }
+                    .class3 { color: green; }
+                    .class4 { color: yellow; }
+                `]
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Custom lower limit exceeded
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: `<div>
+                    Content
+                </div>`
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "template": 1 }])),
+        ),
+    ];
+
+    Tester::new(
+        ComponentMaxInlineDeclarations::NAME,
+        ComponentMaxInlineDeclarations::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/component_selector.rs
+++ b/crates/oxc_linter/src/rules/angular/component_selector.rs
@@ -1,0 +1,353 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        SelectorStyle, SelectorType, check_selector_prefix, check_selector_style,
+        extract_selector_name, get_component_metadata, get_decorator_identifier,
+        get_decorator_name, get_metadata_string_value, is_angular_core_import, parse_selector_type,
+    },
+};
+
+fn component_selector_type_diagnostic(span: Span, expected: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Component selector should be used as {expected}"))
+        .with_help(format!(
+            "Change the selector to use {expected} style (e.g., 'app-example' for element)"
+        ))
+        .with_label(span)
+}
+
+fn component_selector_prefix_diagnostic(span: Span, prefixes: &[String]) -> OxcDiagnostic {
+    let prefix_list = prefixes.join(", ");
+    OxcDiagnostic::warn(format!("Component selector should be prefixed with one of: {prefix_list}"))
+        .with_help("Add a prefix to the selector (e.g., 'app-example' with prefix 'app')")
+        .with_label(span)
+}
+
+fn component_selector_style_diagnostic(span: Span, expected: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Component selector should be {expected}"))
+        .with_help(format!("Use {expected} for the selector (e.g., 'app-example' for kebab-case)"))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ComponentSelectorConfig {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    prefix: PrefixConfig,
+    #[serde(default = "default_style")]
+    style: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(untagged)]
+pub enum PrefixConfig {
+    Single(String),
+    Multiple(Vec<String>),
+    #[default]
+    None,
+}
+
+impl PrefixConfig {
+    fn as_vec(&self) -> Vec<String> {
+        match self {
+            PrefixConfig::Single(s) => vec![s.clone()],
+            PrefixConfig::Multiple(v) => v.clone(),
+            PrefixConfig::None => vec![],
+        }
+    }
+}
+
+fn default_style() -> String {
+    "kebab-case".to_string()
+}
+
+impl Default for ComponentSelectorConfig {
+    fn default() -> Self {
+        Self {
+            r#type: Some("element".to_string()),
+            prefix: PrefixConfig::None,
+            style: default_style(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentSelector {
+    selector_type: Option<SelectorType>,
+    prefixes: Vec<String>,
+    style: SelectorStyle,
+}
+
+impl Default for ComponentSelector {
+    fn default() -> Self {
+        Self {
+            selector_type: Some(SelectorType::Element),
+            prefixes: vec![],
+            style: SelectorStyle::KebabCase,
+        }
+    }
+}
+
+impl From<ComponentSelectorConfig> for ComponentSelector {
+    fn from(config: ComponentSelectorConfig) -> Self {
+        let selector_type = config.r#type.as_deref().and_then(|t| match t {
+            "element" => Some(SelectorType::Element),
+            "attribute" => Some(SelectorType::Attribute),
+            _ => None,
+        });
+        let style = match config.style.as_str() {
+            "camelCase" => SelectorStyle::CamelCase,
+            _ => SelectorStyle::KebabCase,
+        };
+        Self { selector_type, prefixes: config.prefix.as_vec(), style }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates Angular component selectors against configured type, prefix, and style rules.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent selector conventions help:
+    /// - Avoid naming collisions with native HTML elements or third-party components
+    /// - Easily identify your application's components
+    /// - Maintain consistency across the codebase
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/component-selector": ["error", {
+    ///     "type": "element",
+    ///     "prefix": "app",
+    ///     "style": "kebab-case"
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// - `type`: "element" or "attribute"
+    /// - `prefix`: string or array of strings
+    /// - `style`: "kebab-case" or "camelCase"
+    ///
+    /// ### Examples
+    ///
+    /// With configuration `{ "type": "element", "prefix": "app", "style": "kebab-case" }`:
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// @Component({ selector: 'example' })  // Missing prefix
+    /// @Component({ selector: 'AppExample' })  // Wrong style
+    /// @Component({ selector: '[appExample]' })  // Wrong type
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// @Component({ selector: 'app-example' })
+    /// ```
+    ComponentSelector,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for ComponentSelector {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<ComponentSelectorConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Get the selector value
+        let Some(selector) = get_metadata_string_value(metadata, "selector") else {
+            return;
+        };
+
+        // Extract the selector name
+        let Some(selector_name) = extract_selector_name(selector) else {
+            return;
+        };
+
+        // Check type
+        if let Some(expected_type) = &self.selector_type
+            && let Some(actual_type) = parse_selector_type(selector)
+                && actual_type != *expected_type {
+                    let type_str = match expected_type {
+                        SelectorType::Element => "an element",
+                        SelectorType::Attribute => "an attribute",
+                    };
+                    ctx.diagnostic(component_selector_type_diagnostic(decorator.span, type_str));
+                    return;
+                }
+
+        // Check prefix
+        if !self.prefixes.is_empty() {
+            let prefix_refs: Vec<&str> = self.prefixes.iter().map(std::string::String::as_str).collect();
+            if !check_selector_prefix(selector_name, &prefix_refs) {
+                ctx.diagnostic(component_selector_prefix_diagnostic(
+                    decorator.span,
+                    &self.prefixes,
+                ));
+                return;
+            }
+        }
+
+        // Check style
+        if !check_selector_style(selector_name, self.style) {
+            let style_str = match self.style {
+                SelectorStyle::KebabCase => "kebab-case",
+                SelectorStyle::CamelCase => "camelCase",
+            };
+            ctx.diagnostic(component_selector_style_diagnostic(decorator.span, style_str));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Valid kebab-case element with prefix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-example',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": "app", "style": "kebab-case" }]),
+            ),
+        ),
+        // Multiple allowed prefixes
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'my-example',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": ["app", "my"], "style": "kebab-case" }]),
+            ),
+        ),
+        // No prefix requirement
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'example',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(serde_json::json!([{ "type": "element", "style": "kebab-case" }])),
+        ),
+        // Non-Angular Component
+        (
+            r"
+            import { Component } from 'other-lib';
+            @Component({
+                selector: 'INVALID',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": "app", "style": "kebab-case" }]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        // Wrong type (attribute instead of element)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: '[appExample]',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": "app", "style": "kebab-case" }]),
+            ),
+        ),
+        // Missing prefix
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'example',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": "app", "style": "kebab-case" }]),
+            ),
+        ),
+        // Wrong style (PascalCase instead of kebab-case)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'AppExample',
+                template: ''
+            })
+            class ExampleComponent {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "element", "prefix": "app", "style": "kebab-case" }]),
+            ),
+        ),
+    ];
+
+    Tester::new(ComponentSelector::NAME, ComponentSelector::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/computed_must_return.rs
+++ b/crates/oxc_linter/src/rules/angular/computed_must_return.rs
@@ -1,0 +1,259 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_angular_core_import};
+
+fn computed_must_return_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Computed signal callback must return a value")
+        .with_help(
+            "The function passed to `computed()` must return a value. \
+            Computed signals derive their value from the return value of this function. \
+            Add a return statement or use an arrow function with an expression body.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ComputedMustReturn;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that the callback function passed to `computed()` returns a value.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `computed()` function creates a signal that derives its value from other signals.
+    /// The callback function must return a value - this is the computed signal's value.
+    /// If the callback doesn't return anything, the computed signal will always be `undefined`,
+    /// which is almost certainly a bug.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, computed, signal } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   count = signal(0);
+    ///   double = computed(() => {
+    ///     this.count() * 2; // Missing return!
+    ///   });
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, computed, signal } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   count = signal(0);
+    ///   // Arrow function with expression body (implicit return)
+    ///   double = computed(() => this.count() * 2);
+    ///
+    ///   // Or with explicit return
+    ///   triple = computed(() => {
+    ///     return this.count() * 3;
+    ///   });
+    /// }
+    /// ```
+    ComputedMustReturn,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for ComputedMustReturn {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a call to computed
+        let callee_name = match &call_expr.callee {
+            oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        if callee_name != "computed" {
+            return;
+        }
+
+        // Verify it's imported from @angular/core
+        let Some(ident) = call_expr.callee.get_identifier_reference() else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the first argument (the callback function)
+        let Some(first_arg) = call_expr.arguments.first() else {
+            return;
+        };
+
+        // Check if the callback returns a value
+        match first_arg {
+            oxc_ast::ast::Argument::ArrowFunctionExpression(arrow) => {
+                // Arrow functions with expression body always return
+                if arrow.expression {
+                    return;
+                }
+
+                // Check if the function body has a return statement
+                if !has_return_statement(&arrow.body) {
+                    ctx.diagnostic(computed_must_return_diagnostic(arrow.span));
+                }
+            }
+            oxc_ast::ast::Argument::FunctionExpression(func) => {
+                // Check if the function body has a return statement
+                if let Some(body) = &func.body
+                    && !has_return_statement_in_body(body) {
+                        ctx.diagnostic(computed_must_return_diagnostic(func.span));
+                    }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn has_return_statement(body: &oxc_ast::ast::FunctionBody<'_>) -> bool {
+    has_return_statement_in_body(body)
+}
+
+fn has_return_statement_in_body(body: &oxc_ast::ast::FunctionBody<'_>) -> bool {
+    for stmt in &body.statements {
+        if has_return_in_statement(stmt) {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_return_in_statement(stmt: &oxc_ast::ast::Statement<'_>) -> bool {
+    match stmt {
+        oxc_ast::ast::Statement::ReturnStatement(ret) => {
+            // Must return something, not just `return;`
+            ret.argument.is_some()
+        }
+        oxc_ast::ast::Statement::BlockStatement(block) => {
+            block.body.iter().any(has_return_in_statement)
+        }
+        oxc_ast::ast::Statement::IfStatement(if_stmt) => {
+            // Both branches should ideally return, but we check if any returns
+            let consequent_returns = has_return_in_statement(&if_stmt.consequent);
+            let alternate_returns =
+                if_stmt.alternate.as_ref().is_some_and(|alt| has_return_in_statement(alt));
+            consequent_returns || alternate_returns
+        }
+        oxc_ast::ast::Statement::SwitchStatement(switch) => {
+            switch.cases.iter().any(|case| case.consequent.iter().any(has_return_in_statement))
+        }
+        oxc_ast::ast::Statement::TryStatement(try_stmt) => {
+            let block_returns = try_stmt.block.body.iter().any(has_return_in_statement);
+            let handler_returns = try_stmt
+                .handler
+                .as_ref()
+                .is_some_and(|h| h.body.body.iter().any(has_return_in_statement));
+            let finalizer_returns = try_stmt
+                .finalizer
+                .as_ref()
+                .is_some_and(|f| f.body.iter().any(has_return_in_statement));
+            block_returns || handler_returns || finalizer_returns
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Arrow function with expression body (implicit return)
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const double = computed(() => count() * 2);
+        ",
+        // Arrow function with explicit return
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const double = computed(() => {
+            return count() * 2;
+        });
+        ",
+        // Function expression with return
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const double = computed(function() {
+            return count() * 2;
+        });
+        ",
+        // Conditional return
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const value = computed(() => {
+            if (count() > 0) {
+                return 'positive';
+            }
+            return 'non-positive';
+        });
+        ",
+        // Non-Angular computed
+        r"
+        import { computed } from 'other-library';
+        const value = computed(() => {
+            console.log('no return');
+        });
+        ",
+    ];
+
+    let fail = vec![
+        // Arrow function without return
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const double = computed(() => {
+            count() * 2;
+        });
+        ",
+        // Function expression without return
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const double = computed(function() {
+            count() * 2;
+        });
+        ",
+        // Only has side effects
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const value = computed(() => {
+            console.log(count());
+        });
+        ",
+        // Return without value
+        r"
+        import { computed, signal } from '@angular/core';
+        const count = signal(0);
+        const value = computed(() => {
+            if (count() > 0) {
+                return;
+            }
+        });
+        ",
+    ];
+
+    Tester::new(ComputedMustReturn::NAME, ComputedMustReturn::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/consistent_component_styles.rs
+++ b/crates/oxc_linter/src/rules/angular/consistent_component_styles.rs
@@ -1,0 +1,418 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        is_angular_core_import,
+    },
+};
+
+fn consistent_component_styles_diagnostic(span: Span, message_id: &str) -> OxcDiagnostic {
+    let (message, help) = match message_id {
+        "useStylesString" => (
+            "Component styles should use string format",
+            "Use a single string instead of an array for component styles: `styles: 'css-here'`",
+        ),
+        "useStylesArray" => (
+            "Component styles should use array format",
+            "Use an array for component styles: `styles: ['css-here']`",
+        ),
+        "useStyleUrl" => (
+            "Use `styleUrl` instead of `styleUrls` for a single stylesheet",
+            "Use `styleUrl: './style.css'` instead of `styleUrls: ['./style.css']`",
+        ),
+        "useStyleUrls" => (
+            "Use `styleUrls` instead of `styleUrl`",
+            "Use `styleUrls: ['./style.css']` instead of `styleUrl: './style.css'`",
+        ),
+        _ => ("Use consistent style format", "Use consistent style format"),
+    };
+    OxcDiagnostic::warn(message).with_help(help).with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum StyleFormat {
+    #[default]
+    String,
+    Array,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ConsistentComponentStylesConfig {
+    #[serde(default)]
+    format: StyleFormat,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConsistentComponentStyles {
+    format: StyleFormat,
+}
+
+impl Default for ConsistentComponentStyles {
+    fn default() -> Self {
+        Self { format: StyleFormat::String }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces consistent usage of `styles` property format in components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Angular allows both string and array formats for inline styles:
+    /// - `styles: 'css-here'` (string format)
+    /// - `styles: ['css-here']` (array format)
+    ///
+    /// Using a consistent format across your codebase improves readability and
+    /// makes it easier to understand the component structure at a glance.
+    ///
+    /// Note: Since Angular 17, the preferred approach is to use `styleUrl` (singular)
+    /// for a single file or `styleUrls` for multiple files. This rule focuses on
+    /// the inline `styles` property.
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/consistent-component-styles": ["error", { "format": "string" }]
+    /// }
+    /// ```
+    ///
+    /// Options:
+    /// - `"string"` (default): Enforce single string format
+    /// - `"array"`: Enforce array format
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (with `"string"` config):
+    /// ```typescript
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   styles: ['.class { color: red; }'] // Should be a string
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule (with `"string"` config):
+    /// ```typescript
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   styles: '.class { color: red; }'
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ConsistentComponentStyles,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for ConsistentComponentStyles {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+
+        // Handle string shorthand: ["string"] or ["array"]
+        if let Some(format_str) = config_value.as_str() {
+            let format = match format_str {
+                "array" => StyleFormat::Array,
+                _ => StyleFormat::String,
+            };
+            return Ok(Self { format });
+        }
+
+        let config: ConsistentComponentStylesConfig = serde_json::from_value(config_value.clone())?;
+        Ok(Self { format: config.format })
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Find style-related properties
+        for prop in &metadata.properties {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+                let prop_name = match &obj_prop.key {
+                    oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+                    oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+                    _ => None,
+                };
+
+                match prop_name {
+                    Some("styles") => {
+                        let is_array =
+                            matches!(&obj_prop.value, oxc_ast::ast::Expression::ArrayExpression(_));
+
+                        match (&self.format, is_array) {
+                            (StyleFormat::String, true) => {
+                                // Using array but expecting string
+                                if let oxc_ast::ast::Expression::ArrayExpression(array) =
+                                    &obj_prop.value
+                                {
+                                    // Only report if it's a single-element array (could be converted to string)
+                                    if array.elements.len() == 1 {
+                                        ctx.diagnostic(consistent_component_styles_diagnostic(
+                                            obj_prop.span,
+                                            "useStylesString",
+                                        ));
+                                    }
+                                }
+                            }
+                            (StyleFormat::Array, false) => {
+                                // Using string but expecting array
+                                ctx.diagnostic(consistent_component_styles_diagnostic(
+                                    obj_prop.span,
+                                    "useStylesArray",
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+                    Some("styleUrl") => {
+                        // styleUrl is singular - in array mode, we expect styleUrls
+                        if matches!(self.format, StyleFormat::Array) {
+                            ctx.diagnostic(consistent_component_styles_diagnostic(
+                                obj_prop.span,
+                                "useStyleUrls",
+                            ));
+                        }
+                    }
+                    Some("styleUrls") => {
+                        // styleUrls is plural - in string mode with single element, we expect styleUrl
+                        if matches!(self.format, StyleFormat::String)
+                            && let oxc_ast::ast::Expression::ArrayExpression(array) =
+                                &obj_prop.value
+                                && array.elements.len() == 1 {
+                                    ctx.diagnostic(consistent_component_styles_diagnostic(
+                                        obj_prop.span,
+                                        "useStyleUrl",
+                                    ));
+                                }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // String format with string config (default)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: '.class { color: red; }'
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // No styles property
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Array format with array config
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: ['.class { color: red; }']
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "format": "array" }])),
+        ),
+        // Multiple styles in array (always allowed)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: ['.class1 { color: red; }', '.class2 { color: blue; }']
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Template literal string
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: `.class { color: red; }`
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // styleUrl with string config (default) - singular is fine
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styleUrl: './test.component.css'
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // styleUrls with array config
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styleUrls: ['./test.component.css']
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "format": "array" }])),
+        ),
+        // Multiple styleUrls (always allowed with string config)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styleUrls: ['./test1.css', './test2.css']
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // Single-element array with string config (default)
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: ['.class { color: red; }']
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // String format with array config
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: '.class { color: red; }'
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "format": "array" }])),
+        ),
+        // Template literal in single-element array
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styles: [`.class { color: red; }`]
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // Single-element styleUrls with string config - should use styleUrl
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styleUrls: ['./test.component.css']
+            })
+            class TestComponent {}
+            ",
+            None,
+        ),
+        // styleUrl with array config - should use styleUrls
+        (
+            r"
+            import { Component } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: '',
+                styleUrl: './test.component.css'
+            })
+            class TestComponent {}
+            ",
+            Some(serde_json::json!([{ "format": "array" }])),
+        ),
+    ];
+
+    Tester::new(ConsistentComponentStyles::NAME, ConsistentComponentStyles::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/contextual_decorator.rs
+++ b/crates/oxc_linter/src/rules/angular/contextual_decorator.rs
@@ -1,0 +1,271 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        AngularDecoratorType, get_class_angular_decorator, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn contextual_decorator_diagnostic(
+    span: Span,
+    decorator_name: &str,
+    class_decorator: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "`@{decorator_name}` cannot be used in `@{class_decorator}` class"
+    ))
+    .with_help(format!(
+        "The `@{decorator_name}` decorator is not valid in a class decorated with `@{class_decorator}`. \
+        This decorator is only allowed in @Component or @Directive classes."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ContextualDecorator;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that decorators are only used in the correct class context.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Angular decorators have specific contexts where they are valid:
+    /// - `@Input`, `@Output`, `@HostBinding`, `@HostListener`, `@ViewChild`, `@ViewChildren`,
+    ///   `@ContentChild`, `@ContentChildren` are only valid in `@Component` and `@Directive` classes.
+    /// - Using these decorators in `@Injectable`, `@NgModule`, or `@Pipe` classes will cause
+    ///   unexpected behavior or runtime errors.
+    ///
+    /// Only `@Host`, `@Inject`, `@Optional`, `@Self`, and `@SkipSelf` can be used in any Angular class.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Injectable, Input } from '@angular/core';
+    ///
+    /// @Injectable({ providedIn: 'root' })
+    /// export class MyService {
+    ///   @Input() myInput: string; // Invalid - @Input cannot be used in @Injectable
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() myInput: string; // Valid - @Input in @Component
+    /// }
+    /// ```
+    ContextualDecorator,
+    angular,
+    correctness,
+    pending
+);
+
+/// Decorators that are only valid in @Component and @Directive
+const COMPONENT_DIRECTIVE_ONLY_DECORATORS: [&str; 8] = [
+    "Input",
+    "Output",
+    "HostBinding",
+    "HostListener",
+    "ViewChild",
+    "ViewChildren",
+    "ContentChild",
+    "ContentChildren",
+];
+
+impl Rule for ContextualDecorator {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Get decorator name
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        // Check if this is a component/directive-only decorator
+        if !COMPONENT_DIRECTIVE_ONLY_DECORATORS.contains(&decorator_name) {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Get the class's Angular decorator
+        let Some((class_decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        // Check if the decorator is used in an invalid context
+        let is_valid_context = matches!(
+            class_decorator_type,
+            AngularDecoratorType::Component | AngularDecoratorType::Directive
+        );
+
+        if !is_valid_context {
+            let class_decorator_name = match class_decorator_type {
+                AngularDecoratorType::Injectable => "Injectable",
+                AngularDecoratorType::NgModule => "NgModule",
+                AngularDecoratorType::Pipe => "Pipe",
+                _ => return,
+            };
+
+            ctx.diagnostic(contextual_decorator_diagnostic(
+                decorator.span,
+                decorator_name,
+                class_decorator_name,
+            ));
+        }
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // @Input in @Component
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() value: string;
+        }
+        ",
+        // @Output in @Directive
+        r"
+        import { Directive, Output, EventEmitter } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @Output() myEvent = new EventEmitter();
+        }
+        ",
+        // @HostBinding in @Component
+        r"
+        import { Component, HostBinding } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostBinding('class.active') isActive = false;
+        }
+        ",
+        // @ViewChild in @Component
+        r"
+        import { Component, ViewChild, ElementRef } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @ViewChild('myElement') element: ElementRef;
+        }
+        ",
+        // @Inject in @Injectable (valid - DI decorator)
+        r"
+        import { Injectable, Inject } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            constructor(@Inject('TOKEN') private value: string) {}
+        }
+        ",
+        // Non-Angular decorator
+        r"
+        import { Input } from 'other-library';
+        class TestClass {
+            @Input() value: string;
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // @Input in @Injectable
+        r"
+        import { Injectable, Input } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            @Input() value: string;
+        }
+        ",
+        // @Output in @Pipe
+        r"
+        import { Pipe, Output, EventEmitter } from '@angular/core';
+        @Pipe({ name: 'test' })
+        class TestPipe {
+            @Output() myEvent = new EventEmitter();
+        }
+        ",
+        // @HostBinding in @NgModule
+        r"
+        import { NgModule, HostBinding } from '@angular/core';
+        @NgModule({})
+        class TestModule {
+            @HostBinding('class.active') isActive = false;
+        }
+        ",
+        // @ViewChild in @Injectable
+        r"
+        import { Injectable, ViewChild, ElementRef } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            @ViewChild('element') element: ElementRef;
+        }
+        ",
+        // @ContentChild in @Pipe
+        r"
+        import { Pipe, ContentChild, ElementRef } from '@angular/core';
+        @Pipe({ name: 'test' })
+        class TestPipe {
+            @ContentChild('content') content: ElementRef;
+        }
+        ",
+    ];
+
+    Tester::new(ContextualDecorator::NAME, ContextualDecorator::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/contextual_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/angular/contextual_lifecycle.rs
@@ -1,0 +1,269 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        AngularDecoratorType, get_class_angular_decorator, is_lifecycle_method,
+        is_lifecycle_valid_for_decorator,
+    },
+};
+
+fn contextual_lifecycle_diagnostic(
+    span: Span,
+    method_name: &str,
+    decorator_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Angular will not invoke the `{method_name}` lifecycle method within `@{decorator_name}()` classes"
+    ))
+    .with_help(format!(
+        "Remove `{method_name}` or move the class to an appropriate Angular class type that supports this lifecycle method"
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ContextualLifecycle;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that lifecycle methods are used in appropriate Angular class types.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Certain lifecycle methods are only invoked by Angular in specific class types:
+    /// - `@Component` and `@Directive`: All lifecycle methods except `ngDoBootstrap`
+    /// - `@Injectable` and `@Pipe`: Only `ngOnDestroy`
+    /// - `@NgModule`: Only `ngDoBootstrap`
+    ///
+    /// Using a lifecycle method in an inappropriate context will result in dead code
+    /// that is never executed, which can lead to confusion and bugs.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Injectable, OnInit } from '@angular/core';
+    ///
+    /// @Injectable({ providedIn: 'root' })
+    /// export class MyService implements OnInit {
+    ///   ngOnInit() {
+    ///     // This will never be called!
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Injectable, OnDestroy } from '@angular/core';
+    ///
+    /// @Injectable({ providedIn: 'root' })
+    /// export class MyService implements OnDestroy {
+    ///   ngOnDestroy() {
+    ///     // This will be called when the service is destroyed
+    ///   }
+    /// }
+    /// ```
+    ContextualLifecycle,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for ContextualLifecycle {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+
+        // Get the method name
+        let Some(method_name) = method.key.static_name() else {
+            return;
+        };
+
+        // Check if it's a lifecycle method
+        if !is_lifecycle_method(&method_name) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator and get its type
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        // Check if the lifecycle method is valid for this decorator type
+        if !is_lifecycle_valid_for_decorator(&method_name, decorator_type) {
+            let decorator_name = match decorator_type {
+                AngularDecoratorType::Component => "Component",
+                AngularDecoratorType::Directive => "Directive",
+                AngularDecoratorType::Injectable => "Injectable",
+                AngularDecoratorType::Pipe => "Pipe",
+                AngularDecoratorType::NgModule => "NgModule",
+            };
+            ctx.diagnostic(contextual_lifecycle_diagnostic(
+                method.span,
+                &method_name,
+                decorator_name,
+            ));
+        }
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Component with valid lifecycle methods
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Directive with valid lifecycle methods
+        r"
+        import { Directive, OnInit, AfterViewInit } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements OnInit, AfterViewInit {
+            ngOnInit() {}
+            ngAfterViewInit() {}
+        }
+        ",
+        // Injectable with ngOnDestroy
+        r"
+        import { Injectable, OnDestroy } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService implements OnDestroy {
+            ngOnDestroy() {}
+        }
+        ",
+        // Pipe with ngOnDestroy
+        r"
+        import { Pipe, OnDestroy } from '@angular/core';
+        @Pipe({ name: 'myPipe' })
+        class MyPipe implements OnDestroy {
+            ngOnDestroy() {}
+        }
+        ",
+        // NgModule with ngDoBootstrap
+        r"
+        import { NgModule, DoBootstrap } from '@angular/core';
+        @NgModule({})
+        class AppModule implements DoBootstrap {
+            ngDoBootstrap() {}
+        }
+        ",
+        // Non-Angular class (ignored)
+        r"
+        class TestClass {
+            ngOnInit() {}
+        }
+        ",
+        // Component with all valid hooks
+        r"
+        import { Component, OnInit, OnChanges, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnChanges() {}
+            ngOnInit() {}
+            ngDoCheck() {}
+            ngAfterContentInit() {}
+            ngAfterContentChecked() {}
+            ngAfterViewInit() {}
+            ngAfterViewChecked() {}
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Injectable with ngOnInit (invalid)
+        r"
+        import { Injectable, OnInit } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Injectable with ngAfterViewInit (invalid)
+        r"
+        import { Injectable, AfterViewInit } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService implements AfterViewInit {
+            ngAfterViewInit() {}
+        }
+        ",
+        // Pipe with ngOnInit (invalid)
+        r"
+        import { Pipe, OnInit } from '@angular/core';
+        @Pipe({ name: 'myPipe' })
+        class MyPipe implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // NgModule with ngOnInit (invalid)
+        r"
+        import { NgModule, OnInit } from '@angular/core';
+        @NgModule({})
+        class AppModule implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // NgModule with ngOnDestroy (invalid)
+        r"
+        import { NgModule, OnDestroy } from '@angular/core';
+        @NgModule({})
+        class AppModule implements OnDestroy {
+            ngOnDestroy() {}
+        }
+        ",
+        // Component with ngDoBootstrap (invalid - only for NgModule)
+        r"
+        import { Component, DoBootstrap } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements DoBootstrap {
+            ngDoBootstrap() {}
+        }
+        ",
+    ];
+
+    Tester::new(ContextualLifecycle::NAME, ContextualLifecycle::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/directive_class_suffix.rs
+++ b/crates/oxc_linter/src/rules/angular/directive_class_suffix.rs
@@ -1,0 +1,291 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn directive_class_suffix_diagnostic(span: Span, suffixes: &[String]) -> OxcDiagnostic {
+    let suffix_list = suffixes.join(", ");
+    OxcDiagnostic::warn(format!(
+        "Directive class names should end with one of these suffixes: {suffix_list}"
+    ))
+    .with_help("Rename the class to include a valid suffix (e.g., 'HighlightDirective').")
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct DirectiveClassSuffixConfig {
+    #[serde(default = "default_suffixes")]
+    suffixes: Vec<String>,
+}
+
+fn default_suffixes() -> Vec<String> {
+    vec!["Directive".to_string()]
+}
+
+impl Default for DirectiveClassSuffixConfig {
+    fn default() -> Self {
+        Self { suffixes: default_suffixes() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DirectiveClassSuffix {
+    suffixes: Vec<String>,
+}
+
+impl Default for DirectiveClassSuffix {
+    fn default() -> Self {
+        Self { suffixes: default_suffixes() }
+    }
+}
+
+impl From<DirectiveClassSuffixConfig> for DirectiveClassSuffix {
+    fn from(config: DirectiveClassSuffixConfig) -> Self {
+        Self { suffixes: config.suffixes }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that directive class names end with a specific suffix (default: "Directive").
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using a consistent suffix for directive classes:
+    /// - Makes it easy to identify directives in the codebase
+    /// - Follows Angular naming conventions
+    /// - Improves code readability and maintainability
+    ///
+    /// Note: Classes implementing the `Validator` interface are also allowed to use
+    /// the "Validator" suffix.
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/directive-class-suffix": ["error", { "suffixes": ["Directive", "Validator"] }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Directive } from '@angular/core';
+    ///
+    /// @Directive({
+    ///   selector: '[appHighlight]'
+    /// })
+    /// export class Highlight {}  // Missing "Directive" suffix
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Directive } from '@angular/core';
+    ///
+    /// @Directive({
+    ///   selector: '[appHighlight]'
+    /// })
+    /// export class HighlightDirective {}
+    /// ```
+    DirectiveClassSuffix,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for DirectiveClassSuffix {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<DirectiveClassSuffixConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Directive decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Only check directives with a selector (abstract directives without selector are skipped)
+        if get_metadata_property(metadata, "selector").is_none() {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class_from_decorator(node, ctx) else {
+            return;
+        };
+
+        // Get the class name
+        let Some(class_name) = class.id.as_ref().map(|id| id.name.as_str()) else {
+            return;
+        };
+
+        // Build list of valid suffixes (include Validator if class implements Validator)
+        let mut valid_suffixes = self.suffixes.clone();
+        if implements_validator(class) {
+            valid_suffixes.push("Validator".to_string());
+        }
+
+        // Check if the class name ends with any of the configured suffixes
+        let has_valid_suffix = valid_suffixes.iter().any(|suffix| class_name.ends_with(suffix));
+
+        if !has_valid_suffix {
+            let span = class.id.as_ref().map_or(decorator.span, |id| id.span);
+            ctx.diagnostic(directive_class_suffix_diagnostic(span, &valid_suffixes));
+        }
+    }
+}
+
+fn get_parent_class_from_decorator<'a, 'b>(
+    node: &'b crate::AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+fn implements_validator(class: &oxc_ast::ast::Class<'_>) -> bool {
+    if class.implements.is_empty() {
+        return false;
+    }
+    class.implements.iter().any(|ts_impl| {
+        if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &ts_impl.expression {
+            return ident.name.as_str() == "Validator" || ident.name.as_str() == "AsyncValidator";
+        }
+        false
+    })
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Default suffix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appHighlight]'
+            })
+            class HighlightDirective {}
+            ",
+            None,
+        ),
+        // Custom suffix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appHighlight]'
+            })
+            class HighlightDir {}
+            ",
+            Some(serde_json::json!([{ "suffixes": ["Dir", "Directive"] }])),
+        ),
+        // Validator interface allows Validator suffix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appRequired]'
+            })
+            class RequiredValidator implements Validator {
+                validate() { return null; }
+            }
+            ",
+            None,
+        ),
+        // No selector (abstract directive - skipped)
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({})
+            class BaseDirective {}
+            ",
+            None,
+        ),
+        // Non-Angular Directive
+        (
+            r"
+            import { Directive } from 'other-lib';
+            @Directive({
+                selector: '[appTest]'
+            })
+            class Test {}
+            ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // Missing Directive suffix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appHighlight]'
+            })
+            class Highlight {}
+            ",
+            None,
+        ),
+        // Wrong suffix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appHighlight]'
+            })
+            class HighlightComponent {}
+            ",
+            None,
+        ),
+    ];
+
+    Tester::new(DirectiveClassSuffix::NAME, DirectiveClassSuffix::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/directive_selector.rs
+++ b/crates/oxc_linter/src/rules/angular/directive_selector.rs
@@ -1,0 +1,346 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        SelectorStyle, SelectorType, check_selector_prefix, check_selector_style,
+        extract_selector_name, get_component_metadata, get_decorator_identifier,
+        get_decorator_name, get_metadata_string_value, is_angular_core_import, parse_selector_type,
+    },
+};
+
+fn directive_selector_type_diagnostic(span: Span, expected: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Directive selector should be used as {expected}"))
+        .with_help(format!(
+            "Change the selector to use {expected} style (e.g., '[appExample]' for attribute)"
+        ))
+        .with_label(span)
+}
+
+fn directive_selector_prefix_diagnostic(span: Span, prefixes: &[String]) -> OxcDiagnostic {
+    let prefix_list = prefixes.join(", ");
+    OxcDiagnostic::warn(format!("Directive selector should be prefixed with one of: {prefix_list}"))
+        .with_help("Add a prefix to the selector (e.g., '[appHighlight]' with prefix 'app')")
+        .with_label(span)
+}
+
+fn directive_selector_style_diagnostic(span: Span, expected: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Directive selector should be {expected}"))
+        .with_help(format!("Use {expected} for the selector (e.g., 'appHighlight' for camelCase)"))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct DirectiveSelectorConfig {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    prefix: PrefixConfig,
+    #[serde(default = "default_style")]
+    style: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(untagged)]
+pub enum PrefixConfig {
+    Single(String),
+    Multiple(Vec<String>),
+    #[default]
+    None,
+}
+
+impl PrefixConfig {
+    fn as_vec(&self) -> Vec<String> {
+        match self {
+            PrefixConfig::Single(s) => vec![s.clone()],
+            PrefixConfig::Multiple(v) => v.clone(),
+            PrefixConfig::None => vec![],
+        }
+    }
+}
+
+fn default_style() -> String {
+    "camelCase".to_string()
+}
+
+impl Default for DirectiveSelectorConfig {
+    fn default() -> Self {
+        Self {
+            r#type: Some("attribute".to_string()),
+            prefix: PrefixConfig::None,
+            style: default_style(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DirectiveSelector {
+    selector_type: Option<SelectorType>,
+    prefixes: Vec<String>,
+    style: SelectorStyle,
+}
+
+impl Default for DirectiveSelector {
+    fn default() -> Self {
+        Self {
+            selector_type: Some(SelectorType::Attribute),
+            prefixes: vec![],
+            style: SelectorStyle::CamelCase,
+        }
+    }
+}
+
+impl From<DirectiveSelectorConfig> for DirectiveSelector {
+    fn from(config: DirectiveSelectorConfig) -> Self {
+        let selector_type = config.r#type.as_deref().and_then(|t| match t {
+            "element" => Some(SelectorType::Element),
+            "attribute" => Some(SelectorType::Attribute),
+            _ => None,
+        });
+        let style = match config.style.as_str() {
+            "kebab-case" => SelectorStyle::KebabCase,
+            _ => SelectorStyle::CamelCase,
+        };
+        Self { selector_type, prefixes: config.prefix.as_vec(), style }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Validates Angular directive selectors against configured type, prefix, and style rules.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Consistent selector conventions help:
+    /// - Avoid naming collisions with native HTML attributes or third-party directives
+    /// - Easily identify your application's directives
+    /// - Maintain consistency across the codebase
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/directive-selector": ["error", {
+    ///     "type": "attribute",
+    ///     "prefix": "app",
+    ///     "style": "camelCase"
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// - `type`: "element" or "attribute"
+    /// - `prefix`: string or array of strings
+    /// - `style`: "kebab-case" or "camelCase"
+    ///
+    /// ### Examples
+    ///
+    /// With configuration `{ "type": "attribute", "prefix": "app", "style": "camelCase" }`:
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// @Directive({ selector: '[highlight]' })  // Missing prefix
+    /// @Directive({ selector: '[app-highlight]' })  // Wrong style
+    /// @Directive({ selector: 'app-highlight' })  // Wrong type
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// @Directive({ selector: '[appHighlight]' })
+    /// ```
+    DirectiveSelector,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for DirectiveSelector {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<DirectiveSelectorConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Directive decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Get the selector value
+        let Some(selector) = get_metadata_string_value(metadata, "selector") else {
+            return;
+        };
+
+        // Extract the selector name
+        let Some(selector_name) = extract_selector_name(selector) else {
+            return;
+        };
+
+        // Check type
+        if let Some(expected_type) = &self.selector_type
+            && let Some(actual_type) = parse_selector_type(selector)
+                && actual_type != *expected_type {
+                    let type_str = match expected_type {
+                        SelectorType::Element => "an element",
+                        SelectorType::Attribute => "an attribute",
+                    };
+                    ctx.diagnostic(directive_selector_type_diagnostic(decorator.span, type_str));
+                    return;
+                }
+
+        // Check prefix
+        if !self.prefixes.is_empty() {
+            let prefix_refs: Vec<&str> = self.prefixes.iter().map(std::string::String::as_str).collect();
+            if !check_selector_prefix(selector_name, &prefix_refs) {
+                ctx.diagnostic(directive_selector_prefix_diagnostic(
+                    decorator.span,
+                    &self.prefixes,
+                ));
+                return;
+            }
+        }
+
+        // Check style
+        if !check_selector_style(selector_name, self.style) {
+            let style_str = match self.style {
+                SelectorStyle::KebabCase => "kebab-case",
+                SelectorStyle::CamelCase => "camelCase",
+            };
+            ctx.diagnostic(directive_selector_style_diagnostic(decorator.span, style_str));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Valid camelCase attribute with prefix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[appHighlight]'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": "app", "style": "camelCase" }]),
+            ),
+        ),
+        // Multiple allowed prefixes
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[myHighlight]'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": ["app", "my"], "style": "camelCase" }]),
+            ),
+        ),
+        // No prefix requirement
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[highlight]'
+            })
+            class HighlightDirective {}
+            ",
+            Some(serde_json::json!([{ "type": "attribute", "style": "camelCase" }])),
+        ),
+        // Non-Angular Directive
+        (
+            r"
+            import { Directive } from 'other-lib';
+            @Directive({
+                selector: 'INVALID'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": "app", "style": "camelCase" }]),
+            ),
+        ),
+    ];
+
+    let fail = vec![
+        // Wrong type (element instead of attribute)
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: 'app-highlight'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": "app", "style": "camelCase" }]),
+            ),
+        ),
+        // Missing prefix
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[highlight]'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": "app", "style": "camelCase" }]),
+            ),
+        ),
+        // Wrong style (kebab-case instead of camelCase)
+        (
+            r"
+            import { Directive } from '@angular/core';
+            @Directive({
+                selector: '[app-highlight]'
+            })
+            class HighlightDirective {}
+            ",
+            Some(
+                serde_json::json!([{ "type": "attribute", "prefix": "app", "style": "camelCase" }]),
+            ),
+        ),
+    ];
+
+    Tester::new(DirectiveSelector::NAME, DirectiveSelector::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_async_lifecycle_method.rs
+++ b/crates/oxc_linter/src/rules/angular/no_async_lifecycle_method.rs
@@ -1,0 +1,261 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, is_lifecycle_method},
+};
+
+fn no_async_lifecycle_method_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Lifecycle method `{method_name}` should not be async"))
+        .with_help(
+            "Angular does not wait for async lifecycle methods to complete. \
+        Remove the async keyword and handle async operations differently, \
+        such as subscribing to observables or using promises without await.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoAsyncLifecycleMethod;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using async lifecycle methods in Angular classes.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Angular lifecycle methods are designed to be synchronous. When you mark a lifecycle
+    /// method as async, Angular will NOT wait for the async operation to complete before
+    /// continuing with its lifecycle processing. This can lead to:
+    /// - Race conditions with component initialization
+    /// - Unexpected behavior in change detection
+    /// - Misleading code that suggests async operations are awaited
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   async ngOnInit() {
+    ///     await this.loadData();
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   ngOnInit() {
+    ///     this.loadData().then(data => {
+    ///       // handle data
+    ///     });
+    ///   }
+    /// }
+    /// ```
+    NoAsyncLifecycleMethod,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoAsyncLifecycleMethod {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+
+        // Get method name
+        let Some(method_name) = method.key.static_name() else {
+            return;
+        };
+
+        // Check if this is a lifecycle method
+        if !is_lifecycle_method(&method_name) {
+            return;
+        }
+
+        // Check if the method is async
+        if !method.value.r#async {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        // Report the diagnostic on the method
+        ctx.diagnostic(no_async_lifecycle_method_diagnostic(method.span, &method_name));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Non-async lifecycle methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit() {}
+        }
+        ",
+        // Non-async ngOnDestroy
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnDestroy() {}
+        }
+        ",
+        // Async method that is not a lifecycle method
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            async loadData() {}
+        }
+        ",
+        // Standalone async function with lifecycle name (not in Angular class)
+        r"
+        async function ngOnInit() {}
+        ",
+        // Non-Angular class with async lifecycle method name
+        r"
+        class TestClass {
+            async ngOnInit() {}
+        }
+        ",
+        // Injectable with non-async ngOnDestroy
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Async ngOnInit
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            async ngOnInit() {}
+        }
+        ",
+        // Async ngOnDestroy
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            async ngOnDestroy() {}
+        }
+        ",
+        // Async ngAfterViewInit
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            async ngAfterViewInit() {}
+        }
+        ",
+        // Directive with async lifecycle
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            async ngOnInit() {}
+        }
+        ",
+        // Injectable with async ngOnDestroy
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            async ngOnDestroy() {}
+        }
+        ",
+        // Pipe with async ngOnDestroy
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({ name: 'test' })
+        class TestPipe {
+            async ngOnDestroy() {}
+        }
+        ",
+        // Multiple async lifecycle methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            async ngOnInit() {}
+            async ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    Tester::new(NoAsyncLifecycleMethod::NAME, NoAsyncLifecycleMethod::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_attribute_decorator.rs
+++ b/crates/oxc_linter/src/rules/angular/no_attribute_decorator.rs
@@ -1,0 +1,194 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_decorator_identifier, get_decorator_name, is_angular_core_import},
+};
+
+fn no_attribute_decorator_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "The `@Attribute` decorator is rarely what is required; use `@Input` instead",
+    )
+    .with_help(
+        "`@Attribute` can only obtain a single static value from the DOM attribute and does not \
+        support data binding. In most cases, `@Input` is the appropriate choice as it supports \
+        both static values and data binding.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoAttributeDecorator;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of `@Attribute` decorator in Angular classes.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `@Attribute` decorator is commonly misused. It has significant limitations:
+    /// - It can only read a static string value from the DOM attribute
+    /// - It cannot support data binding (`[attr]="value"`)
+    /// - It reads the value only once during construction
+    /// - Changes to the attribute are not reflected
+    ///
+    /// In most cases, developers intend to use `@Input()` which supports:
+    /// - Data binding with `[property]="expression"`
+    /// - Static values with `property="value"`
+    /// - Change detection and updates
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Attribute } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   constructor(@Attribute('type') private type: string) {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() type: string;
+    /// }
+    /// ```
+    NoAttributeDecorator,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for NoAttributeDecorator {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Check for @Attribute decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Attribute" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        ctx.diagnostic(no_attribute_decorator_diagnostic(decorator.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using @Input instead
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() type: string;
+        }
+        ",
+        // Using input() signal
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            type = input<string>();
+        }
+        ",
+        // Non-Angular Attribute decorator
+        r"
+        import { Attribute } from 'other-lib';
+        class TestComponent {
+            constructor(@Attribute('type') private type: string) {}
+        }
+        ",
+        // No decorators
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(private type: string) {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // @Attribute in constructor
+        r"
+        import { Component, Attribute } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(@Attribute('type') private type: string) {}
+        }
+        ",
+        // Multiple @Attribute decorators
+        r"
+        import { Component, Attribute } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(
+                @Attribute('type') private type: string,
+                @Attribute('size') private size: string
+            ) {}
+        }
+        ",
+        // @Attribute in directive
+        r"
+        import { Directive, Attribute } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            constructor(@Attribute('title') private title: string) {}
+        }
+        ",
+    ];
+
+    Tester::new(NoAttributeDecorator::NAME, NoAttributeDecorator::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_conflicting_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/angular/no_conflicting_lifecycle.rs
@@ -1,0 +1,209 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::get_class_angular_decorator};
+
+fn no_conflicting_lifecycle_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Class implements both `DoCheck` and `OnChanges` lifecycle interfaces")
+        .with_help(
+            "Implementing both `DoCheck` and `OnChanges` can lead to unexpected behavior. \
+            `ngOnChanges` is called when input properties change, while `ngDoCheck` is called \
+            during every change detection cycle. Choose one based on your needs: use `ngOnChanges` \
+            for reacting to input changes, or `ngDoCheck` for custom change detection logic.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoConflictingLifecycle;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows implementing both `DoCheck` and `OnChanges` interfaces in the same class.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `DoCheck` and `OnChanges` lifecycle hooks serve different purposes and implementing
+    /// both can lead to confusing behavior:
+    ///
+    /// - `ngOnChanges` is called when Angular detects changes to input properties
+    /// - `ngDoCheck` is called during every change detection run
+    ///
+    /// When both are implemented:
+    /// - `ngOnChanges` runs first (when inputs change)
+    /// - `ngDoCheck` runs immediately after
+    /// - This can cause duplicate processing and performance issues
+    ///
+    /// Note: This rule is marked as deprecated in angular-eslint due to potential false
+    /// positives in legitimate use cases, but is included for completeness.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, DoCheck, OnChanges, SimpleChanges } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements DoCheck, OnChanges {
+    ///   ngDoCheck() {}
+    ///   ngOnChanges(changes: SimpleChanges) {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, OnChanges, SimpleChanges } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnChanges {
+    ///   ngOnChanges(changes: SimpleChanges) {}
+    /// }
+    /// ```
+    NoConflictingLifecycle,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for NoConflictingLifecycle {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        let mut has_do_check = false;
+        let mut has_on_changes = false;
+
+        // Check implemented interfaces
+        for ts_impl in &class.implements {
+            if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &ts_impl.expression {
+                match ident.name.as_str() {
+                    "DoCheck" => has_do_check = true,
+                    "OnChanges" => has_on_changes = true,
+                    _ => {}
+                }
+            }
+        }
+
+        // Also check for the presence of both methods (even without explicit implements)
+        for element in &class.body.body {
+            if let oxc_ast::ast::ClassElement::MethodDefinition(method) = element
+                && let Some(name) = method.key.static_name() {
+                    match name.as_ref() {
+                        "ngDoCheck" => has_do_check = true,
+                        "ngOnChanges" => has_on_changes = true,
+                        _ => {}
+                    }
+                }
+        }
+
+        if has_do_check && has_on_changes {
+            // Report on the class name or the class keyword
+            let span = class.id.as_ref().map_or(class.span, |id| id.span);
+            ctx.diagnostic(no_conflicting_lifecycle_diagnostic(span));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Only OnChanges
+        r"
+        import { Component, OnChanges, SimpleChanges } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnChanges {
+            ngOnChanges(changes: SimpleChanges) {}
+        }
+        ",
+        // Only DoCheck
+        r"
+        import { Component, DoCheck } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements DoCheck {
+            ngDoCheck() {}
+        }
+        ",
+        // Neither DoCheck nor OnChanges
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Non-Angular class with both
+        r"
+        class TestClass implements DoCheck, OnChanges {
+            ngDoCheck() {}
+            ngOnChanges() {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Both interfaces implemented
+        r"
+        import { Component, DoCheck, OnChanges, SimpleChanges } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements DoCheck, OnChanges {
+            ngDoCheck() {}
+            ngOnChanges(changes: SimpleChanges) {}
+        }
+        ",
+        // Both methods present (without explicit implements)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngDoCheck() {}
+            ngOnChanges() {}
+        }
+        ",
+        // Directive with conflicting lifecycle
+        r"
+        import { Directive, DoCheck, OnChanges } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements DoCheck, OnChanges {
+            ngDoCheck() {}
+            ngOnChanges() {}
+        }
+        ",
+    ];
+
+    Tester::new(NoConflictingLifecycle::NAME, NoConflictingLifecycle::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_duplicates_in_metadata_arrays.rs
+++ b/crates/oxc_linter/src/rules/angular/no_duplicates_in_metadata_arrays.rs
@@ -1,0 +1,313 @@
+use oxc_ast::AstKind;
+use rustc_hash::FxHashSet;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        is_angular_core_import,
+    },
+};
+
+fn no_duplicates_in_metadata_arrays_diagnostic(
+    span: Span,
+    name: &str,
+    property: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Duplicate `{name}` in `{property}` metadata array"))
+        .with_help("Remove the duplicate entry from the metadata array.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoDuplicatesInMetadataArrays;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows duplicate entries in Angular decorator metadata arrays.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Duplicate entries in metadata arrays like `imports`, `declarations`, `exports`,
+    /// `providers`, `schemas`, and `bootstrap` are unnecessary and can indicate:
+    /// - Copy-paste errors
+    /// - Misunderstanding of how Angular module configuration works
+    /// - Potential maintenance issues
+    ///
+    /// Duplicates don't cause runtime errors in most cases, but they add clutter
+    /// and can make the code harder to maintain.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { NgModule } from '@angular/core';
+    /// import { CommonModule } from '@angular/common';
+    /// import { MyComponent } from './my.component';
+    ///
+    /// @NgModule({
+    ///   imports: [CommonModule, CommonModule], // Duplicate
+    ///   declarations: [MyComponent, MyComponent] // Duplicate
+    /// })
+    /// export class MyModule {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { NgModule } from '@angular/core';
+    /// import { CommonModule } from '@angular/common';
+    /// import { MyComponent } from './my.component';
+    ///
+    /// @NgModule({
+    ///   imports: [CommonModule],
+    ///   declarations: [MyComponent]
+    /// })
+    /// export class MyModule {}
+    /// ```
+    NoDuplicatesInMetadataArrays,
+    angular,
+    style,
+    pending
+);
+
+/// Metadata properties that are arrays and should be checked for duplicates
+const ARRAY_PROPERTIES: [&str; 7] =
+    ["imports", "declarations", "exports", "providers", "schemas", "bootstrap", "hostDirectives"];
+
+impl Rule for NoDuplicatesInMetadataArrays {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @NgModule, @Component, and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if !matches!(decorator_name, "NgModule" | "Component" | "Directive") {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check each array property for duplicates
+        for prop in &metadata.properties {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+                let Some(prop_name) = get_property_key_name(&obj_prop.key) else {
+                    continue;
+                };
+
+                if !ARRAY_PROPERTIES.contains(&prop_name) {
+                    continue;
+                }
+
+                // Check if the value is an array
+                if let oxc_ast::ast::Expression::ArrayExpression(array) = &obj_prop.value {
+                    check_array_for_duplicates(array, prop_name, ctx);
+                }
+            }
+        }
+    }
+}
+
+fn get_property_key_name<'a>(key: &'a oxc_ast::ast::PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+        oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+        _ => None,
+    }
+}
+
+fn check_array_for_duplicates(
+    array: &oxc_ast::ast::ArrayExpression<'_>,
+    property_name: &str,
+    ctx: &LintContext<'_>,
+) {
+    let mut seen: FxHashSet<String> = FxHashSet::default();
+
+    for element in &array.elements {
+        let Some(expr) = element.as_expression() else {
+            continue;
+        };
+
+        // Get the identifier name from the expression
+        let Some(name) = get_expression_name(expr) else {
+            continue;
+        };
+
+        if seen.contains(&name) {
+            // Find the span of this duplicate
+            let span = get_expression_span(expr);
+            ctx.diagnostic(no_duplicates_in_metadata_arrays_diagnostic(span, &name, property_name));
+        } else {
+            seen.insert(name);
+        }
+    }
+}
+
+fn get_expression_name(expr: &oxc_ast::ast::Expression<'_>) -> Option<String> {
+    match expr {
+        oxc_ast::ast::Expression::Identifier(ident) => Some(ident.name.to_string()),
+        oxc_ast::ast::Expression::CallExpression(call) => {
+            // For cases like forwardRef(() => Component)
+            if let oxc_ast::ast::Expression::Identifier(ident) = &call.callee
+                && ident.name == "forwardRef"
+                    && let Some(arg) = call.arguments.first()
+                        && let oxc_ast::ast::Argument::ArrowFunctionExpression(arrow) = arg {
+                            // Check if arrow function has expression body with single statement
+                            if arrow.expression
+                                && let Some(stmt) = arrow.body.statements.first()
+                                    && let oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) =
+                                        stmt
+                                        && let oxc_ast::ast::Expression::Identifier(ret_ident) =
+                                            &expr_stmt.expression
+                                        {
+                                            return Some(ret_ident.name.to_string());
+                                        }
+                        }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn get_expression_span(expr: &oxc_ast::ast::Expression<'_>) -> Span {
+    match expr {
+        oxc_ast::ast::Expression::Identifier(ident) => ident.span,
+        oxc_ast::ast::Expression::CallExpression(call) => call.span,
+        _ => expr.span(),
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No duplicates in imports
+        r"
+        import { NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+        import { FormsModule } from '@angular/forms';
+        @NgModule({
+            imports: [CommonModule, FormsModule]
+        })
+        class TestModule {}
+        ",
+        // No duplicates in declarations
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            declarations: [ComponentA, ComponentB]
+        })
+        class TestModule {}
+        ",
+        // Empty arrays
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            imports: [],
+            declarations: []
+        })
+        class TestModule {}
+        ",
+        // Single items
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            imports: [CommonModule],
+            declarations: [MyComponent]
+        })
+        class TestModule {}
+        ",
+        // Non-Angular decorator
+        r"
+        import { NgModule } from 'other-library';
+        @NgModule({
+            imports: [CommonModule, CommonModule]
+        })
+        class TestModule {}
+        ",
+    ];
+
+    let fail = vec![
+        // Duplicate in imports
+        r"
+        import { NgModule } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+        @NgModule({
+            imports: [CommonModule, CommonModule]
+        })
+        class TestModule {}
+        ",
+        // Duplicate in declarations
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            declarations: [MyComponent, MyComponent]
+        })
+        class TestModule {}
+        ",
+        // Duplicate in providers
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            providers: [MyService, MyService]
+        })
+        class TestModule {}
+        ",
+        // Duplicate in exports
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            exports: [MyComponent, MyComponent]
+        })
+        class TestModule {}
+        ",
+        // Multiple duplicates in same array
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            imports: [ModuleA, ModuleA, ModuleA]
+        })
+        class TestModule {}
+        ",
+        // Duplicates in Component imports
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            imports: [CommonModule, CommonModule]
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(
+        NoDuplicatesInMetadataArrays::NAME,
+        NoDuplicatesInMetadataArrays::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_empty_lifecycle_method.rs
+++ b/crates/oxc_linter/src/rules/angular/no_empty_lifecycle_method.rs
@@ -1,0 +1,256 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, is_lifecycle_method},
+};
+
+fn no_empty_lifecycle_method_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Lifecycle method `{method_name}` should not be empty"))
+        .with_help("Either implement the lifecycle method or remove it from the class")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEmptyLifecycleMethod;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows empty lifecycle method implementations in Angular components, directives,
+    /// pipes, and services.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Empty lifecycle methods are unnecessary code that adds noise and confusion.
+    /// They serve no purpose and should be removed to keep the codebase clean.
+    /// If a lifecycle method is intentionally empty (e.g., for interface compliance),
+    /// consider adding a comment explaining why.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit {
+    ///   ngOnInit() {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit {
+    ///   ngOnInit() {
+    ///     this.loadData();
+    ///   }
+    /// }
+    /// ```
+    NoEmptyLifecycleMethod,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoEmptyLifecycleMethod {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+
+        // Get the method name
+        let Some(method_name) = method.key.static_name() else {
+            return;
+        };
+
+        // Check if it's a lifecycle method
+        if !is_lifecycle_method(&method_name) {
+            return;
+        }
+
+        // Check if the method body is empty
+        let Some(body) = &method.value.body else {
+            return;
+        };
+
+        if !body.statements.is_empty() {
+            return;
+        }
+
+        // Find the parent class and check if it's an Angular class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        ctx.diagnostic(no_empty_lifecycle_method_diagnostic(method.span, &method_name));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Lifecycle method with implementation
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {
+                console.log('initialized');
+            }
+        }
+        ",
+        // Multiple lifecycle methods with implementations
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnInit() {
+                this.setup();
+            }
+            ngOnDestroy() {
+                this.cleanup();
+            }
+        }
+        ",
+        // No lifecycle methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            onClick() {}
+        }
+        ",
+        // Non-Angular class with empty lifecycle-like method
+        r"
+        class TestClass {
+            ngOnInit() {}
+        }
+        ",
+        // Directive with implementation
+        r"
+        import { Directive, OnInit } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements OnInit {
+            ngOnInit() {
+                this.init();
+            }
+        }
+        ",
+        // Injectable with ngOnDestroy implementation
+        r"
+        import { Injectable, OnDestroy } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService implements OnDestroy {
+            ngOnDestroy() {
+                this.subscription.unsubscribe();
+            }
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Empty ngOnInit
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Empty ngOnDestroy
+        r"
+        import { Component, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnDestroy {
+            ngOnDestroy() {}
+        }
+        ",
+        // Empty ngAfterViewInit
+        r"
+        import { Component, AfterViewInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements AfterViewInit {
+            ngAfterViewInit() {}
+        }
+        ",
+        // Directive with empty lifecycle
+        r"
+        import { Directive, OnInit } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Multiple empty lifecycle methods (reports both)
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    Tester::new(NoEmptyLifecycleMethod::NAME, NoEmptyLifecycleMethod::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_forward_ref.rs
+++ b/crates/oxc_linter/src/rules/angular/no_forward_ref.rs
@@ -1,0 +1,161 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_angular_core_import};
+
+fn no_forward_ref_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using `forwardRef`")
+        .with_help(
+            "The use of `forwardRef` can often be avoided by restructuring your code. \
+            Consider moving the referenced class above the usage, using injection tokens, \
+            or refactoring to avoid circular dependencies.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoForwardRef;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows usage of `forwardRef` in Angular applications.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `forwardRef` is typically used to work around circular dependencies or to reference
+    /// classes that are defined later in the file. While it works, it's often a sign of
+    /// code that could be better structured:
+    /// - It makes the code harder to understand
+    /// - It can hide architectural issues like circular dependencies
+    /// - It may indicate that classes should be reordered or split into separate files
+    ///
+    /// In most cases, `forwardRef` can be avoided by:
+    /// - Moving the referenced class above its usage
+    /// - Using injection tokens
+    /// - Restructuring to avoid circular dependencies
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, forwardRef, Inject } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   constructor(@Inject(forwardRef(() => SomeService)) private service: SomeService) {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Inject } from '@angular/core';
+    /// import { SomeService } from './some.service';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   constructor(private service: SomeService) {}
+    /// }
+    /// ```
+    NoForwardRef,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for NoForwardRef {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a call to forwardRef
+        let callee_name = match &call_expr.callee {
+            oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        if callee_name != "forwardRef" {
+            return;
+        }
+
+        // Verify it's imported from @angular/core
+        let Some(ident) = call_expr.callee.get_identifier_reference() else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        ctx.diagnostic(no_forward_ref_diagnostic(call_expr.span));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Not using forwardRef
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(private service: MyService) {}
+        }
+        ",
+        // forwardRef from non-Angular source
+        r"
+        import { forwardRef } from 'other-library';
+        const ref = forwardRef(() => SomeClass);
+        ",
+        // Regular function call named forwardRef (not imported)
+        r"
+        function forwardRef(fn) { return fn(); }
+        forwardRef(() => 'test');
+        ",
+    ];
+
+    let fail = vec![
+        // Basic forwardRef usage
+        r"
+        import { forwardRef } from '@angular/core';
+        const ref = forwardRef(() => SomeClass);
+        ",
+        // forwardRef in Inject
+        r"
+        import { Component, forwardRef, Inject } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(@Inject(forwardRef(() => SomeService)) private service: any) {}
+        }
+        ",
+        // forwardRef in providers
+        r"
+        import { NgModule, forwardRef } from '@angular/core';
+        @NgModule({
+            providers: [
+                { provide: 'TOKEN', useClass: forwardRef(() => MyService) }
+            ]
+        })
+        class AppModule {}
+        ",
+    ];
+
+    Tester::new(NoForwardRef::NAME, NoForwardRef::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_host_metadata_property.rs
+++ b/crates/oxc_linter/src/rules/angular/no_host_metadata_property.rs
@@ -1,0 +1,310 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn no_host_metadata_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using the `host` metadata property")
+        .with_help(
+            "Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. \
+            Decorator-based host bindings provide better type safety and are easier to understand. \
+            Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoHostMetadataProperty;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using the `host` metadata property in `@Component` and `@Directive` decorators.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the `host` metadata property makes it harder to understand what host bindings
+    /// and listeners are being used. The `@HostBinding()` and `@HostListener()` decorators
+    /// provide better readability, type safety, and are co-located with the class properties
+    /// and methods they affect.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   host: {
+    ///     '[class.active]': 'isActive',
+    ///     '(click)': 'onClick()'
+    ///   }
+    /// })
+    /// export class ExampleComponent {
+    ///   isActive = false;
+    ///   onClick() {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, HostBinding, HostListener } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @HostBinding('class.active') isActive = false;
+    ///
+    ///   @HostListener('click')
+    ///   onClick() {}
+    /// }
+    /// ```
+    NoHostMetadataProperty,
+    angular,
+    pedantic,
+    pending // not yet ready for production
+);
+
+impl Rule for NoHostMetadataProperty {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" && decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the host property
+        if get_metadata_property(metadata, "host").is_some() {
+            // Find the span of the host property key
+            let span = find_property_key_span(metadata, "host");
+            ctx.diagnostic(no_host_metadata_property_diagnostic(span));
+        }
+    }
+}
+
+/// Find the span of a property key in an object expression.
+fn find_property_key_span(obj: &oxc_ast::ast::ObjectExpression<'_>, key: &str) -> Span {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+    use oxc_span::GetSpan;
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == key {
+                    return ident.span();
+                }
+    }
+
+    // Fallback to the object span if we can't find the property
+    obj.span
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No host property - using decorators
+        r"
+        import { Component, HostBinding, HostListener } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostBinding('class.active') isActive = false;
+            @HostListener('click') onClick() {}
+        }
+        ",
+        // Directive without host property
+        r"
+        import { Directive, HostBinding } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @HostBinding('class.highlight') highlight = true;
+        }
+        ",
+        // Component with only basic metadata
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div>Content</div>'
+        })
+        class TestComponent {}
+        ",
+        // Component with multiple HostBinding decorators
+        r"
+        import { Component, HostBinding } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostBinding('class.active') isActive = false;
+            @HostBinding('attr.role') role = 'button';
+            @HostBinding('style.color') color = 'red';
+        }
+        ",
+        // Directive with HostListener
+        r"
+        import { Directive, HostListener } from '@angular/core';
+        @Directive({
+            selector: '[appClickOutside]'
+        })
+        class ClickOutsideDirective {
+            @HostListener('document:click', ['$event'])
+            onDocumentClick(event: Event) {}
+        }
+        ",
+        // Non-Angular decorator (should not trigger)
+        r"
+        import { Component } from 'some-other-lib';
+        @Component({
+            selector: 'app-test',
+            host: { '[class.active]': 'isActive' }
+        })
+        class TestComponent {}
+        ",
+        // Directive from non-Angular library
+        r"
+        import { Directive } from 'some-other-lib';
+        @Directive({
+            selector: '[appTest]',
+            host: { '[class.active]': 'isActive' }
+        })
+        class TestDirective {}
+        ",
+        // Injectable (not Component/Directive)
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({
+            providedIn: 'root'
+        })
+        class TestService {}
+        ",
+        // Pipe (not Component/Directive)
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            standalone: true
+        })
+        class MyPipe {}
+        ",
+        // Component with inputs/outputs but no host
+        r"
+        import { Component, Input, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() value: string;
+            @Output() valueChange = new EventEmitter<string>();
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Component with host property
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            host: {
+                '[class.active]': 'isActive',
+                '(click)': 'onClick()'
+            }
+        })
+        class TestComponent {}
+        ",
+        // Directive with host property
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            host: {
+                '[attr.role]': 'role'
+            }
+        })
+        class TestDirective {}
+        ",
+        // Component with empty host object
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            host: {}
+        })
+        class TestComponent {}
+        ",
+        // Component with style bindings in host
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            host: {
+                '[style.width.px]': 'width',
+                '[style.height.px]': 'height'
+            }
+        })
+        class TestComponent {}
+        ",
+        // Directive with event listener in host
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            host: {
+                '(mouseenter)': 'onMouseEnter()',
+                '(mouseleave)': 'onMouseLeave()'
+            }
+        })
+        class TestDirective {}
+        ",
+    ];
+
+    Tester::new(NoHostMetadataProperty::NAME, NoHostMetadataProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_implicit_take_until_destroyed.rs
+++ b/crates/oxc_linter/src/rules/angular/no_implicit_take_until_destroyed.rs
@@ -1,0 +1,271 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_implicit_take_until_destroyed_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "`takeUntilDestroyed()` called without `DestroyRef` argument outside injection context",
+    )
+    .with_help(
+        "When using `takeUntilDestroyed()` outside of an injection context (like inside `ngOnInit`, \
+        event handlers, or subscriptions), you must pass a `DestroyRef` explicitly. \
+        Example: `takeUntilDestroyed(this.destroyRef)` where `destroyRef = inject(DestroyRef)`.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoImplicitTakeUntilDestroyed;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires that `takeUntilDestroyed()` is called with an explicit `DestroyRef` when used
+    /// outside of an injection context.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `takeUntilDestroyed()` operator from `@angular/core/rxjs-interop` can be called
+    /// without arguments only within an injection context (like constructors or field initializers).
+    /// When called outside an injection context (in lifecycle methods, callbacks, or subscriptions),
+    /// it will throw a runtime error.
+    ///
+    /// Common problematic patterns:
+    /// - Calling `takeUntilDestroyed()` in `ngOnInit`
+    /// - Calling it in event handlers or callbacks
+    /// - Calling it inside `setTimeout`, `setInterval`, or promise callbacks
+    ///
+    /// The solution is to inject `DestroyRef` and pass it explicitly:
+    /// ```typescript
+    /// private destroyRef = inject(DestroyRef);
+    ///
+    /// ngOnInit() {
+    ///   this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, inject } from '@angular/core';
+    /// import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   ngOnInit() {
+    ///     this.data$.pipe(takeUntilDestroyed()).subscribe(); // Error!
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, inject, DestroyRef } from '@angular/core';
+    /// import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   private destroyRef = inject(DestroyRef);
+    ///
+    ///   ngOnInit() {
+    ///     this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+    ///   }
+    /// }
+    /// ```
+    NoImplicitTakeUntilDestroyed,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoImplicitTakeUntilDestroyed {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a call to takeUntilDestroyed
+        let callee_name = match &call_expr.callee {
+            oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        if callee_name != "takeUntilDestroyed" {
+            return;
+        }
+
+        // Verify it's imported from @angular/core/rxjs-interop
+        let Some(ident) = call_expr.callee.get_identifier_reference() else {
+            return;
+        };
+
+        if !is_rxjs_interop_import(ident, ctx) {
+            return;
+        }
+
+        // If it has arguments, it's explicit - no problem
+        if !call_expr.arguments.is_empty() {
+            return;
+        }
+
+        // Check if we're in an injection context
+        if !is_in_injection_context(node, ctx) {
+            ctx.diagnostic(no_implicit_take_until_destroyed_diagnostic(call_expr.span));
+        }
+    }
+}
+
+fn is_rxjs_interop_import(
+    ident: &oxc_ast::ast::IdentifierReference<'_>,
+    ctx: &LintContext<'_>,
+) -> bool {
+    let reference = ctx.scoping().get_reference(ident.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+
+    if !ctx.scoping().symbol_flags(symbol_id).is_import() {
+        return false;
+    }
+
+    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
+        return false;
+    };
+
+    let source = import_decl.source.value.as_str();
+    source == "@angular/core/rxjs-interop" || source == "@angular/core"
+}
+
+fn is_in_injection_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    // Walk up the tree to find the containing context
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        match ancestor.kind() {
+            // Constructors are injection contexts
+            AstKind::MethodDefinition(method) => {
+                if method.kind.is_constructor() {
+                    return true;
+                }
+                // Regular methods are NOT injection contexts
+                return false;
+            }
+            // Field initializers are injection contexts (class property definitions at class level)
+            AstKind::PropertyDefinition(_) => {
+                // Check if this is a direct child of a class body
+                return true;
+            }
+            // Static blocks are NOT injection contexts
+            AstKind::StaticBlock(_) => {
+                return false;
+            }
+            // Arrow functions or regular functions might not be injection contexts
+            // depending on where they are defined
+            AstKind::ArrowFunctionExpression(_) | AstKind::Function(_) => {
+                // Keep walking up - the function might be in a valid context
+                continue;
+            }
+            AstKind::Class(_) => {
+                // If we reach the class without hitting a method, we're in a field initializer
+                return true;
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // With DestroyRef argument
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        import { DestroyRef, inject } from '@angular/core';
+        class TestComponent {
+            destroyRef = inject(DestroyRef);
+            ngOnInit() {
+                this.data$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+            }
+        }
+        ",
+        // In constructor (injection context)
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            constructor() {
+                this.data$.pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+        // In field initializer (injection context)
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            data = this.source$.pipe(takeUntilDestroyed());
+        }
+        ",
+        // Non-Angular takeUntilDestroyed
+        r"
+        import { takeUntilDestroyed } from 'other-library';
+        class TestComponent {
+            ngOnInit() {
+                this.data$.pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // In ngOnInit without argument
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            ngOnInit() {
+                this.data$.pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+        // In ngAfterViewInit without argument
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            ngAfterViewInit() {
+                this.data$.pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+        // In regular method
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            loadData() {
+                this.data$.pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+        // In event handler callback
+        r"
+        import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+        class TestComponent {
+            onClick() {
+                this.service.getData().pipe(takeUntilDestroyed()).subscribe();
+            }
+        }
+        ",
+    ];
+
+    Tester::new(
+        NoImplicitTakeUntilDestroyed::NAME,
+        NoImplicitTakeUntilDestroyed::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_input_prefix.rs
+++ b/crates/oxc_linter/src/rules/angular/no_input_prefix.rs
@@ -1,0 +1,370 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        AngularDecoratorType, get_class_angular_decorator, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn no_input_prefix_diagnostic(span: Span, prefix: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Input should not be prefixed with `{prefix}`"))
+        .with_help(format!(
+            "Rename the input to not start with `{prefix}`. Inputs should use \
+            descriptive names without unnecessary prefixes that can make the code \
+            harder to read or inconsistent with other inputs."
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoInputPrefixConfig {
+    /// Prefixes that should not be used for input names
+    #[serde(default = "default_prefixes")]
+    prefixes: Vec<String>,
+}
+
+fn default_prefixes() -> Vec<String> {
+    vec!["on".to_string()]
+}
+
+impl Default for NoInputPrefixConfig {
+    fn default() -> Self {
+        Self { prefixes: default_prefixes() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoInputPrefix {
+    prefixes: Vec<String>,
+}
+
+impl Default for NoInputPrefix {
+    fn default() -> Self {
+        Self { prefixes: default_prefixes() }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows inputs from having certain prefixes.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Certain prefixes like "on" are often associated with events (like onClick),
+    /// not inputs. Using "on" prefix for inputs can be confusing because:
+    /// - It suggests the property is an event handler, not a data input
+    /// - It creates inconsistency in the component's API
+    /// - It goes against Angular naming conventions
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/no-input-prefix": ["error", {
+    ///     "prefixes": ["on", "is", "can"]
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (with default config):
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() onSelect: (item: any) => void; // Prefixed with 'on'
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Input, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() selectedItem: any;
+    ///   @Output() select = new EventEmitter(); // Events use @Output
+    /// }
+    /// ```
+    NoInputPrefix,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for NoInputPrefix {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        let config: NoInputPrefixConfig = serde_json::from_value(config_value.clone())?;
+        Ok(Self { prefixes: config.prefixes })
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Check if this is an @Input decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Input" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class to verify it's an Angular component/directive
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        if !matches!(
+            decorator_type,
+            AngularDecoratorType::Component | AngularDecoratorType::Directive
+        ) {
+            return;
+        }
+
+        // Get the property name this decorator is applied to
+        let Some(input_name) = get_decorated_property_name(node, ctx) else {
+            return;
+        };
+
+        // Check for alias in decorator arguments
+        let alias = get_input_alias(decorator);
+        let name_to_check = alias.as_ref().map_or(input_name.as_str(), String::as_str);
+
+        // Check if the name starts with any of the forbidden prefixes
+        for prefix in &self.prefixes {
+            if starts_with_prefix(name_to_check, prefix) {
+                ctx.diagnostic(no_input_prefix_diagnostic(decorator.span, prefix));
+                return;
+            }
+        }
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+fn get_decorated_property_name<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> Option<String> {
+    // The parent of the decorator should be the property definition
+    let parent = ctx.nodes().parent_node(node.id());
+
+    match parent.kind() {
+        AstKind::PropertyDefinition(prop) => {
+            if let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &prop.key {
+                return Some(ident.name.to_string());
+            }
+        }
+        AstKind::AccessorProperty(prop) => {
+            if let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &prop.key {
+                return Some(ident.name.to_string());
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+fn get_input_alias(decorator: &oxc_ast::ast::Decorator<'_>) -> Option<String> {
+    let call_expr = match &decorator.expression {
+        oxc_ast::ast::Expression::CallExpression(call) => call,
+        _ => return None,
+    };
+
+    // @Input('alias') or @Input({ alias: 'alias' })
+    let first_arg = call_expr.arguments.first()?;
+
+    match first_arg {
+        oxc_ast::ast::Argument::StringLiteral(lit) => Some(lit.value.to_string()),
+        oxc_ast::ast::Argument::ObjectExpression(obj) => {
+            for prop in &obj.properties {
+                if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop
+                    && let oxc_ast::ast::PropertyKey::StaticIdentifier(key) = &obj_prop.key
+                        && key.name == "alias"
+                            && let oxc_ast::ast::Expression::StringLiteral(lit) = &obj_prop.value {
+                                return Some(lit.value.to_string());
+                            }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn starts_with_prefix(name: &str, prefix: &str) -> bool {
+    if name.len() <= prefix.len() {
+        return false;
+    }
+
+    if !name.starts_with(prefix) {
+        return false;
+    }
+
+    // Check that the character after the prefix is uppercase (camelCase)
+    name.chars().nth(prefix.len()).is_some_and(|c| c.is_ascii_uppercase())
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Input without forbidden prefix
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input() value: string;
+            }
+            ",
+            None,
+        ),
+        // Input with "on" in the middle (not prefix)
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input() selectedOption: string;
+            }
+            ",
+            None,
+        ),
+        // Custom prefix config - input without forbidden prefix
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input() onSelect: any;
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["can", "is"] }])),
+        ),
+        // Non-Angular class
+        (
+            r"
+            import { Input } from 'other-library';
+            class TestClass {
+                @Input() onSelect: any;
+            }
+            ",
+            None,
+        ),
+    ];
+
+    let fail = vec![
+        // Input with 'on' prefix (default config)
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input() onSelect: any;
+            }
+            ",
+            None,
+        ),
+        // Input with 'on' prefix via alias
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input('onSelect') select: any;
+            }
+            ",
+            None,
+        ),
+        // Custom prefix config
+        (
+            r"
+            import { Component, Input } from '@angular/core';
+            @Component({
+                selector: 'app-test',
+                template: ''
+            })
+            class TestComponent {
+                @Input() canEdit: boolean;
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["can", "is"] }])),
+        ),
+        // Directive with forbidden prefix
+        (
+            r"
+            import { Directive, Input } from '@angular/core';
+            @Directive({
+                selector: '[appTest]'
+            })
+            class TestDirective {
+                @Input() onHover: any;
+            }
+            ",
+            None,
+        ),
+    ];
+
+    Tester::new(NoInputPrefix::NAME, NoInputPrefix::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_input_rename.rs
+++ b/crates/oxc_linter/src/rules/angular/no_input_rename.rs
@@ -1,0 +1,380 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_decorator_call, get_decorator_identifier, get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn no_input_rename_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Input bindings should not be aliased")
+        .with_help(
+            "Avoid aliasing inputs as it can lead to confusion. Use the original property name \
+            or rename the property if the alias is more appropriate.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoInputRenameConfig {
+    #[serde(default)]
+    allowed_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NoInputRename {
+    allowed_names: Vec<String>,
+}
+
+impl From<NoInputRenameConfig> for NoInputRename {
+    fn from(config: NoInputRenameConfig) -> Self {
+        Self { allowed_names: config.allowed_names }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows aliasing input bindings (renaming inputs with a different public name).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Two names for the same property (one private, one public) is confusing.
+    /// It requires developers to remember both names and understand the mapping.
+    ///
+    /// Exceptions are made for:
+    /// - Cases where the alias matches the property name (redundant but harmless)
+    /// - Names specified in the `allowedNames` configuration
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input('label') name: string; // Aliased input
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() name: string; // No alias
+    /// }
+    /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/no-input-rename": ["error", { "allowedNames": ["appCustom"] }]
+    /// }
+    /// ```
+    NoInputRename,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoInputRename {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<NoInputRenameConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Check for @Input decorator
+        if let AstKind::Decorator(decorator) = node.kind() {
+            self.check_input_decorator(decorator, node, ctx);
+            return;
+        }
+
+        // Check for input() signal function
+        if let AstKind::PropertyDefinition(prop) = node.kind() {
+            self.check_input_signal(prop, ctx);
+        }
+    }
+}
+
+impl NoInputRename {
+    fn check_input_decorator(
+        &self,
+        decorator: &oxc_ast::ast::Decorator<'_>,
+        _node: &AstNode<'_>,
+        ctx: &LintContext<'_>,
+    ) {
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Input" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the decorator call to check for alias
+        let Some(call) = get_decorator_call(decorator) else {
+            return;
+        };
+
+        // Get the first argument (the alias)
+        let Some(first_arg) = call.arguments.first() else {
+            return;
+        };
+
+        let alias = match first_arg {
+            oxc_ast::ast::Argument::StringLiteral(lit) => Some(lit.value.as_str()),
+            oxc_ast::ast::Argument::ObjectExpression(obj) => {
+                // Check for { alias: 'name' } format
+                get_alias_from_object(obj)
+            }
+            _ => None,
+        };
+
+        let Some(alias) = alias else {
+            return;
+        };
+
+        // Get the property name from parent
+        let property_name = self.get_property_name_from_decorator(_node, ctx);
+
+        // Allow if alias matches property name
+        if property_name.as_deref() == Some(alias) {
+            return;
+        }
+
+        // Allow if alias is in allowed names
+        if self.allowed_names.iter().any(|name| name == alias) {
+            return;
+        }
+
+        ctx.diagnostic(no_input_rename_diagnostic(decorator.span));
+    }
+
+    fn check_input_signal(
+        &self,
+        prop: &oxc_ast::ast::PropertyDefinition<'_>,
+        ctx: &LintContext<'_>,
+    ) {
+        let Some(value) = &prop.value else {
+            return;
+        };
+
+        let Expression::CallExpression(call) = value else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &call.callee else {
+            return;
+        };
+
+        if callee.name.as_str() != "input" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        if !is_angular_core_import(callee.as_ref(), ctx) {
+            return;
+        }
+
+        // Check for alias in options object
+        for arg in &call.arguments {
+            if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg
+                && let Some(alias) = get_alias_from_object(obj) {
+                    let property_name = prop.key.static_name();
+
+                    // Allow if alias matches property name
+                    if property_name.as_deref() == Some(alias) {
+                        continue;
+                    }
+
+                    // Allow if alias is in allowed names
+                    if self.allowed_names.iter().any(|name| name == alias) {
+                        continue;
+                    }
+
+                    ctx.diagnostic(no_input_rename_diagnostic(prop.span));
+                    return;
+                }
+        }
+    }
+
+    fn get_property_name_from_decorator(
+        &self,
+        node: &crate::AstNode<'_>,
+        ctx: &LintContext<'_>,
+    ) -> Option<String> {
+        // Find the parent property definition
+        for ancestor in ctx.nodes().ancestors(node.id()) {
+            if let AstKind::PropertyDefinition(prop) = ancestor.kind() {
+                return prop.key.static_name().map(|s| s.to_string());
+            }
+        }
+        None
+    }
+}
+
+fn get_alias_from_object<'a>(obj: &'a oxc_ast::ast::ObjectExpression<'a>) -> Option<&'a str> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == "alias"
+                    && let Expression::StringLiteral(lit) = &prop.value {
+                        return Some(lit.value.as_str());
+                    }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No alias
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() name: string;
+        }
+        ",
+        // Alias matches property name (redundant but allowed)
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input('name') name: string;
+        }
+        ",
+        // Multiple inputs without alias
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() firstName: string;
+            @Input() lastName: string;
+        }
+        ",
+        // input() signal without alias
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            name = input<string>();
+        }
+        ",
+        // input() signal with matching alias
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            name = input<string>({ alias: 'name' });
+        }
+        ",
+        // Non-Angular Input
+        r"
+        import { Input } from 'other-lib';
+        class TestComponent {
+            @Input('alias') name: string;
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Aliased input with string
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input('label') name: string;
+        }
+        ",
+        // Aliased input with object
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input({ alias: 'label' }) name: string;
+        }
+        ",
+        // input() signal with alias
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            name = input<string>({ alias: 'label' });
+        }
+        ",
+        // Multiple aliased inputs
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input('firstName') name: string;
+            @Input('userAge') age: number;
+        }
+        ",
+    ];
+
+    Tester::new(NoInputRename::NAME, NoInputRename::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_inputs_metadata_property.rs
+++ b/crates/oxc_linter/src/rules/angular/no_inputs_metadata_property.rs
@@ -1,0 +1,258 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        find_property_key_span, get_component_metadata, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn no_inputs_metadata_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `@Input` decorator rather than the `inputs` metadata property")
+        .with_help(
+            "The `inputs` metadata property is a legacy API. Use the `@Input()` decorator \
+            or `input()` signal function directly on properties instead.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoInputsMetadataProperty;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using the `inputs` array in `@Component` and `@Directive` metadata.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the `inputs` metadata property is a legacy approach. The `@Input()` decorator
+    /// or `input()` signal function provides:
+    /// - Better type safety
+    /// - Better IDE support
+    /// - Co-location of metadata with the property
+    /// - Easier to understand and maintain
+    ///
+    /// Note: This rule does not flag `inputs` when used in `hostDirectives` configuration,
+    /// as that is a valid use case.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   inputs: ['name', 'value: inputValue']
+    /// })
+    /// export class ExampleComponent {
+    ///   name: string;
+    ///   value: string;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Input } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Input() name: string;
+    ///   @Input('inputValue') value: string;
+    /// }
+    /// ```
+    NoInputsMetadataProperty,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoInputsMetadataProperty {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" && decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the inputs property at the top level (not inside hostDirectives)
+        for prop in &metadata.properties {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+                let prop_name = match &obj_prop.key {
+                    oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+                    oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+                    _ => None,
+                };
+
+                if prop_name == Some("inputs") {
+                    // This is a top-level inputs property, not inside hostDirectives
+                    let span = find_property_key_span(metadata, "inputs").unwrap_or(metadata.span);
+                    ctx.diagnostic(no_inputs_metadata_property_diagnostic(span));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using @Input decorator
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() name: string;
+        }
+        ",
+        // Using input() signal
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            name = input<string>();
+        }
+        ",
+        // No inputs at all
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Directive with @Input
+        r"
+        import { Directive, Input } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @Input() value: string;
+        }
+        ",
+        // Non-Angular Component
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            inputs: ['name']
+        })
+        class TestComponent {}
+        ",
+        // hostDirectives with inputs (allowed)
+        r"
+        import { Component } from '@angular/core';
+        import { SomeDirective } from './some.directive';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            hostDirectives: [{
+                directive: SomeDirective,
+                inputs: ['value']
+            }]
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // Component with inputs metadata
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            inputs: ['name']
+        })
+        class TestComponent {
+            name: string;
+        }
+        ",
+        // Component with multiple inputs
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            inputs: ['name', 'value', 'count']
+        })
+        class TestComponent {}
+        ",
+        // Component with aliased inputs
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            inputs: ['value: inputValue']
+        })
+        class TestComponent {}
+        ",
+        // Directive with inputs metadata
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            inputs: ['highlight']
+        })
+        class TestDirective {}
+        ",
+        // Empty inputs array (still flagged)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            inputs: []
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(NoInputsMetadataProperty::NAME, NoInputsMetadataProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_lifecycle_call.rs
+++ b/crates/oxc_linter/src/rules/angular/no_lifecycle_call.rs
@@ -1,0 +1,334 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, is_lifecycle_method},
+};
+
+fn no_lifecycle_call_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Avoid explicit calls to lifecycle method `{method_name}`"))
+        .with_help(
+            "Lifecycle methods are called by Angular. Calling them explicitly can lead to \
+            unexpected behavior. Move the logic to a separate method if you need to call it.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoLifecycleCall;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows explicit calls to lifecycle methods like `ngOnInit()`, `ngOnDestroy()`, etc.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Lifecycle methods are meant to be called by Angular, not by the developer.
+    /// Calling them explicitly can lead to:
+    /// - Unexpected side effects
+    /// - Logic being executed at wrong times
+    /// - Difficulty understanding when code is actually running
+    ///
+    /// If you need to reuse logic from a lifecycle method, extract it to a separate method
+    /// and call that method instead.
+    ///
+    /// Note: Calling `super.ngOnInit()` (or other lifecycle) from within the same lifecycle
+    /// method is allowed, as this is a valid pattern for class inheritance.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit {
+    ///   ngOnInit() {}
+    ///
+    ///   reset() {
+    ///     this.ngOnInit(); // Bad: explicit call to lifecycle method
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit {
+    ///   ngOnInit() {
+    ///     this.initialize();
+    ///   }
+    ///
+    ///   reset() {
+    ///     this.initialize(); // Good: call the extracted method
+    ///   }
+    ///
+    ///   private initialize() {
+    ///     // initialization logic
+    ///   }
+    /// }
+    /// ```
+    NoLifecycleCall,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for NoLifecycleCall {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call) = node.kind() else {
+            return;
+        };
+
+        // Check if it's a member expression call like `this.ngOnInit()` or `instance.ngOnInit()`
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return;
+        };
+
+        let method_name = member.property.name.as_str();
+
+        // Check if it's a lifecycle method
+        if !is_lifecycle_method(method_name) {
+            return;
+        }
+
+        // Allow super.ngXxx() calls within the same lifecycle method
+        if is_super_call_in_same_lifecycle(&member.object, method_name, node, ctx) {
+            return;
+        }
+
+        // Only report if we're inside an Angular class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        ctx.diagnostic(no_lifecycle_call_diagnostic(call.span, method_name));
+    }
+}
+
+/// Check if this is a super.ngXxx() call within the same ngXxx method
+fn is_super_call_in_same_lifecycle(
+    object: &Expression<'_>,
+    method_name: &str,
+    node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> bool {
+    // Check if the object is `super`
+    if !matches!(object, Expression::Super(_)) {
+        return false;
+    }
+
+    // Check if we're inside the same lifecycle method
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::MethodDefinition(method) = ancestor.kind()
+            && let Some(name) = method.key.static_name() {
+                return name == method_name;
+            }
+    }
+
+    false
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Normal method calls
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            onClick() {
+                this.doSomething();
+            }
+            doSomething() {}
+        }
+        ",
+        // Super call within same lifecycle method (allowed)
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent extends BaseComponent {
+            ngOnInit() {
+                super.ngOnInit();
+            }
+        }
+        ",
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent extends BaseComponent {
+            ngOnDestroy() {
+                super.ngOnDestroy();
+            }
+        }
+        ",
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent extends BaseComponent {
+            ngAfterViewInit() {
+                super.ngAfterViewInit();
+            }
+        }
+        ",
+        // Calling non-lifecycle methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnInit() {
+                this.initialize();
+            }
+            initialize() {}
+        }
+        ",
+        // Calling methods with similar names but not lifecycle
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnInitCustom() {}
+            test() {
+                this.ngOnInitCustom();
+            }
+        }
+        ",
+        // Non-Angular class - lifecycle calls should be allowed
+        r"
+        class TestClass {
+            ngOnInit() {}
+            reset() {
+                this.ngOnInit();
+            }
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Explicit this.ngOnInit() call
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnInit() {}
+            reset() {
+                this.ngOnInit();
+            }
+        }
+        ",
+        // Explicit this.ngOnDestroy() call
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnDestroy() {}
+            cleanup() {
+                this.ngOnDestroy();
+            }
+        }
+        ",
+        // Explicit this.ngAfterViewInit() call
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngAfterViewInit() {}
+            refresh() {
+                this.ngAfterViewInit();
+            }
+        }
+        ",
+        // Call on another instance
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            otherComponent: OtherComponent;
+            test() {
+                this.otherComponent.ngOnInit();
+            }
+        }
+        ",
+        // Multiple lifecycle calls
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnInit() {}
+            ngOnDestroy() {}
+            reset() {
+                this.ngOnInit();
+                this.ngOnDestroy();
+            }
+        }
+        ",
+        // Super call in different lifecycle method (not allowed)
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent extends BaseComponent {
+            ngOnInit() {
+                super.ngOnDestroy();
+            }
+        }
+        ",
+        // Call in nested function
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            ngOnInit() {}
+            setup() {
+                const fn = () => {
+                    this.ngOnInit();
+                };
+            }
+        }
+        ",
+        // Directive with lifecycle call
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({ selector: '[appTest]' })
+        class TestDirective {
+            ngOnInit() {}
+            reset() {
+                this.ngOnInit();
+            }
+        }
+        ",
+    ];
+
+    Tester::new(NoLifecycleCall::NAME, NoLifecycleCall::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_output_native.rs
+++ b/crates/oxc_linter/src/rules/angular/no_output_native.rs
@@ -1,0 +1,327 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_decorator_call, get_decorator_identifier, get_decorator_name, is_angular_core_import,
+        is_native_event_name,
+    },
+};
+
+fn no_output_native_diagnostic(span: Span, event_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Output bindings, including aliases, should not be named as native DOM events: `{event_name}`"
+    ))
+    .with_help(
+        "Using native event names like 'click', 'change', 'blur' can cause confusion and \
+        unexpected behavior. Rename your output to something more descriptive like 'itemClick' \
+        or 'valueChange'.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOutputNative;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows naming outputs with the same names as native DOM events.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Naming an output the same as a native DOM event (e.g., `click`, `change`, `blur`)
+    /// can lead to confusion about whether the event is a native DOM event or a custom
+    /// Angular output. It can also cause unexpected behavior when the event bubbles or
+    /// is captured at a higher level in the DOM.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() click = new EventEmitter<void>(); // Same as native DOM event
+    ///   @Output() change = new EventEmitter<string>(); // Same as native DOM event
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() itemClick = new EventEmitter<void>();
+    ///   @Output() valueChange = new EventEmitter<string>();
+    /// }
+    /// ```
+    NoOutputNative,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoOutputNative {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::PropertyDefinition(prop) = node.kind() else {
+            return;
+        };
+
+        // Check if this is an output property
+        let (output_name, span) = if let Some(output_info) = self.get_output_info(prop, ctx) {
+            output_info
+        } else {
+            return;
+        };
+
+        // Check if the output name is a native event name
+        if is_native_event_name(&output_name) {
+            ctx.diagnostic(no_output_native_diagnostic(span, &output_name));
+        }
+    }
+}
+
+impl NoOutputNative {
+    /// Returns the effective output name and span if this is an output property
+    fn get_output_info(
+        &self,
+        prop: &oxc_ast::ast::PropertyDefinition<'_>,
+        ctx: &LintContext<'_>,
+    ) -> Option<(String, Span)> {
+        // Check for @Output decorator
+        for decorator in &prop.decorators {
+            let Some(decorator_name) = get_decorator_name(decorator) else {
+                continue;
+            };
+
+            if decorator_name != "Output" {
+                continue;
+            }
+
+            let Some(ident) = get_decorator_identifier(decorator) else {
+                continue;
+            };
+
+            if !is_angular_core_import(ident, ctx) {
+                continue;
+            }
+
+            // Get the alias or property name
+            if let Some(call) = get_decorator_call(decorator)
+                && let Some(first_arg) = call.arguments.first() {
+                    match first_arg {
+                        oxc_ast::ast::Argument::StringLiteral(lit) => {
+                            return Some((lit.value.to_string(), prop.span));
+                        }
+                        oxc_ast::ast::Argument::ObjectExpression(obj) => {
+                            if let Some(alias) = get_alias_from_object(obj) {
+                                return Some((alias.to_string(), prop.span));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+            // Use property name if no alias
+            return prop.key.static_name().map(|name| (name.to_string(), prop.span));
+        }
+
+        // Check for output() signal function
+        let value = prop.value.as_ref()?;
+        let Expression::CallExpression(call) = value else {
+            return None;
+        };
+
+        let Expression::Identifier(callee) = &call.callee else {
+            return None;
+        };
+
+        if callee.name.as_str() != "output" {
+            return None;
+        }
+
+        if !is_angular_core_import(callee.as_ref(), ctx) {
+            return None;
+        }
+
+        // Check for alias in options object
+        for arg in &call.arguments {
+            if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg
+                && let Some(alias) = get_alias_from_object(obj) {
+                    return Some((alias.to_string(), prop.span));
+                }
+        }
+
+        // Use property name
+        prop.key.static_name().map(|name| (name.to_string(), prop.span))
+    }
+}
+
+fn get_alias_from_object<'a>(obj: &'a oxc_ast::ast::ObjectExpression<'a>) -> Option<&'a str> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == "alias"
+                    && let Expression::StringLiteral(lit) = &prop.value {
+                        return Some(lit.value.as_str());
+                    }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Custom output name
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() itemClick = new EventEmitter<void>();
+        }
+        ",
+        // Custom output name with Change suffix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() valueChange = new EventEmitter<string>();
+        }
+        ",
+        // output() signal with custom name
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            itemSelected = output<string>();
+        }
+        ",
+        // Non-Angular Output
+        r"
+        import { Output, EventEmitter } from 'other-lib';
+        class TestComponent {
+            @Output() click = new EventEmitter<void>();
+        }
+        ",
+        // Not an output (Input decorator)
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Input() click: boolean;
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Native event name: click
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() click = new EventEmitter<void>();
+        }
+        ",
+        // Native event name: change
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() change = new EventEmitter<string>();
+        }
+        ",
+        // Native event name: blur
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() blur = new EventEmitter<void>();
+        }
+        ",
+        // Native event name: focus
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() focus = new EventEmitter<void>();
+        }
+        ",
+        // Aliased to native event name
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output('click') buttonClick = new EventEmitter<void>();
+        }
+        ",
+        // output() signal with native event name
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            scroll = output<void>();
+        }
+        ",
+        // output() signal aliased to native event name
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            buttonPress = output<void>({ alias: 'keydown' });
+        }
+        ",
+    ];
+
+    Tester::new(NoOutputNative::NAME, NoOutputNative::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_output_on_prefix.rs
+++ b/crates/oxc_linter/src/rules/angular/no_output_on_prefix.rs
@@ -1,0 +1,339 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_decorator_call, get_decorator_identifier, get_decorator_name, has_on_prefix,
+        is_angular_core_import,
+    },
+};
+
+fn no_output_on_prefix_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Output bindings, including aliases, should not be named \"on\" or prefixed with it: `{name}`"
+    ))
+    .with_help(
+        "Remove the 'on' prefix from the output name. In Angular templates, outputs are already \
+        bound with (output) syntax which implies an event. Adding 'on' is redundant: \
+        (onClick)=\"handler()\" becomes confusing.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOutputOnPrefix;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows naming outputs with the "on" prefix.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In Angular templates, outputs are bound using the `(output)` syntax which already
+    /// implies an event handler. Adding an "on" prefix creates redundancy:
+    ///
+    /// ```html
+    /// <!-- Confusing: (onClick) suggests handling a click twice -->
+    /// <app-button (onClick)="handleClick()"></app-button>
+    ///
+    /// <!-- Clear: (click) or (buttonClick) is more intuitive -->
+    /// <app-button (click)="handleClick()"></app-button>
+    /// ```
+    ///
+    /// The "on" prefix is a convention from DOM event handlers (`onclick`, `onblur`) but
+    /// is not appropriate for Angular outputs.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() onClick = new EventEmitter<void>();
+    ///   @Output() onValueChange = new EventEmitter<string>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() click = new EventEmitter<void>();
+    ///   @Output() valueChange = new EventEmitter<string>();
+    /// }
+    /// ```
+    NoOutputOnPrefix,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoOutputOnPrefix {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::PropertyDefinition(prop) = node.kind() else {
+            return;
+        };
+
+        // Check if this is an output property
+        let (output_name, span) = if let Some(output_info) = self.get_output_info(prop, ctx) {
+            output_info
+        } else {
+            return;
+        };
+
+        // Check if the output name has "on" prefix
+        if has_on_prefix(&output_name) {
+            ctx.diagnostic(no_output_on_prefix_diagnostic(span, &output_name));
+        }
+    }
+}
+
+impl NoOutputOnPrefix {
+    /// Returns the effective output name and span if this is an output property
+    fn get_output_info(
+        &self,
+        prop: &oxc_ast::ast::PropertyDefinition<'_>,
+        ctx: &LintContext<'_>,
+    ) -> Option<(String, Span)> {
+        // Check for @Output decorator
+        for decorator in &prop.decorators {
+            let Some(decorator_name) = get_decorator_name(decorator) else {
+                continue;
+            };
+
+            if decorator_name != "Output" {
+                continue;
+            }
+
+            let Some(ident) = get_decorator_identifier(decorator) else {
+                continue;
+            };
+
+            if !is_angular_core_import(ident, ctx) {
+                continue;
+            }
+
+            // Get the alias or property name
+            if let Some(call) = get_decorator_call(decorator)
+                && let Some(first_arg) = call.arguments.first() {
+                    match first_arg {
+                        oxc_ast::ast::Argument::StringLiteral(lit) => {
+                            return Some((lit.value.to_string(), prop.span));
+                        }
+                        oxc_ast::ast::Argument::ObjectExpression(obj) => {
+                            if let Some(alias) = get_alias_from_object(obj) {
+                                return Some((alias.to_string(), prop.span));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+            // Use property name if no alias
+            return prop.key.static_name().map(|name| (name.to_string(), prop.span));
+        }
+
+        // Check for output() signal function
+        let value = prop.value.as_ref()?;
+        let Expression::CallExpression(call) = value else {
+            return None;
+        };
+
+        let Expression::Identifier(callee) = &call.callee else {
+            return None;
+        };
+
+        if callee.name.as_str() != "output" {
+            return None;
+        }
+
+        if !is_angular_core_import(callee.as_ref(), ctx) {
+            return None;
+        }
+
+        // Check for alias in options object
+        for arg in &call.arguments {
+            if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg
+                && let Some(alias) = get_alias_from_object(obj) {
+                    return Some((alias.to_string(), prop.span));
+                }
+        }
+
+        // Use property name
+        prop.key.static_name().map(|name| (name.to_string(), prop.span))
+    }
+}
+
+fn get_alias_from_object<'a>(obj: &'a oxc_ast::ast::ObjectExpression<'a>) -> Option<&'a str> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == "alias"
+                    && let Expression::StringLiteral(lit) = &prop.value {
+                        return Some(lit.value.as_str());
+                    }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Normal output name without on prefix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() click = new EventEmitter<void>();
+        }
+        ",
+        // Output with 'Change' suffix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() valueChange = new EventEmitter<string>();
+        }
+        ",
+        // Words that start with 'on' but are not prefixed
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() online = new EventEmitter<boolean>();
+            @Output() one = new EventEmitter<number>();
+            @Output() ongoing = new EventEmitter<void>();
+        }
+        ",
+        // output() signal without on prefix
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            selected = output<string>();
+        }
+        ",
+        // Non-Angular Output
+        r"
+        import { Output, EventEmitter } from 'other-lib';
+        class TestComponent {
+            @Output() onClick = new EventEmitter<void>();
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Output with 'on' prefix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() onClick = new EventEmitter<void>();
+        }
+        ",
+        // Output with 'on' prefix - onChange
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() onChange = new EventEmitter<string>();
+        }
+        ",
+        // Output named just 'on'
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() on = new EventEmitter<void>();
+        }
+        ",
+        // Aliased to on prefix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output('onClick') clickHandler = new EventEmitter<void>();
+        }
+        ",
+        // output() signal with on prefix
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            onSelect = output<string>();
+        }
+        ",
+        // output() signal aliased to on prefix
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            selectHandler = output<string>({ alias: 'onSelect' });
+        }
+        ",
+        // Multiple outputs with on prefix
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() onBlur = new EventEmitter<void>();
+            @Output() onFocus = new EventEmitter<void>();
+        }
+        ",
+    ];
+
+    Tester::new(NoOutputOnPrefix::NAME, NoOutputOnPrefix::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_output_rename.rs
+++ b/crates/oxc_linter/src/rules/angular/no_output_rename.rs
@@ -1,0 +1,306 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_decorator_call, get_decorator_identifier, get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn no_output_rename_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Output bindings should not be aliased")
+        .with_help(
+            "Avoid aliasing outputs as it can lead to confusion. Use the original property name \
+            or rename the property if the alias is more appropriate.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOutputRename;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows aliasing output bindings (renaming outputs with a different public name).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Two names for the same property (one private, one public) is confusing.
+    /// It requires developers to remember both names and understand the mapping.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output('valueChanged') change = new EventEmitter<string>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() valueChange = new EventEmitter<string>();
+    /// }
+    /// ```
+    NoOutputRename,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoOutputRename {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Check for @Output decorator
+        if let AstKind::Decorator(decorator) = node.kind() {
+            self.check_output_decorator(decorator, node, ctx);
+            return;
+        }
+
+        // Check for output() signal function
+        if let AstKind::PropertyDefinition(prop) = node.kind() {
+            self.check_output_signal(prop, ctx);
+        }
+    }
+}
+
+impl NoOutputRename {
+    fn check_output_decorator(
+        &self,
+        decorator: &oxc_ast::ast::Decorator<'_>,
+        node: &AstNode<'_>,
+        ctx: &LintContext<'_>,
+    ) {
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Output" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the decorator call to check for alias
+        let Some(call) = get_decorator_call(decorator) else {
+            return;
+        };
+
+        // Get the first argument (the alias)
+        let Some(first_arg) = call.arguments.first() else {
+            return;
+        };
+
+        let alias = match first_arg {
+            oxc_ast::ast::Argument::StringLiteral(lit) => Some(lit.value.as_str()),
+            oxc_ast::ast::Argument::ObjectExpression(obj) => get_alias_from_object(obj),
+            _ => None,
+        };
+
+        let Some(alias) = alias else {
+            return;
+        };
+
+        // Get the property name from parent
+        let property_name = self.get_property_name_from_decorator(node, ctx);
+
+        // Allow if alias matches property name
+        if property_name.as_deref() == Some(alias) {
+            return;
+        }
+
+        ctx.diagnostic(no_output_rename_diagnostic(decorator.span));
+    }
+
+    fn check_output_signal(
+        &self,
+        prop: &oxc_ast::ast::PropertyDefinition<'_>,
+        ctx: &LintContext<'_>,
+    ) {
+        let Some(value) = &prop.value else {
+            return;
+        };
+
+        let Expression::CallExpression(call) = value else {
+            return;
+        };
+
+        let Expression::Identifier(callee) = &call.callee else {
+            return;
+        };
+
+        if callee.name.as_str() != "output" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        if !is_angular_core_import(callee.as_ref(), ctx) {
+            return;
+        }
+
+        // Check for alias in options object
+        for arg in &call.arguments {
+            if let oxc_ast::ast::Argument::ObjectExpression(obj) = arg
+                && let Some(alias) = get_alias_from_object(obj) {
+                    let property_name = prop.key.static_name();
+
+                    // Allow if alias matches property name
+                    if property_name.as_deref() == Some(alias) {
+                        continue;
+                    }
+
+                    ctx.diagnostic(no_output_rename_diagnostic(prop.span));
+                    return;
+                }
+        }
+    }
+
+    fn get_property_name_from_decorator(
+        &self,
+        node: &crate::AstNode<'_>,
+        ctx: &LintContext<'_>,
+    ) -> Option<String> {
+        for ancestor in ctx.nodes().ancestors(node.id()) {
+            if let AstKind::PropertyDefinition(prop) = ancestor.kind() {
+                return prop.key.static_name().map(|s| s.to_string());
+            }
+        }
+        None
+    }
+}
+
+fn get_alias_from_object<'a>(obj: &'a oxc_ast::ast::ObjectExpression<'a>) -> Option<&'a str> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == "alias"
+                    && let Expression::StringLiteral(lit) = &prop.value {
+                        return Some(lit.value.as_str());
+                    }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No alias
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() change = new EventEmitter<string>();
+        }
+        ",
+        // Alias matches property name
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output('change') change = new EventEmitter<string>();
+        }
+        ",
+        // output() signal without alias
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            change = output<string>();
+        }
+        ",
+        // output() signal with matching alias
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            change = output<string>({ alias: 'change' });
+        }
+        ",
+        // Non-Angular Output
+        r"
+        import { Output, EventEmitter } from 'other-lib';
+        class TestComponent {
+            @Output('alias') change = new EventEmitter<string>();
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Aliased output with string
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output('valueChanged') change = new EventEmitter<string>();
+        }
+        ",
+        // Aliased output with object
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output({ alias: 'valueChanged' }) change = new EventEmitter<string>();
+        }
+        ",
+        // output() signal with alias
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            change = output<string>({ alias: 'valueChanged' });
+        }
+        ",
+    ];
+
+    Tester::new(NoOutputRename::NAME, NoOutputRename::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_outputs_metadata_property.rs
+++ b/crates/oxc_linter/src/rules/angular/no_outputs_metadata_property.rs
@@ -1,0 +1,258 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        find_property_key_span, get_component_metadata, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn no_outputs_metadata_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Use `@Output` decorator rather than the `outputs` metadata property")
+        .with_help(
+            "The `outputs` metadata property is a legacy API. Use the `@Output()` decorator \
+            or `output()` signal function directly on properties instead.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoOutputsMetadataProperty;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using the `outputs` array in `@Component` and `@Directive` metadata.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the `outputs` metadata property is a legacy approach. The `@Output()` decorator
+    /// or `output()` signal function provides:
+    /// - Better type safety
+    /// - Better IDE support
+    /// - Co-location of metadata with the property
+    /// - Easier to understand and maintain
+    ///
+    /// Note: This rule does not flag `outputs` when used in `hostDirectives` configuration,
+    /// as that is a valid use case.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   outputs: ['change', 'submit: formSubmit']
+    /// })
+    /// export class ExampleComponent {
+    ///   change = new EventEmitter<string>();
+    ///   submit = new EventEmitter<void>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() change = new EventEmitter<string>();
+    ///   @Output('formSubmit') submit = new EventEmitter<void>();
+    /// }
+    /// ```
+    NoOutputsMetadataProperty,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for NoOutputsMetadataProperty {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" && decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the outputs property at the top level (not inside hostDirectives)
+        for prop in &metadata.properties {
+            if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
+                let prop_name = match &obj_prop.key {
+                    oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+                    oxc_ast::ast::PropertyKey::StringLiteral(lit) => Some(lit.value.as_str()),
+                    _ => None,
+                };
+
+                if prop_name == Some("outputs") {
+                    // This is a top-level outputs property, not inside hostDirectives
+                    let span = find_property_key_span(metadata, "outputs").unwrap_or(metadata.span);
+                    ctx.diagnostic(no_outputs_metadata_property_diagnostic(span));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using @Output decorator
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() change = new EventEmitter<string>();
+        }
+        ",
+        // Using output() signal
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            change = output<string>();
+        }
+        ",
+        // No outputs at all
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Directive with @Output
+        r"
+        import { Directive, Output, EventEmitter } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @Output() triggered = new EventEmitter<void>();
+        }
+        ",
+        // Non-Angular Component
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            outputs: ['change']
+        })
+        class TestComponent {}
+        ",
+        // hostDirectives with outputs (allowed)
+        r"
+        import { Component } from '@angular/core';
+        import { SomeDirective } from './some.directive';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            hostDirectives: [{
+                directive: SomeDirective,
+                outputs: ['valueChange']
+            }]
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // Component with outputs metadata
+        r"
+        import { Component, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            outputs: ['change']
+        })
+        class TestComponent {
+            change = new EventEmitter<string>();
+        }
+        ",
+        // Component with multiple outputs
+        r"
+        import { Component, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            outputs: ['change', 'submit', 'cancel']
+        })
+        class TestComponent {}
+        ",
+        // Component with aliased outputs
+        r"
+        import { Component, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            outputs: ['submit: formSubmit']
+        })
+        class TestComponent {}
+        ",
+        // Directive with outputs metadata
+        r"
+        import { Directive, EventEmitter } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            outputs: ['activated']
+        })
+        class TestDirective {}
+        ",
+        // Empty outputs array (still flagged)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            outputs: []
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(NoOutputsMetadataProperty::NAME, NoOutputsMetadataProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_pipe_impure.rs
+++ b/crates/oxc_linter/src/rules/angular/no_pipe_impure.rs
@@ -1,0 +1,253 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn no_pipe_impure_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Impure pipes should be avoided")
+        .with_help(
+            "Impure pipes (`pure: false`) are invoked on each change-detection cycle, which can \
+            significantly impact performance. Consider redesigning your pipe to be pure, or use \
+            a different approach such as a method in the component.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoPipeImpure;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of impure pipes (`pure: false`) in Angular.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Impure pipes are invoked on every change-detection cycle, regardless of whether
+    /// their input values have changed. This can cause:
+    /// - Significant performance degradation
+    /// - Unexpected behavior
+    /// - Difficulty in debugging
+    ///
+    /// Pure pipes (the default) are only invoked when their input values change,
+    /// which is much more efficient.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Pipe, PipeTransform } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'myPipe',
+    ///   pure: false  // Impure pipe
+    /// })
+    /// export class MyPipe implements PipeTransform {
+    ///   transform(value: any): any {
+    ///     return value;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Pipe, PipeTransform } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'myPipe'
+    ///   // pure: true is the default
+    /// })
+    /// export class MyPipe implements PipeTransform {
+    ///   transform(value: any): any {
+    ///     return value;
+    ///   }
+    /// }
+    /// ```
+    NoPipeImpure,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for NoPipeImpure {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Pipe decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Pipe" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the pure property
+        let Some(pure_value) = get_metadata_property(metadata, "pure") else {
+            return;
+        };
+
+        // Check if pure is set to false
+        let is_impure = match pure_value {
+            Expression::BooleanLiteral(lit) => !lit.value,
+            Expression::UnaryExpression(unary) => {
+                // Handle !true case
+                if unary.operator == oxc_ast::ast::UnaryOperator::LogicalNot {
+                    if let Expression::BooleanLiteral(lit) = &unary.argument {
+                        lit.value
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+
+        if is_impure {
+            let span = find_property_span(metadata, "pure").unwrap_or(decorator.span);
+            ctx.diagnostic(no_pipe_impure_diagnostic(span));
+        }
+    }
+}
+
+fn find_property_span(obj: &oxc_ast::ast::ObjectExpression<'_>, key: &str) -> Option<Span> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+    use oxc_span::GetSpan;
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == key {
+                    return Some(prop.span());
+                }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Pure pipe (default)
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Explicit pure: true
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            pure: true
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Standalone pure pipe
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            standalone: true
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Non-Angular Pipe
+        r"
+        import { Pipe } from 'other-lib';
+        @Pipe({
+            name: 'myPipe',
+            pure: false
+        })
+        class MyPipe {}
+        ",
+    ];
+
+    let fail = vec![
+        // Impure pipe
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            pure: false
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Impure standalone pipe
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            standalone: true,
+            pure: false
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Impure pipe with !true
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            pure: !true
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+    ];
+
+    Tester::new(NoPipeImpure::NAME, NoPipeImpure::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/no_queries_metadata_property.rs
+++ b/crates/oxc_linter/src/rules/angular/no_queries_metadata_property.rs
@@ -1,0 +1,215 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn no_queries_metadata_property_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using `queries` metadata property")
+        .with_help(
+            "Use `@ViewChild`, `@ViewChildren`, `@ContentChild`, or `@ContentChildren` decorators \
+            instead of the `queries` metadata property. Decorator-based queries provide better \
+            type inference and are easier to understand.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoQueriesMetadataProperty;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows using the `queries` metadata property in @Component and @Directive decorators.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// While Angular supports defining queries in the decorator metadata using the `queries` property,
+    /// the preferred approach is to use the query decorators directly on class properties:
+    /// - `@ViewChild` and `@ViewChildren` for view queries
+    /// - `@ContentChild` and `@ContentChildren` for content queries
+    ///
+    /// Benefits of using decorators instead of metadata:
+    /// - Better type inference and IDE support
+    /// - More readable and maintainable code
+    /// - Consistent with other Angular patterns
+    /// - Easier to see which properties are queries
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, ElementRef } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '<div #myDiv></div>',
+    ///   queries: {
+    ///     myDiv: new ViewChild('myDiv')
+    ///   }
+    /// })
+    /// export class ExampleComponent {
+    ///   myDiv: ElementRef;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, ViewChild, ElementRef } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '<div #myDiv></div>'
+    /// })
+    /// export class ExampleComponent {
+    ///   @ViewChild('myDiv') myDiv: ElementRef;
+    /// }
+    /// ```
+    NoQueriesMetadataProperty,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for NoQueriesMetadataProperty {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if !matches!(decorator_name, "Component" | "Directive") {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check for 'queries' property
+        if get_metadata_property(metadata, "queries").is_some() {
+            // Find the span of the 'queries' property
+            for prop in &metadata.properties {
+                if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop
+                    && let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &obj_prop.key
+                        && ident.name == "queries" {
+                            ctx.diagnostic(no_queries_metadata_property_diagnostic(obj_prop.span));
+                            return;
+                        }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using @ViewChild decorator
+        r"
+        import { Component, ViewChild, ElementRef } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div #myDiv></div>'
+        })
+        class TestComponent {
+            @ViewChild('myDiv') myDiv: ElementRef;
+        }
+        ",
+        // Using @ContentChild decorator
+        r"
+        import { Directive, ContentChild, ElementRef } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @ContentChild('content') content: ElementRef;
+        }
+        ",
+        // No queries property
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // queries property in non-Angular decorator
+        r"
+        import { Component } from 'other-library';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            queries: { myDiv: new ViewChild('myDiv') }
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // queries in @Component
+        r"
+        import { Component, ViewChild } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div #myDiv></div>',
+            queries: {
+                myDiv: new ViewChild('myDiv')
+            }
+        })
+        class TestComponent {}
+        ",
+        // queries in @Directive
+        r"
+        import { Directive, ContentChild } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            queries: {
+                content: new ContentChild('content')
+            }
+        })
+        class TestDirective {}
+        ",
+        // Multiple queries
+        r"
+        import { Component, ViewChild, ViewChildren, QueryList } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            queries: {
+                item: new ViewChild('item'),
+                items: new ViewChildren('item')
+            }
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(NoQueriesMetadataProperty::NAME, NoQueriesMetadataProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/pipe_prefix.rs
+++ b/crates/oxc_linter/src/rules/angular/pipe_prefix.rs
@@ -1,0 +1,310 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_string_value, is_angular_core_import,
+    },
+};
+
+fn pipe_prefix_diagnostic(span: Span, prefixes: &[String]) -> OxcDiagnostic {
+    let prefix_list = prefixes.join(", ");
+    OxcDiagnostic::warn(format!("Pipe names should be prefixed with: {prefix_list}"))
+        .with_help(
+            "Use a consistent prefix for pipe names to avoid naming collisions and to make it \
+            clear which pipes belong to your application.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PipePrefixConfig {
+    #[serde(default)]
+    prefixes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PipePrefix {
+    prefixes: Vec<String>,
+}
+
+impl From<PipePrefixConfig> for PipePrefix {
+    fn from(config: PipePrefixConfig) -> Self {
+        Self { prefixes: config.prefixes }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a consistent prefix for pipe names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using a prefix for pipe names helps:
+    /// - Avoid naming collisions with Angular built-in pipes or third-party pipes
+    /// - Easily identify which pipes belong to your application
+    /// - Maintain consistency across the codebase
+    ///
+    /// ### Configuration
+    ///
+    /// This rule requires configuration to specify the allowed prefixes:
+    ///
+    /// ```json
+    /// {
+    ///   "angular/pipe-prefix": ["error", { "prefixes": ["app", "my"] }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// With configuration `{ "prefixes": ["app"] }`:
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Pipe, PipeTransform } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'formatDate'  // Missing prefix
+    /// })
+    /// export class FormatDatePipe implements PipeTransform {
+    ///   transform(value: Date): string {
+    ///     return value.toISOString();
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Pipe, PipeTransform } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'appFormatDate'  // Has 'app' prefix
+    /// })
+    /// export class FormatDatePipe implements PipeTransform {
+    ///   transform(value: Date): string {
+    ///     return value.toISOString();
+    ///   }
+    /// }
+    /// ```
+    PipePrefix,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for PipePrefix {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<PipePrefixConfig>(config_value.clone()).map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // If no prefixes configured, skip the rule
+        if self.prefixes.is_empty() {
+            return;
+        }
+
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Pipe decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Pipe" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Get the pipe name
+        let Some(pipe_name) = get_metadata_string_value(metadata, "name") else {
+            return;
+        };
+
+        // Check if the pipe name starts with any of the configured prefixes
+        let has_valid_prefix = self.prefixes.iter().any(|prefix| {
+            if pipe_name.starts_with(prefix) {
+                // Ensure the prefix is followed by uppercase (camelCase convention)
+                let rest = &pipe_name[prefix.len()..];
+                rest.is_empty() || rest.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            } else {
+                false
+            }
+        });
+
+        if !has_valid_prefix {
+            ctx.diagnostic(pipe_prefix_diagnostic(decorator.span, &self.prefixes));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Correct prefix
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'appFormatDate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+        // Multiple allowed prefixes
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'myFormatDate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app", "my"] }])),
+        ),
+        // No prefixes configured (rule disabled)
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'formatDate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            None,
+        ),
+        // Non-Angular Pipe
+        (
+            r"
+            import { Pipe } from 'other-lib';
+            @Pipe({
+                name: 'formatDate'
+            })
+            class FormatDatePipe {}
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+        // Template literal pipe name with correct prefix
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: `appFormatDate`
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+    ];
+
+    let fail = vec![
+        // Missing prefix
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'formatDate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+        // Wrong prefix
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'myFormatDate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+        // Prefix without proper casing
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: 'appformatdate'
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+        // Template literal missing prefix
+        (
+            r"
+            import { Pipe, PipeTransform } from '@angular/core';
+            @Pipe({
+                name: `formatDate`
+            })
+            class FormatDatePipe implements PipeTransform {
+                transform(value: Date): string {
+                    return value.toISOString();
+                }
+            }
+            ",
+            Some(serde_json::json!([{ "prefixes": ["app"] }])),
+        ),
+    ];
+
+    Tester::new(PipePrefix::NAME, PipePrefix::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_control_flow.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_control_flow.rs
@@ -1,0 +1,334 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+/// Legacy structural directives that should be replaced with built-in control flow.
+const LEGACY_DIRECTIVES: &[(&str, &str)] = &[
+    ("*ngIf", "@if"),
+    ("*ngFor", "@for"),
+    ("*ngSwitch", "@switch"),
+    ("[ngIf]", "@if"),
+    ("[ngFor]", "@for"),
+    ("[ngSwitch]", "@switch"),
+];
+
+fn prefer_control_flow_diagnostic(span: Span, directive: &str, replacement: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer built-in control flow over `{directive}`"))
+        .with_help(format!(
+            "Replace `{directive}` with `{replacement}` syntax. \
+            Built-in control flow was introduced in Angular 17 and is the recommended approach. \
+            See https://angular.dev/guide/templates/control-flow for migration guidance."
+        ))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferControlFlow;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces usage of Angular's built-in control flow syntax (`@if`, `@for`, `@switch`)
+    /// over legacy structural directives (`*ngIf`, `*ngFor`, `*ngSwitch`).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Angular 17+ introduced built-in control flow blocks that provide better performance,
+    /// improved type checking, and cleaner syntax. The legacy structural directives
+    /// (`*ngIf`, `*ngFor`, `*ngSwitch`) are still supported but are considered legacy.
+    ///
+    /// ### Limitations
+    ///
+    /// This rule only analyzes inline templates (the `template` property in decorators).
+    /// It does not analyze external template files (`.html` files referenced via `templateUrl`).
+    /// The detection uses pattern matching which may have false positives in edge cases
+    /// (e.g., if the pattern appears in a string literal within the template).
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: `
+    ///     <div *ngIf="isVisible">Content</div>
+    ///     <div *ngFor="let item of items">{{ item }}</div>
+    ///   `
+    /// })
+    /// export class ExampleComponent {
+    ///   isVisible = true;
+    ///   items = ['a', 'b', 'c'];
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: `
+    ///     @if (isVisible) {
+    ///       <div>Content</div>
+    ///     }
+    ///     @for (item of items; track item) {
+    ///       <div>{{ item }}</div>
+    ///     }
+    ///   `
+    /// })
+    /// export class ExampleComponent {
+    ///   isVisible = true;
+    ///   items = ['a', 'b', 'c'];
+    /// }
+    /// ```
+    PreferControlFlow,
+    angular,
+    pedantic,
+    pending // not yet ready for production
+);
+
+impl Rule for PreferControlFlow {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the template property
+        let Some(template_value) = get_metadata_property(metadata, "template") else {
+            // No inline template - skip (could be using templateUrl)
+            return;
+        };
+
+        // Extract the template string content and check for legacy directives
+        match template_value {
+            Expression::StringLiteral(str_lit) => {
+                check_template_content(str_lit.value.as_str(), str_lit.span, ctx);
+            }
+            Expression::TemplateLiteral(tpl_lit) => {
+                // For template literals, we check each quasi (string part)
+                for quasi in &tpl_lit.quasis {
+                    check_template_content(quasi.value.raw.as_str(), quasi.span, ctx);
+                }
+            }
+            _ => {
+                // Template is not a static string (e.g., variable reference) - can't analyze
+            }
+        }
+    }
+}
+
+/// Check template content for legacy directive patterns and report diagnostics.
+fn check_template_content(content: &str, base_span: Span, ctx: &LintContext<'_>) {
+    for (legacy_directive, replacement) in LEGACY_DIRECTIVES {
+        // Look for the directive pattern followed by '=' (attribute binding)
+        let pattern = format!("{legacy_directive}=");
+
+        if let Some(offset) = content.find(&pattern) {
+            // Calculate the span for the directive occurrence
+            // The base_span.start includes the opening quote, so we add 1
+            let directive_start = base_span.start + 1 + offset as u32;
+            let directive_end = directive_start + legacy_directive.len() as u32;
+            let span = Span::new(directive_start, directive_end);
+
+            ctx.diagnostic(prefer_control_flow_diagnostic(span, legacy_directive, replacement));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using built-in control flow @if
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: `
+                @if (isVisible) {
+                    <div>Content</div>
+                }
+            `
+        })
+        class TestComponent {}
+        ",
+        // Using built-in control flow @for
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: `
+                @for (item of items; track item) {
+                    <div>{{ item }}</div>
+                }
+            `
+        })
+        class TestComponent {}
+        ",
+        // Using built-in control flow @switch
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: `
+                @switch (status) {
+                    @case ('active') { <span>Active</span> }
+                    @default { <span>Unknown</span> }
+                }
+            `
+        })
+        class TestComponent {}
+        ",
+        // Using templateUrl (external template - not analyzed)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            templateUrl: './test.component.html'
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular Component decorator (should not trigger)
+        r#"
+        import { Component } from 'some-other-lib';
+        @Component({
+            template: '<div *ngIf="show">Content</div>'
+        })
+        class TestComponent {}
+        "#,
+        // No template property
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test'
+        })
+        class TestComponent {}
+        ",
+        // Empty template
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Template with regular HTML (no directives)
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div class="container"><span>Hello</span></div>'
+        })
+        class TestComponent {}
+        "#,
+        // Template with Angular event binding (not control flow)
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<button (click)="onClick()">Click me</button>'
+        })
+        class TestComponent {}
+        "#,
+        // Directive with no template property
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {}
+        ",
+    ];
+
+    let fail = vec![
+        // Using *ngIf
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div *ngIf="isVisible">Content</div>'
+        })
+        class TestComponent {}
+        "#,
+        // Using *ngFor
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div *ngFor="let item of items">{{ item }}</div>'
+        })
+        class TestComponent {}
+        "#,
+        // Using *ngSwitch
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div *ngSwitch="status"><span *ngSwitchCase="active">Active</span></div>'
+        })
+        class TestComponent {}
+        "#,
+        // Using [ngIf] binding syntax
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<ng-template [ngIf]="isVisible"><div>Content</div></ng-template>'
+        })
+        class TestComponent {}
+        "#,
+        // Template literal with *ngIf
+        r#"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: `
+                <div *ngIf="isVisible">
+                    Content
+                </div>
+            `
+        })
+        class TestComponent {}
+        "#,
+    ];
+
+    Tester::new(PreferControlFlow::NAME, PreferControlFlow::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_host_metadata_property.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_host_metadata_property.rs
@@ -1,0 +1,251 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        AngularDecoratorType, get_class_angular_decorator, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn prefer_host_metadata_property_diagnostic(span: Span, decorator_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Prefer using the `host` metadata property over `@{decorator_name}`"
+    ))
+    .with_help(
+        "Use the `host` property in the @Component or @Directive decorator instead of \
+            `@HostBinding` and `@HostListener` decorators. This centralizes host-related \
+            configuration and can improve readability.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferHostMetadataProperty;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces using the `host` metadata property instead of `@HostBinding` and `@HostListener` decorators.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// While `@HostBinding` and `@HostListener` decorators work correctly, using the `host` metadata
+    /// property in the component/directive decorator has several advantages:
+    /// - Centralizes all host-related bindings in one place
+    /// - Makes it easier to see all host interactions at a glance
+    /// - Reduces decorator clutter on class members
+    /// - Aligns with the recommended pattern in Angular style guides
+    ///
+    /// Note: This rule is the opposite of `no-host-metadata-property`. Use one or the other
+    /// based on your team's preference.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, HostBinding, HostListener } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @HostBinding('class.active') isActive = false;
+    ///   @HostListener('click') onClick() {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   host: {
+    ///     '[class.active]': 'isActive',
+    ///     '(click)': 'onClick()'
+    ///   }
+    /// })
+    /// export class ExampleComponent {
+    ///   isActive = false;
+    ///   onClick() {}
+    /// }
+    /// ```
+    PreferHostMetadataProperty,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for PreferHostMetadataProperty {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a @HostBinding or @HostListener decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if !matches!(decorator_name, "HostBinding" | "HostListener") {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has a @Component or @Directive decorator
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        if !matches!(
+            decorator_type,
+            AngularDecoratorType::Component | AngularDecoratorType::Directive
+        ) {
+            return;
+        }
+
+        ctx.diagnostic(prefer_host_metadata_property_diagnostic(decorator.span, decorator_name));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using host metadata property
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            host: {
+                '[class.active]': 'isActive',
+                '(click)': 'onClick()'
+            }
+        })
+        class TestComponent {
+            isActive = false;
+            onClick() {}
+        }
+        ",
+        // No host bindings at all
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular class
+        r"
+        import { HostBinding } from 'other-library';
+        class TestClass {
+            @HostBinding('class.active') isActive = false;
+        }
+        ",
+        // HostBinding in non-component/directive class
+        r"
+        import { Injectable, HostBinding } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            @HostBinding('class.active') isActive = false;
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Using @HostBinding
+        r"
+        import { Component, HostBinding } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostBinding('class.active') isActive = false;
+        }
+        ",
+        // Using @HostListener
+        r"
+        import { Component, HostListener } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostListener('click') onClick() {}
+        }
+        ",
+        // Both @HostBinding and @HostListener
+        r"
+        import { Component, HostBinding, HostListener } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostBinding('class.active') isActive = false;
+            @HostListener('click') onClick() {}
+        }
+        ",
+        // In Directive
+        r"
+        import { Directive, HostBinding } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @HostBinding('attr.role') role = 'button';
+        }
+        ",
+        // HostListener with arguments
+        r"
+        import { Component, HostListener } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @HostListener('keydown', ['$event']) onKeyDown(event: KeyboardEvent) {}
+        }
+        ",
+    ];
+
+    Tester::new(PreferHostMetadataProperty::NAME, PreferHostMetadataProperty::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_inject.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_inject.rs
@@ -1,0 +1,339 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, get_decorator_name},
+};
+
+fn prefer_inject_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer using the `inject()` function over constructor parameter injection")
+        .with_help(
+            "Use the `inject()` function to inject dependencies. It provides better type inference, \
+            works with signals, and allows for more flexible dependency injection patterns. \
+            Example: `private readonly service = inject(MyService);`",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferInject;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces using the `inject()` function instead of constructor parameter injection
+    /// in Angular components, directives, pipes, and services.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Constructor injection is the traditional way to inject dependencies in Angular,
+    /// but the `inject()` function provides several advantages:
+    /// - Better type inference
+    /// - Works seamlessly with signals
+    /// - No need for parameter decorators like `@Inject()`, `@Optional()`, etc.
+    /// - More flexible - can be used in any initialization context
+    /// - Cleaner class structure without constructor bloat
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    /// import { MyService } from './my.service';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   constructor(private myService: MyService) {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, inject } from '@angular/core';
+    /// import { MyService } from './my.service';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   private readonly myService = inject(MyService);
+    /// }
+    /// ```
+    PreferInject,
+    angular,
+    pedantic,
+    pending
+);
+
+/// Primitive types that should be skipped (not DI candidates)
+const PRIMITIVE_TYPES: [&str; 10] = [
+    "string",
+    "number",
+    "boolean",
+    "bigint",
+    "symbol",
+    "undefined",
+    "null",
+    "any",
+    "unknown",
+    "never",
+];
+
+impl Rule for PreferInject {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+
+        // Check if this is a constructor
+        if !method.kind.is_constructor() {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has a relevant Angular decorator
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        // Only check Component, Directive, Injectable, and Pipe classes
+        use crate::utils::AngularDecoratorType;
+        if !matches!(
+            decorator_type,
+            AngularDecoratorType::Component
+                | AngularDecoratorType::Directive
+                | AngularDecoratorType::Injectable
+                | AngularDecoratorType::Pipe
+        ) {
+            return;
+        }
+
+        // Check constructor parameters for DI candidates
+        for param in &method.value.params.items {
+            // Check if the parameter has DI decorators like @Inject, @Optional, etc.
+            // This check happens first because even primitives with @Inject should be flagged
+            let has_di_decorator = param.decorators.iter().any(|dec| {
+                let Some(name) = get_decorator_name(dec) else {
+                    return false;
+                };
+                matches!(name, "Inject" | "Optional" | "Self" | "SkipSelf" | "Host" | "Attribute")
+            });
+
+            // If it has DI decorators, it's definitely DI - report it
+            if has_di_decorator {
+                ctx.diagnostic(prefer_inject_diagnostic(param.span));
+                continue;
+            }
+
+            // Skip if it has no type annotation (can't determine if it's DI)
+            let Some(type_annotation) = &param.type_annotation else {
+                continue;
+            };
+
+            // Check if the type is a primitive (skip primitives without DI decorators)
+            if is_primitive_type(type_annotation) {
+                continue;
+            }
+
+            // Check if the type looks like a service/injectable class (starts with uppercase)
+            if looks_like_injectable_type(type_annotation) {
+                ctx.diagnostic(prefer_inject_diagnostic(param.span));
+            }
+        }
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+fn is_primitive_type(type_annotation: &oxc_ast::ast::TSTypeAnnotation<'_>) -> bool {
+    use oxc_ast::ast::TSType;
+
+    match &type_annotation.type_annotation {
+        TSType::TSStringKeyword(_)
+        | TSType::TSNumberKeyword(_)
+        | TSType::TSBooleanKeyword(_)
+        | TSType::TSBigIntKeyword(_)
+        | TSType::TSSymbolKeyword(_)
+        | TSType::TSUndefinedKeyword(_)
+        | TSType::TSNullKeyword(_)
+        | TSType::TSAnyKeyword(_)
+        | TSType::TSUnknownKeyword(_)
+        | TSType::TSNeverKeyword(_)
+        | TSType::TSVoidKeyword(_) => true,
+        TSType::TSTypeReference(type_ref) => {
+            if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &type_ref.type_name {
+                PRIMITIVE_TYPES.contains(&ident.name.as_str())
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn looks_like_injectable_type(type_annotation: &oxc_ast::ast::TSTypeAnnotation<'_>) -> bool {
+    use oxc_ast::ast::TSType;
+
+    match &type_annotation.type_annotation {
+        TSType::TSTypeReference(type_ref) => {
+            if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &type_ref.type_name {
+                // Check if the type name starts with uppercase (likely a class/service)
+                ident.name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using inject() function
+        r"
+        import { Component, inject } from '@angular/core';
+        import { MyService } from './my.service';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            private readonly myService = inject(MyService);
+        }
+        ",
+        // No constructor injection
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor() {}
+        }
+        ",
+        // Constructor with primitive types only
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(private name: string, private count: number) {}
+        }
+        ",
+        // Non-Angular class
+        r"
+        class TestClass {
+            constructor(private service: MyService) {}
+        }
+        ",
+        // NgModule (not flagged - different pattern)
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({})
+        class AppModule {
+            constructor(private service: MyService) {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Component with constructor injection
+        r"
+        import { Component } from '@angular/core';
+        import { MyService } from './my.service';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(private myService: MyService) {}
+        }
+        ",
+        // Directive with constructor injection
+        r"
+        import { Directive } from '@angular/core';
+        import { MyService } from './my.service';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            constructor(private myService: MyService) {}
+        }
+        ",
+        // Injectable with constructor injection
+        r"
+        import { Injectable, Inject } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            constructor(@Inject('TOKEN') private value: string) {}
+        }
+        ",
+        // Pipe with constructor injection
+        r"
+        import { Pipe } from '@angular/core';
+        import { MyService } from './my.service';
+        @Pipe({ name: 'test' })
+        class TestPipe {
+            constructor(private myService: MyService) {}
+        }
+        ",
+        // Multiple constructor parameters
+        r"
+        import { Component } from '@angular/core';
+        import { ServiceA, ServiceB } from './services';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(
+                private serviceA: ServiceA,
+                private serviceB: ServiceB
+            ) {}
+        }
+        ",
+        // With @Optional decorator
+        r"
+        import { Component, Optional } from '@angular/core';
+        import { MyService } from './my.service';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            constructor(@Optional() private myService: MyService) {}
+        }
+        ",
+    ];
+
+    Tester::new(PreferInject::NAME, PreferInject::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_on_push_component_change_detection.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_on_push_component_change_detection.rs
@@ -1,0 +1,270 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn prefer_on_push_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Component should use `ChangeDetectionStrategy.OnPush` for better performance",
+    )
+    .with_help(
+        "Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. \
+        OnPush change detection only checks the component when its inputs change or when \
+        events are triggered within it.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferOnPushComponentChangeDetection;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of `ChangeDetectionStrategy.OnPush` in Angular components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using `ChangeDetectionStrategy.Default` (the default) can lead to performance issues
+    /// because Angular will check the component and its children on every change detection cycle.
+    ///
+    /// `ChangeDetectionStrategy.OnPush` provides better performance by:
+    /// - Only checking when input references change
+    /// - Only checking when events are triggered within the component
+    /// - Only checking when explicitly triggered via `markForCheck()` or `detectChanges()`
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, ChangeDetectionStrategy } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   changeDetection: ChangeDetectionStrategy.OnPush
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    PreferOnPushComponentChangeDetection,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for PreferOnPushComponentChangeDetection {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check if changeDetection is set to OnPush
+        match get_metadata_property(metadata, "changeDetection") {
+            None => {
+                // No changeDetection property - using default
+                ctx.diagnostic(prefer_on_push_diagnostic(decorator.span));
+            }
+            Some(expr) => {
+                if !is_on_push(expr) {
+                    ctx.diagnostic(prefer_on_push_diagnostic(decorator.span));
+                }
+            }
+        }
+    }
+}
+
+fn is_on_push(expr: &Expression<'_>) -> bool {
+    match expr {
+        // ChangeDetectionStrategy.OnPush
+        Expression::StaticMemberExpression(member) => {
+            if let Expression::Identifier(obj) = &member.object {
+                obj.name.as_str() == "ChangeDetectionStrategy"
+                    && member.property.name.as_str() == "OnPush"
+            } else {
+                false
+            }
+        }
+        // Numeric literal 0 (ChangeDetectionStrategy.OnPush = 0)
+        Expression::NumericLiteral(lit) => lit.value == 0.0,
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // OnPush change detection
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            changeDetection: ChangeDetectionStrategy.OnPush
+        })
+        class TestComponent {}
+        ",
+        // OnPush with numeric value 0
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            changeDetection: 0
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular Component
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Directive (not a component)
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {}
+        ",
+        // OnPush with string literal key
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            'changeDetection': ChangeDetectionStrategy.OnPush
+        })
+        class TestComponent {}
+        ",
+        // OnPush with computed string literal key
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            ['changeDetection']: ChangeDetectionStrategy.OnPush
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // No changeDetection property
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Default change detection
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            changeDetection: ChangeDetectionStrategy.Default
+        })
+        class TestComponent {}
+        ",
+        // Numeric value 1 (Default)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            changeDetection: 1
+        })
+        class TestComponent {}
+        ",
+        // Standalone component without OnPush
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            standalone: true
+        })
+        class TestComponent {}
+        ",
+        // String literal key with Default
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            'changeDetection': ChangeDetectionStrategy.Default
+        })
+        class TestComponent {}
+        ",
+        // Computed key with Default
+        r"
+        import { Component, ChangeDetectionStrategy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            ['changeDetection']: ChangeDetectionStrategy.Default
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(
+        PreferOnPushComponentChangeDetection::NAME,
+        PreferOnPushComponentChangeDetection::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_output_emitter_ref.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_output_emitter_ref.rs
@@ -1,0 +1,249 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        AngularDecoratorType, get_class_angular_decorator, get_decorator_identifier,
+        get_decorator_name, is_angular_core_import,
+    },
+};
+
+fn prefer_output_emitter_ref_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer using `output()` function over `@Output()` decorator")
+        .with_help(
+            "Use the `output()` function instead of `@Output()` with `EventEmitter`. \
+            The `output()` function provides better type inference, cleaner syntax, \
+            and integrates better with Angular's signal-based architecture. \
+            Example: `myEvent = output<string>();`",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferOutputEmitterRef;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces using the `output()` function instead of the `@Output()` decorator with `EventEmitter`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The traditional `@Output()` decorator with `EventEmitter` has been the standard way to
+    /// define outputs in Angular, but the newer `output()` function (introduced in Angular 17.3)
+    /// provides several advantages:
+    /// - Better type inference without manual type parameters
+    /// - Cleaner, more concise syntax
+    /// - Better integration with Angular's signal-based architecture
+    /// - Consistent with the `input()` function pattern
+    /// - Returns `OutputEmitterRef` which has a simpler API than `EventEmitter`
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   @Output() myEvent = new EventEmitter<string>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, output } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   myEvent = output<string>();
+    /// }
+    /// ```
+    PreferOutputEmitterRef,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for PreferOutputEmitterRef {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Check if this is an @Output decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Output" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has a @Component or @Directive decorator
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        if !matches!(
+            decorator_type,
+            AngularDecoratorType::Component | AngularDecoratorType::Directive
+        ) {
+            return;
+        }
+
+        ctx.diagnostic(prefer_output_emitter_ref_diagnostic(decorator.span));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using output() function
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            myEvent = output<string>();
+        }
+        ",
+        // Using output() with alias
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            myEvent = output({ alias: 'onMyEvent' });
+        }
+        ",
+        // No outputs
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular class with @Output
+        r"
+        import { Output, EventEmitter } from 'other-library';
+        class TestClass {
+            @Output() myEvent = new EventEmitter();
+        }
+        ",
+        // @Output in non-component/directive class
+        r"
+        import { Injectable, Output, EventEmitter } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            @Output() myEvent = new EventEmitter();
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // @Output with EventEmitter
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() myEvent = new EventEmitter<string>();
+        }
+        ",
+        // @Output with alias
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output('onMyEvent') myEvent = new EventEmitter();
+        }
+        ",
+        // Multiple @Output decorators
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() eventA = new EventEmitter();
+            @Output() eventB = new EventEmitter();
+        }
+        ",
+        // @Output in Directive
+        r"
+        import { Directive, Output, EventEmitter } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            @Output() myEvent = new EventEmitter();
+        }
+        ",
+        // @Output with typed EventEmitter
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            @Output() itemSelected = new EventEmitter<{ id: number; name: string }>();
+        }
+        ",
+    ];
+
+    Tester::new(PreferOutputEmitterRef::NAME, PreferOutputEmitterRef::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_output_readonly.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_output_readonly.rs
@@ -1,0 +1,338 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_decorator_identifier, get_decorator_name, is_angular_core_import},
+};
+
+fn prefer_output_readonly_diagnostic(span: Span, is_signal: bool) -> OxcDiagnostic {
+    let output_type = if is_signal { "output()" } else { "@Output()" };
+    OxcDiagnostic::warn(format!("Prefer `readonly` modifier on {output_type} properties"))
+        .with_help(
+            "Add the `readonly` modifier to prevent accidental reassignment of the output. \
+            Outputs should not be reassigned after initialization.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferOutputReadonly;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that `@Output()` properties and `output()` signals are marked as `readonly`
+    /// to prevent accidental reassignment.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Reassigning an output property can lead to unexpected behavior where event listeners
+    /// are no longer notified of events. The output should remain the same instance throughout
+    /// the component's lifecycle.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter, output } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   // Missing readonly modifier
+    ///   @Output() clicked = new EventEmitter<void>();
+    ///
+    ///   // Signal-based output also needs readonly
+    ///   valueChange = output<string>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, Output, EventEmitter, output } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   @Output() readonly clicked = new EventEmitter<void>();
+    ///
+    ///   readonly valueChange = output<string>();
+    /// }
+    /// ```
+    PreferOutputReadonly,
+    angular,
+    pedantic,
+    pending // not yet ready for production
+);
+
+impl Rule for PreferOutputReadonly {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::PropertyDefinition(prop_def) = node.kind() else {
+            return;
+        };
+
+        // Skip if already readonly
+        if prop_def.readonly {
+            return;
+        }
+
+        // Check for @Output() decorator
+        let has_output_decorator = prop_def.decorators.iter().any(|decorator| {
+            let Some(name) = get_decorator_name(decorator) else {
+                return false;
+            };
+
+            if name != "Output" {
+                return false;
+            }
+
+            // Verify it's from @angular/core
+            let Some(ident) = get_decorator_identifier(decorator) else {
+                return false;
+            };
+
+            is_angular_core_import(ident, ctx)
+        });
+
+        if has_output_decorator {
+            // Get the property name span for the diagnostic
+            let span = prop_def.key.span();
+            ctx.diagnostic(prefer_output_readonly_diagnostic(span, false));
+            return;
+        }
+
+        // Check for output() signal function
+        if let Some(init) = &prop_def.value
+            && is_output_signal_call(init, ctx) {
+                let span = prop_def.key.span();
+                ctx.diagnostic(prefer_output_readonly_diagnostic(span, true));
+                return;
+            }
+
+        // Check for OutputEmitterRef or OutputRef type annotations
+        if let Some(type_ann) = &prop_def.type_annotation
+            && is_output_type_annotation(&type_ann.type_annotation) {
+                let span = prop_def.key.span();
+                ctx.diagnostic(prefer_output_readonly_diagnostic(span, true));
+            }
+    }
+}
+
+/// Check if a type annotation is OutputEmitterRef or OutputRef
+fn is_output_type_annotation(type_ann: &oxc_ast::ast::TSType<'_>) -> bool {
+    match type_ann {
+        oxc_ast::ast::TSType::TSTypeReference(type_ref) => {
+            if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &type_ref.type_name {
+                let name = ident.name.as_str();
+                return name == "OutputEmitterRef" || name == "OutputRef";
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Check if an expression is a call to `output()` or `outputFromObservable()` from `@angular/core`
+fn is_output_signal_call(expr: &Expression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Expression::CallExpression(call) = expr else {
+        return false;
+    };
+
+    let Expression::Identifier(ident) = &call.callee else {
+        return false;
+    };
+
+    let name = ident.name.as_str();
+    if name != "output" && name != "outputFromObservable" {
+        return false;
+    }
+
+    is_angular_core_import(ident.as_ref(), ctx)
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Readonly @Output
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output() readonly clicked = new EventEmitter<void>();
+        }
+        ",
+        // Readonly @Output with alias
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output('click') readonly clicked = new EventEmitter<void>();
+        }
+        ",
+        // Readonly output() signal
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            readonly valueChange = output<string>();
+        }
+        ",
+        // Readonly output() signal with options
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            readonly valueChange = output<string>({ alias: 'change' });
+        }
+        ",
+        // @Output from different library (should not trigger)
+        r"
+        import { Output } from 'some-other-lib';
+        class TestComponent {
+            @Output() clicked = {};
+        }
+        ",
+        // output from different library (should not trigger)
+        r"
+        import { output } from 'some-other-lib';
+        class TestComponent {
+            valueChange = output();
+        }
+        ",
+        // Regular property without @Output (should not trigger)
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            name = 'test';
+        }
+        ",
+        // Input property (should not trigger - different decorator)
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Input() name: string;
+        }
+        ",
+        // Multiple readonly outputs
+        r"
+        import { Component, Output, EventEmitter, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output() readonly clicked = new EventEmitter<void>();
+            @Output() readonly hovered = new EventEmitter<MouseEvent>();
+            readonly valueChange = output<string>();
+        }
+        ",
+        // Directive with readonly output
+        r"
+        import { Directive, Output, EventEmitter } from '@angular/core';
+        @Directive({ selector: '[appTest]' })
+        class TestDirective {
+            @Output() readonly activated = new EventEmitter<void>();
+        }
+        ",
+        // Readonly outputFromObservable
+        r"
+        import { Component, outputFromObservable } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            readonly valueChange = outputFromObservable(this.value$);
+        }
+        ",
+        // Readonly OutputEmitterRef type annotation
+        r"
+        import { Component, OutputEmitterRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            readonly clicked: OutputEmitterRef<void>;
+        }
+        ",
+        // Readonly OutputRef type annotation
+        r"
+        import { Component, OutputRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            readonly valueChange: OutputRef<string>;
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // @Output without readonly
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output() clicked = new EventEmitter<void>();
+        }
+        ",
+        // output() without readonly
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            valueChange = output<string>();
+        }
+        ",
+        // Multiple outputs without readonly
+        r"
+        import { Component, Output, EventEmitter, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output() clicked = new EventEmitter<void>();
+            @Output() hovered = new EventEmitter<MouseEvent>();
+            valueChange = output<string>();
+        }
+        ",
+        // @Output with alias but no readonly
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output('click') clicked = new EventEmitter<void>();
+        }
+        ",
+        // Directive with non-readonly output
+        r"
+        import { Directive, Output, EventEmitter } from '@angular/core';
+        @Directive({ selector: '[appTest]' })
+        class TestDirective {
+            @Output() activated = new EventEmitter<void>();
+        }
+        ",
+        // outputFromObservable without readonly
+        r"
+        import { Component, outputFromObservable } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            valueChange = outputFromObservable(this.value$);
+        }
+        ",
+        // OutputEmitterRef type annotation without readonly
+        r"
+        import { Component, OutputEmitterRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            clicked: OutputEmitterRef<void>;
+        }
+        ",
+        // OutputRef type annotation without readonly
+        r"
+        import { Component, OutputRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            valueChange: OutputRef<string>;
+        }
+        ",
+    ];
+
+    Tester::new(PreferOutputReadonly::NAME, PreferOutputReadonly::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_signal_model.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_signal_model.rs
@@ -1,0 +1,282 @@
+use std::collections::BTreeMap;
+
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{AngularDecoratorType, get_class_angular_decorator},
+};
+
+fn prefer_signal_model_diagnostic(span: Span, input_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Input `{input_name}` and output `{input_name}Change` can be replaced with `model()`"
+    ))
+    .with_help(
+        "Use the `model()` function instead of separate `input()` and `output()` for two-way binding patterns. \
+        Example: `value = model<string>();` replaces both `value = input<string>()` and `valueChange = output<string>()`.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferSignalModel;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Suggests using `model()` instead of separate `input()` and `output()` for two-way binding patterns.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When you have an input and a corresponding output with the naming pattern `propName` and
+    /// `propNameChange`, this is typically used for two-way binding (`[(propName)]`). Angular's
+    /// `model()` function (introduced in Angular 17.2) provides a cleaner way to express this:
+    ///
+    /// - Reduces boilerplate by combining input and output into a single declaration
+    /// - Makes the two-way binding intent explicit
+    /// - Provides a writable signal that automatically emits on changes
+    /// - Better type inference
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, input, output } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   value = input<string>();
+    ///   valueChange = output<string>();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, model } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   value = model<string>();
+    /// }
+    /// ```
+    PreferSignalModel,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for PreferSignalModel {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+
+        // Check if the class has a @Component or @Directive decorator
+        let Some((decorator_type, _)) = get_class_angular_decorator(class, ctx) else {
+            return;
+        };
+
+        if !matches!(
+            decorator_type,
+            AngularDecoratorType::Component | AngularDecoratorType::Directive
+        ) {
+            return;
+        }
+
+        // Collect all input() and output() signal calls
+        let mut inputs: BTreeMap<String, Span> = BTreeMap::new();
+        let mut outputs: BTreeMap<String, Span> = BTreeMap::new();
+
+        for element in &class.body.body {
+            if let oxc_ast::ast::ClassElement::PropertyDefinition(prop) = element {
+                let Some(prop_name) = get_property_name(&prop.key) else {
+                    continue;
+                };
+
+                let Some(value) = &prop.value else {
+                    continue;
+                };
+
+                // Check if it's a call expression
+                let oxc_ast::ast::Expression::CallExpression(call) = value else {
+                    continue;
+                };
+
+                // Get the callee name
+                let callee_name = match &call.callee {
+                    oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+                    _ => continue,
+                };
+
+                // Check if it's input() or output()
+                match callee_name {
+                    "input" => {
+                        // Verify it's from @angular/core
+                        if let Some(ident) = call.callee.get_identifier_reference()
+                            && is_angular_core_import_manual(ident, ctx) {
+                                inputs.insert(prop_name.to_string(), prop.span);
+                            }
+                    }
+                    "output" => {
+                        // Verify it's from @angular/core
+                        if let Some(ident) = call.callee.get_identifier_reference()
+                            && is_angular_core_import_manual(ident, ctx) {
+                                outputs.insert(prop_name.to_string(), prop.span);
+                            }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Find matching pairs: inputName + inputNameChange
+        for (input_name, input_span) in &inputs {
+            let expected_output_name = format!("{input_name}Change");
+            if outputs.contains_key(&expected_output_name) {
+                ctx.diagnostic(prefer_signal_model_diagnostic(*input_span, input_name));
+            }
+        }
+    }
+}
+
+fn get_property_name<'a>(key: &'a oxc_ast::ast::PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => Some(ident.name.as_str()),
+        _ => None,
+    }
+}
+
+fn is_angular_core_import_manual(
+    ident: &oxc_ast::ast::IdentifierReference<'_>,
+    ctx: &LintContext<'_>,
+) -> bool {
+    let reference = ctx.scoping().get_reference(ident.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+
+    if !ctx.scoping().symbol_flags(symbol_id).is_import() {
+        return false;
+    }
+
+    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
+        return false;
+    };
+
+    import_decl.source.value.as_str() == "@angular/core"
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Using model()
+        r"
+        import { Component, model } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            value = model<string>();
+        }
+        ",
+        // Only input, no corresponding output
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            value = input<string>();
+        }
+        ",
+        // Only output, no corresponding input
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            valueChange = output<string>();
+        }
+        ",
+        // Different naming (not a Change suffix)
+        r"
+        import { Component, input, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            value = input<string>();
+            valueUpdated = output<string>();
+        }
+        ",
+        // Non-Angular class
+        r"
+        import { input, output } from 'other-library';
+        class TestClass {
+            value = input<string>();
+            valueChange = output<string>();
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Classic two-way binding pattern
+        r"
+        import { Component, input, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            value = input<string>();
+            valueChange = output<string>();
+        }
+        ",
+        // Multiple two-way binding patterns
+        r"
+        import { Component, input, output } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            count = input<number>();
+            countChange = output<number>();
+            name = input<string>();
+            nameChange = output<string>();
+        }
+        ",
+        // In Directive
+        r"
+        import { Directive, input, output } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            selected = input<boolean>();
+            selectedChange = output<boolean>();
+        }
+        ",
+    ];
+
+    Tester::new(PreferSignalModel::NAME, PreferSignalModel::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_signals.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_signals.rs
@@ -1,0 +1,269 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_decorator_identifier, get_decorator_name, get_signal_replacement,
+        is_angular_core_import, is_legacy_angular_decorator,
+    },
+};
+
+fn prefer_signals_diagnostic(span: Span, decorator_name: &str, replacement: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Prefer signal-based `{replacement}()` over legacy `@{decorator_name}()` decorator"
+    ))
+    .with_help(format!(
+        "Replace `@{decorator_name}()` with `{replacement}()` for better performance and reactivity. \
+        See https://angular.dev/guide/signals for migration guidance."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferSignals;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces the use of Angular signal-based APIs (`input()`, `output()`, `viewChild()`, etc.)
+    /// over legacy decorators (`@Input()`, `@Output()`, `@ViewChild()`, etc.).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Legacy decorators rely on Angular's zone-based change detection, which checks the entire
+    /// component tree for changes. Signal-based APIs provide fine-grained reactivity where only
+    /// affected parts of the UI are updated, resulting in better performance.
+    ///
+    /// Additionally, signals are the future of Angular reactivity and provide better TypeScript
+    /// type inference, making code more maintainable.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   @Input() name: string;
+    ///   @Input({ required: true }) id: number;
+    ///   @Output() nameChange = new EventEmitter<string>();
+    ///   @ViewChild('container') container: ElementRef;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, input, output, viewChild, ElementRef } from '@angular/core';
+    ///
+    /// @Component({ selector: 'app-example', template: '' })
+    /// export class ExampleComponent {
+    ///   name = input<string>();
+    ///   id = input.required<number>();
+    ///   nameChange = output<string>();
+    ///   container = viewChild<ElementRef>('container');
+    /// }
+    /// ```
+    PreferSignals,
+    angular,
+    pedantic,
+    pending // not yet ready for production
+);
+
+impl Rule for PreferSignals {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // We're looking for decorators on class properties
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Get the decorator name (e.g., "Input", "Output", "ViewChild")
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        // Check if it's a legacy Angular decorator we care about
+        if !is_legacy_angular_decorator(decorator_name) {
+            return;
+        }
+
+        // Get the identifier to check import source
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        // Verify it's imported from @angular/core
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the signal-based replacement
+        let Some(replacement) = get_signal_replacement(decorator_name) else {
+            return;
+        };
+
+        ctx.diagnostic(prefer_signals_diagnostic(decorator.span, decorator_name, replacement));
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Signal-based input
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            name = input<string>();
+        }
+        ",
+        // Signal-based required input
+        r"
+        import { Component, input } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            id = input.required<number>();
+        }
+        ",
+        // Signal-based output
+        r"
+        import { Component, output } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            clicked = output<void>();
+        }
+        ",
+        // Signal-based viewChild
+        r"
+        import { Component, viewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            container = viewChild<ElementRef>('container');
+        }
+        ",
+        // Signal-based viewChildren
+        r"
+        import { Component, viewChildren, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            items = viewChildren<ElementRef>('item');
+        }
+        ",
+        // Signal-based contentChild
+        r"
+        import { Component, contentChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            content = contentChild<ElementRef>('content');
+        }
+        ",
+        // Signal-based contentChildren
+        r"
+        import { Component, contentChildren, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            items = contentChildren<ElementRef>('item');
+        }
+        ",
+        // Input from a different library (should not trigger)
+        r"
+        import { Input } from 'some-other-lib';
+        class TestComponent {
+            @Input() name: string;
+        }
+        ",
+        // Output from a different library (should not trigger)
+        r"
+        import { Output } from 'some-other-lib';
+        class TestComponent {
+            @Output() clicked = {};
+        }
+        ",
+        // Component decorator is fine
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {}
+        ",
+        // Injectable decorator is fine
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {}
+        ",
+        // Pipe decorator is fine
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({ name: 'test' })
+        class TestPipe {}
+        ",
+    ];
+
+    let fail = vec![
+        // Legacy @Input decorator
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Input() name: string;
+        }
+        ",
+        // Legacy @Input with options
+        r"
+        import { Component, Input } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Input({ required: true }) id: number;
+        }
+        ",
+        // Legacy @Output decorator
+        r"
+        import { Component, Output, EventEmitter } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @Output() clicked = new EventEmitter<void>();
+        }
+        ",
+        // Legacy @ViewChild decorator
+        r"
+        import { Component, ViewChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @ViewChild('container') container: ElementRef;
+        }
+        ",
+        // Legacy @ViewChildren decorator
+        r"
+        import { Component, ViewChildren, QueryList, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @ViewChildren('item') items: QueryList<ElementRef>;
+        }
+        ",
+        // Legacy @ContentChild decorator
+        r"
+        import { Component, ContentChild, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @ContentChild('content') content: ElementRef;
+        }
+        ",
+        // Legacy @ContentChildren decorator
+        r"
+        import { Component, ContentChildren, QueryList, ElementRef } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {
+            @ContentChildren('item') items: QueryList<ElementRef>;
+        }
+        ",
+    ];
+
+    Tester::new(PreferSignals::NAME, PreferSignals::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/prefer_standalone.rs
+++ b/crates/oxc_linter/src/rules/angular/prefer_standalone.rs
@@ -1,0 +1,292 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn standalone_false_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Component should use standalone architecture")
+        .with_help(
+            "Remove `standalone: false` to use standalone components. \
+            In Angular 20, components are standalone by default. \
+            See https://angular.dev/guide/components/importing for migration guidance.",
+        )
+        .with_label(span)
+}
+
+fn standalone_redundant_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Redundant `standalone: true` property")
+        .with_help(
+            "In Angular 20, components are standalone by default. \
+            You can remove the explicit `standalone: true` declaration.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct PreferStandalone {
+    /// Whether to warn on redundant `standalone: true` (default: false)
+    warn_on_redundant: bool,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces standalone component architecture by flagging components that use
+    /// `standalone: false` and optionally warning about redundant `standalone: true`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In Angular 20, standalone components are the default and recommended approach.
+    /// Using `standalone: false` requires NgModules which adds complexity and is considered
+    /// a legacy pattern.
+    ///
+    /// The `standalone: true` declaration is redundant in Angular 20 since it's the default,
+    /// though this warning is optional and disabled by default.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// // Error: standalone: false is discouraged
+    /// @Component({
+    ///   selector: 'app-legacy',
+    ///   template: '',
+    ///   standalone: false
+    /// })
+    /// export class LegacyComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// // Good: No standalone property (defaults to true in Angular 20)
+    /// @Component({
+    ///   selector: 'app-modern',
+    ///   template: ''
+    /// })
+    /// export class ModernComponent {}
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ```json
+    /// {
+    ///   "angular/prefer-standalone": ["error", { "warnOnRedundant": true }]
+    /// }
+    /// ```
+    ///
+    /// - `warnOnRedundant`: When `true`, warns about explicit `standalone: true` declarations
+    ///   which are redundant in Angular 20. Default is `false`.
+    PreferStandalone,
+    angular,
+    correctness,
+    pending // not yet ready for production
+);
+
+impl Rule for PreferStandalone {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component and @Directive decorators
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" && decorator_name != "Directive" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Look for the standalone property
+        let Some(standalone_value) = get_metadata_property(metadata, "standalone") else {
+            // No standalone property - this is fine (defaults to true in Angular 20)
+            return;
+        };
+
+        // Check the value
+        if let Expression::BooleanLiteral(bool_lit) = standalone_value {
+            if !bool_lit.value {
+                // standalone: false - this is an error
+                ctx.diagnostic(standalone_false_diagnostic(bool_lit.span));
+            } else if self.warn_on_redundant {
+                // standalone: true - this is redundant (optional warning)
+                ctx.diagnostic(standalone_redundant_diagnostic(bool_lit.span));
+            }
+        } else {
+            // Non-boolean value (e.g., a variable) - we can't statically analyze this
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // No standalone property (defaults to true in Angular 20)
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '' })
+        class TestComponent {}
+        ",
+        // Directive without standalone property
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({ selector: '[appTest]' })
+        class TestDirective {}
+        ",
+        // standalone: true without warnOnRedundant option (default)
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '', standalone: true })
+        class TestComponent {}
+        ",
+        // Directive with standalone: true (default option, no warning)
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({ selector: '[appTest]', standalone: true })
+        class TestDirective {}
+        ",
+        // Non-Angular decorator (should not trigger)
+        r"
+        import { Component } from 'some-other-lib';
+        @Component({ selector: 'app-test', standalone: false })
+        class TestComponent {}
+        ",
+        // Directive from non-Angular library (should not trigger)
+        r"
+        import { Directive } from 'some-other-lib';
+        @Directive({ selector: '[appTest]', standalone: false })
+        class TestDirective {}
+        ",
+        // Injectable (not Component/Directive)
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {}
+        ",
+        // Pipe (not Component/Directive)
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({ name: 'test', standalone: true })
+        class TestPipe {}
+        ",
+        // Component with templateUrl and no standalone
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', templateUrl: './test.html' })
+        class TestComponent {}
+        ",
+        // Component with imports array (implicit standalone)
+        r"
+        import { Component } from '@angular/core';
+        import { CommonModule } from '@angular/common';
+        @Component({ selector: 'app-test', template: '', imports: [CommonModule] })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // standalone: false on Component
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '', standalone: false })
+        class TestComponent {}
+        ",
+        // standalone: false on Directive
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({ selector: '[appTest]', standalone: false })
+        class TestDirective {}
+        ",
+        // standalone: false with other metadata
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div>Test</div>',
+            styleUrls: ['./test.css'],
+            standalone: false
+        })
+        class TestComponent {}
+        ",
+        // standalone: false on Component with providers
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            providers: [],
+            standalone: false
+        })
+        class TestComponent {}
+        ",
+        // standalone: false on attribute directive
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appHighlight]',
+            standalone: false
+        })
+        class HighlightDirective {}
+        ",
+    ];
+
+    Tester::new(PreferStandalone::NAME, PreferStandalone::PLUGIN, pass, fail).test_and_snapshot();
+}
+
+#[test]
+fn test_warn_on_redundant() {
+    use crate::tester::Tester;
+    use serde_json::json;
+
+    // When warnOnRedundant is true, standalone: true should trigger a warning
+    let pass: Vec<(&str, Option<serde_json::Value>)> = vec![];
+
+    let fail = vec![(
+        r"
+        import { Component } from '@angular/core';
+        @Component({ selector: 'app-test', template: '', standalone: true })
+        class TestComponent {}
+        ",
+        Some(json!([{ "warnOnRedundant": true }])),
+    )];
+
+    Tester::new(PreferStandalone::NAME, PreferStandalone::PLUGIN, pass, fail)
+        .with_snapshot_suffix("warn_on_redundant")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/relative_url_prefix.rs
+++ b/crates/oxc_linter/src/rules/angular/relative_url_prefix.rs
@@ -1,0 +1,259 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn relative_url_prefix_diagnostic(span: Span, property: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "`{property}` should use relative paths starting with `./` or `../`"
+    ))
+    .with_help(
+        "Use relative paths (starting with `./` or `../`) for `templateUrl` and `styleUrls` \
+        to ensure proper resolution in all build scenarios.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RelativeUrlPrefix;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that `templateUrl` and `styleUrls` in `@Component` decorators use relative
+    /// paths starting with `./` or `../`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using non-relative paths for external templates and styles can cause:
+    /// - Build failures in certain configurations
+    /// - Inconsistent behavior across different bundlers
+    /// - Issues with Angular CLI and component compilation
+    ///
+    /// The standard syntax for relative URLs requires paths to begin with `./` or `../`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   templateUrl: 'example.component.html',
+    ///   styleUrls: ['example.component.css']
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   templateUrl: './example.component.html',
+    ///   styleUrls: ['./example.component.css']
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    RelativeUrlPrefix,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for RelativeUrlPrefix {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check templateUrl
+        if let Some(template_url) = get_metadata_property(metadata, "templateUrl")
+            && let Expression::StringLiteral(lit) = template_url
+                && !is_relative_path(lit.value.as_str()) {
+                    ctx.diagnostic(relative_url_prefix_diagnostic(lit.span, "templateUrl"));
+                }
+
+        // Check styleUrls (array of strings)
+        if let Some(style_urls) = get_metadata_property(metadata, "styleUrls")
+            && let Expression::ArrayExpression(arr) = style_urls {
+                for element in &arr.elements {
+                    // Check if the element is a string literal (either directly or through expression)
+                    let string_lit = match element {
+                        oxc_ast::ast::ArrayExpressionElement::StringLiteral(lit) => Some(lit),
+                        _ => element.as_expression().and_then(|e| {
+                            if let Expression::StringLiteral(lit) = e { Some(lit) } else { None }
+                        }),
+                    };
+
+                    if let Some(lit) = string_lit
+                        && !is_relative_path(lit.value.as_str()) {
+                            ctx.diagnostic(relative_url_prefix_diagnostic(lit.span, "styleUrls"));
+                        }
+                }
+            }
+
+        // Check styleUrl (single string, Angular 17+)
+        if let Some(style_url) = get_metadata_property(metadata, "styleUrl")
+            && let Expression::StringLiteral(lit) = style_url
+                && !is_relative_path(lit.value.as_str()) {
+                    ctx.diagnostic(relative_url_prefix_diagnostic(lit.span, "styleUrl"));
+                }
+    }
+}
+
+fn is_relative_path(path: &str) -> bool {
+    path.starts_with("./") || path.starts_with("../")
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Relative templateUrl
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            templateUrl: './test.component.html'
+        })
+        class TestComponent {}
+        ",
+        // Relative styleUrls
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styleUrls: ['./test.component.css']
+        })
+        class TestComponent {}
+        ",
+        // Multiple relative styleUrls
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styleUrls: ['./test.component.css', '../shared/styles.css']
+        })
+        class TestComponent {}
+        ",
+        // Parent directory relative path
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            templateUrl: '../templates/test.component.html'
+        })
+        class TestComponent {}
+        ",
+        // Inline template (not affected)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '<div>Hello</div>'
+        })
+        class TestComponent {}
+        ",
+        // Inline styles (not affected)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styles: [':host { display: block; }']
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular Component
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            selector: 'app-test',
+            templateUrl: 'test.component.html'
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // Non-relative templateUrl
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            templateUrl: 'test.component.html'
+        })
+        class TestComponent {}
+        ",
+        // Non-relative styleUrls
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styleUrls: ['test.component.css']
+        })
+        class TestComponent {}
+        ",
+        // Absolute path templateUrl
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            templateUrl: '/app/test.component.html'
+        })
+        class TestComponent {}
+        ",
+        // Mixed - one relative, one not
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styleUrls: ['./valid.css', 'invalid.css']
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(RelativeUrlPrefix::NAME, RelativeUrlPrefix::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/require_lifecycle_on_prototype.rs
+++ b/crates/oxc_linter/src/rules/angular/require_lifecycle_on_prototype.rs
@@ -1,0 +1,253 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, is_lifecycle_method},
+};
+
+fn require_lifecycle_on_prototype_diagnostic(span: Span, method_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Lifecycle method `{method_name}` should be defined on the class prototype, not as a property"
+    ))
+    .with_help(
+        "Define lifecycle methods as regular methods on the class, not as property assignments. \
+        Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireLifecycleOnPrototype;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures lifecycle methods are declared on the class prototype rather than as instance properties.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Lifecycle methods defined as arrow functions or property assignments create a new function
+    /// for each component instance. This has several drawbacks:
+    /// - Higher memory usage (each instance has its own copy)
+    /// - Cannot be overridden in subclasses
+    /// - May not work correctly with Angular's change detection in some scenarios
+    /// - Inconsistent with Angular's expected method signature pattern
+    ///
+    /// Regular prototype methods are shared across all instances and work correctly with
+    /// Angular's lifecycle system.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   ngOnInit = () => {
+    ///     console.log('initialized');
+    ///   };
+    ///
+    ///   ngOnDestroy = function() {
+    ///     console.log('destroyed');
+    ///   };
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   ngOnInit() {
+    ///     console.log('initialized');
+    ///   }
+    ///
+    ///   ngOnDestroy() {
+    ///     console.log('destroyed');
+    ///   }
+    /// }
+    /// ```
+    RequireLifecycleOnPrototype,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for RequireLifecycleOnPrototype {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::PropertyDefinition(prop) = node.kind() else {
+            return;
+        };
+
+        // Get property name
+        let prop_name = match &prop.key {
+            oxc_ast::ast::PropertyKey::StaticIdentifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        // Check if this is a lifecycle method name
+        if !is_lifecycle_method(prop_name) {
+            return;
+        }
+
+        // Check if the value is a function expression or arrow function
+        let is_function_value = prop.value.as_ref().is_some_and(|value| {
+            matches!(
+                value,
+                oxc_ast::ast::Expression::ArrowFunctionExpression(_)
+                    | oxc_ast::ast::Expression::FunctionExpression(_)
+            )
+        });
+
+        if !is_function_value {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        ctx.diagnostic(require_lifecycle_on_prototype_diagnostic(prop.key.span(), prop_name));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Regular method
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit() {}
+        }
+        ",
+        // Multiple lifecycle methods as regular methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit() {}
+            ngOnDestroy() {}
+            ngAfterViewInit() {}
+        }
+        ",
+        // Arrow function property that's not a lifecycle method
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            handleClick = () => {};
+        }
+        ",
+        // Non-Angular class with lifecycle property
+        r"
+        class TestClass {
+            ngOnInit = () => {};
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Arrow function lifecycle
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit = () => {};
+        }
+        ",
+        // Function expression lifecycle
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnDestroy = function() {};
+        }
+        ",
+        // Multiple arrow function lifecycles
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit = () => {};
+            ngOnChanges = () => {};
+        }
+        ",
+        // Directive with arrow lifecycle
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            ngAfterViewInit = () => {};
+        }
+        ",
+        // Injectable with arrow lifecycle
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            ngOnDestroy = () => {};
+        }
+        ",
+        // NOTE: Assignment expression detection (this.ngOnInit = () => {}) is a potential
+        // enhancement tracked for future implementation. Angular-eslint checks this pattern
+        // but it requires more complex AST traversal in oxlint.
+    ];
+
+    Tester::new(RequireLifecycleOnPrototype::NAME, RequireLifecycleOnPrototype::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/require_localize_metadata.rs
+++ b/crates/oxc_linter/src/rules/angular/require_localize_metadata.rs
@@ -1,0 +1,341 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn require_localize_description_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("$localize tagged messages should contain a description")
+        .with_help(
+            "Add a description to help translators understand the context. \
+            Use the format: $localize`:description:text` or $localize`:meaning|description:text`",
+        )
+        .with_label(span)
+}
+
+fn require_localize_meaning_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("$localize tagged messages should contain a meaning")
+        .with_help(
+            "Add a meaning to distinguish identical text that needs different translations. \
+            Use the format: $localize`:meaning|description:text`",
+        )
+        .with_label(span)
+}
+
+fn require_localize_custom_id_diagnostic(span: Span, pattern_message: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "$localize tagged messages should contain a custom id{pattern_message}"
+    ))
+    .with_help(
+        "Add a custom ID for stable translation references. \
+        Use the format: $localize`:description@@customId:text`",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[expect(clippy::struct_field_names)]
+pub struct RequireLocalizeMetadataConfig {
+    #[serde(default)]
+    require_description: bool,
+    #[serde(default)]
+    require_meaning: bool,
+    #[serde(default)]
+    require_custom_id: RequireCustomIdOption,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(untagged)]
+pub enum RequireCustomIdOption {
+    #[default]
+    Disabled,
+    Enabled(bool),
+    Pattern(String),
+}
+
+impl RequireCustomIdOption {
+    fn is_required(&self) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::Enabled(b) => *b,
+            Self::Pattern(_) => true,
+        }
+    }
+
+    fn get_pattern(&self) -> Option<&str> {
+        match self {
+            Self::Pattern(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+#[expect(clippy::struct_field_names)]
+pub struct RequireLocalizeMetadata {
+    require_description: bool,
+    require_meaning: bool,
+    require_custom_id: RequireCustomIdOption,
+}
+
+impl From<RequireLocalizeMetadataConfig> for RequireLocalizeMetadata {
+    fn from(config: RequireLocalizeMetadataConfig) -> Self {
+        Self {
+            require_description: config.require_description,
+            require_meaning: config.require_meaning,
+            require_custom_id: config.require_custom_id,
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that `$localize` tagged messages contain helpful metadata to aid with translations.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When internationalizing Angular applications with `@angular/localize`, adding metadata
+    /// (description, meaning, and custom IDs) to `$localize` tagged strings is essential for
+    /// high-quality translations:
+    ///
+    /// - **Description**: Helps translators understand the context and purpose of the text
+    /// - **Meaning**: Distinguishes identical text that needs different translations
+    /// - **Custom ID**: Provides stable references that persist across code changes
+    ///
+    /// Without this metadata, translators work blind, leading to poor translations.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule (with `requireDescription: true`):
+    /// ```typescript
+    /// const message = $localize`Hello World`;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// const message = $localize`:greeting|A friendly greeting:Hello World`;
+    /// const message2 = $localize`:A friendly greeting@@greeting-id:Hello World`;
+    /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/require-localize-metadata": ["error", {
+    ///     "requireDescription": true,
+    ///     "requireMeaning": false,
+    ///     "requireCustomId": false
+    ///   }]
+    /// }
+    /// ```
+    RequireLocalizeMetadata,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for RequireLocalizeMetadata {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<RequireLocalizeMetadataConfig>(config_value.clone())
+            .map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Skip if no requirements are configured
+        if !self.require_description
+            && !self.require_meaning
+            && !self.require_custom_id.is_required()
+        {
+            return;
+        }
+
+        let AstKind::TaggedTemplateExpression(tagged) = node.kind() else {
+            return;
+        };
+
+        // Check if the tag is $localize
+        let tag_name = match &tagged.tag {
+            oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        if tag_name != "$localize" {
+            return;
+        }
+
+        // Get the first quasi (template element)
+        let Some(first_quasi) = tagged.quasi.quasis.first() else {
+            return;
+        };
+
+        let raw_text = first_quasi.value.raw.as_str().trim();
+        let metadata = parse_localize_metadata(raw_text);
+
+        if self.require_description && metadata.description.is_none() {
+            ctx.diagnostic(require_localize_description_diagnostic(first_quasi.span));
+        }
+
+        if self.require_meaning && metadata.meaning.is_none() {
+            ctx.diagnostic(require_localize_meaning_diagnostic(first_quasi.span));
+        }
+
+        if self.require_custom_id.is_required() {
+            let id_valid = match (&metadata.custom_id, self.require_custom_id.get_pattern()) {
+                (Some(id), Some(pattern)) => {
+                    // Check if custom_id matches the pattern
+                    lazy_regex::Regex::new(pattern).is_ok_and(|re| re.is_match(id))
+                }
+                (Some(_), None) => true,
+                (None, _) => false,
+            };
+
+            if !id_valid {
+                let pattern_message = match self.require_custom_id.get_pattern() {
+                    Some(pattern) => {
+                        format!(
+                            " matching the pattern /{pattern}/ on '{}'",
+                            metadata.custom_id.unwrap_or_default()
+                        )
+                    }
+                    None => String::new(),
+                };
+                ctx.diagnostic(require_localize_custom_id_diagnostic(
+                    first_quasi.span,
+                    &pattern_message,
+                ));
+            }
+        }
+    }
+}
+
+/// Parsed metadata from a $localize tagged template
+struct LocalizeMetadata<'a> {
+    meaning: Option<&'a str>,
+    description: Option<&'a str>,
+    custom_id: Option<&'a str>,
+}
+
+/// Parse metadata from the raw text of a $localize tagged template.
+/// Format: `:meaning|description@@customId:` or `:description@@customId:` or `:description:`
+fn parse_localize_metadata(raw_text: &str) -> LocalizeMetadata<'_> {
+    const BLOCK_MARKER: char = ':';
+    const MEANING_SEPARATOR: char = '|';
+    const ID_SEPARATOR: &str = "@@";
+
+    let mut result = LocalizeMetadata { meaning: None, description: None, custom_id: None };
+
+    // Must start with ':'
+    if !raw_text.starts_with(BLOCK_MARKER) {
+        return result;
+    }
+
+    // Find the end of the metadata block
+    let Some(end_index) = raw_text[1..].find(BLOCK_MARKER) else {
+        return result;
+    };
+
+    let text = &raw_text[1..=end_index];
+
+    // Split by @@ to get custom ID
+    let (meaning_and_desc, custom_id) = if let Some(idx) = text.find(ID_SEPARATOR) {
+        (&text[..idx], Some(&text[idx + 2..]))
+    } else {
+        (text, None)
+    };
+
+    // Split by | to get meaning and description
+    let (meaning, description) = if let Some(idx) = meaning_and_desc.find(MEANING_SEPARATOR) {
+        (Some(&meaning_and_desc[..idx]), Some(&meaning_and_desc[idx + 1..]))
+    } else {
+        // If no separator, the whole thing is the description
+        (None, Some(meaning_and_desc))
+    };
+
+    // Filter out empty strings
+    result.meaning = meaning.filter(|s| !s.is_empty());
+    result.description = description.filter(|s| !s.is_empty());
+    result.custom_id = custom_id.filter(|s| !s.is_empty());
+
+    result
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // With description (when required)
+        (
+            r"const msg = $localize`:A greeting message:Hello`;",
+            Some(serde_json::json!([{ "requireDescription": true }])),
+        ),
+        // With meaning and description
+        (
+            r"const msg = $localize`:greeting|A friendly greeting:Hello`;",
+            Some(serde_json::json!([{ "requireDescription": true, "requireMeaning": true }])),
+        ),
+        // With custom ID
+        (
+            r"const msg = $localize`:description@@custom-id:Hello`;",
+            Some(serde_json::json!([{ "requireCustomId": true }])),
+        ),
+        // With all metadata
+        (
+            r"const msg = $localize`:meaning|description@@custom-id:Hello`;",
+            Some(
+                serde_json::json!([{ "requireDescription": true, "requireMeaning": true, "requireCustomId": true }]),
+            ),
+        ),
+        // Custom ID with pattern
+        (
+            r"const msg = $localize`:desc@@MSG_123:Hello`;",
+            Some(serde_json::json!([{ "requireCustomId": "^MSG_" }])),
+        ),
+        // No requirements (default)
+        (r"const msg = $localize`Hello`;", None),
+        // Not $localize
+        (
+            r"const msg = someTag`Hello`;",
+            Some(serde_json::json!([{ "requireDescription": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        // Missing description
+        (
+            r"const msg = $localize`Hello`;",
+            Some(serde_json::json!([{ "requireDescription": true }])),
+        ),
+        // Missing meaning
+        (
+            r"const msg = $localize`:description:Hello`;",
+            Some(serde_json::json!([{ "requireMeaning": true }])),
+        ),
+        // Missing custom ID
+        (
+            r"const msg = $localize`:description:Hello`;",
+            Some(serde_json::json!([{ "requireCustomId": true }])),
+        ),
+        // Custom ID doesn't match pattern
+        (
+            r"const msg = $localize`:desc@@wrong-id:Hello`;",
+            Some(serde_json::json!([{ "requireCustomId": "^MSG_" }])),
+        ),
+        // Empty description
+        (
+            r"const msg = $localize`::Hello`;",
+            Some(serde_json::json!([{ "requireDescription": true }])),
+        ),
+    ];
+
+    Tester::new(RequireLocalizeMetadata::NAME, RequireLocalizeMetadata::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/runtime_localize.rs
+++ b/crates/oxc_linter/src/rules/angular/runtime_localize.rs
@@ -1,0 +1,220 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn runtime_localize_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("`$localize` used at module load time")
+        .with_help(
+            "Move the `$localize` call inside a function, method, or getter to ensure it runs \
+            at runtime when localization data is available. Using `$localize` at module load time \
+            may cause issues if the localization data hasn't been loaded yet.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RuntimeLocalize;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows usage of `$localize` at module load time (top-level code).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `$localize` template tag function requires localization data to be loaded before
+    /// it can properly translate strings. When `$localize` is used at module load time
+    /// (e.g., in top-level variable declarations, class field initializers, or static properties),
+    /// the localization data may not yet be available, resulting in:
+    /// - Untranslated strings
+    /// - Missing translations
+    /// - Runtime errors in some configurations
+    ///
+    /// Instead, use `$localize` inside functions, methods, or getters that are called at runtime
+    /// after the localization data has been loaded.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// // Top-level constant
+    /// const GREETING = $localize`Hello`;
+    ///
+    /// // Static class property
+    /// class MyComponent {
+    ///   static readonly TITLE = $localize`Welcome`;
+    /// }
+    ///
+    /// // Class field initializer
+    /// class MyComponent {
+    ///   message = $localize`Hello World`;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// // Inside a method
+    /// class MyComponent {
+    ///   getGreeting() {
+    ///     return $localize`Hello`;
+    ///   }
+    /// }
+    ///
+    /// // Inside a getter
+    /// class MyComponent {
+    ///   get title() {
+    ///     return $localize`Welcome`;
+    ///   }
+    /// }
+    ///
+    /// // Inside ngOnInit
+    /// class MyComponent {
+    ///   message: string;
+    ///   ngOnInit() {
+    ///     this.message = $localize`Hello World`;
+    ///   }
+    /// }
+    /// ```
+    RuntimeLocalize,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for RuntimeLocalize {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::TaggedTemplateExpression(tagged) = node.kind() else {
+            return;
+        };
+
+        // Check if the tag is $localize
+        let tag_name = match &tagged.tag {
+            oxc_ast::ast::Expression::Identifier(ident) => ident.name.as_str(),
+            _ => return,
+        };
+
+        if tag_name != "$localize" {
+            return;
+        }
+
+        // Check if we're at module load time
+        if is_at_module_load_time(node, ctx) {
+            ctx.diagnostic(runtime_localize_diagnostic(tagged.span));
+        }
+    }
+}
+
+fn is_at_module_load_time(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    // Walk up the tree to check the context
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        match ancestor.kind() {
+            // Inside a function/method/arrow function = runtime
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                return false;
+            }
+            // Inside a getter = runtime
+            AstKind::MethodDefinition(method) => {
+                if method.kind.is_get() {
+                    return false;
+                }
+                // Regular method = runtime
+                return false;
+            }
+            // Inside a property definition = module load time
+            AstKind::PropertyDefinition(prop) => {
+                // Static properties are especially problematic
+                if prop.r#static {
+                    return true;
+                }
+                // Instance properties are also module load time
+                return true;
+            }
+            // Program level = module load time
+            AstKind::Program(_) => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+
+    // If we reach here without finding a function context, it's likely module load time
+    true
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Inside a method
+        r"
+        class TestComponent {
+            getGreeting() {
+                return $localize`Hello`;
+            }
+        }
+        ",
+        // Inside ngOnInit
+        r"
+        class TestComponent {
+            ngOnInit() {
+                this.message = $localize`Hello World`;
+            }
+        }
+        ",
+        // Inside a getter
+        r"
+        class TestComponent {
+            get title() {
+                return $localize`Welcome`;
+            }
+        }
+        ",
+        // Inside constructor
+        r"
+        class TestComponent {
+            constructor() {
+                this.message = $localize`Hello`;
+            }
+        }
+        ",
+        // Inside an arrow function that's called later
+        r"
+        class TestComponent {
+            getMessage = () => $localize`Hello`;
+        }
+        ",
+        // Not $localize
+        r"
+        const value = someOtherTag`Hello`;
+        ",
+    ];
+
+    let fail = vec![
+        // Top-level constant
+        r"
+        const GREETING = $localize`Hello`;
+        ",
+        // Static class property
+        r"
+        class MyComponent {
+            static readonly TITLE = $localize`Welcome`;
+        }
+        ",
+        // Class field initializer
+        r"
+        class MyComponent {
+            message = $localize`Hello World`;
+        }
+        ",
+        // Top-level export
+        r"
+        export const ERROR_MESSAGE = $localize`An error occurred`;
+        ",
+    ];
+
+    Tester::new(RuntimeLocalize::NAME, RuntimeLocalize::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/sort_keys_in_type_decorator.rs
+++ b/crates/oxc_linter/src/rules/angular/sort_keys_in_type_decorator.rs
@@ -1,0 +1,430 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        is_angular_core_import,
+    },
+};
+
+fn sort_keys_diagnostic(span: Span, decorator: &str, expected_order: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Keys in @{decorator} decorator should be ordered: {expected_order}"
+    ))
+    .with_help(
+        "Maintaining a consistent order for properties in Angular decorators makes code more \
+        predictable and easier to scan.",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase", default, deny_unknown_fields)]
+pub struct SortKeysInTypeDecoratorConfig {
+    #[serde(default = "default_component_order")]
+    component: Vec<String>,
+    #[serde(default = "default_directive_order")]
+    directive: Vec<String>,
+    #[serde(default = "default_ng_module_order")]
+    ng_module: Vec<String>,
+    #[serde(default = "default_pipe_order")]
+    pipe: Vec<String>,
+}
+
+fn default_component_order() -> Vec<String> {
+    vec![
+        "selector",
+        "imports",
+        "standalone",
+        "templateUrl",
+        "template",
+        "styleUrl",
+        "styleUrls",
+        "styles",
+        "providers",
+        "changeDetection",
+        "encapsulation",
+        "viewProviders",
+        "host",
+        "hostDirectives",
+        "inputs",
+        "outputs",
+        "animations",
+        "schemas",
+        "exportAs",
+        "queries",
+        "preserveWhitespaces",
+        "jit",
+        "moduleId",
+        "interpolation",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn default_directive_order() -> Vec<String> {
+    vec![
+        "selector",
+        "standalone",
+        "providers",
+        "host",
+        "hostDirectives",
+        "inputs",
+        "outputs",
+        "exportAs",
+        "queries",
+        "jit",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+fn default_ng_module_order() -> Vec<String> {
+    vec!["id", "imports", "declarations", "providers", "exports", "bootstrap", "schemas", "jit"]
+        .into_iter()
+        .map(String::from)
+        .collect()
+}
+
+fn default_pipe_order() -> Vec<String> {
+    vec!["name", "standalone", "pure"].into_iter().map(String::from).collect()
+}
+
+#[derive(Debug, Clone, Default)]
+#[expect(clippy::struct_field_names)]
+pub struct SortKeysInTypeDecorator {
+    component_order: Vec<String>,
+    directive_order: Vec<String>,
+    ng_module_order: Vec<String>,
+    pipe_order: Vec<String>,
+}
+
+impl From<SortKeysInTypeDecoratorConfig> for SortKeysInTypeDecorator {
+    fn from(config: SortKeysInTypeDecoratorConfig) -> Self {
+        Self {
+            component_order: if config.component.is_empty() {
+                default_component_order()
+            } else {
+                config.component
+            },
+            directive_order: if config.directive.is_empty() {
+                default_directive_order()
+            } else {
+                config.directive
+            },
+            ng_module_order: if config.ng_module.is_empty() {
+                default_ng_module_order()
+            } else {
+                config.ng_module
+            },
+            pipe_order: if config.pipe.is_empty() { default_pipe_order() } else { config.pipe },
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that keys in type decorators (`@Component`, `@Directive`, `@NgModule`, `@Pipe`)
+    /// are sorted in a consistent order.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Maintaining a consistent order for properties in Angular decorators makes code more
+    /// predictable and easier to scan. When all components in a codebase follow the same
+    /// property order, developers can quickly locate specific metadata without searching.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// @Component({
+    ///   template: '',
+    ///   selector: 'app-example', // selector should come first
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/sort-keys-in-type-decorator": ["error", {
+    ///     "Component": ["selector", "imports", "standalone", "templateUrl", "template"],
+    ///     "Directive": ["selector", "standalone", "providers"],
+    ///     "NgModule": ["imports", "declarations", "providers", "exports"],
+    ///     "Pipe": ["name", "standalone", "pure"]
+    ///   }]
+    /// }
+    /// ```
+    SortKeysInTypeDecorator,
+    angular,
+    style,
+    pending
+);
+
+impl Rule for SortKeysInTypeDecorator {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::from(SortKeysInTypeDecoratorConfig::default()));
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<SortKeysInTypeDecoratorConfig>(config_value.clone())
+            .map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        // Get the expected order based on decorator type
+        let expected_order = match decorator_name {
+            "Component" => &self.component_order,
+            "Directive" => &self.directive_order,
+            "NgModule" => &self.ng_module_order,
+            "Pipe" => &self.pipe_order,
+            _ => return,
+        };
+
+        if expected_order.is_empty() {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Get property names in order
+        let property_names: Vec<&str> = metadata
+            .properties
+            .iter()
+            .filter_map(|prop| {
+                if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop
+                    && let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &obj_prop.key {
+                        return Some(ident.name.as_str());
+                    }
+                None
+            })
+            .collect();
+
+        if property_names.len() <= 1 {
+            return;
+        }
+
+        // Check if the order is correct
+        let configured_props: Vec<&str> = property_names
+            .iter()
+            .filter(|name| expected_order.iter().any(|e| e == *name))
+            .copied()
+            .collect();
+
+        let expected_configured_props: Vec<&str> = expected_order
+            .iter()
+            .filter(|name| configured_props.contains(&name.as_str()))
+            .map(String::as_str)
+            .collect();
+
+        // Find the first property that's out of order
+        let mut out_of_order_span: Option<Span> = None;
+
+        for (i, name) in configured_props.iter().enumerate() {
+            if i < expected_configured_props.len() && *name != expected_configured_props[i] {
+                // Find the span of the out-of-order property
+                for prop in &metadata.properties {
+                    if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop
+                        && let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) = &obj_prop.key
+                            && ident.name.as_str() == *name {
+                                out_of_order_span = Some(obj_prop.key.span());
+                                break;
+                            }
+                }
+                break;
+            }
+        }
+
+        // Also check for unconfigured props that come before configured props
+        if out_of_order_span.is_none() {
+            let first_configured_idx =
+                property_names.iter().position(|name| expected_order.iter().any(|e| e == *name));
+            let last_unconfigured_idx =
+                property_names.iter().rposition(|name| !expected_order.iter().any(|e| e == *name));
+
+            if let (Some(first_cfg), Some(last_uncfg)) =
+                (first_configured_idx, last_unconfigured_idx)
+                && last_uncfg < first_cfg {
+                    // Unconfigured property comes before configured - find its span
+                    let uncfg_name = property_names[last_uncfg];
+                    for prop in &metadata.properties {
+                        if let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(obj_prop) = prop
+                            && let oxc_ast::ast::PropertyKey::StaticIdentifier(ident) =
+                                &obj_prop.key
+                                && ident.name.as_str() == uncfg_name {
+                                    out_of_order_span = Some(obj_prop.key.span());
+                                    break;
+                                }
+                    }
+                }
+        }
+
+        if let Some(span) = out_of_order_span {
+            let relevant_order: Vec<&str> = expected_order
+                .iter()
+                .filter(|name| property_names.contains(&name.as_str()))
+                .map(String::as_str)
+                .collect();
+
+            ctx.diagnostic(sort_keys_diagnostic(span, decorator_name, &relevant_order.join(", ")));
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Correct order for Component
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            styles: []
+        })
+        class TestComponent {}
+        ",
+        // Correct order for Directive
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]',
+            standalone: true,
+            providers: []
+        })
+        class TestDirective {}
+        ",
+        // Correct order for NgModule
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            imports: [],
+            declarations: [],
+            providers: [],
+            exports: []
+        })
+        class TestModule {}
+        ",
+        // Correct order for Pipe
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({
+            name: 'testPipe',
+            standalone: true,
+            pure: true
+        })
+        class TestPipe {}
+        ",
+        // Single property (no order needed)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test'
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular decorator
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            template: '',
+            selector: 'app-test'
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // Wrong order for Component (template before selector)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            template: '',
+            selector: 'app-test'
+        })
+        class TestComponent {}
+        ",
+        // Wrong order for Component (styles before template)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            styles: [],
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Wrong order for Directive
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            providers: [],
+            selector: '[appTest]'
+        })
+        class TestDirective {}
+        ",
+        // Wrong order for NgModule
+        r"
+        import { NgModule } from '@angular/core';
+        @NgModule({
+            exports: [],
+            imports: []
+        })
+        class TestModule {}
+        ",
+        // Wrong order for Pipe
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({
+            pure: true,
+            name: 'testPipe'
+        })
+        class TestPipe {}
+        ",
+    ];
+
+    Tester::new(SortKeysInTypeDecorator::NAME, SortKeysInTypeDecorator::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/sort_lifecycle_methods.rs
+++ b/crates/oxc_linter/src/rules/angular/sort_lifecycle_methods.rs
@@ -1,0 +1,255 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{get_class_angular_decorator, get_lifecycle_method_order, is_lifecycle_method},
+};
+
+fn sort_lifecycle_methods_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Lifecycle methods are not declared in order of execution")
+        .with_help(
+            "Declare lifecycle methods in the order they are invoked by Angular: \
+            ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → \
+            ngAfterViewInit → ngAfterViewChecked → ngOnDestroy",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SortLifecycleMethods;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that lifecycle methods in Angular classes are declared in the order
+    /// they are invoked by Angular.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Declaring lifecycle methods in execution order:
+    /// - Makes the code more readable and predictable
+    /// - Helps developers understand the component's lifecycle at a glance
+    /// - Follows a consistent pattern across the codebase
+    /// - Makes it easier to reason about initialization and cleanup logic
+    ///
+    /// ### Execution Order
+    ///
+    /// 1. `ngOnChanges` - Called when input properties change
+    /// 2. `ngOnInit` - Called once after the first ngOnChanges
+    /// 3. `ngDoCheck` - Called during every change detection run
+    /// 4. `ngAfterContentInit` - Called after content (ng-content) has been projected
+    /// 5. `ngAfterContentChecked` - Called after every check of projected content
+    /// 6. `ngAfterViewInit` - Called after the component's view has been initialized
+    /// 7. `ngAfterViewChecked` - Called after every check of the component's view
+    /// 8. `ngOnDestroy` - Called before the component is destroyed
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit, OnDestroy } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit, OnDestroy {
+    ///   ngOnDestroy() {}  // Wrong order
+    ///   ngOnInit() {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit, OnDestroy } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit, OnDestroy {
+    ///   ngOnInit() {}
+    ///   ngOnDestroy() {}
+    /// }
+    /// ```
+    SortLifecycleMethods,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for SortLifecycleMethods {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Class(class) = node.kind() else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        // Collect lifecycle methods with their positions
+        let mut lifecycle_methods: Vec<(usize, String, Span)> = Vec::new();
+
+        for member in &class.body.body {
+            if let oxc_ast::ast::ClassElement::MethodDefinition(method) = member
+                && let Some(name) = method.key.static_name()
+                    && is_lifecycle_method(&name)
+                        && let Some(order) = get_lifecycle_method_order(&name) {
+                            lifecycle_methods.push((order, name.to_string(), method.span));
+                        }
+        }
+
+        // Check if methods are in order
+        if lifecycle_methods.len() < 2 {
+            return;
+        }
+
+        let mut prev_order = lifecycle_methods[0].0;
+        for (order, _name, span) in lifecycle_methods.iter().skip(1) {
+            if *order < prev_order {
+                ctx.diagnostic(sort_lifecycle_methods_diagnostic(*span));
+            }
+            prev_order = *order;
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Correct order
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Full lifecycle in order
+        r"
+        import { Component, OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnChanges() {}
+            ngOnInit() {}
+            ngDoCheck() {}
+            ngAfterContentInit() {}
+            ngAfterContentChecked() {}
+            ngAfterViewInit() {}
+            ngAfterViewChecked() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Single lifecycle method
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // No lifecycle methods
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            onClick() {}
+        }
+        ",
+        // Non-Angular class
+        r"
+        class TestClass {
+            ngOnDestroy() {}
+            ngOnInit() {}
+        }
+        ",
+        // Directive with correct order
+        r"
+        import { Directive, OnInit, OnDestroy } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements OnInit, OnDestroy {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Wrong order: OnDestroy before OnInit
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnDestroy() {}
+            ngOnInit() {}
+        }
+        ",
+        // Wrong order: AfterViewInit before OnInit
+        r"
+        import { Component, OnInit, AfterViewInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, AfterViewInit {
+            ngAfterViewInit() {}
+            ngOnInit() {}
+        }
+        ",
+        // Multiple out of order
+        r"
+        import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnDestroy() {}
+            ngAfterViewInit() {}
+            ngOnInit() {}
+        }
+        ",
+        // OnChanges after OnInit
+        r"
+        import { Component, OnInit, OnChanges } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnChanges {
+            ngOnInit() {}
+            ngOnChanges() {}
+        }
+        ",
+    ];
+
+    Tester::new(SortLifecycleMethods::NAME, SortLifecycleMethods::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/use_component_selector.rs
+++ b/crates/oxc_linter/src/rules/angular/use_component_selector.rs
@@ -1,0 +1,200 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn use_component_selector_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Components should have a selector")
+        .with_help(
+            "Add a `selector` property to the @Component decorator. Without a selector, \
+            the component can only be used programmatically and not in templates.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseComponentSelector;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that all `@Component` decorators have a `selector` property defined.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A component without a selector cannot be used in templates and can only be
+    /// created programmatically. While this might be intentional for some components
+    /// (like those used with route configurations), most components should have a
+    /// selector defined.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   template: '<div>Hello</div>'
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '<div>Hello</div>'
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    UseComponentSelector,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for UseComponentSelector {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check if selector is present and non-empty
+        match get_metadata_property(metadata, "selector") {
+            None => {
+                ctx.diagnostic(use_component_selector_diagnostic(decorator.span));
+            }
+            Some(Expression::StringLiteral(lit)) if lit.value.is_empty() => {
+                ctx.diagnostic(use_component_selector_diagnostic(decorator.span));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Component with selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Component with attribute selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: '[appTest]',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Standalone component with selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            standalone: true
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular Component
+        r"
+        import { Component } from 'other-lib';
+        @Component({
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Directive (not a component)
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {}
+        ",
+    ];
+
+    let fail = vec![
+        // Component without selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Component with empty selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: '',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Standalone component without selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            template: '',
+            standalone: true
+        })
+        class TestComponent {}
+        ",
+        // Component with templateUrl but no selector
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            templateUrl: './test.component.html'
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(UseComponentSelector::NAME, UseComponentSelector::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/use_component_view_encapsulation.rs
+++ b/crates/oxc_linter/src/rules/angular/use_component_view_encapsulation.rs
@@ -1,0 +1,247 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn use_component_view_encapsulation_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using `ViewEncapsulation.None`")
+        .with_help(
+            "Using `ViewEncapsulation.None` makes component styles global, which can lead to \
+            unintended style conflicts. Use `ViewEncapsulation.Emulated` (default) or \
+            `ViewEncapsulation.ShadowDom` instead.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseComponentViewEncapsulation;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows the use of `ViewEncapsulation.None` in Angular components.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using `ViewEncapsulation.None` removes Angular's style encapsulation, causing
+    /// all component styles to become global. This can lead to:
+    /// - Unintended style conflicts with other components
+    /// - Difficulty maintaining and debugging styles
+    /// - CSS specificity issues
+    /// - Styles leaking into or out of components
+    ///
+    /// Use `ViewEncapsulation.Emulated` (the default) or `ViewEncapsulation.ShadowDom`
+    /// to keep styles scoped to the component.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component, ViewEncapsulation } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: '',
+    ///   encapsulation: ViewEncapsulation.None
+    /// })
+    /// export class ExampleComponent {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, ViewEncapsulation } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    ///   // Using default Emulated encapsulation
+    /// })
+    /// export class ExampleComponent {}
+    ///
+    /// @Component({
+    ///   selector: 'app-shadow',
+    ///   template: '',
+    ///   encapsulation: ViewEncapsulation.ShadowDom
+    /// })
+    /// export class ShadowComponent {}
+    /// ```
+    UseComponentViewEncapsulation,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for UseComponentViewEncapsulation {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Component decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Component" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            return;
+        };
+
+        // Check if encapsulation is set to ViewEncapsulation.None
+        let Some(encapsulation) = get_metadata_property(metadata, "encapsulation") else {
+            return;
+        };
+
+        if is_view_encapsulation_none(encapsulation) {
+            let span = find_property_span(metadata, "encapsulation").unwrap_or(decorator.span);
+            ctx.diagnostic(use_component_view_encapsulation_diagnostic(span));
+        }
+    }
+}
+
+fn is_view_encapsulation_none(expr: &Expression<'_>) -> bool {
+    match expr {
+        // ViewEncapsulation.None
+        Expression::StaticMemberExpression(member) => {
+            if let Expression::Identifier(obj) = &member.object {
+                obj.name.as_str() == "ViewEncapsulation" && member.property.name.as_str() == "None"
+            } else {
+                false
+            }
+        }
+        // Numeric literal 2 (ViewEncapsulation.None = 2)
+        Expression::NumericLiteral(lit) => {
+            #[expect(clippy::float_cmp)]
+            {
+                lit.value == 2.0
+            }
+        }
+        _ => false,
+    }
+}
+
+fn find_property_span(obj: &oxc_ast::ast::ObjectExpression<'_>, key: &str) -> Option<Span> {
+    use oxc_ast::ast::{ObjectPropertyKind, PropertyKey};
+    use oxc_span::GetSpan;
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == key {
+                    return Some(prop.span());
+                }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Default encapsulation (Emulated)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {}
+        ",
+        // Explicit Emulated encapsulation
+        r"
+        import { Component, ViewEncapsulation } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            encapsulation: ViewEncapsulation.Emulated
+        })
+        class TestComponent {}
+        ",
+        // ShadowDom encapsulation
+        r"
+        import { Component, ViewEncapsulation } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            encapsulation: ViewEncapsulation.ShadowDom
+        })
+        class TestComponent {}
+        ",
+        // Non-Angular Component
+        r"
+        import { Component, ViewEncapsulation } from 'other-lib';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            encapsulation: ViewEncapsulation.None
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    let fail = vec![
+        // ViewEncapsulation.None
+        r"
+        import { Component, ViewEncapsulation } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            encapsulation: ViewEncapsulation.None
+        })
+        class TestComponent {}
+        ",
+        // Numeric value 2 (None)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            encapsulation: 2
+        })
+        class TestComponent {}
+        ",
+        // Standalone component with None
+        r"
+        import { Component, ViewEncapsulation } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: '',
+            standalone: true,
+            encapsulation: ViewEncapsulation.None
+        })
+        class TestComponent {}
+        ",
+    ];
+
+    Tester::new(
+        UseComponentViewEncapsulation::NAME,
+        UseComponentViewEncapsulation::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/use_injectable_provided_in.rs
+++ b/crates/oxc_linter/src/rules/angular/use_injectable_provided_in.rs
@@ -1,0 +1,313 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        get_component_metadata, get_decorator_identifier, get_decorator_name,
+        get_metadata_property, is_angular_core_import,
+    },
+};
+
+fn use_injectable_provided_in_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Injectable should use `providedIn` for tree-shaking support")
+        .with_help(
+            "Add `providedIn: 'root'` (or 'any', 'platform') to the @Injectable decorator. \
+            This enables tree-shaking, which removes unused services from your bundle.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct UseInjectableProvidedInConfig {
+    /// Suffix pattern to ignore certain class names (e.g., "Interceptor")
+    #[serde(default)]
+    ignore_class_name_suffix: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UseInjectableProvidedIn {
+    ignore_suffix: Option<String>,
+}
+
+impl From<UseInjectableProvidedInConfig> for UseInjectableProvidedIn {
+    fn from(config: UseInjectableProvidedInConfig) -> Self {
+        Self { ignore_suffix: config.ignore_class_name_suffix }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that `@Injectable` classes use the `providedIn` property for tree-shaking.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Without `providedIn`, services must be added to a module's `providers` array,
+    /// which prevents tree-shaking. This means:
+    /// - Unused services are included in the bundle
+    /// - Larger bundle sizes
+    /// - Reduced application performance
+    ///
+    /// Using `providedIn: 'root'` (or another value) enables tree-shaking, allowing
+    /// the compiler to remove unused services from the final bundle.
+    ///
+    /// Note: Classes implementing `HttpInterceptor` are excluded from this rule as
+    /// they require a different registration pattern.
+    ///
+    /// ### Configuration
+    ///
+    /// ```json
+    /// {
+    ///   "angular/use-injectable-provided-in": ["error", {
+    ///     "ignoreClassNamePattern": ".*Interceptor$"
+    ///   }]
+    /// }
+    /// ```
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Injectable } from '@angular/core';
+    ///
+    /// @Injectable()
+    /// export class MyService {}
+    ///
+    /// @Injectable({})
+    /// export class AnotherService {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Injectable } from '@angular/core';
+    ///
+    /// @Injectable({ providedIn: 'root' })
+    /// export class MyService {}
+    ///
+    /// @Injectable({ providedIn: 'any' })
+    /// export class ScopedService {}
+    /// ```
+    UseInjectableProvidedIn,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for UseInjectableProvidedIn {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        let config_value = value.get(0).unwrap_or(&value);
+        serde_json::from_value::<UseInjectableProvidedInConfig>(config_value.clone())
+            .map(Into::into)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Injectable decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Injectable" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class_from_decorator(node, ctx) else {
+            return;
+        };
+
+        // Check if class name matches ignore pattern
+        if let Some(class_name) = class.id.as_ref().map(|id| id.name.as_str()) {
+            if let Some(suffix) = &self.ignore_suffix
+                && class_name.ends_with(suffix) {
+                    return;
+                }
+
+            // Skip HttpInterceptor implementations
+            if class_name.ends_with("Interceptor") || implements_http_interceptor(class) {
+                return;
+            }
+        }
+
+        // Get the metadata object
+        let Some(metadata) = get_component_metadata(decorator) else {
+            // No metadata object - @Injectable() with no args
+            ctx.diagnostic(use_injectable_provided_in_diagnostic(decorator.span));
+            return;
+        };
+
+        // Check if providedIn is present and valid
+        match get_metadata_property(metadata, "providedIn") {
+            None => {
+                ctx.diagnostic(use_injectable_provided_in_diagnostic(decorator.span));
+            }
+            Some(Expression::NullLiteral(_)) => {
+                ctx.diagnostic(use_injectable_provided_in_diagnostic(decorator.span));
+            }
+            Some(Expression::Identifier(ident)) if ident.name.as_str() == "undefined" => {
+                ctx.diagnostic(use_injectable_provided_in_diagnostic(decorator.span));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn get_parent_class_from_decorator<'a, 'b>(
+    node: &'b crate::AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+fn implements_http_interceptor(class: &oxc_ast::ast::Class<'_>) -> bool {
+    if class.implements.is_empty() {
+        return false;
+    }
+    class.implements.iter().any(|ts_impl| {
+        if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &ts_impl.expression {
+            return ident.name.as_str() == "HttpInterceptor"
+                || ident.name.as_str() == "HttpInterceptorFn";
+        }
+        false
+    })
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // providedIn: 'root'
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({ providedIn: 'root' })
+            class MyService {}
+            ",
+            None,
+        ),
+        // providedIn: 'any'
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({ providedIn: 'any' })
+            class MyService {}
+            ",
+            None,
+        ),
+        // providedIn: 'platform'
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({ providedIn: 'platform' })
+            class MyService {}
+            ",
+            None,
+        ),
+        // HttpInterceptor (skipped)
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable()
+            class MyInterceptor implements HttpInterceptor {}
+            ",
+            None,
+        ),
+        // Class name ending with Interceptor (skipped)
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable()
+            class AuthInterceptor {}
+            ",
+            None,
+        ),
+        // Non-Angular Injectable
+        (
+            r"
+            import { Injectable } from 'other-lib';
+            @Injectable()
+            class MyService {}
+            ",
+            None,
+        ),
+        // Custom ignore suffix
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable()
+            class MyTestService {}
+            ",
+            Some(serde_json::json!([{ "ignoreClassNameSuffix": "Service" }])),
+        ),
+    ];
+
+    let fail = vec![
+        // No providedIn
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable()
+            class MyService {}
+            ",
+            None,
+        ),
+        // Empty metadata
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({})
+            class MyService {}
+            ",
+            None,
+        ),
+        // providedIn: null
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({ providedIn: null })
+            class MyService {}
+            ",
+            None,
+        ),
+        // providedIn: undefined
+        (
+            r"
+            import { Injectable } from '@angular/core';
+            @Injectable({ providedIn: undefined })
+            class MyService {}
+            ",
+            None,
+        ),
+    ];
+
+    Tester::new(UseInjectableProvidedIn::NAME, UseInjectableProvidedIn::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/use_lifecycle_interface.rs
+++ b/crates/oxc_linter/src/rules/angular/use_lifecycle_interface.rs
@@ -1,0 +1,319 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        class_implements_interface, get_class_angular_decorator,
+        get_lifecycle_interface_for_method, is_lifecycle_method,
+    },
+};
+
+fn use_lifecycle_interface_diagnostic(
+    span: Span,
+    method_name: &str,
+    interface_name: &str,
+) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Lifecycle interface `{interface_name}` should be implemented for method `{method_name}`"
+    ))
+    .with_help(format!(
+        "Add `implements {interface_name}` to the class declaration and import `{interface_name}` from '@angular/core'"
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UseLifecycleInterface;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that classes implementing lifecycle methods also implement the corresponding
+    /// lifecycle interfaces from Angular.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Implementing lifecycle interfaces explicitly:
+    /// - Provides better type checking and IDE support
+    /// - Makes the code more self-documenting
+    /// - Helps catch typos in lifecycle method names
+    /// - Follows Angular style guide recommendations
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Component } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent {
+    ///   ngOnInit() {
+    ///     console.log('initialized');
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Component, OnInit } from '@angular/core';
+    ///
+    /// @Component({
+    ///   selector: 'app-example',
+    ///   template: ''
+    /// })
+    /// export class ExampleComponent implements OnInit {
+    ///   ngOnInit() {
+    ///     console.log('initialized');
+    ///   }
+    /// }
+    /// ```
+    UseLifecycleInterface,
+    angular,
+    pedantic,
+    pending
+);
+
+impl Rule for UseLifecycleInterface {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+
+        // Skip methods with override keyword
+        if method.r#override {
+            return;
+        }
+
+        // Get the method name
+        let Some(method_name) = method.key.static_name() else {
+            return;
+        };
+
+        // Check if it's a lifecycle method
+        if !is_lifecycle_method(&method_name) {
+            return;
+        }
+
+        // Get the corresponding interface name
+        let Some(interface_name) = get_lifecycle_interface_for_method(&method_name) else {
+            return;
+        };
+
+        // Find the parent class
+        let Some(class) = get_parent_class(node, ctx) else {
+            return;
+        };
+
+        // Check if the class has an Angular decorator
+        if get_class_angular_decorator(class, ctx).is_none() {
+            return;
+        }
+
+        // Check if the class implements the interface
+        if class_implements_interface(class, interface_name) {
+            return;
+        }
+
+        ctx.diagnostic(use_lifecycle_interface_diagnostic(
+            method.span,
+            &method_name,
+            interface_name,
+        ));
+    }
+}
+
+fn get_parent_class<'a, 'b>(
+    node: &'b AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Implements OnInit
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Implements multiple interfaces
+        r"
+        import { Component, OnInit, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnDestroy {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Implements all interfaces
+        r"
+        import { Component, OnInit, OnChanges, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit, OnChanges, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked, OnDestroy {
+            ngOnChanges() {}
+            ngOnInit() {}
+            ngDoCheck() {}
+            ngAfterContentInit() {}
+            ngAfterContentChecked() {}
+            ngAfterViewInit() {}
+            ngAfterViewChecked() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Directive with interface
+        r"
+        import { Directive, OnInit } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective implements OnInit {
+            ngOnInit() {}
+        }
+        ",
+        // Injectable with OnDestroy interface
+        r"
+        import { Injectable, OnDestroy } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService implements OnDestroy {
+            ngOnDestroy() {}
+        }
+        ",
+        // Override method (should be skipped)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent extends BaseComponent {
+            override ngOnInit() {}
+        }
+        ",
+        // Non-Angular class (should be ignored)
+        r"
+        class TestClass {
+            ngOnInit() {}
+        }
+        ",
+        // Method with other name (not a lifecycle)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            onClick() {}
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Missing OnInit interface
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit() {}
+        }
+        ",
+        // Missing OnDestroy interface
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnDestroy() {}
+        }
+        ",
+        // Missing AfterViewInit interface
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngAfterViewInit() {}
+        }
+        ",
+        // Directive missing interface
+        r"
+        import { Directive } from '@angular/core';
+        @Directive({
+            selector: '[appTest]'
+        })
+        class TestDirective {
+            ngOnInit() {}
+        }
+        ",
+        // Injectable missing interface
+        r"
+        import { Injectable } from '@angular/core';
+        @Injectable({ providedIn: 'root' })
+        class TestService {
+            ngOnDestroy() {}
+        }
+        ",
+        // Missing multiple interfaces (reports each)
+        r"
+        import { Component } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+        // Partial implementation - has one but not the other
+        r"
+        import { Component, OnInit } from '@angular/core';
+        @Component({
+            selector: 'app-test',
+            template: ''
+        })
+        class TestComponent implements OnInit {
+            ngOnInit() {}
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    Tester::new(UseLifecycleInterface::NAME, UseLifecycleInterface::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/angular/use_pipe_transform_interface.rs
+++ b/crates/oxc_linter/src/rules/angular/use_pipe_transform_interface.rs
@@ -1,0 +1,227 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        class_implements_interface, get_decorator_identifier, get_decorator_name,
+        is_angular_core_import,
+    },
+};
+
+fn use_pipe_transform_interface_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Pipes should implement `PipeTransform` interface")
+        .with_help(
+            "Add `implements PipeTransform` to the class declaration and import \
+            `PipeTransform` from '@angular/core'. This provides type safety for the \
+            `transform` method.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UsePipeTransformInterface;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Ensures that classes decorated with `@Pipe` implement the `PipeTransform` interface.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Implementing the `PipeTransform` interface:
+    /// - Provides type safety for the `transform` method signature
+    /// - Improves IDE support with better autocompletion
+    /// - Makes the code more self-documenting
+    /// - Helps catch errors at compile time rather than runtime
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```typescript
+    /// import { Pipe } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'myPipe'
+    /// })
+    /// export class MyPipe {
+    ///   transform(value: any): any {
+    ///     return value;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// import { Pipe, PipeTransform } from '@angular/core';
+    ///
+    /// @Pipe({
+    ///   name: 'myPipe'
+    /// })
+    /// export class MyPipe implements PipeTransform {
+    ///   transform(value: any): any {
+    ///     return value;
+    ///   }
+    /// }
+    /// ```
+    UsePipeTransformInterface,
+    angular,
+    correctness,
+    pending
+);
+
+impl Rule for UsePipeTransformInterface {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::Decorator(decorator) = node.kind() else {
+            return;
+        };
+
+        // Only check @Pipe decorator
+        let Some(decorator_name) = get_decorator_name(decorator) else {
+            return;
+        };
+
+        if decorator_name != "Pipe" {
+            return;
+        }
+
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            return;
+        };
+
+        if !is_angular_core_import(ident, ctx) {
+            return;
+        }
+
+        // Find the parent class
+        let Some(class) = get_parent_class_from_decorator(node, ctx) else {
+            return;
+        };
+
+        // Check if the class implements PipeTransform
+        if class_implements_interface(class, "PipeTransform") {
+            return;
+        }
+
+        ctx.diagnostic(use_pipe_transform_interface_diagnostic(decorator.span));
+    }
+}
+
+fn get_parent_class_from_decorator<'a, 'b>(
+    node: &'b crate::AstNode<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<&'b oxc_ast::ast::Class<'a>> {
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if let AstKind::Class(class) = ancestor.kind() {
+            return Some(class);
+        }
+    }
+    None
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Implements PipeTransform
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Implements multiple interfaces including PipeTransform
+        r"
+        import { Pipe, PipeTransform, OnDestroy } from '@angular/core';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe implements PipeTransform, OnDestroy {
+            transform(value: any): any {
+                return value;
+            }
+            ngOnDestroy() {}
+        }
+        ",
+        // Standalone pipe with interface
+        r"
+        import { Pipe, PipeTransform } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            standalone: true
+        })
+        class MyPipe implements PipeTransform {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Non-Angular Pipe
+        r"
+        import { Pipe } from 'other-lib';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+    ];
+
+    let fail = vec![
+        // Missing PipeTransform interface
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Standalone pipe missing interface
+        r"
+        import { Pipe } from '@angular/core';
+        @Pipe({
+            name: 'myPipe',
+            standalone: true
+        })
+        class MyPipe {
+            transform(value: any): any {
+                return value;
+            }
+        }
+        ",
+        // Implements other interface but not PipeTransform
+        r"
+        import { Pipe, OnDestroy } from '@angular/core';
+        @Pipe({
+            name: 'myPipe'
+        })
+        class MyPipe implements OnDestroy {
+            transform(value: any): any {
+                return value;
+            }
+            ngOnDestroy() {}
+        }
+        ",
+    ];
+
+    Tester::new(UsePipeTransformInterface::NAME, UsePipeTransformInterface::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/angular_component_class_suffix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_component_class_suffix.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(component-class-suffix): Component class names should end with one of these suffixes: Component
+   ╭─[component_class_suffix.tsx:7:19]
+ 6 │             })
+ 7 │             class Test {}
+   ·                   ────
+ 8 │             
+   ╰────
+  help: Rename the class to include a valid suffix (e.g., 'ExampleComponent'). Note: As of Angular v20, this naming convention is no longer officially recommended.
+
+  ⚠ angular(component-class-suffix): Component class names should end with one of these suffixes: Component
+   ╭─[component_class_suffix.tsx:7:19]
+ 6 │             })
+ 7 │             class TestComp {}
+   ·                   ────────
+ 8 │             
+   ╰────
+  help: Rename the class to include a valid suffix (e.g., 'ExampleComponent'). Note: As of Angular v20, this naming convention is no longer officially recommended.
+
+  ⚠ angular(component-class-suffix): Component class names should end with one of these suffixes: Component, View
+   ╭─[component_class_suffix.tsx:7:19]
+ 6 │             })
+ 7 │             class TestPage {}
+   ·                   ────────
+ 8 │             
+   ╰────
+  help: Rename the class to include a valid suffix (e.g., 'ExampleComponent'). Note: As of Angular v20, this naming convention is no longer officially recommended.

--- a/crates/oxc_linter/src/snapshots/angular_component_max_inline_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/angular_component_max_inline_declarations.snap
@@ -1,0 +1,40 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(component-max-inline-declarations): Inline `template` has too many lines (7). Maximum allowed is 3.
+    ╭─[component_max_inline_declarations.tsx:5:17]
+  4 │                     selector: 'app-test',
+  5 │ ╭─▶                 template: `
+  6 │ │                       <div>Line 1</div>
+  7 │ │                       <div>Line 2</div>
+  8 │ │                       <div>Line 3</div>
+  9 │ │                       <div>Line 4</div>
+ 10 │ │                       <div>Line 5</div>
+ 11 │ ╰─▶                 `
+ 12 │                 })
+    ╰────
+  help: Extract the inline template to a separate file. For templates use `templateUrl`, for styles use `styleUrl` or `styleUrls`.
+
+  ⚠ angular(component-max-inline-declarations): Inline `styles` has too many lines (6). Maximum allowed is 3.
+    ╭─[component_max_inline_declarations.tsx:6:17]
+  5 │                     template: '',
+  6 │ ╭─▶                 styles: [`
+  7 │ │                       .class1 { color: red; }
+  8 │ │                       .class2 { color: blue; }
+  9 │ │                       .class3 { color: green; }
+ 10 │ │                       .class4 { color: yellow; }
+ 11 │ ╰─▶                 `]
+ 12 │                 })
+    ╰────
+  help: Extract the inline styles to a separate file. For templates use `templateUrl`, for styles use `styleUrl` or `styleUrls`.
+
+  ⚠ angular(component-max-inline-declarations): Inline `template` has too many lines (3). Maximum allowed is 1.
+   ╭─[component_max_inline_declarations.tsx:5:17]
+ 4 │                     selector: 'app-test',
+ 5 │ ╭─▶                 template: `<div>
+ 6 │ │                       Content
+ 7 │ ╰─▶                 </div>`
+ 8 │                 })
+   ╰────
+  help: Extract the inline template to a separate file. For templates use `templateUrl`, for styles use `styleUrl` or `styleUrls`.

--- a/crates/oxc_linter/src/snapshots/angular_component_selector.snap
+++ b/crates/oxc_linter/src/snapshots/angular_component_selector.snap
@@ -1,0 +1,36 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(component-selector): Component selector should be used as an element
+   ╭─[component_selector.tsx:3:13]
+ 2 │                 import { Component } from '@angular/core';
+ 3 │ ╭─▶             @Component({
+ 4 │ │                   selector: '[appExample]',
+ 5 │ │                   template: ''
+ 6 │ ╰─▶             })
+ 7 │                 class ExampleComponent {}
+   ╰────
+  help: Change the selector to use an element style (e.g., 'app-example' for element)
+
+  ⚠ angular(component-selector): Component selector should be prefixed with one of: app
+   ╭─[component_selector.tsx:3:13]
+ 2 │                 import { Component } from '@angular/core';
+ 3 │ ╭─▶             @Component({
+ 4 │ │                   selector: 'example',
+ 5 │ │                   template: ''
+ 6 │ ╰─▶             })
+ 7 │                 class ExampleComponent {}
+   ╰────
+  help: Add a prefix to the selector (e.g., 'app-example' with prefix 'app')
+
+  ⚠ angular(component-selector): Component selector should be prefixed with one of: app
+   ╭─[component_selector.tsx:3:13]
+ 2 │                 import { Component } from '@angular/core';
+ 3 │ ╭─▶             @Component({
+ 4 │ │                   selector: 'AppExample',
+ 5 │ │                   template: ''
+ 6 │ ╰─▶             })
+ 7 │                 class ExampleComponent {}
+   ╰────
+  help: Add a prefix to the selector (e.g., 'app-example' with prefix 'app')

--- a/crates/oxc_linter/src/snapshots/angular_computed_must_return.snap
+++ b/crates/oxc_linter/src/snapshots/angular_computed_must_return.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(computed-must-return): Computed signal callback must return a value
+   ╭─[computed_must_return.tsx:4:33]
+ 3 │             const count = signal(0);
+ 4 │ ╭─▶         const double = computed(() => {
+ 5 │ │               count() * 2;
+ 6 │ ╰─▶         });
+ 7 │             
+   ╰────
+  help: The function passed to `computed()` must return a value. Computed signals derive their value from the return value of this function. Add a return statement or use an arrow function with an expression body.
+
+  ⚠ angular(computed-must-return): Computed signal callback must return a value
+   ╭─[computed_must_return.tsx:4:33]
+ 3 │             const count = signal(0);
+ 4 │ ╭─▶         const double = computed(function() {
+ 5 │ │               count() * 2;
+ 6 │ ╰─▶         });
+ 7 │             
+   ╰────
+  help: The function passed to `computed()` must return a value. Computed signals derive their value from the return value of this function. Add a return statement or use an arrow function with an expression body.
+
+  ⚠ angular(computed-must-return): Computed signal callback must return a value
+   ╭─[computed_must_return.tsx:4:32]
+ 3 │             const count = signal(0);
+ 4 │ ╭─▶         const value = computed(() => {
+ 5 │ │               console.log(count());
+ 6 │ ╰─▶         });
+ 7 │             
+   ╰────
+  help: The function passed to `computed()` must return a value. Computed signals derive their value from the return value of this function. Add a return statement or use an arrow function with an expression body.
+
+  ⚠ angular(computed-must-return): Computed signal callback must return a value
+   ╭─[computed_must_return.tsx:4:32]
+ 3 │             const count = signal(0);
+ 4 │ ╭─▶         const value = computed(() => {
+ 5 │ │               if (count() > 0) {
+ 6 │ │                   return;
+ 7 │ │               }
+ 8 │ ╰─▶         });
+ 9 │             
+   ╰────
+  help: The function passed to `computed()` must return a value. Computed signals derive their value from the return value of this function. Add a return statement or use an arrow function with an expression body.

--- a/crates/oxc_linter/src/snapshots/angular_consistent_component_styles.snap
+++ b/crates/oxc_linter/src/snapshots/angular_consistent_component_styles.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(consistent-component-styles): Component styles should use string format
+   ╭─[consistent_component_styles.tsx:6:17]
+ 5 │                 template: '',
+ 6 │                 styles: ['.class { color: red; }']
+   ·                 ──────────────────────────────────
+ 7 │             })
+   ╰────
+  help: Use a single string instead of an array for component styles: `styles: 'css-here'`
+
+  ⚠ angular(consistent-component-styles): Component styles should use array format
+   ╭─[consistent_component_styles.tsx:6:17]
+ 5 │                 template: '',
+ 6 │                 styles: '.class { color: red; }'
+   ·                 ────────────────────────────────
+ 7 │             })
+   ╰────
+  help: Use an array for component styles: `styles: ['css-here']`
+
+  ⚠ angular(consistent-component-styles): Component styles should use string format
+   ╭─[consistent_component_styles.tsx:6:17]
+ 5 │                 template: '',
+ 6 │                 styles: [`.class { color: red; }`]
+   ·                 ──────────────────────────────────
+ 7 │             })
+   ╰────
+  help: Use a single string instead of an array for component styles: `styles: 'css-here'`
+
+  ⚠ angular(consistent-component-styles): Use `styleUrl` instead of `styleUrls` for a single stylesheet
+   ╭─[consistent_component_styles.tsx:6:17]
+ 5 │                 template: '',
+ 6 │                 styleUrls: ['./test.component.css']
+   ·                 ───────────────────────────────────
+ 7 │             })
+   ╰────
+  help: Use `styleUrl: './style.css'` instead of `styleUrls: ['./style.css']`
+
+  ⚠ angular(consistent-component-styles): Use `styleUrls` instead of `styleUrl`
+   ╭─[consistent_component_styles.tsx:6:17]
+ 5 │                 template: '',
+ 6 │                 styleUrl: './test.component.css'
+   ·                 ────────────────────────────────
+ 7 │             })
+   ╰────
+  help: Use `styleUrls: ['./style.css']` instead of `styleUrl: './style.css'`

--- a/crates/oxc_linter/src/snapshots/angular_contextual_decorator.snap
+++ b/crates/oxc_linter/src/snapshots/angular_contextual_decorator.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(contextual-decorator): `@Input` cannot be used in `@Injectable` class
+   ╭─[contextual_decorator.tsx:5:13]
+ 4 │         class TestService {
+ 5 │             @Input() value: string;
+   ·             ────────
+ 6 │         }
+   ╰────
+  help: The `@Input` decorator is not valid in a class decorated with `@Injectable`. This decorator is only allowed in @Component or @Directive classes.
+
+  ⚠ angular(contextual-decorator): `@Output` cannot be used in `@Pipe` class
+   ╭─[contextual_decorator.tsx:5:13]
+ 4 │         class TestPipe {
+ 5 │             @Output() myEvent = new EventEmitter();
+   ·             ─────────
+ 6 │         }
+   ╰────
+  help: The `@Output` decorator is not valid in a class decorated with `@Pipe`. This decorator is only allowed in @Component or @Directive classes.
+
+  ⚠ angular(contextual-decorator): `@HostBinding` cannot be used in `@NgModule` class
+   ╭─[contextual_decorator.tsx:5:13]
+ 4 │         class TestModule {
+ 5 │             @HostBinding('class.active') isActive = false;
+   ·             ────────────────────────────
+ 6 │         }
+   ╰────
+  help: The `@HostBinding` decorator is not valid in a class decorated with `@NgModule`. This decorator is only allowed in @Component or @Directive classes.
+
+  ⚠ angular(contextual-decorator): `@ViewChild` cannot be used in `@Injectable` class
+   ╭─[contextual_decorator.tsx:5:13]
+ 4 │         class TestService {
+ 5 │             @ViewChild('element') element: ElementRef;
+   ·             ─────────────────────
+ 6 │         }
+   ╰────
+  help: The `@ViewChild` decorator is not valid in a class decorated with `@Injectable`. This decorator is only allowed in @Component or @Directive classes.
+
+  ⚠ angular(contextual-decorator): `@ContentChild` cannot be used in `@Pipe` class
+   ╭─[contextual_decorator.tsx:5:13]
+ 4 │         class TestPipe {
+ 5 │             @ContentChild('content') content: ElementRef;
+   ·             ────────────────────────
+ 6 │         }
+   ╰────
+  help: The `@ContentChild` decorator is not valid in a class decorated with `@Pipe`. This decorator is only allowed in @Component or @Directive classes.

--- a/crates/oxc_linter/src/snapshots/angular_contextual_lifecycle.snap
+++ b/crates/oxc_linter/src/snapshots/angular_contextual_lifecycle.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngOnInit` lifecycle method within `@Injectable()` classes
+   ╭─[contextual_lifecycle.tsx:5:13]
+ 4 │         class TestService implements OnInit {
+ 5 │             ngOnInit() {}
+   ·             ─────────────
+ 6 │         }
+   ╰────
+  help: Remove `ngOnInit` or move the class to an appropriate Angular class type that supports this lifecycle method
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngAfterViewInit` lifecycle method within `@Injectable()` classes
+   ╭─[contextual_lifecycle.tsx:5:13]
+ 4 │         class TestService implements AfterViewInit {
+ 5 │             ngAfterViewInit() {}
+   ·             ────────────────────
+ 6 │         }
+   ╰────
+  help: Remove `ngAfterViewInit` or move the class to an appropriate Angular class type that supports this lifecycle method
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngOnInit` lifecycle method within `@Pipe()` classes
+   ╭─[contextual_lifecycle.tsx:5:13]
+ 4 │         class MyPipe implements OnInit {
+ 5 │             ngOnInit() {}
+   ·             ─────────────
+ 6 │         }
+   ╰────
+  help: Remove `ngOnInit` or move the class to an appropriate Angular class type that supports this lifecycle method
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngOnInit` lifecycle method within `@NgModule()` classes
+   ╭─[contextual_lifecycle.tsx:5:13]
+ 4 │         class AppModule implements OnInit {
+ 5 │             ngOnInit() {}
+   ·             ─────────────
+ 6 │         }
+   ╰────
+  help: Remove `ngOnInit` or move the class to an appropriate Angular class type that supports this lifecycle method
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngOnDestroy` lifecycle method within `@NgModule()` classes
+   ╭─[contextual_lifecycle.tsx:5:13]
+ 4 │         class AppModule implements OnDestroy {
+ 5 │             ngOnDestroy() {}
+   ·             ────────────────
+ 6 │         }
+   ╰────
+  help: Remove `ngOnDestroy` or move the class to an appropriate Angular class type that supports this lifecycle method
+
+  ⚠ angular(contextual-lifecycle): Angular will not invoke the `ngDoBootstrap` lifecycle method within `@Component()` classes
+   ╭─[contextual_lifecycle.tsx:8:13]
+ 7 │         class TestComponent implements DoBootstrap {
+ 8 │             ngDoBootstrap() {}
+   ·             ──────────────────
+ 9 │         }
+   ╰────
+  help: Remove `ngDoBootstrap` or move the class to an appropriate Angular class type that supports this lifecycle method

--- a/crates/oxc_linter/src/snapshots/angular_directive_class_suffix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_directive_class_suffix.snap
@@ -1,0 +1,21 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(directive-class-suffix): Directive class names should end with one of these suffixes: Directive
+   ╭─[directive_class_suffix.tsx:6:19]
+ 5 │             })
+ 6 │             class Highlight {}
+   ·                   ─────────
+ 7 │             
+   ╰────
+  help: Rename the class to include a valid suffix (e.g., 'HighlightDirective').
+
+  ⚠ angular(directive-class-suffix): Directive class names should end with one of these suffixes: Directive
+   ╭─[directive_class_suffix.tsx:6:19]
+ 5 │             })
+ 6 │             class HighlightComponent {}
+   ·                   ──────────────────
+ 7 │             
+   ╰────
+  help: Rename the class to include a valid suffix (e.g., 'HighlightDirective').

--- a/crates/oxc_linter/src/snapshots/angular_directive_selector.snap
+++ b/crates/oxc_linter/src/snapshots/angular_directive_selector.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(directive-selector): Directive selector should be used as an attribute
+   ╭─[directive_selector.tsx:3:13]
+ 2 │                 import { Directive } from '@angular/core';
+ 3 │ ╭─▶             @Directive({
+ 4 │ │                   selector: 'app-highlight'
+ 5 │ ╰─▶             })
+ 6 │                 class HighlightDirective {}
+   ╰────
+  help: Change the selector to use an attribute style (e.g., '[appExample]' for attribute)
+
+  ⚠ angular(directive-selector): Directive selector should be prefixed with one of: app
+   ╭─[directive_selector.tsx:3:13]
+ 2 │                 import { Directive } from '@angular/core';
+ 3 │ ╭─▶             @Directive({
+ 4 │ │                   selector: '[highlight]'
+ 5 │ ╰─▶             })
+ 6 │                 class HighlightDirective {}
+   ╰────
+  help: Add a prefix to the selector (e.g., '[appHighlight]' with prefix 'app')
+
+  ⚠ angular(directive-selector): Directive selector should be camelCase
+   ╭─[directive_selector.tsx:3:13]
+ 2 │                 import { Directive } from '@angular/core';
+ 3 │ ╭─▶             @Directive({
+ 4 │ │                   selector: '[app-highlight]'
+ 5 │ ╰─▶             })
+ 6 │                 class HighlightDirective {}
+   ╰────
+  help: Use camelCase for the selector (e.g., 'appHighlight' for camelCase)

--- a/crates/oxc_linter/src/snapshots/angular_no_async_lifecycle_method.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_async_lifecycle_method.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnInit` should not be async
+   ╭─[no_async_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             async ngOnInit() {}
+   ·             ───────────────────
+ 9 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnDestroy` should not be async
+   ╭─[no_async_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             async ngOnDestroy() {}
+   ·             ──────────────────────
+ 9 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngAfterViewInit` should not be async
+   ╭─[no_async_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             async ngAfterViewInit() {}
+   ·             ──────────────────────────
+ 9 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnInit` should not be async
+   ╭─[no_async_lifecycle_method.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             async ngOnInit() {}
+   ·             ───────────────────
+ 8 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnDestroy` should not be async
+   ╭─[no_async_lifecycle_method.tsx:5:13]
+ 4 │         class TestService {
+ 5 │             async ngOnDestroy() {}
+   ·             ──────────────────────
+ 6 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnDestroy` should not be async
+   ╭─[no_async_lifecycle_method.tsx:5:13]
+ 4 │         class TestPipe {
+ 5 │             async ngOnDestroy() {}
+   ·             ──────────────────────
+ 6 │         }
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnInit` should not be async
+   ╭─[no_async_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             async ngOnInit() {}
+   ·             ───────────────────
+ 9 │             async ngOnDestroy() {}
+   ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.
+
+  ⚠ angular(no-async-lifecycle-method): Lifecycle method `ngOnDestroy` should not be async
+    ╭─[no_async_lifecycle_method.tsx:9:13]
+  8 │             async ngOnInit() {}
+  9 │             async ngOnDestroy() {}
+    ·             ──────────────────────
+ 10 │         }
+    ╰────
+  help: Angular does not wait for async lifecycle methods to complete. Remove the async keyword and handle async operations differently, such as subscribing to observables or using promises without await.

--- a/crates/oxc_linter/src/snapshots/angular_no_attribute_decorator.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_attribute_decorator.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-attribute-decorator): The `@Attribute` decorator is rarely what is required; use `@Input` instead
+   ╭─[no_attribute_decorator.tsx:8:25]
+ 7 │         class TestComponent {
+ 8 │             constructor(@Attribute('type') private type: string) {}
+   ·                         ──────────────────
+ 9 │         }
+   ╰────
+  help: `@Attribute` can only obtain a single static value from the DOM attribute and does not support data binding. In most cases, `@Input` is the appropriate choice as it supports both static values and data binding.
+
+  ⚠ angular(no-attribute-decorator): The `@Attribute` decorator is rarely what is required; use `@Input` instead
+    ╭─[no_attribute_decorator.tsx:9:17]
+  8 │             constructor(
+  9 │                 @Attribute('type') private type: string,
+    ·                 ──────────────────
+ 10 │                 @Attribute('size') private size: string
+    ╰────
+  help: `@Attribute` can only obtain a single static value from the DOM attribute and does not support data binding. In most cases, `@Input` is the appropriate choice as it supports both static values and data binding.
+
+  ⚠ angular(no-attribute-decorator): The `@Attribute` decorator is rarely what is required; use `@Input` instead
+    ╭─[no_attribute_decorator.tsx:10:17]
+  9 │                 @Attribute('type') private type: string,
+ 10 │                 @Attribute('size') private size: string
+    ·                 ──────────────────
+ 11 │             ) {}
+    ╰────
+  help: `@Attribute` can only obtain a single static value from the DOM attribute and does not support data binding. In most cases, `@Input` is the appropriate choice as it supports both static values and data binding.
+
+  ⚠ angular(no-attribute-decorator): The `@Attribute` decorator is rarely what is required; use `@Input` instead
+   ╭─[no_attribute_decorator.tsx:7:25]
+ 6 │         class TestDirective {
+ 7 │             constructor(@Attribute('title') private title: string) {}
+   ·                         ───────────────────
+ 8 │         }
+   ╰────
+  help: `@Attribute` can only obtain a single static value from the DOM attribute and does not support data binding. In most cases, `@Input` is the appropriate choice as it supports both static values and data binding.

--- a/crates/oxc_linter/src/snapshots/angular_no_conflicting_lifecycle.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_conflicting_lifecycle.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-conflicting-lifecycle): Class implements both `DoCheck` and `OnChanges` lifecycle interfaces
+   ╭─[no_conflicting_lifecycle.tsx:7:15]
+ 6 │         })
+ 7 │         class TestComponent implements DoCheck, OnChanges {
+   ·               ─────────────
+ 8 │             ngDoCheck() {}
+   ╰────
+  help: Implementing both `DoCheck` and `OnChanges` can lead to unexpected behavior. `ngOnChanges` is called when input properties change, while `ngDoCheck` is called during every change detection cycle. Choose one based on your needs: use `ngOnChanges` for reacting to input changes, or `ngDoCheck` for custom change detection logic.
+
+  ⚠ angular(no-conflicting-lifecycle): Class implements both `DoCheck` and `OnChanges` lifecycle interfaces
+   ╭─[no_conflicting_lifecycle.tsx:7:15]
+ 6 │         })
+ 7 │         class TestComponent {
+   ·               ─────────────
+ 8 │             ngDoCheck() {}
+   ╰────
+  help: Implementing both `DoCheck` and `OnChanges` can lead to unexpected behavior. `ngOnChanges` is called when input properties change, while `ngDoCheck` is called during every change detection cycle. Choose one based on your needs: use `ngOnChanges` for reacting to input changes, or `ngDoCheck` for custom change detection logic.
+
+  ⚠ angular(no-conflicting-lifecycle): Class implements both `DoCheck` and `OnChanges` lifecycle interfaces
+   ╭─[no_conflicting_lifecycle.tsx:6:15]
+ 5 │         })
+ 6 │         class TestDirective implements DoCheck, OnChanges {
+   ·               ─────────────
+ 7 │             ngDoCheck() {}
+   ╰────
+  help: Implementing both `DoCheck` and `OnChanges` can lead to unexpected behavior. `ngOnChanges` is called when input properties change, while `ngDoCheck` is called during every change detection cycle. Choose one based on your needs: use `ngOnChanges` for reacting to input changes, or `ngDoCheck` for custom change detection logic.

--- a/crates/oxc_linter/src/snapshots/angular_no_duplicates_in_metadata_arrays.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_duplicates_in_metadata_arrays.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `CommonModule` in `imports` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:5:37]
+ 4 │         @NgModule({
+ 5 │             imports: [CommonModule, CommonModule]
+   ·                                     ────────────
+ 6 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `MyComponent` in `declarations` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:4:41]
+ 3 │         @NgModule({
+ 4 │             declarations: [MyComponent, MyComponent]
+   ·                                         ───────────
+ 5 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `MyService` in `providers` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:4:36]
+ 3 │         @NgModule({
+ 4 │             providers: [MyService, MyService]
+   ·                                    ─────────
+ 5 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `MyComponent` in `exports` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:4:36]
+ 3 │         @NgModule({
+ 4 │             exports: [MyComponent, MyComponent]
+   ·                                    ───────────
+ 5 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `ModuleA` in `imports` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:4:32]
+ 3 │         @NgModule({
+ 4 │             imports: [ModuleA, ModuleA, ModuleA]
+   ·                                ───────
+ 5 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `ModuleA` in `imports` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:4:41]
+ 3 │         @NgModule({
+ 4 │             imports: [ModuleA, ModuleA, ModuleA]
+   ·                                         ───────
+ 5 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.
+
+  ⚠ angular(no-duplicates-in-metadata-arrays): Duplicate `CommonModule` in `imports` metadata array
+   ╭─[no_duplicates_in_metadata_arrays.tsx:6:37]
+ 5 │             template: '',
+ 6 │             imports: [CommonModule, CommonModule]
+   ·                                     ────────────
+ 7 │         })
+   ╰────
+  help: Remove the duplicate entry from the metadata array.

--- a/crates/oxc_linter/src/snapshots/angular_no_empty_lifecycle_method.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_empty_lifecycle_method.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngOnInit` should not be empty
+   ╭─[no_empty_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent implements OnInit {
+ 8 │             ngOnInit() {}
+   ·             ─────────────
+ 9 │         }
+   ╰────
+  help: Either implement the lifecycle method or remove it from the class
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngOnDestroy` should not be empty
+   ╭─[no_empty_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent implements OnDestroy {
+ 8 │             ngOnDestroy() {}
+   ·             ────────────────
+ 9 │         }
+   ╰────
+  help: Either implement the lifecycle method or remove it from the class
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngAfterViewInit` should not be empty
+   ╭─[no_empty_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent implements AfterViewInit {
+ 8 │             ngAfterViewInit() {}
+   ·             ────────────────────
+ 9 │         }
+   ╰────
+  help: Either implement the lifecycle method or remove it from the class
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngOnInit` should not be empty
+   ╭─[no_empty_lifecycle_method.tsx:7:13]
+ 6 │         class TestDirective implements OnInit {
+ 7 │             ngOnInit() {}
+   ·             ─────────────
+ 8 │         }
+   ╰────
+  help: Either implement the lifecycle method or remove it from the class
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngOnInit` should not be empty
+   ╭─[no_empty_lifecycle_method.tsx:8:13]
+ 7 │         class TestComponent implements OnInit, OnDestroy {
+ 8 │             ngOnInit() {}
+   ·             ─────────────
+ 9 │             ngOnDestroy() {}
+   ╰────
+  help: Either implement the lifecycle method or remove it from the class
+
+  ⚠ angular(no-empty-lifecycle-method): Lifecycle method `ngOnDestroy` should not be empty
+    ╭─[no_empty_lifecycle_method.tsx:9:13]
+  8 │             ngOnInit() {}
+  9 │             ngOnDestroy() {}
+    ·             ────────────────
+ 10 │         }
+    ╰────
+  help: Either implement the lifecycle method or remove it from the class

--- a/crates/oxc_linter/src/snapshots/angular_no_forward_ref.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_forward_ref.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-forward-ref): Avoid using `forwardRef`
+   ╭─[no_forward_ref.tsx:3:21]
+ 2 │         import { forwardRef } from '@angular/core';
+ 3 │         const ref = forwardRef(() => SomeClass);
+   ·                     ───────────────────────────
+ 4 │         
+   ╰────
+  help: The use of `forwardRef` can often be avoided by restructuring your code. Consider moving the referenced class above the usage, using injection tokens, or refactoring to avoid circular dependencies.
+
+  ⚠ angular(no-forward-ref): Avoid using `forwardRef`
+   ╭─[no_forward_ref.tsx:8:33]
+ 7 │         class TestComponent {
+ 8 │             constructor(@Inject(forwardRef(() => SomeService)) private service: any) {}
+   ·                                 ─────────────────────────────
+ 9 │         }
+   ╰────
+  help: The use of `forwardRef` can often be avoided by restructuring your code. Consider moving the referenced class above the usage, using injection tokens, or refactoring to avoid circular dependencies.
+
+  ⚠ angular(no-forward-ref): Avoid using `forwardRef`
+   ╭─[no_forward_ref.tsx:5:47]
+ 4 │             providers: [
+ 5 │                 { provide: 'TOKEN', useClass: forwardRef(() => MyService) }
+   ·                                               ───────────────────────────
+ 6 │             ]
+   ╰────
+  help: The use of `forwardRef` can often be avoided by restructuring your code. Consider moving the referenced class above the usage, using injection tokens, or refactoring to avoid circular dependencies.

--- a/crates/oxc_linter/src/snapshots/angular_no_host_metadata_property.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_host_metadata_property.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-host-metadata-property): Avoid using the `host` metadata property
+   ╭─[no_host_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             host: {
+   ·             ────
+ 7 │                 '[class.active]': 'isActive',
+   ╰────
+  help: Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. Decorator-based host bindings provide better type safety and are easier to understand. Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.
+
+  ⚠ angular(no-host-metadata-property): Avoid using the `host` metadata property
+   ╭─[no_host_metadata_property.tsx:5:13]
+ 4 │             selector: '[appTest]',
+ 5 │             host: {
+   ·             ────
+ 6 │                 '[attr.role]': 'role'
+   ╰────
+  help: Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. Decorator-based host bindings provide better type safety and are easier to understand. Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.
+
+  ⚠ angular(no-host-metadata-property): Avoid using the `host` metadata property
+   ╭─[no_host_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             host: {}
+   ·             ────
+ 7 │         })
+   ╰────
+  help: Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. Decorator-based host bindings provide better type safety and are easier to understand. Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.
+
+  ⚠ angular(no-host-metadata-property): Avoid using the `host` metadata property
+   ╭─[no_host_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             host: {
+   ·             ────
+ 7 │                 '[style.width.px]': 'width',
+   ╰────
+  help: Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. Decorator-based host bindings provide better type safety and are easier to understand. Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.
+
+  ⚠ angular(no-host-metadata-property): Avoid using the `host` metadata property
+   ╭─[no_host_metadata_property.tsx:5:13]
+ 4 │             selector: '[appTest]',
+ 5 │             host: {
+   ·             ────
+ 6 │                 '(mouseenter)': 'onMouseEnter()',
+   ╰────
+  help: Use `@HostBinding()` and `@HostListener()` decorators instead of the `host` metadata property. Decorator-based host bindings provide better type safety and are easier to understand. Alternatively, consider using the `host` property with signal-based syntax in Angular 18+.

--- a/crates/oxc_linter/src/snapshots/angular_no_implicit_take_until_destroyed.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_implicit_take_until_destroyed.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-implicit-take-until-destroyed): `takeUntilDestroyed()` called without `DestroyRef` argument outside injection context
+   ╭─[no_implicit_take_until_destroyed.tsx:5:33]
+ 4 │             ngOnInit() {
+ 5 │                 this.data$.pipe(takeUntilDestroyed()).subscribe();
+   ·                                 ────────────────────
+ 6 │             }
+   ╰────
+  help: When using `takeUntilDestroyed()` outside of an injection context (like inside `ngOnInit`, event handlers, or subscriptions), you must pass a `DestroyRef` explicitly. Example: `takeUntilDestroyed(this.destroyRef)` where `destroyRef = inject(DestroyRef)`.
+
+  ⚠ angular(no-implicit-take-until-destroyed): `takeUntilDestroyed()` called without `DestroyRef` argument outside injection context
+   ╭─[no_implicit_take_until_destroyed.tsx:5:33]
+ 4 │             ngAfterViewInit() {
+ 5 │                 this.data$.pipe(takeUntilDestroyed()).subscribe();
+   ·                                 ────────────────────
+ 6 │             }
+   ╰────
+  help: When using `takeUntilDestroyed()` outside of an injection context (like inside `ngOnInit`, event handlers, or subscriptions), you must pass a `DestroyRef` explicitly. Example: `takeUntilDestroyed(this.destroyRef)` where `destroyRef = inject(DestroyRef)`.
+
+  ⚠ angular(no-implicit-take-until-destroyed): `takeUntilDestroyed()` called without `DestroyRef` argument outside injection context
+   ╭─[no_implicit_take_until_destroyed.tsx:5:33]
+ 4 │             loadData() {
+ 5 │                 this.data$.pipe(takeUntilDestroyed()).subscribe();
+   ·                                 ────────────────────
+ 6 │             }
+   ╰────
+  help: When using `takeUntilDestroyed()` outside of an injection context (like inside `ngOnInit`, event handlers, or subscriptions), you must pass a `DestroyRef` explicitly. Example: `takeUntilDestroyed(this.destroyRef)` where `destroyRef = inject(DestroyRef)`.
+
+  ⚠ angular(no-implicit-take-until-destroyed): `takeUntilDestroyed()` called without `DestroyRef` argument outside injection context
+   ╭─[no_implicit_take_until_destroyed.tsx:5:45]
+ 4 │             onClick() {
+ 5 │                 this.service.getData().pipe(takeUntilDestroyed()).subscribe();
+   ·                                             ────────────────────
+ 6 │             }
+   ╰────
+  help: When using `takeUntilDestroyed()` outside of an injection context (like inside `ngOnInit`, event handlers, or subscriptions), you must pass a `DestroyRef` explicitly. Example: `takeUntilDestroyed(this.destroyRef)` where `destroyRef = inject(DestroyRef)`.

--- a/crates/oxc_linter/src/snapshots/angular_no_input_prefix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_input_prefix.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-input-prefix): Input should not be prefixed with `on`
+   ╭─[no_input_prefix.tsx:8:17]
+ 7 │             class TestComponent {
+ 8 │                 @Input() onSelect: any;
+   ·                 ────────
+ 9 │             }
+   ╰────
+  help: Rename the input to not start with `on`. Inputs should use descriptive names without unnecessary prefixes that can make the code harder to read or inconsistent with other inputs.
+
+  ⚠ angular(no-input-prefix): Input should not be prefixed with `on`
+   ╭─[no_input_prefix.tsx:8:17]
+ 7 │             class TestComponent {
+ 8 │                 @Input('onSelect') select: any;
+   ·                 ──────────────────
+ 9 │             }
+   ╰────
+  help: Rename the input to not start with `on`. Inputs should use descriptive names without unnecessary prefixes that can make the code harder to read or inconsistent with other inputs.
+
+  ⚠ angular(no-input-prefix): Input should not be prefixed with `can`
+   ╭─[no_input_prefix.tsx:8:17]
+ 7 │             class TestComponent {
+ 8 │                 @Input() canEdit: boolean;
+   ·                 ────────
+ 9 │             }
+   ╰────
+  help: Rename the input to not start with `can`. Inputs should use descriptive names without unnecessary prefixes that can make the code harder to read or inconsistent with other inputs.
+
+  ⚠ angular(no-input-prefix): Input should not be prefixed with `on`
+   ╭─[no_input_prefix.tsx:7:17]
+ 6 │             class TestDirective {
+ 7 │                 @Input() onHover: any;
+   ·                 ────────
+ 8 │             }
+   ╰────
+  help: Rename the input to not start with `on`. Inputs should use descriptive names without unnecessary prefixes that can make the code harder to read or inconsistent with other inputs.

--- a/crates/oxc_linter/src/snapshots/angular_no_input_rename.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_input_rename.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-input-rename): Input bindings should not be aliased
+   ╭─[no_input_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Input('label') name: string;
+   ·             ───────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing inputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-input-rename): Input bindings should not be aliased
+   ╭─[no_input_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Input({ alias: 'label' }) name: string;
+   ·             ──────────────────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing inputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-input-rename): Input bindings should not be aliased
+   ╭─[no_input_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             name = input<string>({ alias: 'label' });
+   ·             ─────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing inputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-input-rename): Input bindings should not be aliased
+   ╭─[no_input_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Input('firstName') name: string;
+   ·             ───────────────────
+ 9 │             @Input('userAge') age: number;
+   ╰────
+  help: Avoid aliasing inputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-input-rename): Input bindings should not be aliased
+    ╭─[no_input_rename.tsx:9:13]
+  8 │             @Input('firstName') name: string;
+  9 │             @Input('userAge') age: number;
+    ·             ─────────────────
+ 10 │         }
+    ╰────
+  help: Avoid aliasing inputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.

--- a/crates/oxc_linter/src/snapshots/angular_no_inputs_metadata_property.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_inputs_metadata_property.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-inputs-metadata-property): Use `@Input` decorator rather than the `inputs` metadata property
+   ╭─[no_inputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             inputs: ['name']
+   ·             ──────
+ 7 │         })
+   ╰────
+  help: The `inputs` metadata property is a legacy API. Use the `@Input()` decorator or `input()` signal function directly on properties instead.
+
+  ⚠ angular(no-inputs-metadata-property): Use `@Input` decorator rather than the `inputs` metadata property
+   ╭─[no_inputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             inputs: ['name', 'value', 'count']
+   ·             ──────
+ 7 │         })
+   ╰────
+  help: The `inputs` metadata property is a legacy API. Use the `@Input()` decorator or `input()` signal function directly on properties instead.
+
+  ⚠ angular(no-inputs-metadata-property): Use `@Input` decorator rather than the `inputs` metadata property
+   ╭─[no_inputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             inputs: ['value: inputValue']
+   ·             ──────
+ 7 │         })
+   ╰────
+  help: The `inputs` metadata property is a legacy API. Use the `@Input()` decorator or `input()` signal function directly on properties instead.
+
+  ⚠ angular(no-inputs-metadata-property): Use `@Input` decorator rather than the `inputs` metadata property
+   ╭─[no_inputs_metadata_property.tsx:5:13]
+ 4 │             selector: '[appTest]',
+ 5 │             inputs: ['highlight']
+   ·             ──────
+ 6 │         })
+   ╰────
+  help: The `inputs` metadata property is a legacy API. Use the `@Input()` decorator or `input()` signal function directly on properties instead.
+
+  ⚠ angular(no-inputs-metadata-property): Use `@Input` decorator rather than the `inputs` metadata property
+   ╭─[no_inputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             inputs: []
+   ·             ──────
+ 7 │         })
+   ╰────
+  help: The `inputs` metadata property is a legacy API. Use the `@Input()` decorator or `input()` signal function directly on properties instead.

--- a/crates/oxc_linter/src/snapshots/angular_no_lifecycle_call.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_lifecycle_call.snap
@@ -1,0 +1,84 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnInit`
+   ╭─[no_lifecycle_call.tsx:7:17]
+ 6 │             reset() {
+ 7 │                 this.ngOnInit();
+   ·                 ───────────────
+ 8 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnDestroy`
+   ╭─[no_lifecycle_call.tsx:7:17]
+ 6 │             cleanup() {
+ 7 │                 this.ngOnDestroy();
+   ·                 ──────────────────
+ 8 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngAfterViewInit`
+   ╭─[no_lifecycle_call.tsx:7:17]
+ 6 │             refresh() {
+ 7 │                 this.ngAfterViewInit();
+   ·                 ──────────────────────
+ 8 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnInit`
+   ╭─[no_lifecycle_call.tsx:7:17]
+ 6 │             test() {
+ 7 │                 this.otherComponent.ngOnInit();
+   ·                 ──────────────────────────────
+ 8 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnInit`
+   ╭─[no_lifecycle_call.tsx:8:17]
+ 7 │             reset() {
+ 8 │                 this.ngOnInit();
+   ·                 ───────────────
+ 9 │                 this.ngOnDestroy();
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnDestroy`
+    ╭─[no_lifecycle_call.tsx:9:17]
+  8 │                 this.ngOnInit();
+  9 │                 this.ngOnDestroy();
+    ·                 ──────────────────
+ 10 │             }
+    ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnDestroy`
+   ╭─[no_lifecycle_call.tsx:6:17]
+ 5 │             ngOnInit() {
+ 6 │                 super.ngOnDestroy();
+   ·                 ───────────────────
+ 7 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnInit`
+   ╭─[no_lifecycle_call.tsx:8:21]
+ 7 │                 const fn = () => {
+ 8 │                     this.ngOnInit();
+   ·                     ───────────────
+ 9 │                 };
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.
+
+  ⚠ angular(no-lifecycle-call): Avoid explicit calls to lifecycle method `ngOnInit`
+   ╭─[no_lifecycle_call.tsx:7:17]
+ 6 │             reset() {
+ 7 │                 this.ngOnInit();
+   ·                 ───────────────
+ 8 │             }
+   ╰────
+  help: Lifecycle methods are called by Angular. Calling them explicitly can lead to unexpected behavior. Move the logic to a separate method if you need to call it.

--- a/crates/oxc_linter/src/snapshots/angular_no_output_native.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_output_native.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `click`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() click = new EventEmitter<void>();
+   ·             ───────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `change`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() change = new EventEmitter<string>();
+   ·             ──────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `blur`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() blur = new EventEmitter<void>();
+   ·             ──────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `focus`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() focus = new EventEmitter<void>();
+   ·             ───────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `click`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output('click') buttonClick = new EventEmitter<void>();
+   ·             ────────────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `scroll`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             scroll = output<void>();
+   ·             ────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.
+
+  ⚠ angular(no-output-native): Output bindings, including aliases, should not be named as native DOM events: `keydown`
+   ╭─[no_output_native.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             buttonPress = output<void>({ alias: 'keydown' });
+   ·             ─────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Using native event names like 'click', 'change', 'blur' can cause confusion and unexpected behavior. Rename your output to something more descriptive like 'itemClick' or 'valueChange'.

--- a/crates/oxc_linter/src/snapshots/angular_no_output_on_prefix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_output_on_prefix.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onClick`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() onClick = new EventEmitter<void>();
+   ·             ─────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onChange`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() onChange = new EventEmitter<string>();
+   ·             ────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `on`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() on = new EventEmitter<void>();
+   ·             ────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onClick`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output('onClick') clickHandler = new EventEmitter<void>();
+   ·             ───────────────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onSelect`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             onSelect = output<string>();
+   ·             ────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onSelect`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             selectHandler = output<string>({ alias: 'onSelect' });
+   ·             ──────────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onBlur`
+   ╭─[no_output_on_prefix.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() onBlur = new EventEmitter<void>();
+   ·             ────────────────────────────────────────────
+ 9 │             @Output() onFocus = new EventEmitter<void>();
+   ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.
+
+  ⚠ angular(no-output-on-prefix): Output bindings, including aliases, should not be named "on" or prefixed with it: `onFocus`
+    ╭─[no_output_on_prefix.tsx:9:13]
+  8 │             @Output() onBlur = new EventEmitter<void>();
+  9 │             @Output() onFocus = new EventEmitter<void>();
+    ·             ─────────────────────────────────────────────
+ 10 │         }
+    ╰────
+  help: Remove the 'on' prefix from the output name. In Angular templates, outputs are already bound with (output) syntax which implies an event. Adding 'on' is redundant: (onClick)="handler()" becomes confusing.

--- a/crates/oxc_linter/src/snapshots/angular_no_output_rename.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_output_rename.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-output-rename): Output bindings should not be aliased
+   ╭─[no_output_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output('valueChanged') change = new EventEmitter<string>();
+   ·             ───────────────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing outputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-output-rename): Output bindings should not be aliased
+   ╭─[no_output_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output({ alias: 'valueChanged' }) change = new EventEmitter<string>();
+   ·             ──────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing outputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.
+
+  ⚠ angular(no-output-rename): Output bindings should not be aliased
+   ╭─[no_output_rename.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             change = output<string>({ alias: 'valueChanged' });
+   ·             ───────────────────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Avoid aliasing outputs as it can lead to confusion. Use the original property name or rename the property if the alias is more appropriate.

--- a/crates/oxc_linter/src/snapshots/angular_no_outputs_metadata_property.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_outputs_metadata_property.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-outputs-metadata-property): Use `@Output` decorator rather than the `outputs` metadata property
+   ╭─[no_outputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             outputs: ['change']
+   ·             ───────
+ 7 │         })
+   ╰────
+  help: The `outputs` metadata property is a legacy API. Use the `@Output()` decorator or `output()` signal function directly on properties instead.
+
+  ⚠ angular(no-outputs-metadata-property): Use `@Output` decorator rather than the `outputs` metadata property
+   ╭─[no_outputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             outputs: ['change', 'submit', 'cancel']
+   ·             ───────
+ 7 │         })
+   ╰────
+  help: The `outputs` metadata property is a legacy API. Use the `@Output()` decorator or `output()` signal function directly on properties instead.
+
+  ⚠ angular(no-outputs-metadata-property): Use `@Output` decorator rather than the `outputs` metadata property
+   ╭─[no_outputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             outputs: ['submit: formSubmit']
+   ·             ───────
+ 7 │         })
+   ╰────
+  help: The `outputs` metadata property is a legacy API. Use the `@Output()` decorator or `output()` signal function directly on properties instead.
+
+  ⚠ angular(no-outputs-metadata-property): Use `@Output` decorator rather than the `outputs` metadata property
+   ╭─[no_outputs_metadata_property.tsx:5:13]
+ 4 │             selector: '[appTest]',
+ 5 │             outputs: ['activated']
+   ·             ───────
+ 6 │         })
+   ╰────
+  help: The `outputs` metadata property is a legacy API. Use the `@Output()` decorator or `output()` signal function directly on properties instead.
+
+  ⚠ angular(no-outputs-metadata-property): Use `@Output` decorator rather than the `outputs` metadata property
+   ╭─[no_outputs_metadata_property.tsx:6:13]
+ 5 │             template: '',
+ 6 │             outputs: []
+   ·             ───────
+ 7 │         })
+   ╰────
+  help: The `outputs` metadata property is a legacy API. Use the `@Output()` decorator or `output()` signal function directly on properties instead.

--- a/crates/oxc_linter/src/snapshots/angular_no_pipe_impure.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_pipe_impure.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-pipe-impure): Impure pipes should be avoided
+   ╭─[no_pipe_impure.tsx:5:13]
+ 4 │             name: 'myPipe',
+ 5 │             pure: false
+   ·             ───────────
+ 6 │         })
+   ╰────
+  help: Impure pipes (`pure: false`) are invoked on each change-detection cycle, which can significantly impact performance. Consider redesigning your pipe to be pure, or use a different approach such as a method in the component.
+
+  ⚠ angular(no-pipe-impure): Impure pipes should be avoided
+   ╭─[no_pipe_impure.tsx:6:13]
+ 5 │             standalone: true,
+ 6 │             pure: false
+   ·             ───────────
+ 7 │         })
+   ╰────
+  help: Impure pipes (`pure: false`) are invoked on each change-detection cycle, which can significantly impact performance. Consider redesigning your pipe to be pure, or use a different approach such as a method in the component.
+
+  ⚠ angular(no-pipe-impure): Impure pipes should be avoided
+   ╭─[no_pipe_impure.tsx:5:13]
+ 4 │             name: 'myPipe',
+ 5 │             pure: !true
+   ·             ───────────
+ 6 │         })
+   ╰────
+  help: Impure pipes (`pure: false`) are invoked on each change-detection cycle, which can significantly impact performance. Consider redesigning your pipe to be pure, or use a different approach such as a method in the component.

--- a/crates/oxc_linter/src/snapshots/angular_no_queries_metadata_property.snap
+++ b/crates/oxc_linter/src/snapshots/angular_no_queries_metadata_property.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(no-queries-metadata-property): Avoid using `queries` metadata property
+   ╭─[no_queries_metadata_property.tsx:6:13]
+ 5 │                 template: '<div #myDiv></div>',
+ 6 │ ╭─▶             queries: {
+ 7 │ │                   myDiv: new ViewChild('myDiv')
+ 8 │ ╰─▶             }
+ 9 │             })
+   ╰────
+  help: Use `@ViewChild`, `@ViewChildren`, `@ContentChild`, or `@ContentChildren` decorators instead of the `queries` metadata property. Decorator-based queries provide better type inference and are easier to understand.
+
+  ⚠ angular(no-queries-metadata-property): Avoid using `queries` metadata property
+   ╭─[no_queries_metadata_property.tsx:5:13]
+ 4 │                 selector: '[appTest]',
+ 5 │ ╭─▶             queries: {
+ 6 │ │                   content: new ContentChild('content')
+ 7 │ ╰─▶             }
+ 8 │             })
+   ╰────
+  help: Use `@ViewChild`, `@ViewChildren`, `@ContentChild`, or `@ContentChildren` decorators instead of the `queries` metadata property. Decorator-based queries provide better type inference and are easier to understand.
+
+  ⚠ angular(no-queries-metadata-property): Avoid using `queries` metadata property
+    ╭─[no_queries_metadata_property.tsx:6:13]
+  5 │                 template: '',
+  6 │ ╭─▶             queries: {
+  7 │ │                   item: new ViewChild('item'),
+  8 │ │                   items: new ViewChildren('item')
+  9 │ ╰─▶             }
+ 10 │             })
+    ╰────
+  help: Use `@ViewChild`, `@ViewChildren`, `@ContentChild`, or `@ContentChildren` decorators instead of the `queries` metadata property. Decorator-based queries provide better type inference and are easier to understand.

--- a/crates/oxc_linter/src/snapshots/angular_pipe_prefix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_pipe_prefix.snap
@@ -1,0 +1,43 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(pipe-prefix): Pipe names should be prefixed with: app
+   ╭─[pipe_prefix.tsx:3:13]
+ 2 │                 import { Pipe, PipeTransform } from '@angular/core';
+ 3 │ ╭─▶             @Pipe({
+ 4 │ │                   name: 'formatDate'
+ 5 │ ╰─▶             })
+ 6 │                 class FormatDatePipe implements PipeTransform {
+   ╰────
+  help: Use a consistent prefix for pipe names to avoid naming collisions and to make it clear which pipes belong to your application.
+
+  ⚠ angular(pipe-prefix): Pipe names should be prefixed with: app
+   ╭─[pipe_prefix.tsx:3:13]
+ 2 │                 import { Pipe, PipeTransform } from '@angular/core';
+ 3 │ ╭─▶             @Pipe({
+ 4 │ │                   name: 'myFormatDate'
+ 5 │ ╰─▶             })
+ 6 │                 class FormatDatePipe implements PipeTransform {
+   ╰────
+  help: Use a consistent prefix for pipe names to avoid naming collisions and to make it clear which pipes belong to your application.
+
+  ⚠ angular(pipe-prefix): Pipe names should be prefixed with: app
+   ╭─[pipe_prefix.tsx:3:13]
+ 2 │                 import { Pipe, PipeTransform } from '@angular/core';
+ 3 │ ╭─▶             @Pipe({
+ 4 │ │                   name: 'appformatdate'
+ 5 │ ╰─▶             })
+ 6 │                 class FormatDatePipe implements PipeTransform {
+   ╰────
+  help: Use a consistent prefix for pipe names to avoid naming collisions and to make it clear which pipes belong to your application.
+
+  ⚠ angular(pipe-prefix): Pipe names should be prefixed with: app
+   ╭─[pipe_prefix.tsx:3:13]
+ 2 │                 import { Pipe, PipeTransform } from '@angular/core';
+ 3 │ ╭─▶             @Pipe({
+ 4 │ │                   name: `formatDate`
+ 5 │ ╰─▶             })
+ 6 │                 class FormatDatePipe implements PipeTransform {
+   ╰────
+  help: Use a consistent prefix for pipe names to avoid naming collisions and to make it clear which pipes belong to your application.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_control_flow.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_control_flow.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-control-flow): Prefer built-in control flow over `*ngIf`
+   ╭─[prefer_control_flow.tsx:5:29]
+ 4 │             selector: 'app-test',
+ 5 │             template: '<div *ngIf="isVisible">Content</div>'
+   ·                             ─────
+ 6 │         })
+   ╰────
+  help: Replace `*ngIf` with `@if` syntax. Built-in control flow was introduced in Angular 17 and is the recommended approach. See https://angular.dev/guide/templates/control-flow for migration guidance.
+
+  ⚠ angular(prefer-control-flow): Prefer built-in control flow over `*ngFor`
+   ╭─[prefer_control_flow.tsx:5:29]
+ 4 │             selector: 'app-test',
+ 5 │             template: '<div *ngFor="let item of items">{{ item }}</div>'
+   ·                             ──────
+ 6 │         })
+   ╰────
+  help: Replace `*ngFor` with `@for` syntax. Built-in control flow was introduced in Angular 17 and is the recommended approach. See https://angular.dev/guide/templates/control-flow for migration guidance.
+
+  ⚠ angular(prefer-control-flow): Prefer built-in control flow over `*ngSwitch`
+   ╭─[prefer_control_flow.tsx:5:29]
+ 4 │             selector: 'app-test',
+ 5 │             template: '<div *ngSwitch="status"><span *ngSwitchCase="active">Active</span></div>'
+   ·                             ─────────
+ 6 │         })
+   ╰────
+  help: Replace `*ngSwitch` with `@switch` syntax. Built-in control flow was introduced in Angular 17 and is the recommended approach. See https://angular.dev/guide/templates/control-flow for migration guidance.
+
+  ⚠ angular(prefer-control-flow): Prefer built-in control flow over `[ngIf]`
+   ╭─[prefer_control_flow.tsx:5:37]
+ 4 │             selector: 'app-test',
+ 5 │             template: '<ng-template [ngIf]="isVisible"><div>Content</div></ng-template>'
+   ·                                     ──────
+ 6 │         })
+   ╰────
+  help: Replace `[ngIf]` with `@if` syntax. Built-in control flow was introduced in Angular 17 and is the recommended approach. See https://angular.dev/guide/templates/control-flow for migration guidance.
+
+  ⚠ angular(prefer-control-flow): Prefer built-in control flow over `*ngIf`
+   ╭─[prefer_control_flow.tsx:6:23]
+ 5 │             template: `
+ 6 │                 <div *ngIf="isVisible">
+   ·                       ─────
+ 7 │                     Content
+   ╰────
+  help: Replace `*ngIf` with `@if` syntax. Built-in control flow was introduced in Angular 17 and is the recommended approach. See https://angular.dev/guide/templates/control-flow for migration guidance.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_host_metadata_property.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_host_metadata_property.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostBinding`
+   ╭─[prefer_host_metadata_property.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @HostBinding('class.active') isActive = false;
+   ·             ────────────────────────────
+ 9 │         }
+   ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostListener`
+   ╭─[prefer_host_metadata_property.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @HostListener('click') onClick() {}
+   ·             ──────────────────────
+ 9 │         }
+   ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostBinding`
+   ╭─[prefer_host_metadata_property.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @HostBinding('class.active') isActive = false;
+   ·             ────────────────────────────
+ 9 │             @HostListener('click') onClick() {}
+   ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostListener`
+    ╭─[prefer_host_metadata_property.tsx:9:13]
+  8 │             @HostBinding('class.active') isActive = false;
+  9 │             @HostListener('click') onClick() {}
+    ·             ──────────────────────
+ 10 │         }
+    ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostBinding`
+   ╭─[prefer_host_metadata_property.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             @HostBinding('attr.role') role = 'button';
+   ·             ─────────────────────────
+ 8 │         }
+   ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.
+
+  ⚠ angular(prefer-host-metadata-property): Prefer using the `host` metadata property over `@HostListener`
+   ╭─[prefer_host_metadata_property.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @HostListener('keydown', ['$event']) onKeyDown(event: KeyboardEvent) {}
+   ·             ────────────────────────────────────
+ 9 │         }
+   ╰────
+  help: Use the `host` property in the @Component or @Directive decorator instead of `@HostBinding` and `@HostListener` decorators. This centralizes host-related configuration and can improve readability.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_inject.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_inject.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+    ╭─[prefer_inject.tsx:9:25]
+  8 │         class TestComponent {
+  9 │             constructor(private myService: MyService) {}
+    ·                         ────────────────────────────
+ 10 │         }
+    ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+   ╭─[prefer_inject.tsx:8:25]
+ 7 │         class TestDirective {
+ 8 │             constructor(private myService: MyService) {}
+   ·                         ────────────────────────────
+ 9 │         }
+   ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+   ╭─[prefer_inject.tsx:5:25]
+ 4 │         class TestService {
+ 5 │             constructor(@Inject('TOKEN') private value: string) {}
+   ·                         ──────────────────────────────────────
+ 6 │         }
+   ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+   ╭─[prefer_inject.tsx:6:25]
+ 5 │         class TestPipe {
+ 6 │             constructor(private myService: MyService) {}
+   ·                         ────────────────────────────
+ 7 │         }
+   ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+    ╭─[prefer_inject.tsx:10:17]
+  9 │             constructor(
+ 10 │                 private serviceA: ServiceA,
+    ·                 ──────────────────────────
+ 11 │                 private serviceB: ServiceB
+    ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+    ╭─[prefer_inject.tsx:11:17]
+ 10 │                 private serviceA: ServiceA,
+ 11 │                 private serviceB: ServiceB
+    ·                 ──────────────────────────
+ 12 │             ) {}
+    ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`
+
+  ⚠ angular(prefer-inject): Prefer using the `inject()` function over constructor parameter injection
+    ╭─[prefer_inject.tsx:9:25]
+  8 │         class TestComponent {
+  9 │             constructor(@Optional() private myService: MyService) {}
+    ·                         ────────────────────────────────────────
+ 10 │         }
+    ╰────
+  help: Use the `inject()` function to inject dependencies. It provides better type inference, works with signals, and allows for more flexible dependency injection patterns. Example: `private readonly service = inject(MyService);`

--- a/crates/oxc_linter/src/snapshots/angular_prefer_on_push_component_change_detection.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_on_push_component_change_detection.snap
@@ -1,0 +1,74 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: ''
+ 6 │ ╰─▶         })
+ 7 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component, ChangeDetectionStrategy } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: '',
+ 6 │ │               changeDetection: ChangeDetectionStrategy.Default
+ 7 │ ╰─▶         })
+ 8 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: '',
+ 6 │ │               changeDetection: 1
+ 7 │ ╰─▶         })
+ 8 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: '',
+ 6 │ │               standalone: true
+ 7 │ ╰─▶         })
+ 8 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component, ChangeDetectionStrategy } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: '',
+ 6 │ │               'changeDetection': ChangeDetectionStrategy.Default
+ 7 │ ╰─▶         })
+ 8 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.
+
+  ⚠ angular(prefer-on-push-component-change-detection): Component should use `ChangeDetectionStrategy.OnPush` for better performance
+   ╭─[prefer_on_push_component_change_detection.tsx:3:9]
+ 2 │             import { Component, ChangeDetectionStrategy } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: 'app-test',
+ 5 │ │               template: '',
+ 6 │ │               ['changeDetection']: ChangeDetectionStrategy.Default
+ 7 │ ╰─▶         })
+ 8 │             class TestComponent {}
+   ╰────
+  help: Add `changeDetection: ChangeDetectionStrategy.OnPush` to the component decorator. OnPush change detection only checks the component when its inputs change or when events are triggered within it.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_output_emitter_ref.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_output_emitter_ref.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+   ╭─[prefer_output_emitter_ref.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() myEvent = new EventEmitter<string>();
+   ·             ─────────
+ 9 │         }
+   ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+   ╭─[prefer_output_emitter_ref.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output('onMyEvent') myEvent = new EventEmitter();
+   ·             ────────────────────
+ 9 │         }
+   ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+   ╭─[prefer_output_emitter_ref.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() eventA = new EventEmitter();
+   ·             ─────────
+ 9 │             @Output() eventB = new EventEmitter();
+   ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+    ╭─[prefer_output_emitter_ref.tsx:9:13]
+  8 │             @Output() eventA = new EventEmitter();
+  9 │             @Output() eventB = new EventEmitter();
+    ·             ─────────
+ 10 │         }
+    ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+   ╭─[prefer_output_emitter_ref.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             @Output() myEvent = new EventEmitter();
+   ·             ─────────
+ 8 │         }
+   ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`
+
+  ⚠ angular(prefer-output-emitter-ref): Prefer using `output()` function over `@Output()` decorator
+   ╭─[prefer_output_emitter_ref.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             @Output() itemSelected = new EventEmitter<{ id: number; name: string }>();
+   ·             ─────────
+ 9 │         }
+   ╰────
+  help: Use the `output()` function instead of `@Output()` with `EventEmitter`. The `output()` function provides better type inference, cleaner syntax, and integrates better with Angular's signal-based architecture. Example: `myEvent = output<string>();`

--- a/crates/oxc_linter/src/snapshots/angular_prefer_output_readonly.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_output_readonly.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on @Output() properties
+   ╭─[prefer_output_readonly.tsx:5:23]
+ 4 │         class TestComponent {
+ 5 │             @Output() clicked = new EventEmitter<void>();
+   ·                       ───────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on output() properties
+   ╭─[prefer_output_readonly.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             valueChange = output<string>();
+   ·             ───────────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on @Output() properties
+   ╭─[prefer_output_readonly.tsx:5:23]
+ 4 │         class TestComponent {
+ 5 │             @Output() clicked = new EventEmitter<void>();
+   ·                       ───────
+ 6 │             @Output() hovered = new EventEmitter<MouseEvent>();
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on @Output() properties
+   ╭─[prefer_output_readonly.tsx:6:23]
+ 5 │             @Output() clicked = new EventEmitter<void>();
+ 6 │             @Output() hovered = new EventEmitter<MouseEvent>();
+   ·                       ───────
+ 7 │             valueChange = output<string>();
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on output() properties
+   ╭─[prefer_output_readonly.tsx:7:13]
+ 6 │             @Output() hovered = new EventEmitter<MouseEvent>();
+ 7 │             valueChange = output<string>();
+   ·             ───────────
+ 8 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on @Output() properties
+   ╭─[prefer_output_readonly.tsx:5:30]
+ 4 │         class TestComponent {
+ 5 │             @Output('click') clicked = new EventEmitter<void>();
+   ·                              ───────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on @Output() properties
+   ╭─[prefer_output_readonly.tsx:5:23]
+ 4 │         class TestDirective {
+ 5 │             @Output() activated = new EventEmitter<void>();
+   ·                       ─────────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on output() properties
+   ╭─[prefer_output_readonly.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             valueChange = outputFromObservable(this.value$);
+   ·             ───────────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on output() properties
+   ╭─[prefer_output_readonly.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             clicked: OutputEmitterRef<void>;
+   ·             ───────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.
+
+  ⚠ angular(prefer-output-readonly): Prefer `readonly` modifier on output() properties
+   ╭─[prefer_output_readonly.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             valueChange: OutputRef<string>;
+   ·             ───────────
+ 6 │         }
+   ╰────
+  help: Add the `readonly` modifier to prevent accidental reassignment of the output. Outputs should not be reassigned after initialization.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_signal_model.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_signal_model.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-signal-model): Input `value` and output `valueChange` can be replaced with `model()`
+   ╭─[prefer_signal_model.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             value = input<string>();
+   ·             ────────────────────────
+ 9 │             valueChange = output<string>();
+   ╰────
+  help: Use the `model()` function instead of separate `input()` and `output()` for two-way binding patterns. Example: `value = model<string>();` replaces both `value = input<string>()` and `valueChange = output<string>()`.
+
+  ⚠ angular(prefer-signal-model): Input `count` and output `countChange` can be replaced with `model()`
+   ╭─[prefer_signal_model.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             count = input<number>();
+   ·             ────────────────────────
+ 9 │             countChange = output<number>();
+   ╰────
+  help: Use the `model()` function instead of separate `input()` and `output()` for two-way binding patterns. Example: `value = model<string>();` replaces both `value = input<string>()` and `valueChange = output<string>()`.
+
+  ⚠ angular(prefer-signal-model): Input `name` and output `nameChange` can be replaced with `model()`
+    ╭─[prefer_signal_model.tsx:10:13]
+  9 │             countChange = output<number>();
+ 10 │             name = input<string>();
+    ·             ───────────────────────
+ 11 │             nameChange = output<string>();
+    ╰────
+  help: Use the `model()` function instead of separate `input()` and `output()` for two-way binding patterns. Example: `value = model<string>();` replaces both `value = input<string>()` and `valueChange = output<string>()`.
+
+  ⚠ angular(prefer-signal-model): Input `selected` and output `selectedChange` can be replaced with `model()`
+   ╭─[prefer_signal_model.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             selected = input<boolean>();
+   ·             ────────────────────────────
+ 8 │             selectedChange = output<boolean>();
+   ╰────
+  help: Use the `model()` function instead of separate `input()` and `output()` for two-way binding patterns. Example: `value = model<string>();` replaces both `value = input<string>()` and `valueChange = output<string>()`.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_signals.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_signals.snap
@@ -1,0 +1,66 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-signals): Prefer signal-based `input()` over legacy `@Input()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @Input() name: string;
+   ·             ────────
+ 6 │         }
+   ╰────
+  help: Replace `@Input()` with `input()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `input()` over legacy `@Input()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @Input({ required: true }) id: number;
+   ·             ──────────────────────────
+ 6 │         }
+   ╰────
+  help: Replace `@Input()` with `input()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `output()` over legacy `@Output()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @Output() clicked = new EventEmitter<void>();
+   ·             ─────────
+ 6 │         }
+   ╰────
+  help: Replace `@Output()` with `output()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `viewChild()` over legacy `@ViewChild()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @ViewChild('container') container: ElementRef;
+   ·             ───────────────────────
+ 6 │         }
+   ╰────
+  help: Replace `@ViewChild()` with `viewChild()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `viewChildren()` over legacy `@ViewChildren()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @ViewChildren('item') items: QueryList<ElementRef>;
+   ·             ─────────────────────
+ 6 │         }
+   ╰────
+  help: Replace `@ViewChildren()` with `viewChildren()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `contentChild()` over legacy `@ContentChild()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @ContentChild('content') content: ElementRef;
+   ·             ────────────────────────
+ 6 │         }
+   ╰────
+  help: Replace `@ContentChild()` with `contentChild()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.
+
+  ⚠ angular(prefer-signals): Prefer signal-based `contentChildren()` over legacy `@ContentChildren()` decorator
+   ╭─[prefer_signals.tsx:5:13]
+ 4 │         class TestComponent {
+ 5 │             @ContentChildren('item') items: QueryList<ElementRef>;
+   ·             ────────────────────────
+ 6 │         }
+   ╰────
+  help: Replace `@ContentChildren()` with `contentChildren()` for better performance and reactivity. See https://angular.dev/guide/signals for migration guidance.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_standalone.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_standalone.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-standalone): Component should use standalone architecture
+   ╭─[prefer_standalone.tsx:3:70]
+ 2 │         import { Component } from '@angular/core';
+ 3 │         @Component({ selector: 'app-test', template: '', standalone: false })
+   ·                                                                      ─────
+ 4 │         class TestComponent {}
+   ╰────
+  help: Remove `standalone: false` to use standalone components. In Angular 20, components are standalone by default. See https://angular.dev/guide/components/importing for migration guidance.
+
+  ⚠ angular(prefer-standalone): Component should use standalone architecture
+   ╭─[prefer_standalone.tsx:3:57]
+ 2 │         import { Directive } from '@angular/core';
+ 3 │         @Directive({ selector: '[appTest]', standalone: false })
+   ·                                                         ─────
+ 4 │         class TestDirective {}
+   ╰────
+  help: Remove `standalone: false` to use standalone components. In Angular 20, components are standalone by default. See https://angular.dev/guide/components/importing for migration guidance.
+
+  ⚠ angular(prefer-standalone): Component should use standalone architecture
+   ╭─[prefer_standalone.tsx:7:25]
+ 6 │             styleUrls: ['./test.css'],
+ 7 │             standalone: false
+   ·                         ─────
+ 8 │         })
+   ╰────
+  help: Remove `standalone: false` to use standalone components. In Angular 20, components are standalone by default. See https://angular.dev/guide/components/importing for migration guidance.
+
+  ⚠ angular(prefer-standalone): Component should use standalone architecture
+   ╭─[prefer_standalone.tsx:7:25]
+ 6 │             providers: [],
+ 7 │             standalone: false
+   ·                         ─────
+ 8 │         })
+   ╰────
+  help: Remove `standalone: false` to use standalone components. In Angular 20, components are standalone by default. See https://angular.dev/guide/components/importing for migration guidance.
+
+  ⚠ angular(prefer-standalone): Component should use standalone architecture
+   ╭─[prefer_standalone.tsx:5:25]
+ 4 │             selector: '[appHighlight]',
+ 5 │             standalone: false
+   ·                         ─────
+ 6 │         })
+   ╰────
+  help: Remove `standalone: false` to use standalone components. In Angular 20, components are standalone by default. See https://angular.dev/guide/components/importing for migration guidance.

--- a/crates/oxc_linter/src/snapshots/angular_prefer_standalone@warn_on_redundant.snap
+++ b/crates/oxc_linter/src/snapshots/angular_prefer_standalone@warn_on_redundant.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(prefer-standalone): Redundant `standalone: true` property
+   ╭─[prefer_standalone.tsx:3:70]
+ 2 │         import { Component } from '@angular/core';
+ 3 │         @Component({ selector: 'app-test', template: '', standalone: true })
+   ·                                                                      ────
+ 4 │         class TestComponent {}
+   ╰────
+  help: In Angular 20, components are standalone by default. You can remove the explicit `standalone: true` declaration.

--- a/crates/oxc_linter/src/snapshots/angular_relative_url_prefix.snap
+++ b/crates/oxc_linter/src/snapshots/angular_relative_url_prefix.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(relative-url-prefix): `templateUrl` should use relative paths starting with `./` or `../`
+   ╭─[relative_url_prefix.tsx:5:26]
+ 4 │             selector: 'app-test',
+ 5 │             templateUrl: 'test.component.html'
+   ·                          ─────────────────────
+ 6 │         })
+   ╰────
+  help: Use relative paths (starting with `./` or `../`) for `templateUrl` and `styleUrls` to ensure proper resolution in all build scenarios.
+
+  ⚠ angular(relative-url-prefix): `styleUrls` should use relative paths starting with `./` or `../`
+   ╭─[relative_url_prefix.tsx:6:25]
+ 5 │             template: '',
+ 6 │             styleUrls: ['test.component.css']
+   ·                         ────────────────────
+ 7 │         })
+   ╰────
+  help: Use relative paths (starting with `./` or `../`) for `templateUrl` and `styleUrls` to ensure proper resolution in all build scenarios.
+
+  ⚠ angular(relative-url-prefix): `templateUrl` should use relative paths starting with `./` or `../`
+   ╭─[relative_url_prefix.tsx:5:26]
+ 4 │             selector: 'app-test',
+ 5 │             templateUrl: '/app/test.component.html'
+   ·                          ──────────────────────────
+ 6 │         })
+   ╰────
+  help: Use relative paths (starting with `./` or `../`) for `templateUrl` and `styleUrls` to ensure proper resolution in all build scenarios.
+
+  ⚠ angular(relative-url-prefix): `styleUrls` should use relative paths starting with `./` or `../`
+   ╭─[relative_url_prefix.tsx:6:40]
+ 5 │             template: '',
+ 6 │             styleUrls: ['./valid.css', 'invalid.css']
+   ·                                        ─────────────
+ 7 │         })
+   ╰────
+  help: Use relative paths (starting with `./` or `../`) for `templateUrl` and `styleUrls` to ensure proper resolution in all build scenarios.

--- a/crates/oxc_linter/src/snapshots/angular_require_lifecycle_on_prototype.snap
+++ b/crates/oxc_linter/src/snapshots/angular_require_lifecycle_on_prototype.snap
@@ -1,0 +1,57 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngOnInit` should be defined on the class prototype, not as a property
+   ╭─[require_lifecycle_on_prototype.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnInit = () => {};
+   ·             ────────
+ 9 │         }
+   ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngOnDestroy` should be defined on the class prototype, not as a property
+   ╭─[require_lifecycle_on_prototype.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnDestroy = function() {};
+   ·             ───────────
+ 9 │         }
+   ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngOnInit` should be defined on the class prototype, not as a property
+   ╭─[require_lifecycle_on_prototype.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnInit = () => {};
+   ·             ────────
+ 9 │             ngOnChanges = () => {};
+   ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngOnChanges` should be defined on the class prototype, not as a property
+    ╭─[require_lifecycle_on_prototype.tsx:9:13]
+  8 │             ngOnInit = () => {};
+  9 │             ngOnChanges = () => {};
+    ·             ───────────
+ 10 │         }
+    ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngAfterViewInit` should be defined on the class prototype, not as a property
+   ╭─[require_lifecycle_on_prototype.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             ngAfterViewInit = () => {};
+   ·             ───────────────
+ 8 │         }
+   ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.
+
+  ⚠ angular(require-lifecycle-on-prototype): Lifecycle method `ngOnDestroy` should be defined on the class prototype, not as a property
+   ╭─[require_lifecycle_on_prototype.tsx:5:13]
+ 4 │         class TestService {
+ 5 │             ngOnDestroy = () => {};
+   ·             ───────────
+ 6 │         }
+   ╰────
+  help: Define lifecycle methods as regular methods on the class, not as property assignments. Angular's change detection and lifecycle hooks work with prototype methods, not instance properties.

--- a/crates/oxc_linter/src/snapshots/angular_require_localize_metadata.snap
+++ b/crates/oxc_linter/src/snapshots/angular_require_localize_metadata.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(require-localize-metadata): $localize tagged messages should contain a description
+   ╭─[require_localize_metadata.tsx:1:23]
+ 1 │ const msg = $localize`Hello`;
+   ·                       ─────
+   ╰────
+  help: Add a description to help translators understand the context. Use the format: $localize`:description:text` or $localize`:meaning|description:text`
+
+  ⚠ angular(require-localize-metadata): $localize tagged messages should contain a meaning
+   ╭─[require_localize_metadata.tsx:1:23]
+ 1 │ const msg = $localize`:description:Hello`;
+   ·                       ──────────────────
+   ╰────
+  help: Add a meaning to distinguish identical text that needs different translations. Use the format: $localize`:meaning|description:text`
+
+  ⚠ angular(require-localize-metadata): $localize tagged messages should contain a custom id
+   ╭─[require_localize_metadata.tsx:1:23]
+ 1 │ const msg = $localize`:description:Hello`;
+   ·                       ──────────────────
+   ╰────
+  help: Add a custom ID for stable translation references. Use the format: $localize`:description@@customId:text`
+
+  ⚠ angular(require-localize-metadata): $localize tagged messages should contain a custom id matching the pattern /^MSG_/ on 'wrong-id'
+   ╭─[require_localize_metadata.tsx:1:23]
+ 1 │ const msg = $localize`:desc@@wrong-id:Hello`;
+   ·                       ─────────────────────
+   ╰────
+  help: Add a custom ID for stable translation references. Use the format: $localize`:description@@customId:text`
+
+  ⚠ angular(require-localize-metadata): $localize tagged messages should contain a description
+   ╭─[require_localize_metadata.tsx:1:23]
+ 1 │ const msg = $localize`::Hello`;
+   ·                       ───────
+   ╰────
+  help: Add a description to help translators understand the context. Use the format: $localize`:description:text` or $localize`:meaning|description:text`

--- a/crates/oxc_linter/src/snapshots/angular_runtime_localize.snap
+++ b/crates/oxc_linter/src/snapshots/angular_runtime_localize.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(runtime-localize): `$localize` used at module load time
+   ╭─[runtime_localize.tsx:2:26]
+ 1 │ 
+ 2 │         const GREETING = $localize`Hello`;
+   ·                          ────────────────
+ 3 │         
+   ╰────
+  help: Move the `$localize` call inside a function, method, or getter to ensure it runs at runtime when localization data is available. Using `$localize` at module load time may cause issues if the localization data hasn't been loaded yet.
+
+  ⚠ angular(runtime-localize): `$localize` used at module load time
+   ╭─[runtime_localize.tsx:3:37]
+ 2 │         class MyComponent {
+ 3 │             static readonly TITLE = $localize`Welcome`;
+   ·                                     ──────────────────
+ 4 │         }
+   ╰────
+  help: Move the `$localize` call inside a function, method, or getter to ensure it runs at runtime when localization data is available. Using `$localize` at module load time may cause issues if the localization data hasn't been loaded yet.
+
+  ⚠ angular(runtime-localize): `$localize` used at module load time
+   ╭─[runtime_localize.tsx:3:23]
+ 2 │         class MyComponent {
+ 3 │             message = $localize`Hello World`;
+   ·                       ──────────────────────
+ 4 │         }
+   ╰────
+  help: Move the `$localize` call inside a function, method, or getter to ensure it runs at runtime when localization data is available. Using `$localize` at module load time may cause issues if the localization data hasn't been loaded yet.
+
+  ⚠ angular(runtime-localize): `$localize` used at module load time
+   ╭─[runtime_localize.tsx:2:38]
+ 1 │ 
+ 2 │         export const ERROR_MESSAGE = $localize`An error occurred`;
+   ·                                      ────────────────────────────
+ 3 │         
+   ╰────
+  help: Move the `$localize` call inside a function, method, or getter to ensure it runs at runtime when localization data is available. Using `$localize` at module load time may cause issues if the localization data hasn't been loaded yet.

--- a/crates/oxc_linter/src/snapshots/angular_sort_keys_in_type_decorator.snap
+++ b/crates/oxc_linter/src/snapshots/angular_sort_keys_in_type_decorator.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(sort-keys-in-type-decorator): Keys in @Component decorator should be ordered: selector, template
+   ╭─[sort_keys_in_type_decorator.tsx:4:13]
+ 3 │         @Component({
+ 4 │             template: '',
+   ·             ────────
+ 5 │             selector: 'app-test'
+   ╰────
+  help: Maintaining a consistent order for properties in Angular decorators makes code more predictable and easier to scan.
+
+  ⚠ angular(sort-keys-in-type-decorator): Keys in @Component decorator should be ordered: selector, template, styles
+   ╭─[sort_keys_in_type_decorator.tsx:5:13]
+ 4 │             selector: 'app-test',
+ 5 │             styles: [],
+   ·             ──────
+ 6 │             template: ''
+   ╰────
+  help: Maintaining a consistent order for properties in Angular decorators makes code more predictable and easier to scan.
+
+  ⚠ angular(sort-keys-in-type-decorator): Keys in @Directive decorator should be ordered: selector, providers
+   ╭─[sort_keys_in_type_decorator.tsx:4:13]
+ 3 │         @Directive({
+ 4 │             providers: [],
+   ·             ─────────
+ 5 │             selector: '[appTest]'
+   ╰────
+  help: Maintaining a consistent order for properties in Angular decorators makes code more predictable and easier to scan.
+
+  ⚠ angular(sort-keys-in-type-decorator): Keys in @NgModule decorator should be ordered: imports, exports
+   ╭─[sort_keys_in_type_decorator.tsx:4:13]
+ 3 │         @NgModule({
+ 4 │             exports: [],
+   ·             ───────
+ 5 │             imports: []
+   ╰────
+  help: Maintaining a consistent order for properties in Angular decorators makes code more predictable and easier to scan.
+
+  ⚠ angular(sort-keys-in-type-decorator): Keys in @Pipe decorator should be ordered: name, pure
+   ╭─[sort_keys_in_type_decorator.tsx:4:13]
+ 3 │         @Pipe({
+ 4 │             pure: true,
+   ·             ────
+ 5 │             name: 'testPipe'
+   ╰────
+  help: Maintaining a consistent order for properties in Angular decorators makes code more predictable and easier to scan.

--- a/crates/oxc_linter/src/snapshots/angular_sort_lifecycle_methods.snap
+++ b/crates/oxc_linter/src/snapshots/angular_sort_lifecycle_methods.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(sort-lifecycle-methods): Lifecycle methods are not declared in order of execution
+    ╭─[sort_lifecycle_methods.tsx:9:13]
+  8 │             ngOnDestroy() {}
+  9 │             ngOnInit() {}
+    ·             ─────────────
+ 10 │         }
+    ╰────
+  help: Declare lifecycle methods in the order they are invoked by Angular: ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → ngAfterViewInit → ngAfterViewChecked → ngOnDestroy
+
+  ⚠ angular(sort-lifecycle-methods): Lifecycle methods are not declared in order of execution
+    ╭─[sort_lifecycle_methods.tsx:9:13]
+  8 │             ngAfterViewInit() {}
+  9 │             ngOnInit() {}
+    ·             ─────────────
+ 10 │         }
+    ╰────
+  help: Declare lifecycle methods in the order they are invoked by Angular: ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → ngAfterViewInit → ngAfterViewChecked → ngOnDestroy
+
+  ⚠ angular(sort-lifecycle-methods): Lifecycle methods are not declared in order of execution
+    ╭─[sort_lifecycle_methods.tsx:9:13]
+  8 │             ngOnDestroy() {}
+  9 │             ngAfterViewInit() {}
+    ·             ────────────────────
+ 10 │             ngOnInit() {}
+    ╰────
+  help: Declare lifecycle methods in the order they are invoked by Angular: ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → ngAfterViewInit → ngAfterViewChecked → ngOnDestroy
+
+  ⚠ angular(sort-lifecycle-methods): Lifecycle methods are not declared in order of execution
+    ╭─[sort_lifecycle_methods.tsx:10:13]
+  9 │             ngAfterViewInit() {}
+ 10 │             ngOnInit() {}
+    ·             ─────────────
+ 11 │         }
+    ╰────
+  help: Declare lifecycle methods in the order they are invoked by Angular: ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → ngAfterViewInit → ngAfterViewChecked → ngOnDestroy
+
+  ⚠ angular(sort-lifecycle-methods): Lifecycle methods are not declared in order of execution
+    ╭─[sort_lifecycle_methods.tsx:9:13]
+  8 │             ngOnInit() {}
+  9 │             ngOnChanges() {}
+    ·             ────────────────
+ 10 │         }
+    ╰────
+  help: Declare lifecycle methods in the order they are invoked by Angular: ngOnChanges → ngOnInit → ngDoCheck → ngAfterContentInit → ngAfterContentChecked → ngAfterViewInit → ngAfterViewChecked → ngOnDestroy

--- a/crates/oxc_linter/src/snapshots/angular_use_component_selector.snap
+++ b/crates/oxc_linter/src/snapshots/angular_use_component_selector.snap
@@ -1,0 +1,45 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(use-component-selector): Components should have a selector
+   ╭─[use_component_selector.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               template: ''
+ 5 │ ╰─▶         })
+ 6 │             class TestComponent {}
+   ╰────
+  help: Add a `selector` property to the @Component decorator. Without a selector, the component can only be used programmatically and not in templates.
+
+  ⚠ angular(use-component-selector): Components should have a selector
+   ╭─[use_component_selector.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               selector: '',
+ 5 │ │               template: ''
+ 6 │ ╰─▶         })
+ 7 │             class TestComponent {}
+   ╰────
+  help: Add a `selector` property to the @Component decorator. Without a selector, the component can only be used programmatically and not in templates.
+
+  ⚠ angular(use-component-selector): Components should have a selector
+   ╭─[use_component_selector.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               template: '',
+ 5 │ │               standalone: true
+ 6 │ ╰─▶         })
+ 7 │             class TestComponent {}
+   ╰────
+  help: Add a `selector` property to the @Component decorator. Without a selector, the component can only be used programmatically and not in templates.
+
+  ⚠ angular(use-component-selector): Components should have a selector
+   ╭─[use_component_selector.tsx:3:9]
+ 2 │             import { Component } from '@angular/core';
+ 3 │ ╭─▶         @Component({
+ 4 │ │               templateUrl: './test.component.html'
+ 5 │ ╰─▶         })
+ 6 │             class TestComponent {}
+   ╰────
+  help: Add a `selector` property to the @Component decorator. Without a selector, the component can only be used programmatically and not in templates.

--- a/crates/oxc_linter/src/snapshots/angular_use_component_view_encapsulation.snap
+++ b/crates/oxc_linter/src/snapshots/angular_use_component_view_encapsulation.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(use-component-view-encapsulation): Avoid using `ViewEncapsulation.None`
+   ╭─[use_component_view_encapsulation.tsx:6:13]
+ 5 │             template: '',
+ 6 │             encapsulation: ViewEncapsulation.None
+   ·             ─────────────────────────────────────
+ 7 │         })
+   ╰────
+  help: Using `ViewEncapsulation.None` makes component styles global, which can lead to unintended style conflicts. Use `ViewEncapsulation.Emulated` (default) or `ViewEncapsulation.ShadowDom` instead.
+
+  ⚠ angular(use-component-view-encapsulation): Avoid using `ViewEncapsulation.None`
+   ╭─[use_component_view_encapsulation.tsx:6:13]
+ 5 │             template: '',
+ 6 │             encapsulation: 2
+   ·             ────────────────
+ 7 │         })
+   ╰────
+  help: Using `ViewEncapsulation.None` makes component styles global, which can lead to unintended style conflicts. Use `ViewEncapsulation.Emulated` (default) or `ViewEncapsulation.ShadowDom` instead.
+
+  ⚠ angular(use-component-view-encapsulation): Avoid using `ViewEncapsulation.None`
+   ╭─[use_component_view_encapsulation.tsx:7:13]
+ 6 │             standalone: true,
+ 7 │             encapsulation: ViewEncapsulation.None
+   ·             ─────────────────────────────────────
+ 8 │         })
+   ╰────
+  help: Using `ViewEncapsulation.None` makes component styles global, which can lead to unintended style conflicts. Use `ViewEncapsulation.Emulated` (default) or `ViewEncapsulation.ShadowDom` instead.

--- a/crates/oxc_linter/src/snapshots/angular_use_injectable_provided_in.snap
+++ b/crates/oxc_linter/src/snapshots/angular_use_injectable_provided_in.snap
@@ -1,0 +1,39 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(use-injectable-provided-in): Injectable should use `providedIn` for tree-shaking support
+   ╭─[use_injectable_provided_in.tsx:3:13]
+ 2 │             import { Injectable } from '@angular/core';
+ 3 │             @Injectable()
+   ·             ─────────────
+ 4 │             class MyService {}
+   ╰────
+  help: Add `providedIn: 'root'` (or 'any', 'platform') to the @Injectable decorator. This enables tree-shaking, which removes unused services from your bundle.
+
+  ⚠ angular(use-injectable-provided-in): Injectable should use `providedIn` for tree-shaking support
+   ╭─[use_injectable_provided_in.tsx:3:13]
+ 2 │             import { Injectable } from '@angular/core';
+ 3 │             @Injectable({})
+   ·             ───────────────
+ 4 │             class MyService {}
+   ╰────
+  help: Add `providedIn: 'root'` (or 'any', 'platform') to the @Injectable decorator. This enables tree-shaking, which removes unused services from your bundle.
+
+  ⚠ angular(use-injectable-provided-in): Injectable should use `providedIn` for tree-shaking support
+   ╭─[use_injectable_provided_in.tsx:3:13]
+ 2 │             import { Injectable } from '@angular/core';
+ 3 │             @Injectable({ providedIn: null })
+   ·             ─────────────────────────────────
+ 4 │             class MyService {}
+   ╰────
+  help: Add `providedIn: 'root'` (or 'any', 'platform') to the @Injectable decorator. This enables tree-shaking, which removes unused services from your bundle.
+
+  ⚠ angular(use-injectable-provided-in): Injectable should use `providedIn` for tree-shaking support
+   ╭─[use_injectable_provided_in.tsx:3:13]
+ 2 │             import { Injectable } from '@angular/core';
+ 3 │             @Injectable({ providedIn: undefined })
+   ·             ──────────────────────────────────────
+ 4 │             class MyService {}
+   ╰────
+  help: Add `providedIn: 'root'` (or 'any', 'platform') to the @Injectable decorator. This enables tree-shaking, which removes unused services from your bundle.

--- a/crates/oxc_linter/src/snapshots/angular_use_lifecycle_interface.snap
+++ b/crates/oxc_linter/src/snapshots/angular_use_lifecycle_interface.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnInit` should be implemented for method `ngOnInit`
+   ╭─[use_lifecycle_interface.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnInit() {}
+   ·             ─────────────
+ 9 │         }
+   ╰────
+  help: Add `implements OnInit` to the class declaration and import `OnInit` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnDestroy` should be implemented for method `ngOnDestroy`
+   ╭─[use_lifecycle_interface.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnDestroy() {}
+   ·             ────────────────
+ 9 │         }
+   ╰────
+  help: Add `implements OnDestroy` to the class declaration and import `OnDestroy` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `AfterViewInit` should be implemented for method `ngAfterViewInit`
+   ╭─[use_lifecycle_interface.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngAfterViewInit() {}
+   ·             ────────────────────
+ 9 │         }
+   ╰────
+  help: Add `implements AfterViewInit` to the class declaration and import `AfterViewInit` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnInit` should be implemented for method `ngOnInit`
+   ╭─[use_lifecycle_interface.tsx:7:13]
+ 6 │         class TestDirective {
+ 7 │             ngOnInit() {}
+   ·             ─────────────
+ 8 │         }
+   ╰────
+  help: Add `implements OnInit` to the class declaration and import `OnInit` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnDestroy` should be implemented for method `ngOnDestroy`
+   ╭─[use_lifecycle_interface.tsx:5:13]
+ 4 │         class TestService {
+ 5 │             ngOnDestroy() {}
+   ·             ────────────────
+ 6 │         }
+   ╰────
+  help: Add `implements OnDestroy` to the class declaration and import `OnDestroy` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnInit` should be implemented for method `ngOnInit`
+   ╭─[use_lifecycle_interface.tsx:8:13]
+ 7 │         class TestComponent {
+ 8 │             ngOnInit() {}
+   ·             ─────────────
+ 9 │             ngOnDestroy() {}
+   ╰────
+  help: Add `implements OnInit` to the class declaration and import `OnInit` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnDestroy` should be implemented for method `ngOnDestroy`
+    ╭─[use_lifecycle_interface.tsx:9:13]
+  8 │             ngOnInit() {}
+  9 │             ngOnDestroy() {}
+    ·             ────────────────
+ 10 │         }
+    ╰────
+  help: Add `implements OnDestroy` to the class declaration and import `OnDestroy` from '@angular/core'
+
+  ⚠ angular(use-lifecycle-interface): Lifecycle interface `OnDestroy` should be implemented for method `ngOnDestroy`
+    ╭─[use_lifecycle_interface.tsx:9:13]
+  8 │             ngOnInit() {}
+  9 │             ngOnDestroy() {}
+    ·             ────────────────
+ 10 │         }
+    ╰────
+  help: Add `implements OnDestroy` to the class declaration and import `OnDestroy` from '@angular/core'

--- a/crates/oxc_linter/src/snapshots/angular_use_pipe_transform_interface.snap
+++ b/crates/oxc_linter/src/snapshots/angular_use_pipe_transform_interface.snap
@@ -1,0 +1,34 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ angular(use-pipe-transform-interface): Pipes should implement `PipeTransform` interface
+   ╭─[use_pipe_transform_interface.tsx:3:9]
+ 2 │             import { Pipe } from '@angular/core';
+ 3 │ ╭─▶         @Pipe({
+ 4 │ │               name: 'myPipe'
+ 5 │ ╰─▶         })
+ 6 │             class MyPipe {
+   ╰────
+  help: Add `implements PipeTransform` to the class declaration and import `PipeTransform` from '@angular/core'. This provides type safety for the `transform` method.
+
+  ⚠ angular(use-pipe-transform-interface): Pipes should implement `PipeTransform` interface
+   ╭─[use_pipe_transform_interface.tsx:3:9]
+ 2 │             import { Pipe } from '@angular/core';
+ 3 │ ╭─▶         @Pipe({
+ 4 │ │               name: 'myPipe',
+ 5 │ │               standalone: true
+ 6 │ ╰─▶         })
+ 7 │             class MyPipe {
+   ╰────
+  help: Add `implements PipeTransform` to the class declaration and import `PipeTransform` from '@angular/core'. This provides type safety for the `transform` method.
+
+  ⚠ angular(use-pipe-transform-interface): Pipes should implement `PipeTransform` interface
+   ╭─[use_pipe_transform_interface.tsx:3:9]
+ 2 │             import { Pipe, OnDestroy } from '@angular/core';
+ 3 │ ╭─▶         @Pipe({
+ 4 │ │               name: 'myPipe'
+ 5 │ ╰─▶         })
+ 6 │             class MyPipe implements OnDestroy {
+   ╰────
+  help: Add `implements PipeTransform` to the class declaration and import `PipeTransform` from '@angular/core'. This provides type safety for the `transform` method.

--- a/crates/oxc_linter/src/utils/angular.rs
+++ b/crates/oxc_linter/src/utils/angular.rs
@@ -1,0 +1,685 @@
+//! Angular utility functions for linting rules.
+//!
+//! This module provides shared utilities for Angular-specific lint rules.
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        Argument, CallExpression, Decorator, Expression, ObjectExpression, ObjectPropertyKind,
+        PropertyKey,
+    },
+};
+use oxc_span::Span;
+
+use crate::LintContext;
+
+/// Names of legacy Angular decorators that should be replaced with signal-based APIs.
+pub const LEGACY_INPUT_DECORATORS: [&str; 6] =
+    ["Input", "Output", "ViewChild", "ViewChildren", "ContentChild", "ContentChildren"];
+
+/// Signal-based replacements for legacy decorators.
+pub const SIGNAL_REPLACEMENTS: [(&str, &str); 6] = [
+    ("Input", "input"),
+    ("Output", "output"),
+    ("ViewChild", "viewChild"),
+    ("ViewChildren", "viewChildren"),
+    ("ContentChild", "contentChild"),
+    ("ContentChildren", "contentChildren"),
+];
+
+/// Angular lifecycle methods in execution order.
+pub const ANGULAR_LIFECYCLE_METHODS: [&str; 9] = [
+    "ngOnChanges",
+    "ngOnInit",
+    "ngDoCheck",
+    "ngAfterContentInit",
+    "ngAfterContentChecked",
+    "ngAfterViewInit",
+    "ngAfterViewChecked",
+    "ngOnDestroy",
+    "ngDoBootstrap",
+];
+
+/// Lifecycle methods in execution order (for sorting).
+pub const LIFECYCLE_METHODS_ORDERED: [&str; 8] = [
+    "ngOnChanges",
+    "ngOnInit",
+    "ngDoCheck",
+    "ngAfterContentInit",
+    "ngAfterContentChecked",
+    "ngAfterViewInit",
+    "ngAfterViewChecked",
+    "ngOnDestroy",
+];
+
+/// Mapping from lifecycle method names to their corresponding interface names.
+pub const LIFECYCLE_METHOD_INTERFACES: [(&str, &str); 9] = [
+    ("ngOnChanges", "OnChanges"),
+    ("ngOnInit", "OnInit"),
+    ("ngDoCheck", "DoCheck"),
+    ("ngAfterContentInit", "AfterContentInit"),
+    ("ngAfterContentChecked", "AfterContentChecked"),
+    ("ngAfterViewInit", "AfterViewInit"),
+    ("ngAfterViewChecked", "AfterViewChecked"),
+    ("ngOnDestroy", "OnDestroy"),
+    ("ngDoBootstrap", "DoBootstrap"),
+];
+
+/// Native DOM event names that should not be used as output names.
+pub const NATIVE_EVENT_NAMES: [&str; 67] = [
+    "abort",
+    "animationcancel",
+    "animationend",
+    "animationiteration",
+    "animationstart",
+    "auxclick",
+    "beforeinput",
+    "blur",
+    "cancel",
+    "canplay",
+    "canplaythrough",
+    "change",
+    "click",
+    "close",
+    "contextmenu",
+    "copy",
+    "cuechange",
+    "cut",
+    "dblclick",
+    "drag",
+    "dragend",
+    "dragenter",
+    "dragleave",
+    "dragover",
+    "dragstart",
+    "drop",
+    "durationchange",
+    "emptied",
+    "ended",
+    "error",
+    "focus",
+    "focusin",
+    "focusout",
+    "formdata",
+    "gotpointercapture",
+    "input",
+    "invalid",
+    "keydown",
+    "keypress",
+    "keyup",
+    "load",
+    "loadeddata",
+    "loadedmetadata",
+    "loadstart",
+    "lostpointercapture",
+    "mousedown",
+    "mouseenter",
+    "mouseleave",
+    "mousemove",
+    "mouseout",
+    "mouseover",
+    "mouseup",
+    "paste",
+    "pause",
+    "play",
+    "playing",
+    "pointercancel",
+    "pointerdown",
+    "pointerenter",
+    "pointerleave",
+    "pointermove",
+    "pointerout",
+    "pointerover",
+    "pointerup",
+    "progress",
+    "ratechange",
+    "reset",
+    // Additional events follow in extension
+];
+
+/// Extended native event names (continuation).
+pub const NATIVE_EVENT_NAMES_EXTENDED: [&str; 25] = [
+    "resize",
+    "scroll",
+    "securitypolicyviolation",
+    "seeked",
+    "seeking",
+    "select",
+    "selectionchange",
+    "selectstart",
+    "slotchange",
+    "stalled",
+    "submit",
+    "suspend",
+    "timeupdate",
+    "toggle",
+    "touchcancel",
+    "touchend",
+    "touchmove",
+    "touchstart",
+    "transitioncancel",
+    "transitionend",
+    "transitionrun",
+    "transitionstart",
+    "volumechange",
+    "waiting",
+    "wheel",
+];
+
+/// Angular decorator types that support specific lifecycle methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AngularDecoratorType {
+    Component,
+    Directive,
+    Injectable,
+    Pipe,
+    NgModule,
+}
+
+/// Selector style types for validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectorStyle {
+    KebabCase,
+    CamelCase,
+}
+
+/// Selector type (element or attribute).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectorType {
+    Element,
+    Attribute,
+}
+
+/// Check if an identifier reference is imported from `@angular/core`.
+///
+/// This function verifies that an identifier with the given name is actually
+/// imported from the Angular core package, not from another library.
+pub fn is_angular_core_import(
+    ident: &oxc_ast::ast::IdentifierReference,
+    ctx: &LintContext<'_>,
+) -> bool {
+    let reference = ctx.scoping().get_reference(ident.reference_id());
+    let Some(symbol_id) = reference.symbol_id() else {
+        return false;
+    };
+
+    if !ctx.scoping().symbol_flags(symbol_id).is_import() {
+        return false;
+    }
+
+    let declaration_id = ctx.scoping().symbol_declaration(symbol_id);
+    let AstKind::ImportDeclaration(import_decl) = ctx.nodes().parent_kind(declaration_id) else {
+        return false;
+    };
+
+    import_decl.source.value.as_str() == "@angular/core"
+}
+
+/// Get the name of a decorator if it's a simple identifier or call expression.
+pub fn get_decorator_name<'a>(decorator: &'a Decorator<'a>) -> Option<&'a str> {
+    match &decorator.expression {
+        Expression::Identifier(ident) => Some(ident.name.as_str()),
+        Expression::CallExpression(call) => {
+            if let Expression::Identifier(ident) = &call.callee {
+                Some(ident.name.as_str())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Get the identifier reference from a decorator expression.
+pub fn get_decorator_identifier<'a>(
+    decorator: &'a Decorator<'a>,
+) -> Option<&'a oxc_ast::ast::IdentifierReference<'a>> {
+    match &decorator.expression {
+        Expression::Identifier(ident) => Some(ident.as_ref()),
+        Expression::CallExpression(call) => {
+            if let Expression::Identifier(ident) = &call.callee {
+                Some(ident.as_ref())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Get the call expression from a decorator if it's a call.
+pub fn get_decorator_call<'a>(decorator: &'a Decorator<'a>) -> Option<&'a CallExpression<'a>> {
+    if let Expression::CallExpression(call) = &decorator.expression {
+        Some(call.as_ref())
+    } else {
+        None
+    }
+}
+
+/// Extract the metadata object from a `@Component` or `@Directive` decorator.
+pub fn get_component_metadata<'a>(
+    decorator: &'a Decorator<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let call = get_decorator_call(decorator)?;
+
+    // The metadata object should be the first argument
+    let first_arg = call.arguments.first()?;
+
+    if let Argument::ObjectExpression(obj) = first_arg { Some(obj.as_ref()) } else { None }
+}
+
+/// Get a property value from a metadata object by key name.
+/// Supports identifier keys, string literal keys, and computed keys with string/template literals.
+pub fn get_metadata_property<'a>(
+    obj: &'a ObjectExpression<'a>,
+    key: &str,
+) -> Option<&'a Expression<'a>> {
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property {
+            let key_matches = match &prop.key {
+                // Standard identifier key: `changeDetection: value`
+                PropertyKey::StaticIdentifier(ident) => ident.name.as_str() == key,
+                // String literal key: `'changeDetection': value`
+                PropertyKey::StringLiteral(lit) => lit.value.as_str() == key,
+                _ => {
+                    // For computed keys, check the expression
+                    if prop.computed {
+                        match prop.key.as_expression() {
+                            // Computed string literal: `['changeDetection']: value`
+                            Some(Expression::StringLiteral(lit)) => lit.value.as_str() == key,
+                            // Computed template literal with no expressions: `[\`changeDetection\`]: value`
+                            Some(Expression::TemplateLiteral(tpl))
+                                if tpl.expressions.is_empty() =>
+                            {
+                                tpl.quasis.first().is_some_and(|q| q.value.raw.as_str() == key)
+                            }
+                            _ => false,
+                        }
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if key_matches {
+                return Some(&prop.value);
+            }
+        }
+    }
+    None
+}
+
+/// Get the signal replacement function name for a legacy decorator.
+pub fn get_signal_replacement(decorator_name: &str) -> Option<&'static str> {
+    SIGNAL_REPLACEMENTS
+        .iter()
+        .find(|(legacy, _)| *legacy == decorator_name)
+        .map(|(_, signal)| *signal)
+}
+
+/// Check if a decorator is a legacy Angular decorator that should be replaced.
+pub fn is_legacy_angular_decorator(name: &str) -> bool {
+    LEGACY_INPUT_DECORATORS.contains(&name)
+}
+
+/// Get the corresponding interface name for a lifecycle method.
+pub fn get_lifecycle_interface_for_method(method: &str) -> Option<&'static str> {
+    LIFECYCLE_METHOD_INTERFACES.iter().find(|(m, _)| *m == method).map(|(_, interface)| *interface)
+}
+
+/// Check if a method name is an Angular lifecycle method.
+pub fn is_lifecycle_method(name: &str) -> bool {
+    ANGULAR_LIFECYCLE_METHODS.contains(&name)
+}
+
+/// Check if a name is a native DOM event name.
+pub fn is_native_event_name(name: &str) -> bool {
+    NATIVE_EVENT_NAMES.contains(&name) || NATIVE_EVENT_NAMES_EXTENDED.contains(&name)
+}
+
+/// Get the order index of a lifecycle method for sorting purposes.
+pub fn get_lifecycle_method_order(name: &str) -> Option<usize> {
+    LIFECYCLE_METHODS_ORDERED.iter().position(|&m| m == name)
+}
+
+/// Check if a lifecycle method is valid for a given decorator type.
+pub fn is_lifecycle_valid_for_decorator(method: &str, decorator: AngularDecoratorType) -> bool {
+    match decorator {
+        AngularDecoratorType::Component | AngularDecoratorType::Directive => {
+            // Components and Directives support all lifecycle methods except ngDoBootstrap
+            method != "ngDoBootstrap" && is_lifecycle_method(method)
+        }
+        AngularDecoratorType::Injectable | AngularDecoratorType::Pipe => {
+            // Injectables and Pipes only support ngOnDestroy
+            method == "ngOnDestroy"
+        }
+        AngularDecoratorType::NgModule => {
+            // NgModules only support ngDoBootstrap
+            method == "ngDoBootstrap"
+        }
+    }
+}
+
+/// Check if a string matches kebab-case format.
+pub fn is_kebab_case(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.chars().all(|c| c.is_ascii_lowercase() || c == '-' || c.is_ascii_digit())
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+        && !s.contains("--")
+}
+
+/// Check if a string matches camelCase format.
+pub fn is_camel_case(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let first = s.chars().next().unwrap();
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    // No hyphens or underscores in camelCase
+    !s.contains('-') && !s.contains('_')
+}
+
+/// Check if a selector matches the specified style.
+pub fn check_selector_style(selector: &str, style: SelectorStyle) -> bool {
+    match style {
+        SelectorStyle::KebabCase => is_kebab_case(selector),
+        SelectorStyle::CamelCase => is_camel_case(selector),
+    }
+}
+
+/// Check if a selector starts with one of the specified prefixes.
+pub fn check_selector_prefix(selector: &str, prefixes: &[&str]) -> bool {
+    if prefixes.is_empty() {
+        return true;
+    }
+    prefixes.iter().any(|prefix| {
+        if let Some(rest) = selector.strip_prefix(prefix) {
+            // Check that after the prefix, either:
+            // - The selector ends (exact match)
+            // - The next char is uppercase (for camelCase: appButton)
+            // - The next char is '-' (for kebab-case: app-button)
+            rest.is_empty()
+                || rest.starts_with('-')
+                || rest.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        } else {
+            false
+        }
+    })
+}
+
+/// Parse a selector to determine its type (element vs attribute).
+pub fn parse_selector_type(selector: &str) -> Option<SelectorType> {
+    let trimmed = selector.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Attribute selector: [attrName] or [attr][other]
+    if trimmed.starts_with('[') {
+        return Some(SelectorType::Attribute);
+    }
+
+    // Element selector: element-name or element-name[attr]
+    if trimmed.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        return Some(SelectorType::Element);
+    }
+
+    None
+}
+
+/// Extract the main selector name from a potentially complex selector.
+/// For "[appDir]" returns "appDir", for "app-comp" returns "app-comp".
+pub fn extract_selector_name(selector: &str) -> Option<&str> {
+    let trimmed = selector.trim();
+
+    // Handle attribute selectors
+    if trimmed.starts_with('[') {
+        let end = trimmed.find(']')?;
+        let name = &trimmed[1..end];
+        // Handle [attr=value] format
+        if let Some(eq_pos) = name.find('=') {
+            return Some(&name[..eq_pos]);
+        }
+        return Some(name);
+    }
+
+    // Handle element selectors
+    // Find where the element name ends (at '[', '.', '#', ':' or end)
+    let end_chars = ['[', '.', '#', ':'];
+    let end_pos = trimmed.find(|c| end_chars.contains(&c)).unwrap_or(trimmed.len());
+    let name = &trimmed[..end_pos];
+
+    if name.is_empty() { None } else { Some(name) }
+}
+
+/// Check if an output name starts with "on" prefix.
+pub fn has_on_prefix(name: &str) -> bool {
+    if !name.starts_with("on") {
+        return false;
+    }
+    // "on" alone is not allowed
+    if name.len() == 2 {
+        return true;
+    }
+    // "onX" where X is not lowercase is not allowed (e.g., "onClick", "onBlur")
+    name.chars().nth(2).is_some_and(|c| !c.is_ascii_lowercase())
+}
+
+/// Find the span of a property key in an object expression.
+pub fn find_property_key_span(obj: &ObjectExpression<'_>, key: &str) -> Option<Span> {
+    use oxc_span::GetSpan;
+
+    for property in &obj.properties {
+        if let ObjectPropertyKind::ObjectProperty(prop) = property
+            && let PropertyKey::StaticIdentifier(ident) = &prop.key
+                && ident.name.as_str() == key {
+                    return Some(ident.span());
+                }
+    }
+    None
+}
+
+/// Get the string value from a metadata property if it's a string literal or static template literal.
+pub fn get_metadata_string_value<'a>(obj: &'a ObjectExpression<'a>, key: &str) -> Option<&'a str> {
+    let value = get_metadata_property(obj, key)?;
+    match value {
+        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        Expression::TemplateLiteral(lit) => {
+            // Only handle static templates (no expressions)
+            if lit.expressions.is_empty() && lit.quasis.len() == 1 {
+                Some(lit.quasis[0].value.raw.as_str())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Check if a class implements a specific interface by checking the implements clause.
+pub fn class_implements_interface(class: &oxc_ast::ast::Class<'_>, interface_name: &str) -> bool {
+    if class.implements.is_empty() {
+        return false;
+    }
+
+    class.implements.iter().any(|ts_impl| {
+        if let oxc_ast::ast::TSTypeName::IdentifierReference(ident) = &ts_impl.expression {
+            return ident.name.as_str() == interface_name;
+        }
+        false
+    })
+}
+
+/// Get the decorator type from a decorator name.
+pub fn get_decorator_type(name: &str) -> Option<AngularDecoratorType> {
+    match name {
+        "Component" => Some(AngularDecoratorType::Component),
+        "Directive" => Some(AngularDecoratorType::Directive),
+        "Injectable" => Some(AngularDecoratorType::Injectable),
+        "Pipe" => Some(AngularDecoratorType::Pipe),
+        "NgModule" => Some(AngularDecoratorType::NgModule),
+        _ => None,
+    }
+}
+
+/// Find Angular decorators on a class.
+pub fn get_class_angular_decorator<'a, 'b>(
+    class: &'b oxc_ast::ast::Class<'a>,
+    ctx: &'b LintContext<'a>,
+) -> Option<(AngularDecoratorType, &'b Decorator<'a>)> {
+    for decorator in &class.decorators {
+        let Some(name) = get_decorator_name(decorator) else {
+            continue;
+        };
+        let Some(decorator_type) = get_decorator_type(name) else {
+            continue;
+        };
+        // Verify it's from @angular/core
+        let Some(ident) = get_decorator_identifier(decorator) else {
+            continue;
+        };
+        if is_angular_core_import(ident, ctx) {
+            return Some((decorator_type, decorator));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_legacy_angular_decorator() {
+        assert!(is_legacy_angular_decorator("Input"));
+        assert!(is_legacy_angular_decorator("Output"));
+        assert!(is_legacy_angular_decorator("ViewChild"));
+        assert!(!is_legacy_angular_decorator("Component"));
+        assert!(!is_legacy_angular_decorator("Injectable"));
+    }
+
+    #[test]
+    fn test_get_signal_replacement() {
+        assert_eq!(get_signal_replacement("Input"), Some("input"));
+        assert_eq!(get_signal_replacement("Output"), Some("output"));
+        assert_eq!(get_signal_replacement("ViewChild"), Some("viewChild"));
+        assert_eq!(get_signal_replacement("Unknown"), None);
+    }
+
+    #[test]
+    fn test_is_lifecycle_method() {
+        assert!(is_lifecycle_method("ngOnInit"));
+        assert!(is_lifecycle_method("ngOnDestroy"));
+        assert!(is_lifecycle_method("ngAfterViewInit"));
+        assert!(!is_lifecycle_method("onClick"));
+        assert!(!is_lifecycle_method("constructor"));
+    }
+
+    #[test]
+    fn test_get_lifecycle_interface() {
+        assert_eq!(get_lifecycle_interface_for_method("ngOnInit"), Some("OnInit"));
+        assert_eq!(get_lifecycle_interface_for_method("ngOnDestroy"), Some("OnDestroy"));
+        assert_eq!(get_lifecycle_interface_for_method("ngOnChanges"), Some("OnChanges"));
+        assert_eq!(get_lifecycle_interface_for_method("unknown"), None);
+    }
+
+    #[test]
+    fn test_is_native_event_name() {
+        assert!(is_native_event_name("click"));
+        assert!(is_native_event_name("blur"));
+        assert!(is_native_event_name("change"));
+        assert!(is_native_event_name("wheel"));
+        assert!(!is_native_event_name("customEvent"));
+        assert!(!is_native_event_name("valueChange"));
+    }
+
+    #[test]
+    fn test_is_kebab_case() {
+        assert!(is_kebab_case("my-component"));
+        assert!(is_kebab_case("app-header"));
+        assert!(is_kebab_case("app-header-nav"));
+        assert!(!is_kebab_case("myComponent"));
+        assert!(!is_kebab_case("MyComponent"));
+        assert!(!is_kebab_case("-invalid"));
+        assert!(!is_kebab_case("invalid-"));
+        assert!(!is_kebab_case("my--component"));
+    }
+
+    #[test]
+    fn test_is_camel_case() {
+        assert!(is_camel_case("myComponent"));
+        assert!(is_camel_case("appHeader"));
+        assert!(is_camel_case("component"));
+        assert!(!is_camel_case("MyComponent"));
+        assert!(!is_camel_case("my-component"));
+        assert!(!is_camel_case("my_component"));
+    }
+
+    #[test]
+    fn test_check_selector_prefix() {
+        assert!(check_selector_prefix("app-header", &["app"]));
+        assert!(check_selector_prefix("appHeader", &["app"]));
+        assert!(check_selector_prefix("my-component", &["app", "my"]));
+        assert!(!check_selector_prefix("other-header", &["app"]));
+        // With empty prefixes, everything passes
+        assert!(check_selector_prefix("any-thing", &[]));
+    }
+
+    #[test]
+    fn test_parse_selector_type() {
+        assert_eq!(parse_selector_type("app-component"), Some(SelectorType::Element));
+        assert_eq!(parse_selector_type("[appDir]"), Some(SelectorType::Attribute));
+        assert_eq!(parse_selector_type("  app-component  "), Some(SelectorType::Element));
+        assert_eq!(parse_selector_type(""), None);
+    }
+
+    #[test]
+    fn test_extract_selector_name() {
+        assert_eq!(extract_selector_name("app-component"), Some("app-component"));
+        assert_eq!(extract_selector_name("[appDir]"), Some("appDir"));
+        assert_eq!(extract_selector_name("[attr=value]"), Some("attr"));
+        assert_eq!(extract_selector_name("app[attr]"), Some("app"));
+    }
+
+    #[test]
+    fn test_has_on_prefix() {
+        assert!(has_on_prefix("onClick"));
+        assert!(has_on_prefix("onBlur"));
+        assert!(has_on_prefix("on"));
+        assert!(!has_on_prefix("online"));
+        assert!(!has_on_prefix("opened"));
+        assert!(!has_on_prefix("valueChange"));
+    }
+
+    #[test]
+    fn test_get_decorator_type() {
+        assert_eq!(get_decorator_type("Component"), Some(AngularDecoratorType::Component));
+        assert_eq!(get_decorator_type("Directive"), Some(AngularDecoratorType::Directive));
+        assert_eq!(get_decorator_type("Injectable"), Some(AngularDecoratorType::Injectable));
+        assert_eq!(get_decorator_type("Unknown"), None);
+    }
+
+    #[test]
+    fn test_lifecycle_valid_for_decorator() {
+        // Component supports all except ngDoBootstrap
+        assert!(is_lifecycle_valid_for_decorator("ngOnInit", AngularDecoratorType::Component));
+        assert!(is_lifecycle_valid_for_decorator("ngOnDestroy", AngularDecoratorType::Component));
+        assert!(!is_lifecycle_valid_for_decorator(
+            "ngDoBootstrap",
+            AngularDecoratorType::Component
+        ));
+
+        // Injectable only supports ngOnDestroy
+        assert!(!is_lifecycle_valid_for_decorator("ngOnInit", AngularDecoratorType::Injectable));
+        assert!(is_lifecycle_valid_for_decorator("ngOnDestroy", AngularDecoratorType::Injectable));
+
+        // NgModule only supports ngDoBootstrap
+        assert!(is_lifecycle_valid_for_decorator("ngDoBootstrap", AngularDecoratorType::NgModule));
+        assert!(!is_lifecycle_valid_for_decorator("ngOnInit", AngularDecoratorType::NgModule));
+    }
+}

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -11,6 +11,7 @@ use oxc_allocator::Allocator;
 use oxc_span::Span;
 use oxc_syntax::identifier::{is_identifier_part, is_identifier_start};
 
+mod angular;
 mod comment;
 mod config;
 mod express;
@@ -28,8 +29,8 @@ mod vitest;
 mod vue;
 
 pub use self::{
-    comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*,
-    react_perf::*, regex::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
+    angular::*, comment::*, config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*,
+    react::*, react_perf::*, regex::*, typescript::*, unicorn::*, url::*, vitest::*, vue::*,
 };
 
 /// List of Jest rules that have Vitest equivalents.

--- a/justfile
+++ b/justfile
@@ -188,6 +188,7 @@ new-n-rule name: (new-rule name "n")
 new-promise-rule name: (new-rule name "promise")
 new-vitest-rule name: (new-rule name "vitest")
 new-vue-rule name: (new-rule name "vue")
+new-angular-rule name: (new-rule name "angular")
 
 # Alias for backward compatibility
 alias new-typescript-rule := new-ts-rule

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -396,7 +396,8 @@
         "react-perf",
         "promise",
         "node",
-        "vue"
+        "vue",
+        "angular"
       ]
     },
     "LintPlugins": {

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1363,6 +1363,7 @@ pub enum RuleKind {
     Promise,
     Vitest,
     Vue,
+    Angular,
 }
 
 impl TryFrom<&str> for RuleKind {
@@ -1385,6 +1386,7 @@ impl TryFrom<&str> for RuleKind {
             "promise" => Ok(Self::Promise),
             "vitest" => Ok(Self::Vitest),
             "vue" => Ok(Self::Vue),
+            "angular" => Ok(Self::Angular),
             _ => Err(format!("Invalid `RuleKind`, got `{value}`")),
         }
     }
@@ -1408,6 +1410,7 @@ impl Display for RuleKind {
             Self::Promise => "eslint-plugin-promise",
             Self::Vitest => "eslint-plugin-vitest",
             Self::Vue => "eslint-plugin-vue",
+            Self::Angular => "angular",
         };
         f.write_str(kind_name)
     }
@@ -1442,6 +1445,7 @@ fn main() {
         RuleKind::Vitest => format!("{VITEST_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Vue => format!("{VUE_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
+        RuleKind::Angular => String::new(),
     };
     let rule_src_path = match rule_kind {
         RuleKind::ESLint => format!("{ESLINT_RULES_PATH}/{kebab_rule_name}.js"),
@@ -1459,9 +1463,10 @@ fn main() {
         RuleKind::Vitest => format!("{VITEST_RULES_PATH}/{kebab_rule_name}.ts"),
         RuleKind::Vue => format!("{VUE_RULES_PATH}/{kebab_rule_name}.js"),
         RuleKind::Oxc => String::new(),
+        RuleKind::Angular => String::new(),
     };
     let language = match rule_kind {
-        RuleKind::Typescript | RuleKind::Oxc => "ts",
+        RuleKind::Typescript | RuleKind::Oxc | RuleKind::Angular => "ts",
         RuleKind::NextJS => "tsx",
         RuleKind::React | RuleKind::ReactPerf | RuleKind::JSXA11y => "jsx",
         _ => "js",
@@ -1734,6 +1739,7 @@ fn get_rule_path(rule_kind: RuleKind) -> &'static Path {
         RuleKind::Promise => Path::new("crates/oxc_linter/src/rules/promise"),
         RuleKind::Vitest => Path::new("crates/oxc_linter/src/rules/vitest"),
         RuleKind::Vue => Path::new("crates/oxc_linter/src/rules/vue"),
+        RuleKind::Angular => Path::new("crates/oxc_linter/src/rules/angular"),
     }
 }
 
@@ -1864,6 +1870,7 @@ fn get_mod_name(rule_kind: RuleKind) -> String {
         RuleKind::Vitest => "vitest".into(),
         RuleKind::Node => "node".into(),
         RuleKind::Vue => "vue".into(),
+        RuleKind::Angular => "angular".into(),
     }
 }
 
@@ -1885,6 +1892,7 @@ fn get_unsupported_rule_prefix(rule_kind: RuleKind) -> &'static str {
         RuleKind::Promise => "promise",
         RuleKind::Vitest => "vitest",
         RuleKind::Vue => "vue",
+        RuleKind::Angular => "angular",
     }
 }
 

--- a/tasks/rulegen/src/template.rs
+++ b/tasks/rulegen/src/template.rs
@@ -45,6 +45,7 @@ impl<'a> Template<'a> {
             RuleKind::Promise => Path::new("crates/oxc_linter/src/rules/promise"),
             RuleKind::Vitest => Path::new("crates/oxc_linter/src/rules/vitest"),
             RuleKind::Vue => Path::new("crates/oxc_linter/src/rules/vue"),
+            RuleKind::Angular => Path::new("crates/oxc_linter/src/rules/angular"),
         };
 
         std::fs::create_dir_all(path)?;


### PR DESCRIPTION
## Summary
- Add new Angular plugin for oxlint with 48 rules ported from angular-eslint
- Near-complete parity with angular-eslint's TypeScript rules
- Comprehensive test coverage (62 tests)

# Angular Plugin for Oxlint

This plugin provides Angular-specific linting rules for oxlint, ported from [angular-eslint](https://github.com/angular-eslint/angular-eslint).

## Implementation Status

The Angular plugin implements **48 rules** covering component/directive conventions, lifecycle methods, signals, inputs/outputs, pipes, and more. This represents near-complete parity with angular-eslint's TypeScript rules.

## Implemented Rules

### Component/Directive Rules

| Rule                                        | Category    | Description                                                           |
| ------------------------------------------- | ----------- | --------------------------------------------------------------------- |
| `component-class-suffix`                    | correctness | Ensures component classes end with 'Component' or a custom suffix     |
| `component-max-inline-declarations`         | style       | Enforces maximum lines for inline template/styles/animations          |
| `component-selector`                        | correctness | Validates component selector naming conventions (prefix, style, type) |
| `consistent-component-styles`               | style       | Enforces consistent usage of `styles`/`styleUrl`/`styleUrls`          |
| `directive-class-suffix`                    | correctness | Ensures directive classes end with 'Directive' or a custom suffix     |
| `directive-selector`                        | correctness | Validates directive selector naming conventions                       |
| `no-host-metadata-property`                 | style       | Disallows `host` metadata property in decorators                      |
| `prefer-host-metadata-property`             | style       | Prefers `host` metadata over `@HostBinding`/`@HostListener`           |
| `prefer-on-push-component-change-detection` | style       | Enforces OnPush change detection strategy                             |
| `prefer-standalone`                         | style       | Enforces standalone components (Angular 14+)                          |
| `relative-url-prefix`                       | correctness | Ensures relative URLs start with `./` or `../`                        |
| `use-component-selector`                    | correctness | Ensures components have a selector defined                            |
| `use-component-view-encapsulation`          | style       | Disallows ViewEncapsulation.None                                      |

### Lifecycle Rules

| Rule                             | Category    | Description                                           |
| -------------------------------- | ----------- | ----------------------------------------------------- |
| `contextual-lifecycle`           | correctness | Ensures lifecycle methods match the decorator context |
| `no-async-lifecycle-method`      | correctness | Disallows async lifecycle methods                     |
| `no-conflicting-lifecycle`       | correctness | Disallows implementing both DoCheck and OnChanges     |
| `no-empty-lifecycle-method`      | correctness | Disallows empty lifecycle methods                     |
| `no-lifecycle-call`              | correctness | Disallows explicit lifecycle method calls             |
| `require-lifecycle-on-prototype` | correctness | Ensures lifecycle methods on prototype, not instance  |
| `sort-lifecycle-methods`         | style       | Ensures lifecycle methods are in canonical order      |
| `use-lifecycle-interface`        | correctness | Ensures lifecycle interface implementation            |

### Signal Rules

| Rule                        | Category    | Description                                   |
| --------------------------- | ----------- | --------------------------------------------- |
| `computed-must-return`      | correctness | Ensures `computed()` signals return a value   |
| `prefer-output-emitter-ref` | style       | Prefers `output()` over `@Output()` decorator |
| `prefer-signal-model`       | style       | Suggests `model()` for input/output pairs     |
| `prefer-signals`            | style       | Enforces signal-based APIs over decorators    |

### Input/Output Rules

| Rule                           | Category    | Description                             |
| ------------------------------ | ----------- | --------------------------------------- |
| `no-input-prefix`              | style       | Disallows certain input name prefixes   |
| `no-input-rename`              | correctness | Disallows input aliasing                |
| `no-inputs-metadata-property`  | style       | Disallows `inputs` metadata property    |
| `no-output-native`             | correctness | Disallows native event names as outputs |
| `no-output-on-prefix`          | style       | Disallows "on" prefix for outputs       |
| `no-output-rename`             | correctness | Disallows output aliasing               |
| `no-outputs-metadata-property` | style       | Disallows `outputs` metadata property   |
| `prefer-output-readonly`       | correctness | Enforces readonly on outputs            |

### Pipe Rules

| Rule                           | Category    | Description                                    |
| ------------------------------ | ----------- | ---------------------------------------------- |
| `no-pipe-impure`               | style       | Disallows impure pipes                         |
| `pipe-prefix`                  | style       | Enforces pipe name prefix conventions          |
| `use-pipe-transform-interface` | correctness | Ensures PipeTransform interface implementation |

### Decorator Rules

| Rule                               | Category    | Description                                           |
| ---------------------------------- | ----------- | ----------------------------------------------------- |
| `contextual-decorator`             | correctness | Ensures decorators used in appropriate class contexts |
| `no-attribute-decorator`           | style       | Disallows `@Attribute` decorator                      |
| `no-duplicates-in-metadata-arrays` | correctness | Disallows duplicates in metadata arrays               |
| `no-queries-metadata-property`     | style       | Disallows `queries` metadata property                 |
| `sort-keys-in-type-decorator`      | style       | Orders decorator properties consistently              |

### Dependency Injection Rules

| Rule                         | Category    | Description                                   |
| ---------------------------- | ----------- | --------------------------------------------- |
| `no-forward-ref`             | style       | Disallows `forwardRef()` usage                |
| `prefer-inject`              | style       | Prefers `inject()` over constructor injection |
| `use-injectable-provided-in` | correctness | Ensures `providedIn` in `@Injectable`         |

### Localization Rules

| Rule                        | Category | Description                              |
| --------------------------- | -------- | ---------------------------------------- |
| `require-localize-metadata` | pedantic | Ensures `$localize` has metadata         |
| `runtime-localize`          | pedantic | Prevents `$localize` at module load time |

### Other Rules

| Rule                               | Category    | Description                                    |
| ---------------------------------- | ----------- | ---------------------------------------------- |
| `no-implicit-take-until-destroyed` | correctness | Requires DestroyRef for `takeUntilDestroyed()` |
| `prefer-control-flow`              | style       | Enforces `@if`/`@for`/`@switch` syntax         |

## Rules Not Implemented

The following angular-eslint rules are **not implemented** due to requiring TypeScript type information:

| Rule                   | Reason                                                          |
| ---------------------- | --------------------------------------------------------------- |
| `no-developer-preview` | Requires JSDoc/type analysis to detect `@developerPreview` tags |
| `no-experimental`      | Requires JSDoc/type analysis to detect `@experimental` tags     |
| `no-uncalled-signals`  | Requires type information to detect Signal types                |

These rules cannot be implemented without full TypeScript semantic analysis capabilities.

## Known Limitations

### General Limitations

1. **No type information**: Oxlint operates on AST only, without TypeScript's type checker. Rules requiring type inference cannot be implemented.

2. **No auto-fix**: Most rules do not support automatic fixing yet. Angular-eslint provides auto-fix for many rules.

### Rule-Specific Limitations

#### `component-selector` / `directive-selector`

- **Complex compound selectors** (e.g., `app-[custom]`, `button[appHighlight]`) are not fully supported
  - **Why**: Angular-eslint uses `CssSelector.parse()` from `@angular-eslint/bundled-angular-compiler` which contains Angular's full CSS selector parser. This parser handles all CSS selector syntax including attribute selectors, pseudo-classes, and compound selectors. Oxlint uses a simpler regex-based approach that handles common cases (element selectors, attribute selectors) but cannot parse arbitrary CSS selector combinations.
- **Multiple selector configurations in array format** not supported
  - **Why**: The angular-eslint rule supports passing an array of selector configurations (different prefixes/types per selector). The oxlint implementation only supports a single configuration object.

#### `require-lifecycle-on-prototype`

- Only detects PropertyDefinition patterns (`ngOnInit = () => {}`)
- Does not detect AssignmentExpression patterns (`this.ngOnInit = () => {}` in constructor)
  - **Why**: Angular-eslint uses ESLint's selector query system which can match AST patterns declaratively (e.g., `AssignmentExpression > MemberExpression[property.name=ngOnInit]`). Oxlint uses a visitor pattern that processes nodes individually. Detecting constructor assignments requires traversing into constructor bodies and matching specific assignment patterns, which is more complex to implement correctly and was deferred.

## Usage

To enable Angular rules in oxlint, add them to your configuration:

```json
{
  "rules": {
    "angular/component-class-suffix": "error",
    "angular/prefer-standalone": "warn",
    "angular/use-lifecycle-interface": "error"
  }
}
```

Or enable all Angular rules:

```json
{
  "plugins": ["angular"]
}
```

## Configuration Examples

### Component Selector Validation

```json
{
  "rules": {
    "angular/component-selector": [
      "error",
      {
        "type": "element",
        "prefix": "app",
        "style": "kebab-case"
      }
    ]
  }
}
```

### Directive Selector Validation

```json
{
  "rules": {
    "angular/directive-selector": [
      "error",
      {
        "type": "attribute",
        "prefix": "app",
        "style": "camelCase"
      }
    ]
  }
}
```

### Custom Class Suffixes

```json
{
  "rules": {
    "angular/component-class-suffix": [
      "error",
      {
        "suffixes": ["Component", "Page", "View"]
      }
    ]
  }
}
```

### Input Prefix Restrictions

```json
{
  "rules": {
    "angular/no-input-prefix": [
      "error",
      {
        "prefixes": ["on", "is", "can"]
      }
    ]
  }
}
```

## Contributing

When adding new Angular rules:

1. Create the rule file in `crates/oxc_linter/src/rules/angular/`
2. Register the rule in `crates/oxc_linter/src/rules/angular.rs`
3. Add comprehensive test cases (pass and fail)
4. Update this README with the rule documentation

## Reference

- [angular-eslint](https://github.com/angular-eslint/angular-eslint) - Original ESLint implementation
- [Angular Style Guide](https://angular.io/guide/styleguide) - Official Angular style guidelines


## Test plan
- [x] All 62 Angular linter tests pass (`cargo test -p oxc_linter -- angular`)
- [x] Snapshot tests included for all failing cases
- [x] Documentation added in `crates/oxc_linter/src/rules/angular/README.md`

## Notes
AI tools were used to assist with this implementation (per AI Usage Policy in CONTRIBUTING.md).