### PR TITLE
fix(codegen): Fix code generation for empty JSXElement names

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2558,31 +2558,45 @@ impl Gen for JSXAttributeItem<'_> {
 
 impl Gen for JSXElement<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
-        // Opening element.
-        // Cannot `impl Gen for JSXOpeningElement` because it needs to know value of `self.closing_element`
-        // to determine whether to print a trailing `/`.
-        p.add_source_mapping(self.opening_element.span);
-        p.print_ascii_byte(b'<');
-        self.opening_element.name.print(p, ctx);
-        if let Some(type_arguments) = &self.opening_element.type_arguments {
-            type_arguments.print(p, ctx);
-        }
-        for attr in &self.opening_element.attributes {
-            match attr {
-                JSXAttributeItem::Attribute(_) => {
-                    p.print_hard_space();
-                }
-                JSXAttributeItem::SpreadAttribute(_) => {
-                    p.print_soft_space();
-                }
+        // Check if this JSXElement represents a fragment (empty JSXIdentifier name).
+        // This can occur when transformers create fragment-like JSXElements programmatically
+        // instead of using JSXFragment nodes.
+        let is_fragment = matches!(
+            &self.opening_element.name,
+            JSXElementName::Identifier(ident) if ident.name.is_empty()
+        );
+
+        if is_fragment {
+            // Print as fragment: <>
+            p.add_source_mapping(self.opening_element.span);
+            p.print_str("<>");
+        } else {
+            // Opening element.
+            // Cannot `impl Gen for JSXOpeningElement` because it needs to know value of `self.closing_element`
+            // to determine whether to print a trailing `/`.
+            p.add_source_mapping(self.opening_element.span);
+            p.print_ascii_byte(b'<');
+            self.opening_element.name.print(p, ctx);
+            if let Some(type_arguments) = &self.opening_element.type_arguments {
+                type_arguments.print(p, ctx);
             }
-            attr.print(p, ctx);
+            for attr in &self.opening_element.attributes {
+                match attr {
+                    JSXAttributeItem::Attribute(_) => {
+                        p.print_hard_space();
+                    }
+                    JSXAttributeItem::SpreadAttribute(_) => {
+                        p.print_soft_space();
+                    }
+                }
+                attr.print(p, ctx);
+            }
+            if self.closing_element.is_none() {
+                p.print_soft_space();
+                p.print_ascii_byte(b'/');
+            }
+            p.print_ascii_byte(b'>');
         }
-        if self.closing_element.is_none() {
-            p.print_soft_space();
-            p.print_ascii_byte(b'/');
-        }
-        p.print_ascii_byte(b'>');
 
         // Children
         for child in &self.children {
@@ -2590,7 +2604,11 @@ impl Gen for JSXElement<'_> {
         }
 
         // Closing element
-        if let Some(closing_element) = &self.closing_element {
+        if is_fragment {
+            if self.closing_element.is_some() {
+                p.print_str("</>");
+            }
+        } else if let Some(closing_element) = &self.closing_element {
             p.add_source_mapping(closing_element.span);
             p.print_str("</");
             closing_element.name.print(p, ctx);

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -783,3 +783,77 @@ fn html_comments() {
         "const x = 1;\n--> comment\nconst y = 2;\n",
     );
 }
+
+/// Regression: JSXElement with empty name (fragment-like) should codegen as `<>...</>`
+/// not `<<>>...</>`. This occurs when transformers create JSXElement nodes with empty
+/// JSXIdentifier names instead of using JSXFragment nodes.
+#[test]
+fn jsx_element_with_empty_name_as_fragment() {
+    use oxc_ast::ast::*;
+
+    let allocator = Allocator::default();
+    let ast = AstBuilder::new(&allocator);
+
+    // Build: <>{b ? <div /> : <section />}</>
+    // represented as a JSXElement with empty name (not JSXFragment)
+
+    // Inner <div /> element (self-closing, no closing element)
+    let div_opening = ast.jsx_opening_element(
+        SPAN,
+        ast.jsx_element_name_identifier(SPAN, "div"),
+        None::<TSTypeParameterInstantiation>,
+        ast.vec(),
+    );
+    let div_expr =
+        ast.expression_jsx_element(SPAN, div_opening, ast.vec(), None::<JSXClosingElement>);
+
+    // Inner <section /> element (self-closing, no closing element)
+    let section_opening = ast.jsx_opening_element(
+        SPAN,
+        ast.jsx_element_name_identifier(SPAN, "section"),
+        None::<TSTypeParameterInstantiation>,
+        ast.vec(),
+    );
+    let section_expr =
+        ast.expression_jsx_element(SPAN, section_opening, ast.vec(), None::<JSXClosingElement>);
+
+    // b ? <div /> : <section />
+    let cond = ast.expression_conditional(
+        SPAN,
+        ast.expression_identifier(SPAN, "b"),
+        div_expr,
+        section_expr,
+    );
+
+    // Wrap in expression container as JSXChild
+    let expr_container = ast.jsx_child_expression_container(SPAN, JSXExpression::from(cond));
+
+    // Fragment-like JSXElement with empty name and empty type_arguments.
+    // This is the key: type_arguments = Some(TSTypeParameterInstantiation { params: [] })
+    // Without the fix, codegen prints '<' + '' (empty name) + '<>' (empty type args) + '>' = '<<>>'
+    let empty_type_args = ast.ts_type_parameter_instantiation(SPAN, ast.vec());
+    let opening = ast.jsx_opening_element(
+        SPAN,
+        ast.jsx_element_name_identifier(SPAN, ""),
+        Some(empty_type_args),
+        ast.vec(),
+    );
+    let closing = ast.jsx_closing_element(SPAN, ast.jsx_element_name_identifier(SPAN, ""));
+
+    let fragment_el =
+        ast.expression_jsx_element(SPAN, opening, ast.vec1(expr_container), Some(closing));
+
+    let stmt = ast.statement_expression(SPAN, fragment_el);
+    let program = ast.program(
+        SPAN,
+        oxc_span::SourceType::tsx(),
+        "",
+        ast.vec(),
+        None,
+        ast.vec(),
+        ast.vec1(stmt),
+    );
+
+    let result = Codegen::new().build(&program).code;
+    assert_eq!(result, "<>{b ? <div /> : <section />}</>;\n");
+}

--- a/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/stacktrace_is_correct.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_codegen/tests/integration/sourcemap.rs
 ---
-Node.js version: v24.12.0
+Node.js version: v24.13.0
 
 ## Input
 const fn = () => {


### PR DESCRIPTION
While working on the devup-ui framework, I discovered a bug in oxc_codegen = "0.117.0" related to fragment handling.
This worked correctly in previous versions.

When transformers create JSXElement nodes with an empty JSXIdentifier
name to represent fragments, codegen printed `<` + `""` + `<>` (from
empty type_arguments) + `>` = `<<>>`. Detect the empty-name case and
emit fragment syntax directly.

<img width="976" height="248" alt="image" src="https://github.com/user-attachments/assets/df13cb70-12ce-47c5-b12c-e55b911f040c" />
