### PR TITLE
fix(linter): add config options and comprehensive implicit roles to `no-redundant-roles`

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -1,16 +1,22 @@
+use cow_utils::CowUtils;
 use oxc_ast::{
     AstKind,
-    ast::{JSXAttributeItem, JSXAttributeValue},
+    ast::{JSXAttributeItem, JSXAttributeValue, JSXExpression, JSXOpeningElement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    utils::{get_element_type, has_jsx_prop_ignore_case},
+    utils::{
+        get_element_type, get_prop_value, get_string_literal_prop_value, has_jsx_prop_ignore_case,
+        parse_jsx_value,
+    },
 };
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
@@ -22,7 +28,31 @@ fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDi
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct NoRedundantRoles;
+pub struct NoRedundantRoles(Box<NoRedundantRolesConfig>);
+
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(default)]
+pub struct NoRedundantRolesConfig {
+    /// A map of element names to arrays of roles that are allowed to be redundant.
+    /// For example, `{ "nav": ["navigation"] }` allows `<nav role="navigation">`.
+    allowed_redundant_roles: FxHashMap<String, Vec<String>>,
+}
+
+impl Default for NoRedundantRolesConfig {
+    fn default() -> Self {
+        let mut allowed = FxHashMap::default();
+        allowed.insert("nav".into(), vec!["navigation".into()]);
+        Self { allowed_redundant_roles: allowed }
+    }
+}
+
+impl std::ops::Deref for NoRedundantRoles {
+    type Target = NoRedundantRolesConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -35,43 +65,172 @@ declare_oxc_lint!(
     ///
     /// Redundant roles can lead to confusion and verbosity in the codebase.
     ///
+    /// ### Configuration
+    ///
+    /// This rule accepts a configuration object mapping element names to arrays
+    /// of roles that are allowed to be explicitly set even though they match
+    /// the element's implicit role.
+    ///
+    /// By default, `{ "nav": ["navigation"] }` is allowed.
+    ///
+    /// ```json
+    /// {
+    ///   "jsx-a11y/no-redundant-roles": ["error", { "nav": ["navigation"], "ul": ["list"] }]
+    /// }
+    /// ```
+    ///
     /// ### Examples
-    ///
-    /// This rule applies for the following elements and their implicit roles:
-    ///
-    /// - `<nav>`: `navigation`
-    /// - `<button>`: `button`
-    /// - `<body>`: `document`
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// <nav role="navigation"></nav>
     /// <button role="button"></button>
     /// <body role="document"></body>
+    /// <h1 role="heading"></h1>
+    /// <article role="article"></article>
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// <nav></nav>
+    /// // `nav` with `navigation` is allowed by default config
+    /// <nav role="navigation"></nav>
     /// <button></button>
     /// <body></body>
     /// ```
     NoRedundantRoles,
     jsx_a11y,
     correctness,
-    fix
+    fix,
+    config = NoRedundantRolesConfig,
 );
 
-fn get_default_role_exception(tag: &str) -> Option<&'static str> {
-    match tag {
-        "nav" => Some("navigation"),
-        "button" => Some("button"),
-        "body" => Some("document"),
-        _ => None,
+/// Check if a JSX attribute has a truthy literal value.
+///
+/// Valueless attributes (e.g., `<select multiple>`) are treated as `true`.
+fn is_truthy_prop(item: &JSXAttributeItem<'_>) -> bool {
+    match get_prop_value(item) {
+        // Valueless attribute: <select multiple> → true
+        None => true,
+        Some(JSXAttributeValue::StringLiteral(s)) => !s.value.is_empty(),
+        Some(JSXAttributeValue::ExpressionContainer(container)) => match &container.expression {
+            JSXExpression::BooleanLiteral(b) => b.value,
+            JSXExpression::NumericLiteral(n) => n.value != 0.0 && !n.value.is_nan(),
+            JSXExpression::StringLiteral(s) => !s.value.is_empty(),
+            _ => false,
+        },
+        _ => false,
     }
 }
 
+fn get_implicit_role<'a>(
+    node: &'a JSXOpeningElement<'a>,
+    element_type: &str,
+) -> Option<&'static str> {
+    let implicit_role = match element_type {
+        "a" | "area" | "link" => match has_jsx_prop_ignore_case(node, "href") {
+            Some(_) => "link",
+            None => return None,
+        },
+        "article" => "article",
+        "aside" => "complementary",
+        "body" => "document",
+        "button" => "button",
+        "datalist" => "listbox",
+        "details" => "group",
+        "dialog" => "dialog",
+        "form" => "form",
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => "heading",
+        "hr" => "separator",
+        "img" => {
+            // <img alt=""> → no implicit role (per ESLint)
+            if has_jsx_prop_ignore_case(node, "alt")
+                .and_then(get_string_literal_prop_value)
+                .is_some_and(str::is_empty)
+            {
+                return None;
+            }
+            // <img src="foo.svg"> → no implicit role (WebKit SVG workaround)
+            if has_jsx_prop_ignore_case(node, "src")
+                .and_then(get_string_literal_prop_value)
+                .is_some_and(|s| s.contains(".svg"))
+            {
+                return None;
+            }
+            "img"
+        }
+        "input" => has_jsx_prop_ignore_case(node, "type").map_or("textbox", |input_type| {
+            match get_string_literal_prop_value(input_type) {
+                Some("button" | "image" | "reset" | "submit") => "button",
+                Some("checkbox") => "checkbox",
+                Some("radio") => "radio",
+                Some("range") => "slider",
+                _ => "textbox",
+            }
+        }),
+        "li" => "listitem",
+        "menu" => {
+            // <menu type="toolbar"> → "toolbar", otherwise no implicit role
+            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
+                get_string_literal_prop_value(v).and_then(|v| {
+                    if v.eq_ignore_ascii_case("toolbar") { Some("toolbar") } else { None }
+                })
+            });
+        }
+        "menuitem" => {
+            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
+                match get_string_literal_prop_value(v) {
+                    Some("checkbox") => Some("menuitemcheckbox"),
+                    Some("command") => Some("menuitem"),
+                    Some("radio") => Some("menuitemradio"),
+                    _ => None,
+                }
+            });
+        }
+        "meter" | "progress" => "progressbar",
+        "nav" => "navigation",
+        "ol" | "ul" => "list",
+        "option" => "option",
+        "output" => "status",
+        "section" => "region",
+        "select" => {
+            // <select multiple> or <select size={2+}> → "listbox"
+            // otherwise → "combobox"
+            if has_jsx_prop_ignore_case(node, "multiple").is_some_and(is_truthy_prop) {
+                return Some("listbox");
+            }
+            if has_jsx_prop_ignore_case(node, "size")
+                .and_then(get_prop_value)
+                .is_some_and(|v| parse_jsx_value(v).is_ok_and(|n| n > 1.0))
+            {
+                return Some("listbox");
+            }
+            "combobox"
+        }
+        "tbody" | "tfoot" | "thead" => "rowgroup",
+        "textarea" => "textbox",
+        _ => return None,
+    };
+
+    Some(implicit_role)
+}
+
 impl Rule for NoRedundantRoles {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let mut config = NoRedundantRolesConfig::default();
+
+        if let Some(obj) = value.get(0).and_then(serde_json::Value::as_object) {
+            for (element, roles) in obj {
+                if let Some(arr) = roles.as_array() {
+                    let role_list: Vec<String> =
+                        arr.iter().filter_map(|v| v.as_str().map(String::from)).collect();
+                    config.allowed_redundant_roles.insert(element.clone(), role_list);
+                }
+            }
+        }
+
+        Ok(Self(Box::new(config)))
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_el) = node.kind() else {
             return;
@@ -79,29 +238,47 @@ impl Rule for NoRedundantRoles {
 
         let component = get_element_type(ctx, jsx_el);
 
-        if let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
-            && let Some(JSXAttributeValue::StringLiteral(role_values)) = &attr.value
-        {
-            let roles = role_values.value.split_whitespace().collect::<Vec<_>>();
-            for role in &roles {
-                let exceptions = get_default_role_exception(&component);
-                if exceptions.is_some_and(|set| set.contains(role)) {
-                    ctx.diagnostic_with_fix(
-                        no_redundant_roles_diagnostic(attr.span, &component, role),
-                        |fixer| fixer.delete_range(attr.span),
-                    );
-                }
-            }
+        let Some(implicit_role) = get_implicit_role(jsx_el, &component) else {
+            return;
+        };
+
+        let Some(JSXAttributeItem::Attribute(attr)) = has_jsx_prop_ignore_case(jsx_el, "role")
+        else {
+            return;
+        };
+
+        let Some(JSXAttributeValue::StringLiteral(role_values)) = &attr.value else {
+            return;
+        };
+
+        let explicit_role = role_values.value.trim().cow_to_ascii_lowercase();
+
+        if explicit_role != implicit_role {
+            return;
         }
+
+        if self
+            .allowed_redundant_roles
+            .get(&*component)
+            .is_some_and(|allowed_roles| allowed_roles.iter().any(|r| r == &explicit_role))
+        {
+            return;
+        }
+
+        ctx.diagnostic_with_fix(
+            no_redundant_roles_diagnostic(attr.span, &component, &explicit_role),
+            |fixer| fixer.delete_range(attr.span),
+        );
     }
 }
 
 #[test]
 fn test() {
     use crate::tester::Tester;
+    use serde_json::json;
 
     fn settings() -> serde_json::Value {
-        serde_json::json!({
+        json!({
             "settings": { "jsx-a11y": {
                 "components": {
                     "Button": "button",
@@ -122,6 +299,19 @@ fn test() {
         ("<MyComponent role='button' />", None, None),
         ("<button role={`${foo}button`} />", None, None),
         ("<Button role={`${foo}button`} />", None, Some(settings())),
+        // Default exception: nav + navigation is allowed
+        ("<nav role='navigation' />", None, None),
+        // Config-based exceptions
+        ("<ul role='list' />", Some(json!([{ "ul": ["list"] }])), None),
+        ("<ol role='list' />", Some(json!([{ "ol": ["list"] }])), None),
+        // select: role that doesn't match implicit role
+        ("<select role='menu'><option>1</option><option>2</option></select>", None, None),
+        ("<select role='menu' size={2}><option>1</option><option>2</option></select>", None, None),
+        ("<select role='menu' multiple><option>1</option><option>2</option></select>", None, None),
+        // img: SVG src has no implicit role
+        ("<img src='example.svg' role='img' />", None, None),
+        // img: empty alt has no implicit role
+        ("<img alt='' role='presentation' />", None, None),
     ];
 
     let fail = vec![
@@ -134,8 +324,47 @@ fn test() {
         ("<button role='button'><p>Test</p></button>", None, None),
         ("<button role='button' title='button'></button>", None, None),
         ("<body role='document' />", None, None),
-        ("<nav role='navigation' />", None, None),
+        // Case insensitive: DOCUMENT matches implicit "document"
+        ("<body role='DOCUMENT' />", None, None),
         ("<Button role='button' />", None, Some(settings())),
+        // Expanded implicit role detection
+        ("<article role='article' />", None, None),
+        ("<h1 role='heading' />", None, None),
+        ("<ul role='list' />", None, None),
+        ("<li role='listitem' />", None, None),
+        ("<aside role='complementary' />", None, None),
+        ("<textarea role='textbox' />", None, None),
+        ("<hr role='separator' />", None, None),
+        ("<dialog role='dialog' />", None, None),
+        ("<form role='form' />", None, None),
+        ("<option role='option' />", None, None),
+        ("<output role='status' />", None, None),
+        ("<section role='region' />", None, None),
+        ("<details role='group' />", None, None),
+        // select: combobox (default, no multiple, no size > 1)
+        ("<select role='combobox'><option>1</option><option>2</option></select>", None, None),
+        ("<select role='combobox' size='' />", None, None),
+        ("<select role='combobox' size={1} />", None, None),
+        ("<select role='combobox' size='1' />", None, None),
+        ("<select role='combobox' size={null} />", None, None),
+        ("<select role='combobox' size={undefined} />", None, None),
+        ("<select role='combobox' multiple={undefined} />", None, None),
+        ("<select role='combobox' multiple={false} />", None, None),
+        ("<select role='combobox' multiple='' />", None, None),
+        // select: listbox (multiple or size > 1)
+        ("<select role='listbox' size='3' />", None, None),
+        ("<select role='listbox' size={2} />", None, None),
+        (
+            "<select role='listbox' multiple><option>1</option><option>2</option></select>",
+            None,
+            None,
+        ),
+        ("<select role='listbox' multiple={true} />", None, None),
+        // img without alt or SVG src
+        ("<img role='img' />", None, None),
+        ("<img src={someVariable} role='img' />", None, None),
+        // Config override: remove default nav exception
+        ("<nav role='navigation' />", Some(json!([{ "nav": [] }])), None),
     ];
 
     let fix = vec![
@@ -151,11 +380,19 @@ fn test() {
               Foo
              </button>",
         ),
-        ("<nav role='navigation' />", "<nav  />"),
         ("<body role='document' />", "<body  />"),
         (
             "<body role='document'><p>Foobarbaz!! document body role</p></body>",
             "<body ><p>Foobarbaz!! document body role</p></body>",
+        ),
+        ("<article role='article' />", "<article  />"),
+        ("<h1 role='heading' />", "<h1  />"),
+        ("<ul role='list' />", "<ul  />"),
+        ("<textarea role='textbox' />", "<textarea  />"),
+        ("<img role='img' />", "<img  />"),
+        (
+            "<select role='combobox'><option>1</option></select>",
+            "<select ><option>1</option></select>",
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -1,22 +1,21 @@
 use cow_utils::CowUtils;
 use oxc_ast::{
     AstKind,
-    ast::{JSXAttributeItem, JSXAttributeValue, JSXExpression, JSXOpeningElement},
+    ast::{JSXAttributeItem, JSXAttributeValue},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::Rule,
-    utils::{
-        get_element_type, get_prop_value, get_string_literal_prop_value, has_jsx_prop_ignore_case,
-        parse_jsx_value,
-    },
+    globals::VALID_ARIA_ROLES,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{get_element_type, get_implicit_role, has_jsx_prop_ignore_case},
 };
 
 fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDiagnostic {
@@ -30,19 +29,52 @@ fn no_redundant_roles_diagnostic(span: Span, element: &str, role: &str) -> OxcDi
 #[derive(Debug, Default, Clone)]
 pub struct NoRedundantRoles(Box<NoRedundantRolesConfig>);
 
-#[derive(Debug, Clone, JsonSchema)]
-#[serde(default)]
-pub struct NoRedundantRolesConfig {
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct NoRedundantRolesConfig(
     /// A map of element names to arrays of roles that are allowed to be redundant.
     /// For example, `{ "nav": ["navigation"] }` allows `<nav role="navigation">`.
-    allowed_redundant_roles: FxHashMap<String, Vec<String>>,
-}
+    FxHashMap<String, Vec<String>>,
+);
 
 impl Default for NoRedundantRolesConfig {
     fn default() -> Self {
         let mut allowed = FxHashMap::default();
         allowed.insert("nav".into(), vec!["navigation".into()]);
-        Self { allowed_redundant_roles: allowed }
+        Self(allowed)
+    }
+}
+
+impl NoRedundantRolesConfig {
+    fn extend(&mut self, other: Self) {
+        self.0.extend(other.0);
+    }
+
+    fn is_allowed(&self, element: &str, role: &str) -> bool {
+        self.0.get(element).is_some_and(|allowed_roles| allowed_roles.iter().any(|r| r == role))
+    }
+
+    fn normalize(self) -> Self {
+        let allowed_redundant_roles = self
+            .0
+            .into_iter()
+            .filter_map(|(element, roles)| {
+                let element = element.trim().cow_to_ascii_lowercase().into_owned();
+                if element.is_empty() {
+                    return None;
+                }
+
+                let roles = roles
+                    .into_iter()
+                    .map(|role| role.trim().cow_to_ascii_lowercase().into_owned())
+                    .filter(|role| !role.is_empty())
+                    .collect();
+
+                Some((element, roles))
+            })
+            .collect();
+
+        Self(allowed_redundant_roles)
     }
 }
 
@@ -104,129 +136,14 @@ declare_oxc_lint!(
     config = NoRedundantRolesConfig,
 );
 
-/// Check if a JSX attribute has a truthy literal value.
-///
-/// Valueless attributes (e.g., `<select multiple>`) are treated as `true`.
-fn is_truthy_prop(item: &JSXAttributeItem<'_>) -> bool {
-    match get_prop_value(item) {
-        // Valueless attribute: <select multiple> → true
-        None => true,
-        Some(JSXAttributeValue::StringLiteral(s)) => !s.value.is_empty(),
-        Some(JSXAttributeValue::ExpressionContainer(container)) => match &container.expression {
-            JSXExpression::BooleanLiteral(b) => b.value,
-            JSXExpression::NumericLiteral(n) => n.value != 0.0 && !n.value.is_nan(),
-            JSXExpression::StringLiteral(s) => !s.value.is_empty(),
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
-fn get_implicit_role<'a>(
-    node: &'a JSXOpeningElement<'a>,
-    element_type: &str,
-) -> Option<&'static str> {
-    let implicit_role = match element_type {
-        "a" | "area" | "link" => match has_jsx_prop_ignore_case(node, "href") {
-            Some(_) => "link",
-            None => return None,
-        },
-        "article" => "article",
-        "aside" => "complementary",
-        "body" => "document",
-        "button" => "button",
-        "datalist" => "listbox",
-        "details" => "group",
-        "dialog" => "dialog",
-        "form" => "form",
-        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => "heading",
-        "hr" => "separator",
-        "img" => {
-            // <img alt=""> → no implicit role (per ESLint)
-            if has_jsx_prop_ignore_case(node, "alt")
-                .and_then(get_string_literal_prop_value)
-                .is_some_and(str::is_empty)
-            {
-                return None;
-            }
-            // <img src="foo.svg"> → no implicit role (WebKit SVG workaround)
-            if has_jsx_prop_ignore_case(node, "src")
-                .and_then(get_string_literal_prop_value)
-                .is_some_and(|s| s.contains(".svg"))
-            {
-                return None;
-            }
-            "img"
-        }
-        "input" => has_jsx_prop_ignore_case(node, "type").map_or("textbox", |input_type| {
-            match get_string_literal_prop_value(input_type) {
-                Some("button" | "image" | "reset" | "submit") => "button",
-                Some("checkbox") => "checkbox",
-                Some("radio") => "radio",
-                Some("range") => "slider",
-                _ => "textbox",
-            }
-        }),
-        "li" => "listitem",
-        "menu" => {
-            // <menu type="toolbar"> → "toolbar", otherwise no implicit role
-            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
-                get_string_literal_prop_value(v).and_then(|v| {
-                    if v.eq_ignore_ascii_case("toolbar") { Some("toolbar") } else { None }
-                })
-            });
-        }
-        "menuitem" => {
-            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
-                match get_string_literal_prop_value(v) {
-                    Some("checkbox") => Some("menuitemcheckbox"),
-                    Some("command") => Some("menuitem"),
-                    Some("radio") => Some("menuitemradio"),
-                    _ => None,
-                }
-            });
-        }
-        "meter" | "progress" => "progressbar",
-        "nav" => "navigation",
-        "ol" | "ul" => "list",
-        "option" => "option",
-        "output" => "status",
-        "section" => "region",
-        "select" => {
-            // <select multiple> or <select size={2+}> → "listbox"
-            // otherwise → "combobox"
-            if has_jsx_prop_ignore_case(node, "multiple").is_some_and(is_truthy_prop) {
-                return Some("listbox");
-            }
-            if has_jsx_prop_ignore_case(node, "size")
-                .and_then(get_prop_value)
-                .is_some_and(|v| parse_jsx_value(v).is_ok_and(|n| n > 1.0))
-            {
-                return Some("listbox");
-            }
-            "combobox"
-        }
-        "tbody" | "tfoot" | "thead" => "rowgroup",
-        "textarea" => "textbox",
-        _ => return None,
-    };
-
-    Some(implicit_role)
-}
-
 impl Rule for NoRedundantRoles {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let user_config =
+            serde_json::from_value::<DefaultRuleConfig<NoRedundantRolesConfig>>(value)
+                .map(DefaultRuleConfig::into_inner)?
+                .normalize();
         let mut config = NoRedundantRolesConfig::default();
-
-        if let Some(obj) = value.get(0).and_then(serde_json::Value::as_object) {
-            for (element, roles) in obj {
-                if let Some(arr) = roles.as_array() {
-                    let role_list: Vec<String> =
-                        arr.iter().filter_map(|v| v.as_str().map(String::from)).collect();
-                    config.allowed_redundant_roles.insert(element.clone(), role_list);
-                }
-            }
-        }
+        config.extend(user_config);
 
         Ok(Self(Box::new(config)))
     }
@@ -251,24 +168,31 @@ impl Rule for NoRedundantRoles {
             return;
         };
 
-        let explicit_role = role_values.value.trim().cow_to_ascii_lowercase();
+        let role_tokens: Vec<&str> = role_values.value.split_whitespace().collect();
+        let Some(explicit_role) = role_tokens
+            .iter()
+            .map(|role| role.cow_to_ascii_lowercase())
+            .find(|role| VALID_ARIA_ROLES.contains(role.as_ref()))
+        else {
+            return;
+        };
 
         if explicit_role != implicit_role {
             return;
         }
 
-        if self
-            .allowed_redundant_roles
-            .get(&*component)
-            .is_some_and(|allowed_roles| allowed_roles.iter().any(|r| r == &explicit_role))
-        {
+        if self.is_allowed(&component, &explicit_role) {
             return;
         }
 
-        ctx.diagnostic_with_fix(
-            no_redundant_roles_diagnostic(attr.span, &component, &explicit_role),
-            |fixer| fixer.delete_range(attr.span),
-        );
+        if role_tokens.len() == 1 {
+            ctx.diagnostic_with_fix(
+                no_redundant_roles_diagnostic(attr.span, &component, &explicit_role),
+                |fixer| fixer.delete_range(attr.span),
+            );
+        } else {
+            ctx.diagnostic(no_redundant_roles_diagnostic(attr.span, &component, &explicit_role));
+        }
     }
 }
 
@@ -304,6 +228,7 @@ fn test() {
         // Config-based exceptions
         ("<ul role='list' />", Some(json!([{ "ul": ["list"] }])), None),
         ("<ol role='list' />", Some(json!([{ "ol": ["list"] }])), None),
+        ("<ul role='LIST' />", Some(json!([{ "ul": [" List "] }])), None),
         // select: role that doesn't match implicit role
         ("<select role='menu'><option>1</option><option>2</option></select>", None, None),
         ("<select role='menu' size={2}><option>1</option><option>2</option></select>", None, None),
@@ -312,6 +237,8 @@ fn test() {
         ("<img src='example.svg' role='img' />", None, None),
         // img: empty alt has no implicit role
         ("<img alt='' role='presentation' />", None, None),
+        // The first supported token is not redundant.
+        ("<button role='presentation button' />", None, None),
     ];
 
     let fail = vec![
@@ -326,6 +253,8 @@ fn test() {
         ("<body role='document' />", None, None),
         // Case insensitive: DOCUMENT matches implicit "document"
         ("<body role='DOCUMENT' />", None, None),
+        // The first supported token is redundant, even with fallback tokens.
+        ("<button role='button presentation' />", None, None),
         ("<Button role='button' />", None, Some(settings())),
         // Expanded implicit role detection
         ("<article role='article' />", None, None),

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -97,17 +97,19 @@ declare_oxc_lint!(
     ///
     /// Redundant roles can lead to confusion and verbosity in the codebase.
     ///
-    /// ### Configuration
+    /// ### Options
     ///
-    /// This rule accepts a configuration object mapping element names to arrays
-    /// of roles that are allowed to be explicitly set even though they match
-    /// the element's implicit role.
+    /// The options are provided as an object keyed by HTML element name;
+    /// the value is an array of implicit ARIA roles that are allowed on
+    /// the specified element.
     ///
-    /// By default, `{ "nav": ["navigation"] }` is allowed.
+    /// The default options allow an implicit role of `navigation` on a
+    /// `nav` element as is
+    /// [advised by W3](https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element).
     ///
     /// ```json
     /// {
-    ///   "jsx-a11y/no-redundant-roles": ["error", { "nav": ["navigation"], "ul": ["list"] }]
+    ///   "jsx-a11y/no-redundant-roles": ["error", { "nav": ["navigation"] }]
     /// }
     /// ```
     ///
@@ -115,19 +117,18 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
-    /// <button role="button"></button>
+    /// <button role="button" />
     /// <body role="document"></body>
-    /// <h1 role="heading"></h1>
-    /// <article role="article"></article>
+    /// <img role="img" src="foo.jpg" />
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
-    /// <nav></nav>
-    /// // `nav` with `navigation` is allowed by default config
-    /// <nav role="navigation"></nav>
+    /// <div />
     /// <button></button>
     /// <body></body>
+    /// <button role="presentation" />
+    /// <MyComponent role="main" />
     /// ```
     NoRedundantRoles,
     jsx_a11y,

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -1,8 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_ast::{
-    AstKind,
-    ast::{JSXAttributeItem, JSXOpeningElement},
-};
+use oxc_ast::{AstKind, ast::JSXAttributeItem};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -13,7 +10,7 @@ use crate::{
     globals::{AriaProperty, VALID_ARIA_ROLES, is_valid_aria_property},
     rule::Rule,
     utils::{
-        get_element_type, get_jsx_attribute_name, get_string_literal_prop_value,
+        get_element_type, get_implicit_role, get_jsx_attribute_name, get_string_literal_prop_value,
         has_jsx_prop_ignore_case,
     },
 };
@@ -106,66 +103,6 @@ impl Rule for RoleSupportsAriaProps {
             }
         }
     }
-}
-
-/// ref: <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/getImplicitRole.js>
-fn get_implicit_role<'a>(
-    node: &'a JSXOpeningElement<'a>,
-    element_type: &str,
-) -> Option<&'static str> {
-    let implicit_role = match element_type {
-        "a" | "area" | "link" => match has_jsx_prop_ignore_case(node, "href") {
-            Some(_) => "link",
-            None => "",
-        },
-        "article" => "article",
-        "aside" => "complementary",
-        "body" => "document",
-        "button" => "button",
-        "datalist" | "select" => "listbox",
-        "details" => "group",
-        "dialog" => "dialog",
-        "form" => "form",
-        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => "heading",
-        "hr" => "separator",
-        "img" => has_jsx_prop_ignore_case(node, "alt").map_or("img", |i| {
-            get_string_literal_prop_value(i)
-                .map_or("img", |v| if v.is_empty() { "" } else { "img" })
-        }),
-        "input" => has_jsx_prop_ignore_case(node, "type").map_or("textbox", |input_type| {
-            match get_string_literal_prop_value(input_type) {
-                Some("button" | "image" | "reset" | "submit") => "button",
-                Some("checkbox") => "checkbox",
-                Some("radio") => "radio",
-                Some("range") => "slider",
-                _ => "textbox",
-            }
-        }),
-        "li" => "listitem",
-        "menu" => has_jsx_prop_ignore_case(node, "type").map_or("", |v| {
-            get_string_literal_prop_value(v)
-                .map_or("", |v| if v == "toolbar" { "toolbar" } else { "" })
-        }),
-        "menuitem" => has_jsx_prop_ignore_case(node, "type").map_or("", |v| {
-            match get_string_literal_prop_value(v) {
-                Some("checkbox") => "menuitemcheckbox",
-                Some("command") => "menuitem",
-                Some("radio") => "menuitemradio",
-                _ => "",
-            }
-        }),
-        "meter" | "progress" => "progressbar",
-        "nav" => "navigation",
-        "ol" | "ul" => "list",
-        "option" => "option",
-        "output" => "status",
-        "section" => "region",
-        "tbody" | "tfoot" | "thead" => "rowgroup",
-        "textarea" => "textbox",
-        _ => "",
-    };
-
-    VALID_ARIA_ROLES.contains(implicit_role).then_some(implicit_role)
 }
 
 const ALERT_ETC_PROPS: &[AriaProperty] = &[

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
@@ -65,12 +66,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `document` from the element `body`.
 
-  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `nav` element has an implicit role of `navigation`. Defining this explicitly is redundant and should be avoided.
-   ╭─[no_redundant_roles.tsx:1:6]
- 1 │ <nav role='navigation' />
-   ·      ─────────────────
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `body` element has an implicit role of `document`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:7]
+ 1 │ <body role='DOCUMENT' />
+   ·       ───────────────
    ╰────
-  help: Remove the redundant role `navigation` from the element `nav`.
+  help: Remove the redundant role `document` from the element `body`.
 
   ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
@@ -78,3 +79,206 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
    ╰────
   help: Remove the redundant role `button` from the element `button`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `article` element has an implicit role of `article`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:10]
+ 1 │ <article role='article' />
+   ·          ──────────────
+   ╰────
+  help: Remove the redundant role `article` from the element `article`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `h1` element has an implicit role of `heading`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:5]
+ 1 │ <h1 role='heading' />
+   ·     ──────────────
+   ╰────
+  help: Remove the redundant role `heading` from the element `h1`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `ul` element has an implicit role of `list`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:5]
+ 1 │ <ul role='list' />
+   ·     ───────────
+   ╰────
+  help: Remove the redundant role `list` from the element `ul`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `li` element has an implicit role of `listitem`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:5]
+ 1 │ <li role='listitem' />
+   ·     ───────────────
+   ╰────
+  help: Remove the redundant role `listitem` from the element `li`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `aside` element has an implicit role of `complementary`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:8]
+ 1 │ <aside role='complementary' />
+   ·        ────────────────────
+   ╰────
+  help: Remove the redundant role `complementary` from the element `aside`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `textarea` element has an implicit role of `textbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:11]
+ 1 │ <textarea role='textbox' />
+   ·           ──────────────
+   ╰────
+  help: Remove the redundant role `textbox` from the element `textarea`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `hr` element has an implicit role of `separator`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:5]
+ 1 │ <hr role='separator' />
+   ·     ────────────────
+   ╰────
+  help: Remove the redundant role `separator` from the element `hr`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `dialog` element has an implicit role of `dialog`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <dialog role='dialog' />
+   ·         ─────────────
+   ╰────
+  help: Remove the redundant role `dialog` from the element `dialog`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `form` element has an implicit role of `form`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:7]
+ 1 │ <form role='form' />
+   ·       ───────────
+   ╰────
+  help: Remove the redundant role `form` from the element `form`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `option` element has an implicit role of `option`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <option role='option' />
+   ·         ─────────────
+   ╰────
+  help: Remove the redundant role `option` from the element `option`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `output` element has an implicit role of `status`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <output role='status' />
+   ·         ─────────────
+   ╰────
+  help: Remove the redundant role `status` from the element `output`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `section` element has an implicit role of `region`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:10]
+ 1 │ <section role='region' />
+   ·          ─────────────
+   ╰────
+  help: Remove the redundant role `region` from the element `section`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `details` element has an implicit role of `group`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:10]
+ 1 │ <details role='group' />
+   ·          ────────────
+   ╰────
+  help: Remove the redundant role `group` from the element `details`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox'><option>1</option><option>2</option></select>
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' size='' />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' size={1} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' size='1' />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' size={null} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' size={undefined} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' multiple={undefined} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' multiple={false} />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='combobox' multiple='' />
+   ·         ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='listbox' size='3' />
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='listbox' size={2} />
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='listbox' multiple><option>1</option><option>2</option></select>
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `select` element has an implicit role of `listbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <select role='listbox' multiple={true} />
+   ·         ──────────────
+   ╰────
+  help: Remove the redundant role `listbox` from the element `select`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `img` element has an implicit role of `img`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:6]
+ 1 │ <img role='img' />
+   ·      ──────────
+   ╰────
+  help: Remove the redundant role `img` from the element `img`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `img` element has an implicit role of `img`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:25]
+ 1 │ <img src={someVariable} role='img' />
+   ·                         ──────────
+   ╰────
+  help: Remove the redundant role `img` from the element `img`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `nav` element has an implicit role of `navigation`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:6]
+ 1 │ <nav role='navigation' />
+   ·      ─────────────────
+   ╰────
+  help: Remove the redundant role `navigation` from the element `nav`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -75,6 +75,13 @@ assertion_line: 444
 
   ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:9]
