### PR TITLE
test(linter/plugins): Add eslint-plugin-storybook to the JS Plugins conformance suite

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -7,6 +7,7 @@ STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
 SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
 E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
 TESTING_LIBRARY_SHA="b8ef3772487a32c886cb5c338da2a144560a437b" # 7.15.4
+STORYBOOK_SHA="99aa48989f6798ae24d9867bc2b5fe6991a2e341" # v10.3.0-alpha.12
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -58,6 +59,7 @@ cd ../..
 # @overlookmotel says: @camc314 added the next block to this script, but it doesn't seem to work on my machine.
 # Presumably it's because we're using different versions of `yarn`, but I can't track down the problem exactly.
 # So I'm commenting it out again for now.
+# @connorshea says: I also ran into the problem cam had, I'm using yarn v1 via homebrew.
 
 # Ensure `eslint-plugin-react-hooks` can be resolved from the React tests directory.
 # In recent React workspace setups this is already satisfied after `yarn`, and forcing
@@ -198,6 +200,19 @@ clone testing_library https://github.com/testing-library/eslint-plugin-testing-l
 
 # Install dependencies
 pnpm install --ignore-workspace
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# Storybook
+###############################################################################
+
+# Clone `eslint-plugin-storybook` repo into `submodules/storybook`
+clone storybook https://github.com/storybookjs/storybook.git "$STORYBOOK_SHA"
+
+# Install dependencies
+yarn install
 
 # Return to `submodules` directory
 cd ..

--- a/apps/oxlint/conformance/snapshots/storybook.md
+++ b/apps/oxlint/conformance/snapshots/storybook.md
@@ -18,9 +18,9 @@
 | Status      | Count | %      |
 | ----------- | ----- | ------ |
 | Total tests |   161 | 100.0% |
-| Passing     |   141 |  87.6% |
+| Passing     |   161 | 100.0% |
 | Failing     |     0 |   0.0% |
-| Skipped     |    20 |  12.4% |
+| Skipped     |     0 |   0.0% |
 
 ## Fully Passing Rules
 
@@ -35,7 +35,7 @@
 - `no-renderer-packages` (7 tests)
 - `no-stories-of` (3 tests)
 - `no-title-property-in-meta` (12 tests)
-- `no-uninstalled-addons` (20 tests) (20 skipped)
+- `no-uninstalled-addons` (20 tests)
 - `prefer-pascal-case` (10 tests)
 - `story-exports` (14 tests)
 - `use-storybook-expect` (8 tests)

--- a/apps/oxlint/conformance/snapshots/storybook.md
+++ b/apps/oxlint/conformance/snapshots/storybook.md
@@ -1,0 +1,46 @@
+# Conformance test results - storybook
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |    16 | 100.0% |
+| Fully passing     |    16 | 100.0% |
+| Partially passing |     0 |   0.0% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |   161 | 100.0% |
+| Passing     |   141 |  87.6% |
+| Failing     |     0 |   0.0% |
+| Skipped     |    20 |  12.4% |
+
+## Fully Passing Rules
+
+- `await-interactions` (22 tests)
+- `context-in-play-function` (13 tests)
+- `csf-component` (5 tests)
+- `default-exports` (11 tests)
+- `hierarchy-separator` (8 tests)
+- `meta-inline-properties` (8 tests)
+- `meta-satisfies-type` (7 tests)
+- `no-redundant-story-name` (9 tests)
+- `no-renderer-packages` (7 tests)
+- `no-stories-of` (3 tests)
+- `no-title-property-in-meta` (12 tests)
+- `no-uninstalled-addons` (20 tests) (20 skipped)
+- `prefer-pascal-case` (10 tests)
+- `story-exports` (14 tests)
+- `use-storybook-expect` (8 tests)
+- `use-storybook-testing-library` (4 tests)
+
+## Rules with Failures
+
+No rules with failures

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -6,6 +6,7 @@ import stylistic from "./stylistic.ts";
 import sonarjs from "./sonarjs.ts";
 import e18e from "./e18e.ts";
 import testingLibrary from "./testing_library.ts";
