### PR TITLE
perf(linter/plugins): faster reset of visitor state

### DIFF
--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -235,9 +235,7 @@ let visitPropsCacheNextIndex = 0;
  */
 export function initCompiledVisitor(): void {
   // Reset `compiledVisitor` array after previous compilation
-  for (let i = 0; i < TYPE_IDS_COUNT; i++) {
-    compiledVisitor[i] = null;
-  }
+  compiledVisitor.fill(null);
 
   // Reset enter+exit objects which were used in previous compilation
   for (let i = 0; i < enterExitObjectCacheNextIndex; i++) {


### PR DESCRIPTION
Perf optimization to visitor compilation.

Reset compiled visitor with a single `compiledVisitor.fill(null)` call, instead of a loop which writes `null` to each entry individually. V8 should optimize this to a single `memset` call.