+ 1 │ <button role='button presentation' />
+   ·         ──────────────────────────
+   ╰────
+  help: Remove the redundant role `button` from the element `button`.
+
+  ⚠ eslint-plugin-jsx-a11y(no-redundant-roles): The `button` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:9]
  1 │ <Button role='button' />
    ·         ─────────────
    ╰────

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -67,6 +67,111 @@ pub fn get_string_literal_prop_value<'a>(item: &'a JSXAttributeItem<'_>) -> Opti
 
 // TODO: Move the a11y methods to their own util for jsx-a11y?
 
+/// Check if a JSX attribute has a truthy literal value.
+///
+/// Valueless attributes (e.g., `<select multiple>`) are treated as `true`.
+fn is_truthy_prop(item: &JSXAttributeItem<'_>) -> bool {
+    match get_prop_value(item) {
+        None => true,
+        Some(JSXAttributeValue::StringLiteral(s)) => !s.value.is_empty(),
+        Some(JSXAttributeValue::ExpressionContainer(container)) => match &container.expression {
+            JSXExpression::BooleanLiteral(b) => b.value,
+            JSXExpression::NumericLiteral(n) => n.value != 0.0 && !n.value.is_nan(),
+            JSXExpression::StringLiteral(s) => !s.value.is_empty(),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// ref: <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/getImplicitRole.js>
+pub fn get_implicit_role<'a>(
+    node: &'a JSXOpeningElement<'a>,
+    element_type: &str,
+) -> Option<&'static str> {
+    let implicit_role = match element_type {
+        "a" | "area" | "link" => match has_jsx_prop_ignore_case(node, "href") {
+            Some(_) => "link",
+            None => return None,
+        },
+        "article" => "article",
+        "aside" => "complementary",
+        "body" => "document",
+        "button" => "button",
+        "datalist" => "listbox",
+        "details" => "group",
+        "dialog" => "dialog",
+        "form" => "form",
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => "heading",
+        "hr" => "separator",
+        "img" => {
+            if has_jsx_prop_ignore_case(node, "alt")
+                .and_then(get_string_literal_prop_value)
+                .is_some_and(str::is_empty)
+            {
+                return None;
+            }
+            if has_jsx_prop_ignore_case(node, "src")
+                .and_then(get_string_literal_prop_value)
+                .is_some_and(|s| s.contains(".svg"))
+            {
+                return None;
+            }
+            "img"
+        }
+        "input" => has_jsx_prop_ignore_case(node, "type").map_or("textbox", |input_type| {
+            match get_string_literal_prop_value(input_type) {
+                Some("button" | "image" | "reset" | "submit") => "button",
+                Some("checkbox") => "checkbox",
+                Some("radio") => "radio",
+                Some("range") => "slider",
+                _ => "textbox",
+            }
+        }),
+        "li" => "listitem",
+        "menu" => {
+            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
+                get_string_literal_prop_value(v).and_then(|v| {
+                    if v.eq_ignore_ascii_case("toolbar") { Some("toolbar") } else { None }
+                })
+            });
+        }
+        "menuitem" => {
+            return has_jsx_prop_ignore_case(node, "type").and_then(|v| {
+                match get_string_literal_prop_value(v) {
+                    Some("checkbox") => Some("menuitemcheckbox"),
+                    Some("command") => Some("menuitem"),
+                    Some("radio") => Some("menuitemradio"),
+                    _ => None,
+                }
+            });
+        }
+        "meter" | "progress" => "progressbar",
+        "nav" => "navigation",
+        "ol" | "ul" => "list",
+        "option" => "option",
+        "output" => "status",
+        "section" => "region",
+        "select" => {
+            if has_jsx_prop_ignore_case(node, "multiple").is_some_and(is_truthy_prop) {
+                return Some("listbox");
+            }
+            if has_jsx_prop_ignore_case(node, "size")
+                .and_then(get_prop_value)
+                .is_some_and(|v| parse_jsx_value(v).is_ok_and(|n| n > 1.0))
+            {
+                return Some("listbox");
+            }
+            "combobox"
+        }
+        "tbody" | "tfoot" | "thead" => "rowgroup",
+        "textarea" => "textbox",
+        _ => return None,
+    };
+
+    Some(implicit_role)
+}
+
 // ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.9.0/src/util/isHiddenFromScreenReader.js
 pub fn is_hidden_from_screen_reader<'a>(
     ctx: &LintContext<'a>,


