### PR TITLE
perf(oxfmt): Try rust printer for .json

### DIFF
--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -29,6 +29,14 @@ type Source = {
 
 const categories: Category[] = [
   {
+    name: "json",
+    sources: [
+      { dir: PRETTIER_FIXTURES_DIR, ext: ".json" },
+      { dir: join(EDGE_CASES_DIR, "json") },
+    ],
+    optionSets: [{ printWidth: 80 }, { printWidth: 100 }],
+  },
+  {
     name: "js-in-vue",
     sources: [
       { dir: PRETTIER_FIXTURES_DIR, ext: ".vue" },

--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -30,10 +30,7 @@ type Source = {
 const categories: Category[] = [
   {
     name: "json",
-    sources: [
-      { dir: PRETTIER_FIXTURES_DIR, ext: ".json" },
-      { dir: join(EDGE_CASES_DIR, "json") },
-    ],
+    sources: [{ dir: PRETTIER_FIXTURES_DIR, ext: ".json" }, { dir: join(EDGE_CASES_DIR, "json") }],
     optionSets: [{ printWidth: 80 }, { printWidth: 100 }],
   },
   {

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -1,3 +1,27 @@
+## json
+
+### Option 1: 47/49 (95.92%)
+
+```json
+{"printWidth":80}
+```
+
+| File | Note |
+| :--- | :--- |
+| [json/json/json6.json](diffs/json/json__json__json6.json.md) |  |
+| [json/json/pass1.json](diffs/json/json__json__pass1.json.md) |  |
+
+### Option 2: 47/49 (95.92%)
+
+```json
+{"printWidth":100}
+```
+
+| File | Note |
+| :--- | :--- |
+| [json/json/json6.json](diffs/json/json__json__json6.json.md) |  |
+| [json/json/pass1.json](diffs/json/json__json__pass1.json.md) |  |
+
 ## js-in-vue
 
 ### Option 1: 423/425 (99.53%)

--- a/apps/oxfmt/conformance/snapshots/diffs/json/json__json__json6.json.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/json/json__json__json6.json.md
@@ -1,0 +1,295 @@
+# json/json/json6.json
+
+## Option 1
+
+`````json
+{"printWidth":80}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -2,9 +2,8 @@
+   {
+     "//": "Keyword `undefined`",
+     "data": [{ "undefined": undefined }, undefined, [undefined]]
+   },
+-
+   {
+     "//": "back-tick quoted strings",
+     "data": [
+       ``,
+@@ -15,11 +14,9 @@
+       `\u{1F409}\`'"\${}`,
+       { "as-object-value": `foo` }
+     ]
+   },
+-
+   { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+-
+   {
+     "//": "Numbers",
+     "data": [
+       0o123,
+@@ -43,7 +40,6 @@
+       -123_456,
+       -0xdeed_beef
+     ]
+   },
+-
+   { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+ ]
+
+`````
+
+### Actual (oxfmt)
+
+`````json
+[
+  {
+    "//": "Keyword `undefined`",
+    "data": [{ "undefined": undefined }, undefined, [undefined]]
+  },
+  {
+    "//": "back-tick quoted strings",
+    "data": [
+      ``,
+      `foo`,
+      `
+  multiple-line
+`,
+      `\u{1F409}\`'"\${}`,
+      { "as-object-value": `foo` }
+    ]
+  },
+  { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+  {
+    "//": "Numbers",
+    "data": [
+      0o123,
+      0b101010,
+      1e5,
+      123_456,
+      0xdeed_beef,
+      0123,
+      -Infinity,
+      -NaN,
+      +1,
+      -1,
+      +0o123,
+      +0b101010,
+      +1e5,
+      +123_456,
+      +0xdeed_beef,
+      -0o123,
+      -0b101010,
+      -1e5,
+      -123_456,
+      -0xdeed_beef
+    ]
+  },
+  { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+]
+
+`````
+
+### Expected (prettier)
+
+`````json
+[
+  {
+    "//": "Keyword `undefined`",
+    "data": [{ "undefined": undefined }, undefined, [undefined]]
+  },
+
+  {
+    "//": "back-tick quoted strings",
+    "data": [
+      ``,
+      `foo`,
+      `
+  multiple-line
+`,
+      `\u{1F409}\`'"\${}`,
+      { "as-object-value": `foo` }
+    ]
+  },
+
+  { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+
+  {
+    "//": "Numbers",
+    "data": [
+      0o123,
+      0b101010,
+      1e5,
+      123_456,
+      0xdeed_beef,
+      0123,
+      -Infinity,
+      -NaN,
+      +1,
+      -1,
+      +0o123,
+      +0b101010,
+      +1e5,
+      +123_456,
+      +0xdeed_beef,
+      -0o123,
+      -0b101010,
+      -1e5,
+      -123_456,
+      -0xdeed_beef
+    ]
+  },
+
+  { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+]
+
+`````
+
+## Option 2
+
+`````json
+{"printWidth":100}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -1,7 +1,6 @@
+ [
+   { "//": "Keyword `undefined`", "data": [{ "undefined": undefined }, undefined, [undefined]] },
+-
+   {
+     "//": "back-tick quoted strings",
+     "data": [
+       ``,
+@@ -12,11 +11,9 @@
+       `\u{1F409}\`'"\${}`,
+       { "as-object-value": `foo` }
+     ]
+   },
+-
+   { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+-
+   {
+     "//": "Numbers",
+     "data": [
+       0o123,
+@@ -40,7 +37,6 @@
+       -123_456,
+       -0xdeed_beef
+     ]
+   },
+-
+   { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+ ]
+
+`````
+
+### Actual (oxfmt)
+
+`````json
+[
+  { "//": "Keyword `undefined`", "data": [{ "undefined": undefined }, undefined, [undefined]] },
+  {
+    "//": "back-tick quoted strings",
+    "data": [
+      ``,
+      `foo`,
+      `
+  multiple-line
+`,
+      `\u{1F409}\`'"\${}`,
+      { "as-object-value": `foo` }
+    ]
+  },
+  { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+  {
+    "//": "Numbers",
+    "data": [
+      0o123,
+      0b101010,
+      1e5,
+      123_456,
+      0xdeed_beef,
+      0123,
+      -Infinity,
+      -NaN,
+      +1,
+      -1,
+      +0o123,
+      +0b101010,
+      +1e5,
+      +123_456,
+      +0xdeed_beef,
+      -0o123,
+      -0b101010,
+      -1e5,
+      -123_456,
+      -0xdeed_beef
+    ]
+  },
+  { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+]
+
+`````
+
+### Expected (prettier)
+
+`````json
+[
+  { "//": "Keyword `undefined`", "data": [{ "undefined": undefined }, undefined, [undefined]] },
+
+  {
+    "//": "back-tick quoted strings",
+    "data": [
+      ``,
+      `foo`,
+      `
+  multiple-line
+`,
+      `\u{1F409}\`'"\${}`,
+      { "as-object-value": `foo` }
+    ]
+  },
+
+  { "//": "String escapes ", "data": ["\0", "\xFF", "\u00FF", `\u{1F409}`] },
+
+  {
+    "//": "Numbers",
+    "data": [
+      0o123,
+      0b101010,
+      1e5,
+      123_456,
+      0xdeed_beef,
+      0123,
+      -Infinity,
+      -NaN,
+      +1,
+      -1,
+      +0o123,
+      +0b101010,
+      +1e5,
+      +123_456,
+      +0xdeed_beef,
+      -0o123,
+      -0b101010,
+      -1e5,
+      -123_456,
+      -0xdeed_beef
+    ]
+  },
+
+  { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
+]
+
+`````

--- a/apps/oxfmt/conformance/snapshots/diffs/json/json__json__pass1.json.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/json/json__json__pass1.json.md
@@ -1,0 +1,313 @@
+# json/json/pass1.json
+
+## Option 1
+
+`````json
+{"printWidth":80}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -47,9 +47,8 @@
+   },
+   0.5,
+   98.6,
+   99.44,
+-
+   1066,
+   1e1,
+   0.1e1,
+   1e-1,
+
+`````
+
+### Actual (oxfmt)
+
+`````json
+[
+  "JSON Test Pattern pass1",
+  { "object with 1 member": ["array with 1 element"] },
+  {},
+  [],
+  -42,
+  true,
+  false,
+  null,
+  {
+    "integer": 1234567890,
+    "real": -9876.54321,
+    "e": 0.123456789e-12,
+    "E": 1.23456789e34,
+    "": 23456789012e66,
+    "zero": 0,
+    "one": 1,
+    "space": " ",
+    "quote": "\"",
+    "backslash": "\\",
+    "controls": "\b\f\n\r\t",
+    "slash": "/ & \/",
+    "alpha": "abcdefghijklmnopqrstuvwyz",
+    "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+    "digit": "0123456789",
+    "0123456789": "digit",
+    "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+    "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
+    "true": true,
+    "false": false,
+    "null": null,
+    "array": [],
+    "object": {},
+    "address": "50 St. James Street",
+    "url": "http://www.JSON.org/",
+    "comment": "// /* <!-- --",
+    "# -- --> */": " ",
+    " s p a c e d ": [
+      1, 2, 3,
+
+      4, 5, 6, 7
+    ],
+    "compact": [1, 2, 3, 4, 5, 6, 7],
+    "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
+    "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+  },
+  0.5,
+  98.6,
+  99.44,
+  1066,
+  1e1,
+  0.1e1,
+  1e-1,
+  1,
+  2,
+  2,
+  "rosebud"
+]
+
+`````
+
+### Expected (prettier)
+
+`````json
+[
+  "JSON Test Pattern pass1",
+  { "object with 1 member": ["array with 1 element"] },
+  {},
+  [],
+  -42,
+  true,
+  false,
+  null,
+  {
+    "integer": 1234567890,
+    "real": -9876.54321,
+    "e": 0.123456789e-12,
+    "E": 1.23456789e34,
+    "": 23456789012e66,
+    "zero": 0,
+    "one": 1,
+    "space": " ",
+    "quote": "\"",
+    "backslash": "\\",
+    "controls": "\b\f\n\r\t",
+    "slash": "/ & \/",
+    "alpha": "abcdefghijklmnopqrstuvwyz",
+    "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+    "digit": "0123456789",
+    "0123456789": "digit",
+    "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+    "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
+    "true": true,
+    "false": false,
+    "null": null,
+    "array": [],
+    "object": {},
+    "address": "50 St. James Street",
+    "url": "http://www.JSON.org/",
+    "comment": "// /* <!-- --",
+    "# -- --> */": " ",
+    " s p a c e d ": [
+      1, 2, 3,
+
+      4, 5, 6, 7
+    ],
+    "compact": [1, 2, 3, 4, 5, 6, 7],
+    "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
+    "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+  },
+  0.5,
+  98.6,
+  99.44,
+
+  1066,
+  1e1,
+  0.1e1,
+  1e-1,
+  1,
+  2,
+  2,
+  "rosebud"
+]
+
+`````
+
+## Option 2
+
+`````json
+{"printWidth":100}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -47,9 +47,8 @@
+   },
+   0.5,
+   98.6,
+   99.44,
+-
+   1066,
+   1e1,
+   0.1e1,
+   1e-1,
+
+`````
+
+### Actual (oxfmt)
+
+`````json
+[
+  "JSON Test Pattern pass1",
+  { "object with 1 member": ["array with 1 element"] },
+  {},
+  [],
+  -42,
+  true,
+  false,
+  null,
+  {
+    "integer": 1234567890,
+    "real": -9876.54321,
+    "e": 0.123456789e-12,
+    "E": 1.23456789e34,
+    "": 23456789012e66,
+    "zero": 0,
+    "one": 1,
+    "space": " ",
+    "quote": "\"",
+    "backslash": "\\",
+    "controls": "\b\f\n\r\t",
+    "slash": "/ & \/",
+    "alpha": "abcdefghijklmnopqrstuvwyz",
+    "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+    "digit": "0123456789",
+    "0123456789": "digit",
+    "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+    "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
+    "true": true,
+    "false": false,
+    "null": null,
+    "array": [],
+    "object": {},
+    "address": "50 St. James Street",
+    "url": "http://www.JSON.org/",
+    "comment": "// /* <!-- --",
+    "# -- --> */": " ",
+    " s p a c e d ": [
+      1, 2, 3,
+
+      4, 5, 6, 7
+    ],
+    "compact": [1, 2, 3, 4, 5, 6, 7],
+    "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
+    "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+  },
+  0.5,
+  98.6,
+  99.44,
+  1066,
+  1e1,
+  0.1e1,
+  1e-1,
+  1,
+  2,
+  2,
+  "rosebud"
+]
+
+`````
+
+### Expected (prettier)
+
+`````json
+[
+  "JSON Test Pattern pass1",
+  { "object with 1 member": ["array with 1 element"] },
+  {},
+  [],
+  -42,
+  true,
+  false,
+  null,
+  {
+    "integer": 1234567890,
+    "real": -9876.54321,
+    "e": 0.123456789e-12,
+    "E": 1.23456789e34,
+    "": 23456789012e66,
+    "zero": 0,
+    "one": 1,
+    "space": " ",
+    "quote": "\"",
+    "backslash": "\\",
+    "controls": "\b\f\n\r\t",
+    "slash": "/ & \/",
+    "alpha": "abcdefghijklmnopqrstuvwyz",
+    "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+    "digit": "0123456789",
+    "0123456789": "digit",
+    "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+    "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
+    "true": true,
+    "false": false,
+    "null": null,
+    "array": [],
+    "object": {},
+    "address": "50 St. James Street",
+    "url": "http://www.JSON.org/",
+    "comment": "// /* <!-- --",
+    "# -- --> */": " ",
+    " s p a c e d ": [
+      1, 2, 3,
+
+      4, 5, 6, 7
+    ],
+    "compact": [1, 2, 3, 4, 5, 6, 7],
+    "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
+    "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+  },
+  0.5,
+  98.6,
+  99.44,
+
+  1066,
+  1e1,
+  0.1e1,
+  1e-1,
+  1,
+  2,
+  2,
+  "rosebud"
+]
+
+`````

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -57,11 +57,32 @@ export type FormatFileParam = {
 export async function formatFile({ code, options }: FormatFileParam): Promise<string> {
   const prettier = await loadPrettier();
 
+  // Check if Rust side wants Doc JSON instead of formatted code
+  const returnDoc = "_returnDoc" in options;
+  if (returnDoc) delete (options as Record<string, unknown>)._returnDoc;
+
   // Enable Tailwind CSS plugin for non-JS files if needed
   await setupTailwindPlugin(options);
   // Add oxfmt plugin for (j|t)-in-xxx files to use `oxc_formatter` instead of built-in formatter.
   // NOTE: This must be last since Prettier plugins are applied in order
   await setupOxfmtPlugin(options);
+
+  if (returnDoc) {
+    // @ts-expect-error: Use internal API to get `Doc`
+    const doc = await prettier.__debug.printToDoc(code, options);
+
+    const symbolToNumber = new Map<symbol, number>();
+    let nextId = 1;
+
+    return JSON.stringify(doc, (_key, value) => {
+      if (typeof value === "symbol") {
+        if (!symbolToNumber.has(value)) symbolToNumber.set(value, nextId++);
+        return symbolToNumber.get(value);
+      }
+      if (value === -Infinity) return "__NEGATIVE_INFINITY__";
+      return value;
+    });
+  }
 
   return prettier.format(code, options);
 }

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -5,11 +5,49 @@ use tracing::instrument;
 
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_formatter::{FormatOptions, Formatter, enable_jsx_source_type, get_parse_options};
+use oxc_formatter::{
+    FormatOptions, Formatter, PrinterOptions, UniqueGroupIdBuilder, enable_jsx_source_type,
+    get_parse_options, propagate_expand_elements,
+};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
+use oxc_formatter::{IndentStyle, IndentWidth, LineEnding};
+
 use super::{FormatFileStrategy, ResolvedOptions};
+
+/// Extract `PrinterOptions` from Prettier-compatible external options JSON.
+#[cfg(feature = "napi")]
+fn external_options_to_printer_options(options: &Value) -> PrinterOptions {
+    let mut printer = PrinterOptions::default();
+
+    if let Some(obj) = options.as_object() {
+        if let Some(w) = obj.get("printWidth").and_then(|v| v.as_u64()) {
+            #[expect(clippy::cast_possible_truncation)]
+            {
+                printer.print_width = oxc_formatter::PrintWidth::new(w as u32);
+            }
+        }
+        if let Some(use_tabs) = obj.get("useTabs").and_then(|v| v.as_bool()) {
+            printer.indent_style = if use_tabs { IndentStyle::Tab } else { IndentStyle::Space };
+        }
+        if let Some(tw) = obj.get("tabWidth").and_then(|v| v.as_u64()) {
+            #[expect(clippy::cast_possible_truncation)]
+            {
+                printer.indent_width = IndentWidth::try_from(tw as u8).unwrap_or_default();
+            }
+        }
+        if let Some(eol) = obj.get("endOfLine").and_then(|v| v.as_str()) {
+            printer.line_ending = match eol {
+                "crlf" => LineEnding::Crlf,
+                "cr" => LineEnding::Cr,
+                _ => LineEnding::Lf,
+            };
+        }
+    }
+
+    printer
+}
 
 pub enum FormatResult {
     Success { is_changed: bool, code: String },
@@ -236,22 +274,25 @@ impl SourceFormatter {
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
 
+        // Experimental: Use Doc path for JSON files
+        let use_doc_path = matches!(parser_name, "json" | "json-stringify" | "json5");
+
         // Set `parser` and `filepath` on options for Prettier.
         // We specify `parser` to skip parser inference for perf,
         // and `filepath` because some plugins depend on it.
         if let Value::Object(ref mut map) = external_options {
             map.insert("parser".to_string(), Value::String(parser_name.to_string()));
             map.insert("filepath".to_string(), Value::String(path.to_string_lossy().to_string()));
+            if use_doc_path {
+                map.insert("_returnDoc".to_string(), Value::Bool(true));
+            }
         }
 
-        external_formatter.format_file(external_options, source_text).map_err(|err| {
-            // NOTE: We are trying to make the error from oxc_formatter and external_formatter (Prettier) look similar.
-            // Ideally, we would unify them into `OxcDiagnostic`,
-            // which would eliminate the need for relative path conversion.
-            // However, doing so would require:
-            // - Parsing Prettier's error messages
-            // - Converting span information from UTF-16 to UTF-8
-            // This is a non-trivial amount of work, so for now, just leave this as a best effort.
+        // Extract printer options before moving external_options
+        let printer_options =
+            if use_doc_path { Some(external_options_to_printer_options(&external_options)) } else { None };
+
+        let result = external_formatter.format_file(external_options, source_text).map_err(|err| {
             let relative = std::env::current_dir()
                 .ok()
                 .and_then(|cwd| path.strip_prefix(cwd).ok().map(Path::to_path_buf));
@@ -262,7 +303,44 @@ impl SourceFormatter {
                 format!("{err}\n[{display_path}]")
             };
             OxcDiagnostic::error(message)
-        })
+        })?;
+
+        if let Some(printer_options) = printer_options {
+            self.print_doc_json(&result, &printer_options)
+                .map_err(|err| OxcDiagnostic::error(format!("Doc path failed for {}: {err}", path.display())))
+        } else {
+            Ok(result)
+        }
+    }
+
+    /// Convert Doc JSON string to formatted code via IR.
+    fn print_doc_json(
+        &self,
+        doc_json_str: &str,
+        printer_options: &PrinterOptions,
+    ) -> Result<String, String> {
+        use crate::prettier_compat::from_prettier_doc;
+        use oxc_formatter::Printer;
+
+        let allocator = self.allocator_pool.get();
+        let group_id_builder = UniqueGroupIdBuilder::default();
+
+        let doc_json: serde_json::Value =
+            serde_json::from_str(doc_json_str).map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
+
+        let elements = from_prettier_doc::to_format_elements_for_file(
+            &doc_json,
+            &allocator,
+            &group_id_builder,
+        )?;
+
+        propagate_expand_elements(&elements);
+
+        let printed = Printer::new(printer_options.clone(), &[])
+            .print(&elements)
+            .map_err(|e| format!("Failed to print: {e}"))?;
+
+        Ok(printed.into_code())
     }
 
     /// Format `package.json`: optionally sort then format by external formatter.

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -289,25 +289,30 @@ impl SourceFormatter {
         }
 
         // Extract printer options before moving external_options
-        let printer_options =
-            if use_doc_path { Some(external_options_to_printer_options(&external_options)) } else { None };
+        let printer_options = if use_doc_path {
+            Some(external_options_to_printer_options(&external_options))
+        } else {
+            None
+        };
 
-        let result = external_formatter.format_file(external_options, source_text).map_err(|err| {
-            let relative = std::env::current_dir()
-                .ok()
-                .and_then(|cwd| path.strip_prefix(cwd).ok().map(Path::to_path_buf));
-            let display_path = relative.as_deref().unwrap_or(path).to_string_lossy();
-            let message = if let Some((first, rest)) = err.split_once('\n') {
-                format!("{first}\n[{display_path}]\n{rest}")
-            } else {
-                format!("{err}\n[{display_path}]")
-            };
-            OxcDiagnostic::error(message)
-        })?;
+        let result =
+            external_formatter.format_file(external_options, source_text).map_err(|err| {
+                let relative = std::env::current_dir()
+                    .ok()
+                    .and_then(|cwd| path.strip_prefix(cwd).ok().map(Path::to_path_buf));
+                let display_path = relative.as_deref().unwrap_or(path).to_string_lossy();
+                let message = if let Some((first, rest)) = err.split_once('\n') {
+                    format!("{first}\n[{display_path}]\n{rest}")
+                } else {
+                    format!("{err}\n[{display_path}]")
+                };
+                OxcDiagnostic::error(message)
+            })?;
 
         if let Some(printer_options) = printer_options {
-            self.print_doc_json(&result, &printer_options)
-                .map_err(|err| OxcDiagnostic::error(format!("Doc path failed for {}: {err}", path.display())))
+            self.print_doc_json(&result, &printer_options).map_err(|err| {
+                OxcDiagnostic::error(format!("Doc path failed for {}: {err}", path.display()))
+            })
         } else {
             Ok(result)
         }
@@ -325,8 +330,8 @@ impl SourceFormatter {
         let allocator = self.allocator_pool.get();
         let group_id_builder = UniqueGroupIdBuilder::default();
 
-        let doc_json: serde_json::Value =
-            serde_json::from_str(doc_json_str).map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
+        let doc_json: serde_json::Value = serde_json::from_str(doc_json_str)
+            .map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
 
         let elements = from_prettier_doc::to_format_elements_for_file(
             &doc_json,

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -14,6 +14,51 @@ use oxc_formatter::{
 /// See `src-js/lib/apis.ts` for details.
 const NEGATIVE_INFINITY_MARKER: &str = "__NEGATIVE_INFINITY__";
 
+/// Converts a Prettier Doc JSON value into [`FormatElement`]s for an entire file.
+///
+/// Unlike [`to_format_elements_for_template`], this does not apply template-specific
+/// postprocessing (escape template characters, count placeholders, strip trailing hardlines).
+pub fn to_format_elements_for_file<'a>(
+    doc_json: &Value,
+    allocator: &'a Allocator,
+    group_id_builder: &UniqueGroupIdBuilder,
+) -> Result<Vec<FormatElement<'a>>, String> {
+    let mut ctx = FmtCtx::new(allocator, group_id_builder);
+    let mut out = vec![];
+    convert_doc(doc_json, &mut out, &mut ctx)?;
+    collapse_double_hardlines(&mut out);
+    Ok(out)
+}
+
+/// Collapse double-hardline sequences `[Hard, ExpandParent, Hard, ExpandParent]`
+/// into `[Empty, ExpandParent]` (empty line).
+///
+/// This is the subset of [`postprocess`] that applies to file-level formatting.
+fn collapse_double_hardlines(ir: &mut Vec<FormatElement>) {
+    let mut write = 0;
+    let mut read = 0;
+    while read < ir.len() {
+        if read + 3 < ir.len()
+            && matches!(ir[read], FormatElement::Line(LineMode::Hard))
+            && matches!(ir[read + 1], FormatElement::ExpandParent)
+            && matches!(ir[read + 2], FormatElement::Line(LineMode::Hard))
+            && matches!(ir[read + 3], FormatElement::ExpandParent)
+        {
+            ir[write] = FormatElement::Line(LineMode::Empty);
+            ir[write + 1] = FormatElement::ExpandParent;
+            write += 2;
+            read += 4;
+        } else {
+            if write != read {
+                ir[write] = ir[read].clone();
+            }
+            write += 1;
+            read += 1;
+        }
+    }
+    ir.truncate(write);
+}
+
 /// Converts parsed Prettier Doc JSON values into an [`EmbeddedDocResult`].
 ///
 /// Handles language-specific processing:

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -86,87 +86,87 @@ pub fn propagate_expand_elements(elements: &[FormatElement]) {
         enclosing: &mut Vec<Enclosing<'a>>,
         checked_interned: &mut FxHashMap<&'a Interned<'a>, bool>,
     ) -> bool {
-            let mut expands = false;
-            for element in elements {
-                let element_expands = match element {
-                    FormatElement::Tag(Tag::StartGroup(group)) => {
-                        enclosing.push(Enclosing::Group(group));
-                        false
-                    }
-                    FormatElement::Tag(Tag::EndGroup) => match enclosing.pop() {
-                        Some(Enclosing::Group(group)) => !group.mode().is_flat(),
-                        _ => false,
-                    },
-                    FormatElement::Interned(interned) => {
-                        if let Some(interned_expands) = checked_interned.get(interned) {
-                            *interned_expands
-                        } else {
-                            let interned_expands =
-                                propagate_expands(interned, enclosing, checked_interned);
-                            checked_interned.insert(interned, interned_expands);
-                            interned_expands
-                        }
-                    }
-                    FormatElement::BestFitting(best_fitting) => {
-                        enclosing.push(Enclosing::BestFitting);
-
-                        for variant in best_fitting.variants() {
-                            propagate_expands(variant, enclosing, checked_interned);
-                        }
-
-                        enclosing.pop();
-                        // BestFitting acts as a boundary, meaning there is no need to continue
-                        // processing this element and we can move onto the next. However, we
-                        // _don't_ set `expands = false`, because that ends up negating the
-                        // expansion when processing `Interned` elements.
-                        //
-                        // Only interned lists are affected, because they cache the expansion value
-                        // based on the value of `expands` at the end of iterating the children. If
-                        // a `best_fitting` element occurs after the last expanding element, and we
-                        // end up setting `expands = false` here, then the interned element ends up
-                        // thinking that its content doesn't expand, even though it might. Example:
-                        //   group(1,
-                        //     interned 1 [
-                        //       expand_parent,
-                        //       best_fitting,
-                        //     ]
-                        //   )
-                        //   group(2,
-                        //     [ref interned 1]
-                        //   )
-                        // Here, `group(1)` gets expanded directly by the `expand_parent` element.
-                        // This happens immediately, and then `expands = true` is set. The interned
-                        // element continues processing, and encounters the `best_fitting`. If
-                        // we set `expands = false` there, then the interned element's result ends
-                        // up being `false`, even though it does actually expand. Then, when
-                        // `group(2)` checks for expansion, it looks at the ref to `interned 1`,
-                        // which thinks it doesn't expand, and so `group(2)` stays flat.
-                        //
-                        // By _not_ setting `expands = false`, even though `best_fitting` is a
-                        // boundary for expansion, we ensure that any references to the interned
-                        // element will get the correct value for whether the contained content
-                        // actually expands, regardless of the order of elements within it.
-                        //
-                        // Instead, just returning false here enforces that `best_fitting` doesn't
-                        // think it expands _itself_, but allows other sibling elements to still
-                        // propagate their expansion.
-                        false
-                    }
-                    // `FormatElement::Token` cannot contain line breaks
-                    FormatElement::Text { text: _, width } => width.is_multiline(),
-                    FormatElement::ExpandParent
-                    | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
-                    _ => false,
-                };
-
-                if element_expands {
-                    expands = true;
-                    expand_parent(enclosing);
+        let mut expands = false;
+        for element in elements {
+            let element_expands = match element {
+                FormatElement::Tag(Tag::StartGroup(group)) => {
+                    enclosing.push(Enclosing::Group(group));
+                    false
                 }
-            }
+                FormatElement::Tag(Tag::EndGroup) => match enclosing.pop() {
+                    Some(Enclosing::Group(group)) => !group.mode().is_flat(),
+                    _ => false,
+                },
+                FormatElement::Interned(interned) => {
+                    if let Some(interned_expands) = checked_interned.get(interned) {
+                        *interned_expands
+                    } else {
+                        let interned_expands =
+                            propagate_expands(interned, enclosing, checked_interned);
+                        checked_interned.insert(interned, interned_expands);
+                        interned_expands
+                    }
+                }
+                FormatElement::BestFitting(best_fitting) => {
+                    enclosing.push(Enclosing::BestFitting);
 
-            expands
+                    for variant in best_fitting.variants() {
+                        propagate_expands(variant, enclosing, checked_interned);
+                    }
+
+                    enclosing.pop();
+                    // BestFitting acts as a boundary, meaning there is no need to continue
+                    // processing this element and we can move onto the next. However, we
+                    // _don't_ set `expands = false`, because that ends up negating the
+                    // expansion when processing `Interned` elements.
+                    //
+                    // Only interned lists are affected, because they cache the expansion value
+                    // based on the value of `expands` at the end of iterating the children. If
+                    // a `best_fitting` element occurs after the last expanding element, and we
+                    // end up setting `expands = false` here, then the interned element ends up
+                    // thinking that its content doesn't expand, even though it might. Example:
+                    //   group(1,
+                    //     interned 1 [
+                    //       expand_parent,
+                    //       best_fitting,
+                    //     ]
+                    //   )
+                    //   group(2,
+                    //     [ref interned 1]
+                    //   )
+                    // Here, `group(1)` gets expanded directly by the `expand_parent` element.
+                    // This happens immediately, and then `expands = true` is set. The interned
+                    // element continues processing, and encounters the `best_fitting`. If
+                    // we set `expands = false` there, then the interned element's result ends
+                    // up being `false`, even though it does actually expand. Then, when
+                    // `group(2)` checks for expansion, it looks at the ref to `interned 1`,
+                    // which thinks it doesn't expand, and so `group(2)` stays flat.
+                    //
+                    // By _not_ setting `expands = false`, even though `best_fitting` is a
+                    // boundary for expansion, we ensure that any references to the interned
+                    // element will get the correct value for whether the contained content
+                    // actually expands, regardless of the order of elements within it.
+                    //
+                    // Instead, just returning false here enforces that `best_fitting` doesn't
+                    // think it expands _itself_, but allows other sibling elements to still
+                    // propagate their expansion.
+                    false
+                }
+                // `FormatElement::Token` cannot contain line breaks
+                FormatElement::Text { text: _, width } => width.is_multiline(),
+                FormatElement::ExpandParent
+                | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
+                _ => false,
+            };
+
+            if element_expands {
+                expands = true;
+                expand_parent(enclosing);
+            }
         }
+
+        expands
+    }
 
     let mut enclosing: Vec<Enclosing> = Vec::new();
     let mut interned = FxHashMap::default();

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -53,23 +53,39 @@ impl Document<'_> {
     ///
     /// [`BestFitting`]: FormatElement::BestFitting
     pub(crate) fn propagate_expand(&self) {
-        #[derive(Debug)]
-        enum Enclosing<'a> {
-            Group(&'a tag::Group),
-            BestFitting,
-        }
+        propagate_expand_elements(self);
+    }
+}
 
-        fn expand_parent(enclosing: &[Enclosing]) {
-            if let Some(Enclosing::Group(group)) = enclosing.last() {
-                group.propagate_expand();
-            }
-        }
+/// Propagates expand from child elements to parent groups.
+///
+/// Sets [`expand`](tag::Group::expand) to [`GroupMode::Propagated`] if the group contains any of:
+/// * a group with [`expand`](tag::Group::expand) set to [GroupMode::Propagated] or [GroupMode::Expand].
+/// * a non-soft [line break](FormatElement::Line) with mode [LineMode::Hard], [LineMode::Empty], or [LineMode::Literal].
+/// * a [FormatElement::ExpandParent]
+///
+/// [`BestFitting`] elements act as expand boundaries, meaning that the fact that a
+/// [`BestFitting`]'s content expands is not propagated past the [`BestFitting`] element.
+///
+/// [`BestFitting`]: FormatElement::BestFitting
+pub fn propagate_expand_elements(elements: &[FormatElement]) {
+    #[derive(Debug)]
+    enum Enclosing<'a> {
+        Group(&'a tag::Group),
+        BestFitting,
+    }
 
-        fn propagate_expands<'a>(
-            elements: &'a [FormatElement<'a>],
-            enclosing: &mut Vec<Enclosing<'a>>,
-            checked_interned: &mut FxHashMap<&'a Interned<'a>, bool>,
-        ) -> bool {
+    fn expand_parent(enclosing: &[Enclosing]) {
+        if let Some(Enclosing::Group(group)) = enclosing.last() {
+            group.propagate_expand();
+        }
+    }
+
+    fn propagate_expands<'a>(
+        elements: &'a [FormatElement<'a>],
+        enclosing: &mut Vec<Enclosing<'a>>,
+        checked_interned: &mut FxHashMap<&'a Interned<'a>, bool>,
+    ) -> bool {
             let mut expands = false;
             for element in elements {
                 let element_expands = match element {
@@ -152,10 +168,9 @@ impl Document<'_> {
             expands
         }
 
-        let mut enclosing: Vec<Enclosing> = Vec::new();
-        let mut interned = FxHashMap::default();
-        propagate_expands(self, &mut enclosing, &mut interned);
-    }
+    let mut enclosing: Vec<Enclosing> = Vec::new();
+    let mut interned = FxHashMap::default();
+    propagate_expands(elements, &mut enclosing, &mut interned);
 }
 
 impl<'a> Deref for Document<'a> {

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -22,14 +22,14 @@ pub use crate::external_formatter::{
     EmbeddedDocFormatterCallback, EmbeddedDocResult, EmbeddedFormatterCallback, ExternalCallbacks,
     TailwindCallback,
 };
+pub use crate::formatter::format_element::document::propagate_expand_elements;
 pub use crate::formatter::format_element::tag::{
     Align, Condition, DedentMode, Group, GroupMode, Tag,
 };
-pub use crate::formatter::format_element::document::propagate_expand_elements;
 pub use crate::formatter::format_element::{
     BestFittingElement, FormatElement, LineMode, PrintMode, TextWidth,
 };
-pub use crate::formatter::printer::{Printer, PrintWidth, PrinterOptions};
+pub use crate::formatter::printer::{PrintWidth, Printer, PrinterOptions};
 pub use crate::formatter::{Format, Formatted, PrintError, Printed};
 pub use crate::formatter::{GroupId, UniqueGroupIdBuilder};
 pub use crate::ir_transform::options::*;

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -25,10 +25,12 @@ pub use crate::external_formatter::{
 pub use crate::formatter::format_element::tag::{
     Align, Condition, DedentMode, Group, GroupMode, Tag,
 };
+pub use crate::formatter::format_element::document::propagate_expand_elements;
 pub use crate::formatter::format_element::{
     BestFittingElement, FormatElement, LineMode, PrintMode, TextWidth,
 };
-pub use crate::formatter::{Format, Formatted};
+pub use crate::formatter::printer::{Printer, PrintWidth, PrinterOptions};
+pub use crate::formatter::{Format, Formatted, PrintError, Printed};
 pub use crate::formatter::{GroupId, UniqueGroupIdBuilder};
 pub use crate::ir_transform::options::*;
 pub use crate::options::*;


### PR DESCRIPTION
Just experiments.

For now, `.json` files are handled:

- Rust: Collect `.json` file
- JS: Prettier formats it as `Doc` then print as `string`, then returns `string`
- Rust: Save returned `string`

This PR changes this flow:

- Rust: Collect `.json` file
- JS: Prettier formats it as `Doc` then returns `Doc` JSON
- Rust: Convert `Doc` into our IR, then print as `string`
