### PR TITLE
feat(oxfmt/lsp): respect `angular` language id as `.component.html` file

### DIFF
--- a/apps/oxfmt/src/lsp/mod.rs
+++ b/apps/oxfmt/src/lsp/mod.rs
@@ -33,6 +33,7 @@ pub(super) fn get_file_extension_from_language_id(
         "less" => Some("less"),
         "vue" => Some("vue"),
         "yaml" => Some("yaml"),
+        "angular" => Some("component.html"),
         _ => None,
     }
 }


### PR DESCRIPTION
related https://github.com/oxc-project/oxc-zed/issues/138#issuecomment-4042069365
This does not resolve the original issue. The editor is not sending the language id to the server, but we know at least how to handle them.