### PR DESCRIPTION
Closes #18864.

## Summary

The `jsx-a11y/no-redundant-roles` rule previously rejected all user configuration and only detected redundant roles for 3 elements (`nav`/`button`/`body`). This PR aligns the rule with ESLint's `eslint-plugin-jsx-a11y` reference implementation:

- **Add config support**: Accept `{ element: [allowedRole, ...] }` to allow specific redundant roles per element. Default: `{ "nav": ["navigation"] }` (matching ESLint). User keys override per-element; missing keys fall back to defaults.
- **Expand implicit role detection**: From 3 elements to ~25, covering `article`, `aside`, `h1`–`h6`, `hr`, `img`, `input` (with `type` variants), `li`, `datalist`, `select` (with `multiple`/`size` → `combobox` vs `listbox`), `menu`, `menuitem`, `meter`, `progress`, `nav`, `ol`, `ul`, `option`, `output`, `section`, `tbody`/`tfoot`/`thead`, `textarea`, `details`, `dialog`, `form`.
- **Case-insensitive role comparison**: `<body role="DOCUMENT">` is now correctly flagged (matching ESLint's `getExplicitRole` which lowercases).
- **`img` special cases**: `<img alt="">` (no implicit role), `<img src="foo.svg">` (no implicit role per WebKit workaround) — both aligned with ESLint.
- **`select` combobox/listbox**: `<select>` defaults to `combobox`; `<select multiple>` or `<select size={2+}>` → `listbox`. Handles `multiple={true/false/undefined/null/""}` and `size={n}/"n"` correctly.
- **`menu` without type**: No implicit role (was incorrectly returning `"list"`).
- **Default `nav` exception**: `<nav role="navigation">` now passes by default (was incorrectly failing).

## Test plan

- [x] `cargo test -p oxc_linter -- no_redundant_roles` — all pass
- [x] `cargo clippy -p oxc_linter --lib` — no warnings in changed file
- [x] `typos` — clean
- [x] Snapshot regenerated via `cargo insta`
- [x] Test cases cover all ESLint test scenarios: `select` combobox/listbox variants, case-insensitive roles, `img` edge cases, config overrides