+import storybook from "./storybook.ts";
 
 export const TEST_GROUPS: TestGroup[] = [
   eslint,
@@ -14,4 +15,5 @@ export const TEST_GROUPS: TestGroup[] = [
   sonarjs,
   e18e,
   testingLibrary,
+  storybook,
 ];

--- a/apps/oxlint/conformance/src/groups/storybook.ts
+++ b/apps/oxlint/conformance/src/groups/storybook.ts
@@ -1,0 +1,96 @@
+import { RuleTester } from "../rule_tester.ts";
+
+import type { MockFn, TestGroup } from "../index.ts";
+import type { LanguageOptions, TestCase, TestCases } from "../rule_tester.ts";
+import type { Rule } from "#oxlint/plugins";
+
+type TSEslintParser = typeof import("@typescript-eslint/parser");
+
+const group: TestGroup = {
+  name: "storybook",
+
+  submoduleName: "storybook",
+  testFilesDirPath: "code/lib/eslint-plugin/src/rules",
+
+  transformTestFilename(filename: string) {
+    if (!filename.endsWith(".test.ts")) return null;
+    return filename.slice(0, -".test.ts".length);
+  },
+
+  prepare(require: NodeJS.Require, mock: MockFn) {
+    // Load the copy of TS-ESLint parser which is used by the test cases
+    const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
+
+    // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester`
+    mock("@typescript-eslint/rule-tester", createTsRuleTester(tsEslintParser));
+
+    // Mock `vitest` - it's ESM-only and can't be `require()`-ed.
+    // `no-uninstalled-addons` test uses `vi.mock()` which can't work in CJS context anyway.
+    mock("vitest", { vi: { mock: () => {}, importActual: () => ({}) } });
+  },
+
+  shouldSkipTest(ruleName: string): boolean {
+    // `no-uninstalled-addons` relies on `vi.mock('fs')` and reading `package.json` files,
+    // which can't work in the CJS conformance context.
+    if (ruleName === "no-uninstalled-addons") {
+      return true;
+    }
+
+    return false;
+  },
+
+  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+
+  parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
+};
+
+export default group;
+
+/**
+ * Create a module to replace `@typescript-eslint/rule-tester`,
+ * which presents the same API, but uses conformance `RuleTester` with TS-ESLint parser.
+ *
+ * @param tsEslintParser - TSESLint parser module
+ * @returns Module to replace `@typescript-eslint/rule-tester` module with
+ */
+function createTsRuleTester(tsEslintParser: TSEslintParser): { RuleTester: typeof RuleTester } {
+  class TsRuleTester extends RuleTester {
+    constructor(config?: { languageOptions?: LanguageOptions } | null) {
+      super({
+        ...config,
+        languageOptions: {
+          parser: tsEslintParser,
+          ...config?.languageOptions,
+        },
+      });
+    }
+
+    // Patch test case filenames from `.js` to `.tsx` so oxlint parses as TypeScript.
+    // Storybook's `StorybookRuleTester` sets `filename: 'MyComponent.stories.js'` as default,
+    // but many test cases contain TypeScript and/or JSX syntax.
+    run(ruleName: string, rule: Rule, tests: TestCases): void {
+      tests = {
+        valid: tests.valid.map((test) => {
+          if (typeof test === "string") return test;
+          return patchFilename(test);
+        }),
+        invalid: tests.invalid.map((test) => patchFilename(test)),
+      };
+      super.run(ruleName, rule, tests);
+    }
+  }
+
+  return { RuleTester: TsRuleTester };
+}
+
+/**
+ * Change `.js` file extension to `.tsx` so oxlint parses as TypeScript + JSX.
+ * Storybook test cases may contain both TS syntax (type annotations) and JSX.
+ */
+function patchFilename<T extends TestCase>(test: T): T {
+  const { filename } = test;
+  if (filename != null && filename.endsWith(".js")) {
+    return { ...test, filename: `${filename.slice(0, -".js".length)}.tsx` };
+  }
+  return test;
+}

--- a/apps/oxlint/conformance/src/groups/storybook.ts
+++ b/apps/oxlint/conformance/src/groups/storybook.ts
@@ -1,3 +1,7 @@
+import { dirname } from "node:path";
+import { createRequire } from "node:module";
+import assert from "node:assert";
+
 import { RuleTester } from "../rule_tester.ts";
 
 import type { MockFn, TestGroup } from "../index.ts";
@@ -6,6 +10,43 @@ import type { Rule } from "#oxlint/plugins";
 
 type TSEslintParser = typeof import("@typescript-eslint/parser");
 
+const require = createRequire(import.meta.url);
+const fs = require("fs");
+
+// Test for `no-uninstalled-addons` rule mocks `fs.readFileSync` using Vitest's `vi.mock()`
+// to return a fake `package.json` file.
+//
+// We replicate this behavior by:
+// 1. Mocking `vitest` and capturing the `package.json` file contents in a variable.
+// 2. Tracking when we're in a test case for this plugin by adding `before` and `after` hooks to all test cases,
+//    which set/unset `isInTestCase` flag.
+// 3. Mocking `fs.readFileSync` to return the `package.json` file contents when `isInTestCase === true`.
+let readFileSyncResult: string | null = null;
+
+const vitestMock = {
+  vi: {
+    mock(moduleName: string, getMockedMethods: () => Record<string, Function>) {
+      assert.equal(moduleName, "fs");
+      const mockedMethods = getMockedMethods();
+      assert(Object.keys(mockedMethods).length === 1);
+      readFileSyncResult = mockedMethods.readFileSync();
+    },
+    importActual(moduleName: string): null {
+      assert.equal(moduleName, "fs");
+      return null;
+    },
+  },
+};
+
+let isInTestCase = false;
+
+const readFileSyncOriginal = fs.readFileSync;
+fs.readFileSync = function (...args: unknown[]): unknown {
+  if (isInTestCase && readFileSyncResult !== null) return readFileSyncResult;
+  return readFileSyncOriginal.apply(this, args);
+};
+
+// Test group definition
 const group: TestGroup = {
   name: "storybook",
 
@@ -21,25 +62,18 @@ const group: TestGroup = {
     // Load the copy of TS-ESLint parser which is used by the test cases
     const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
 
-    // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester`
-    mock("@typescript-eslint/rule-tester", createTsRuleTester(tsEslintParser));
+    // Get path to `code` directory in submodule
+    const codeDirPath = dirname(require.resolve("../../../../package.json"));
 
-    // Mock `vitest` - it's ESM-only and can't be `require()`-ed.
-    // `no-uninstalled-addons` test uses `vi.mock()` which can't work in CJS context anyway.
-    mock("vitest", { vi: { mock: () => {}, importActual: () => ({}) } });
+    // Mock `vitest` to capture call to `vi.mock()` which `no-uninstalled-addons` rule test uses
+    mock("vitest", vitestMock);
+
+    // Mock `@typescript-eslint/rule-tester` to use conformance `RuleTester`,
+    // and add `before` and `after` hooks to track when we're in a test case for this plugin.
+    mock("@typescript-eslint/rule-tester", createTsRuleTester(tsEslintParser, codeDirPath));
   },
 
-  shouldSkipTest(ruleName: string): boolean {
-    // `no-uninstalled-addons` relies on `vi.mock('fs')` and reading `package.json` files,
-    // which can't work in the CJS conformance context.
-    if (ruleName === "no-uninstalled-addons") {
-      return true;
-    }
-
-    return false;
-  },
-
-  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+  ruleTesters: [],
 
   parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
 };
@@ -49,11 +83,16 @@ export default group;
 /**
  * Create a module to replace `@typescript-eslint/rule-tester`,
  * which presents the same API, but uses conformance `RuleTester` with TS-ESLint parser.
+ * It also adds `before` and `after` hooks to all test cases to track when we're in a test case for this plugin.
  *
  * @param tsEslintParser - TSESLint parser module
+ * @param codeDirPath - Path to `code` directory in submodule
  * @returns Module to replace `@typescript-eslint/rule-tester` module with
  */
-function createTsRuleTester(tsEslintParser: TSEslintParser): { RuleTester: typeof RuleTester } {
+function createTsRuleTester(
+  tsEslintParser: TSEslintParser,
+  codeDirPath: string,
+): { RuleTester: typeof RuleTester } {
   class TsRuleTester extends RuleTester {
     constructor(config?: { languageOptions?: LanguageOptions } | null) {
       super({
@@ -71,10 +110,10 @@ function createTsRuleTester(tsEslintParser: TSEslintParser): { RuleTester: typeo
     run(ruleName: string, rule: Rule, tests: TestCases): void {
       tests = {
         valid: tests.valid.map((test) => {
-          if (typeof test === "string") return test;
-          return patchFilename(test);
+          if (typeof test === "string") test = { code: test };
+          return patchTestCase(test, codeDirPath);
         }),
-        invalid: tests.invalid.map((test) => patchFilename(test)),
+        invalid: tests.invalid.map((test) => patchTestCase(test, codeDirPath)),
       };
       super.run(ruleName, rule, tests);
     }
@@ -86,11 +125,38 @@ function createTsRuleTester(tsEslintParser: TSEslintParser): { RuleTester: typeo
 /**
  * Change `.js` file extension to `.tsx` so oxlint parses as TypeScript + JSX.
  * Storybook test cases may contain both TS syntax (type annotations) and JSX.
+ *
+ * Track when in a test case for this plugin by adding `before` and `after` hooks to all test cases.
+ * Set CWD to `codeDirPath` (`code` directory in submodule) while running a test case.
+ * The last 2 are required for `no-uninstalled-addons` rule test to work (see above).
+ *
+ * @param test - Test case
+ * @param codeDirPath - Path to `code` directory in submodule
+ * @returns Test case with `filename` property patched, and `before` and `after` hooks added
  */
-function patchFilename<T extends TestCase>(test: T): T {
+function patchTestCase<T extends TestCase>(test: T, codeDirPath: string): T {
+  test = { ...test };
+
   const { filename } = test;
   if (filename != null && filename.endsWith(".js")) {
-    return { ...test, filename: `${filename.slice(0, -".js".length)}.tsx` };
+    test.filename = `${filename.slice(0, -".js".length)}.tsx`;
   }
+
+  let cwd: string | undefined;
+
+  // oxlint-disable-next-line typescript/unbound-method
+  const { before, after } = test;
+  test.before = function () {
+    isInTestCase = true;
+    cwd = process.cwd();
+    process.chdir(codeDirPath);
+    if (before != null) before.call(this);
+  };
+  test.after = function () {
+    if (after != null) after.call(this);
+    process.chdir(cwd!);
+    isInTestCase = false;
+  };
+
   return test;
 }

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -33,7 +33,7 @@
     "generate-config-types": "node scripts/generate-config-types.ts",
     "test": "vitest --dir ./test run",
     "init-conformance": "cd conformance; ./init.sh",
-    "conformance": "cross-env NODE_DISABLE_COLORS=1 tsx ./conformance/src/index.ts"
+    "conformance": "cross-env NODE_DISABLE_COLORS=1 tsx --conditions=code ./conformance/src/index.ts"
   },
   "devDependencies": {
     "@arethetypeswrong/core": "catalog:",


### PR DESCRIPTION
- Tried to keep it as simple as I could, basically copy-pasted the e18e code and then had Claude help me with parsing issues I ran into. The `stories.js` files that are used for these tests are actually JSX/TSX and so I needed to force Oxlint to use the TypeScript/TSX parser by overriding the file name. I am unsure why Storybook does this or if there's a simpler fix, but it works for now.
- `--conditions=code` in the conformance command is seemingly necessary for storybook's eslint plugin to be loaded, I am admittedly unsure if that causes any problems for the other plugins but I was able to run all of them (excluding reactHooks) fine locally after the change with no diffs in the snaps, so ¯\\\_(ツ)_/¯. reactHooks wasn't working for me before this change either, so I don't think that's a problem with my change.
- The `no-uninstalled-addons` rule is skipped because it relies on reading package.json files and that seems to be not-possible, as best as I can tell. Or at least, I didn't feel it worthwhile to try to figure out how to make it work after solving for the parser issues on the other rules.

See the storybook plugin source code here: https://github.com/storybookjs/storybook/tree/1ba2d0721a9b5e50dcb3974bae7f40d10d71c043/code/lib/eslint-plugin

AI Disclosure: As noted above, used Claude for troubleshooting/fixing parser config issues.

Result:

```
### Rules

| Status            | Count | %      |
| ----------------- | ----- | ------ |
| Total rules       |    16 | 100.0% |
| Fully passing     |    16 | 100.0% |
| Partially passing |     0 |   0.0% |
| Fully failing     |     0 |   0.0% |
| Load errors       |     0 |   0.0% |
| No tests run      |     0 |   0.0% |

### Tests

| Status      | Count | %      |
| ----------- | ----- | ------ |
| Total tests |   161 | 100.0% |
| Passing     |   141 |  87.6% |
| Failing     |     0 |   0.0% |
| Skipped     |    20 |  12.4% |
```

(note that one of the rules is skipped, so I'd think the "No tests run" should be 1?)