### PR TITLE
fix(ci): skip already-published npm packages instead of erroring

### DIFF
--- a/.github/scripts/check-npm-packages.js
+++ b/.github/scripts/check-npm-packages.js
@@ -12,13 +12,18 @@ const path = require("path");
  * Example: node check-npm-packages.js "release-dir/*" "napi/parser"
  */
 
-function checkPackageExists(packageName) {
+/**
+ * Query npm registry for a package version.
+ * Returns the version string if found, or null on any error (not found, network issue, etc).
+ */
+function npmViewVersion(spec) {
   try {
-    execSync(`npm view ${packageName} version`, { stdio: "pipe" });
-    return true;
-  } catch (error) {
-    console.error(`Failed to check package ${packageName}:`, error.message);
-    return false;
+    return execSync(`npm view ${spec} version`, {
+      stdio: "pipe",
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return null;
   }
 }
 
@@ -81,12 +86,20 @@ function checkPackage(packageDir, skipExistenceCheck = false) {
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
   const packageName = packageJson.name;
+  const packageVersion = packageJson.version;
+
+  // Check if this exact version is already published (single npm registry call)
+  if (npmViewVersion(`${packageName}@${packageVersion}`) === packageVersion) {
+    console.log(`⏭ ${packageName}@${packageVersion} already published, skipping.`);
+    console.log("");
+    return true;
+  }
 
   // Check if package exists on npm (unless skipped)
   if (!skipExistenceCheck) {
     console.log(`Checking if package '${packageName}' exists on npm...`);
 
-    if (!checkPackageExists(packageName)) {
+    if (!npmViewVersion(packageName)) {
       console.error(`::error::Package '${packageName}' does not exist on npm!`);
       console.log("");
       console.log(

--- a/.github/scripts/check-npm-packages.js
+++ b/.github/scripts/check-npm-packages.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
@@ -14,16 +14,21 @@ const path = require("path");
 
 /**
  * Query npm registry for a package version.
- * Returns the version string if found, or null on any error (not found, network issue, etc).
+ * Returns the version string if found, or null if the package/version does not exist.
+ * Throws on unexpected errors (network issues, auth failures, etc).
  */
 function npmViewVersion(spec) {
   try {
-    return execSync(`npm view ${spec} version`, {
+    return execFileSync("npm", ["view", spec, "version"], {
       stdio: "pipe",
       encoding: "utf-8",
     }).trim();
-  } catch {
-    return null;
+  } catch (error) {
+    // npm exits with E404 when the package or version doesn't exist
+    if (error.stderr && error.stderr.includes("E404")) {
+      return null;
+    }
+    throw error;
   }
 }
 

--- a/.github/scripts/publish-if-needed.sh
+++ b/.github/scripts/publish-if-needed.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Publish an npm package only if its version is not already on the registry.
+# Usage: bash .github/scripts/publish-if-needed.sh <pkg_dir> [publish_flags...]
+# Example: bash .github/scripts/publish-if-needed.sh npm/oxlint --provenance --access public --no-git-checks
+
+set -euo pipefail
+
+pkg_dir="$1"
+shift
+publish_flags="$*"
+
+read -r name version < <(node -e "const p=require('./${pkg_dir}/package.json'); console.log(p.name+' '+p.version)")
+
+published=$(npm view "${name}@${version}" version 2>/dev/null || true)
+if [ "$published" = "$version" ]; then
+  echo "⏭ ${name}@${version} already published, skipping."
+  exit 0
+fi
+
+pnpm publish "${pkg_dir}/" ${publish_flags}

--- a/.github/scripts/publish-if-needed.sh
+++ b/.github/scripts/publish-if-needed.sh
@@ -7,14 +7,18 @@ set -euo pipefail
 
 pkg_dir="$1"
 shift
-publish_flags="$*"
 
 read -r name version < <(node -e "const p=require('./${pkg_dir}/package.json'); console.log(p.name+' '+p.version)")
 
-published=$(npm view "${name}@${version}" version 2>/dev/null || true)
-if [ "$published" = "$version" ]; then
-  echo "⏭ ${name}@${version} already published, skipping."
-  exit 0
+if published=$(npm view "${name}@${version}" version 2>&1); then
+  if [ "$published" = "$version" ]; then
+    echo "⏭ ${name}@${version} already published, skipping."
+    exit 0
+  fi
+else
+  # npm view failed — log the error but continue to publish (which will
+  # produce a clear error if the registry is actually unreachable).
+  echo "⚠ npm view ${name}@${version} failed: ${published}"
 fi
 
-pnpm publish "${pkg_dir}/" ${publish_flags}
+pnpm publish "${pkg_dir}/" "$@"

--- a/.github/scripts/publish-if-needed.sh
+++ b/.github/scripts/publish-if-needed.sh
@@ -10,15 +10,19 @@ shift
 
 read -r name version < <(node -e "const p=require('./${pkg_dir}/package.json'); console.log(p.name+' '+p.version)")
 
-if published=$(npm view "${name}@${version}" version 2>&1); then
+npm_stderr=$(mktemp)
+if published=$(npm view "${name}@${version}" version 2>"$npm_stderr"); then
   if [ "$published" = "$version" ]; then
+    rm -f "$npm_stderr"
     echo "⏭ ${name}@${version} already published, skipping."
     exit 0
   fi
 else
   # npm view failed — log the error but continue to publish (which will
   # produce a clear error if the registry is actually unreachable).
-  echo "⚠ npm view ${name}@${version} failed: ${published}"
+  echo "⚠ npm view ${name}@${version} failed:"
+  cat "$npm_stderr" >&2
 fi
+rm -f "$npm_stderr"
 
 pnpm publish "${pkg_dir}/" "$@"

--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -325,11 +325,11 @@ jobs:
           # Publish sub-packages and adds `optionalDependencies` to main package.
           pnpm napi pre-publish --no-gh-release -t npm --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
           # Publish `oxlint` package
-          pnpm publish ${package_path}/ ${PUBLISH_FLAGS}
+          bash .github/scripts/publish-if-needed.sh ${package_path} ${PUBLISH_FLAGS}
           # Publish `@oxlint/plugins` package
-          pnpm publish ${plugins_package_path}/ ${PUBLISH_FLAGS}
+          bash .github/scripts/publish-if-needed.sh ${plugins_package_path} ${PUBLISH_FLAGS}
           # Publish `oxlint-plugin-eslint` package
-          pnpm publish ${plugin_eslint_package_path}/ ${PUBLISH_FLAGS}
+          bash .github/scripts/publish-if-needed.sh ${plugin_eslint_package_path} ${PUBLISH_FLAGS}
 
   build-oxfmt:
     needs: check
@@ -604,7 +604,7 @@ jobs:
           # Trusted publishing is configured, publish token is not required.
           # Publish sub-packages and adds `optionalDependencies` to main package.
           pnpm napi pre-publish --no-gh-release -t npm --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
-          pnpm publish ${package_path}/ ${PUBLISH_FLAGS}
+          bash .github/scripts/publish-if-needed.sh ${package_path} ${PUBLISH_FLAGS}
 
   github-release:
     name: GitHub Release

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -256,4 +256,4 @@ jobs:
           # Trusted publishing is configured, publish token is not required.
           # Publish sub-packages and adds `optionalDependencies` to `package_path`.
           pnpm napi pre-publish --no-gh-release -t npm --package-json-path ${package_path}/package.json --npm-dir ${npm_dir}
-          pnpm publish ${package_path}/ ${PUBLISH_FLAGS}
+          bash .github/scripts/publish-if-needed.sh ${package_path} ${PUBLISH_FLAGS}


### PR DESCRIPTION
## Summary

- CI publish workflow fails when re-run after a partial publish because npm rejects republishing an existing version
- Add version-published checks to `check-npm-packages.js` so already-published packages are skipped in the dry-run step
- Extract a shared `publish-if-needed.sh` script that checks the npm registry before publishing, used by all three trusted publish steps
- Consolidate the old `checkPackageExists` and new version check into a single `npmViewVersion` helper to avoid redundant npm registry calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)