### PR TITLE
fix(linter/explicit-module-boundary-types): ignore constructor callbacks

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -576,6 +576,16 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         // ignore
     }
 
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        // Constructor arguments are implementation details of the exported value,
+        // not part of the module boundary. Still inspect the callee so class
+        // expressions used with `new` continue to be checked.
+        self.visit_expression(&it.callee);
+        if let Some(type_arguments) = &it.type_arguments {
+            self.visit_ts_type_parameter_instantiation(type_arguments);
+        }
+    }
+
     fn visit_jsx_element(&mut self, _it: &JSXElement<'a>) {
         // ignore
     }
@@ -1536,6 +1546,14 @@ mod test {
             ("function Test(): void { const _x = () => {}; } export default Test;", None),
             (
                 "function Test(): void { const _x = () => { }; } function Test2() { return (): void => { }; } export { Test2 };",
+                None,
+            ),
+            (
+                "
+            export const widgetSettingsDeserializer = new JsonInterfaceDeserializer<WidgetSettings, SupportedWidget>(
+              raw => raw.widgetSpecificationId as SupportedWidget
+            );
+            ",
                 None,
             ),
         ];


### PR DESCRIPTION
- Ignore constructor arguments when checking `explicit-module-boundary-types` so inline callbacks passed to exported `new` expressions are not treated as module-boundary functions.
- Keep traversing the constructor callee so exported instances created from class expressions can still be checked.

Fixes #20220

