### PR TITLE
docs(linter/plugins): update conformance README

### DIFF
--- a/apps/oxlint/conformance/README.md
+++ b/apps/oxlint/conformance/README.md
@@ -1,11 +1,14 @@
 # Oxlint JS plugins conformance tests
 
-Conformance tests run all ESLint's tests for its built-in rules as Oxlint JS plugins.
+Conformance tests run:
 
-They do this by substituting ESLint's `RuleTester` for Oxlint's version, and then `require()`ing the ESLint test files
+- All ESLint's tests for its built-in rules as Oxlint JS plugins.
+- Tests from various ESLint plugins, running in Oxlint.
+
+They do this by substituting ESLint's `RuleTester` for Oxlint's version, and then `require()`ing the test files
 to run the tests.
 
-The results are saved in `conformance/snapshot.md`.
+The results are saved in `snapshots` directory.
 
 ## Setup
 
@@ -16,7 +19,7 @@ cd apps/oxlint
 pnpm run build-conformance
 ```
 
-Initialize ESLint submodule:
+Initialize plugin submodules:
 
 ```sh
 pnpm run init-conformance
@@ -27,3 +30,9 @@ pnpm run init-conformance
 ```sh
 pnpm run conformance
 ```
+
+## Adding a plugin to conformance tests
+
+- Add code to `init.sh` to clone the plugin's repo.
+- Add a file to `src/groups` directory (copy pattern used for other plugins).
+- Add the group to `src/groups/index.ts`.


### PR DESCRIPTION
Update README for Oxlint JS plugins conformance tests. Going to link to this in alpha blog post.