### PR TITLE
test(linter/plugins): Add eslint-plugin-playwright to the conformance tests

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -8,6 +8,7 @@ SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
 E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
 TESTING_LIBRARY_SHA="b8ef3772487a32c886cb5c338da2a144560a437b" # 7.15.4
 STORYBOOK_SHA="99aa48989f6798ae24d9867bc2b5fe6991a2e341" # v10.3.0-alpha.12
+PLAYWRIGHT_SHA="7e16bd565cfccd365a6a8f1f7f6fe29a1c868036" # v2.9.0
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -210,6 +211,19 @@ cd ..
 
 # Clone `eslint-plugin-storybook` repo into `submodules/storybook`
 clone storybook https://github.com/storybookjs/storybook.git "$STORYBOOK_SHA"
+
+# Install dependencies
+yarn install
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# Playwright
+###############################################################################
+
+# Clone `eslint-plugin-playwright` repo into `submodules/playwright`
+clone playwright https://github.com/mskelton/eslint-plugin-playwright.git "$PLAYWRIGHT_SHA"
 
 # Install dependencies
 yarn install

--- a/apps/oxlint/conformance/snapshots/playwright.md
+++ b/apps/oxlint/conformance/snapshots/playwright.md
@@ -1,0 +1,299 @@
+# Conformance test results - playwright
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |    58 | 100.0% |
+| Fully passing     |    57 |  98.3% |
+| Partially passing |     1 |   1.7% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |  3048 | 100.0% |
+| Passing     |  3044 |  99.9% |
+| Failing     |     4 |   0.1% |
+| Skipped     |     0 |   0.0% |
+
+## Fully Passing Rules
+
+- `consistent-spacing-between-blocks` (45 tests)
+- `expect-expect` (40 tests)
+- `max-expects` (30 tests)
+- `max-nested-describe` (24 tests)
+- `missing-playwright-await` (90 tests)
+- `no-commented-out-tests` (38 tests)
+- `no-conditional-expect` (49 tests)
+- `no-conditional-in-test` (57 tests)
+- `no-duplicate-hooks` (20 tests)
+- `no-duplicate-slow` (24 tests)
+- `no-element-handle` (33 tests)
+- `no-eval` (25 tests)
+- `no-focused-test` (29 tests)
+- `no-force-option` (31 tests)
+- `no-get-by-title` (5 tests)
+- `no-hooks` (11 tests)
+- `no-nested-step` (18 tests)
+- `no-networkidle` (22 tests)
+- `no-nth-methods` (22 tests)
+- `no-page-pause` (12 tests)
+- `no-raw-locators` (46 tests)
+- `no-restricted-locators` (27 tests)
+- `no-restricted-matchers` (33 tests)
+- `no-restricted-roles` (34 tests)
+- `no-skipped-test` (50 tests)
+- `no-slowed-test` (33 tests)
+- `no-standalone-expect` (40 tests)
+- `no-unsafe-references` (46 tests)
+- `no-unused-locators` (24 tests)
+- `no-useless-await` (56 tests)
+- `no-useless-not` (45 tests)
+- `no-wait-for-navigation` (32 tests)
+- `no-wait-for-selector` (25 tests)
+- `no-wait-for-timeout` (25 tests)
+- `prefer-comparison-matcher` (626 tests)
+- `prefer-equality-matcher` (34 tests)
+- `prefer-hooks-in-order` (44 tests)
+- `prefer-hooks-on-top` (14 tests)
+- `prefer-locator` (32 tests)
+- `prefer-lowercase-title` (82 tests)
+- `prefer-native-locators` (57 tests)
+- `prefer-strict-equal` (15 tests)
+- `prefer-to-be` (131 tests)
+- `prefer-to-contain` (55 tests)
+- `prefer-to-have-count` (32 tests)
+- `prefer-to-have-length` (22 tests)
+- `prefer-web-first-assertions` (116 tests)
+- `require-hook` (40 tests)
+- `require-soft-assertions` (18 tests)
+- `require-tags` (29 tests)
+- `require-to-pass-timeout` (16 tests)
+- `require-to-throw-message` (26 tests)
+- `require-top-level-describe` (46 tests)
+- `valid-describe-callback` (40 tests)
+- `valid-expect-in-promise` (141 tests)
+- `valid-expect` (57 tests)
+- `valid-title` (174 tests)
+
+## Rules with Failures
+
+- `valid-test-tags` - 56 / 60 (93.3%)
+
+## Rules with Failures Detail
+
+### `valid-test-tags`
+
+Pass: 56 / 60 (93.3%)
+Fail: 4 / 60 (6.7%)
+Skip: 0 / 60 (0.0%)
+
+#### valid-test-tags > valid
+
+```js
+test('my test', { tag: '@my-tag-123' }, async ({ page }) => {})
+```
+
+```json
+{
+  "languageOptions": {
+    "parser": {},
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    }
+  },
+  "options": [
+    {
+      "allowedTags": [
+        "@regression",
+        {}
+      ]
+    }
+  ],
+  "_parser": {
+    "specifier": "@typescript-eslint/parser",
+    "lang": "ts"
+  }
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/valid-test-tags',
+    message: 'Unknown tag "@my-tag-123"',
+    messageId: 'unknownTag',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 0,
+    endLine: 1,
+    endColumn: 63,
+    fixes: null,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertValidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runValidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+
+
+#### valid-test-tags > valid
+
+```js
+test('@my-tag-123 my test', async ({ page }) => {})
+```
+
+```json
+{
+  "languageOptions": {
+    "parser": {},
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    }
+  },
+  "options": [
+    {
+      "allowedTags": [
+        "@regression",
+        {}
+      ]
+    }
+  ],
+  "_parser": {
+    "specifier": "@typescript-eslint/parser",
+    "lang": "ts"
+  }
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have no errors but had 1: [
+  {
+    ruleId: 'rule-to-test/valid-test-tags',
+    message: 'Unknown tag "@my-tag-123"',
+    messageId: 'unknownTag',
+    severity: 1,
+    nodeType: 'Identifier',
+    line: 1,
+    column: 0,
+    endLine: 1,
+    endColumn: 51,
+    fixes: null,
+    suggestions: null
+  }
+]
+
+1 !== 0
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertValidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runValidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+
+
+#### valid-test-tags > invalid
+
+```js
+test('my test', { tag: '@temp-123' }, async ({ page }) => {})
+```
+
+```json
+{
+  "languageOptions": {
+    "parser": {},
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    }
+  },
+  "errors": [
+    {
+      "data": {
+        "tag": "@temp-123"
+      },
+      "messageId": "disallowedTag"
+    }
+  ],
+  "options": [
+    {
+      "disallowedTags": [
+        "@skip",
+        {}
+      ]
+    }
+  ],
+  "_parser": {
+    "specifier": "@typescript-eslint/parser",
+    "lang": "ts"
+  }
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+
+
+#### valid-test-tags > invalid
+
+```js
+test('@temp-123 my test', async ({ page }) => {})
+```
+
+```json
+{
+  "languageOptions": {
+    "parser": {},
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    }
+  },
+  "errors": [
+    {
+      "data": {
+        "tag": "@temp-123"
+      },
+      "messageId": "disallowedTag"
+    }
+  ],
+  "options": [
+    {
+      "disallowedTags": [
+        "@skip",
+        {}
+      ]
+    }
+  ],
+  "_parser": {
+    "specifier": "@typescript-eslint/parser",
+    "lang": "ts"
+  }
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+

--- a/apps/oxlint/conformance/snapshots/playwright.md
+++ b/apps/oxlint/conformance/snapshots/playwright.md
@@ -103,11 +103,9 @@ test('my test', { tag: '@my-tag-123' }, async ({ page }) => {})
 ```json
 {
   "languageOptions": {
-    "parser": {},
-    "parserOptions": {
-      "ecmaVersion": 2022,
-      "sourceType": "module"
-    }
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "parser": {}
   },
   "options": [
     {
@@ -157,11 +155,9 @@ test('@my-tag-123 my test', async ({ page }) => {})
 ```json
 {
   "languageOptions": {
-    "parser": {},
-    "parserOptions": {
-      "ecmaVersion": 2022,
-      "sourceType": "module"
-    }
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "parser": {}
   },
   "options": [
     {
@@ -211,11 +207,9 @@ test('my test', { tag: '@temp-123' }, async ({ page }) => {})
 ```json
 {
   "languageOptions": {
-    "parser": {},
-    "parserOptions": {
-      "ecmaVersion": 2022,
-      "sourceType": "module"
-    }
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "parser": {}
   },
   "errors": [
     {
@@ -259,11 +253,9 @@ test('@temp-123 my test', async ({ page }) => {})
 ```json
 {
   "languageOptions": {
-    "parser": {},
-    "parserOptions": {
-      "ecmaVersion": 2022,
-      "sourceType": "module"
-    }
+    "ecmaVersion": 2022,
+    "sourceType": "module",
+    "parser": {}
   },
   "errors": [
     {

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -7,6 +7,7 @@ import sonarjs from "./sonarjs.ts";
 import e18e from "./e18e.ts";
 import testingLibrary from "./testing_library.ts";
 import storybook from "./storybook.ts";
+import playwright from "./playwright.ts";
 
 export const TEST_GROUPS: TestGroup[] = [
   eslint,
@@ -16,4 +17,5 @@ export const TEST_GROUPS: TestGroup[] = [
   e18e,
   testingLibrary,
   storybook,
+  playwright,
 ];

--- a/apps/oxlint/conformance/src/groups/playwright.ts
+++ b/apps/oxlint/conformance/src/groups/playwright.ts
@@ -30,7 +30,7 @@ const group: TestGroup = {
     mock("../utils/rule-tester", createRuleTesterModule(tsEslintParser));
   },
 
-  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+  ruleTesters: [],
 
   parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
 };

--- a/apps/oxlint/conformance/src/groups/playwright.ts
+++ b/apps/oxlint/conformance/src/groups/playwright.ts
@@ -50,19 +50,22 @@ export default group;
  */
 function createRuleTesterModule(tsEslintParser: TSEslintParser) {
   function runRuleTester(name: string, rule: Rule, tests: TestCases) {
-    return new RuleTester().run(name, rule, tests);
+    const languageOptions: LanguageOptions = {
+      ecmaVersion: 2022,
+      sourceType: "module",
+    };
+
+    return new RuleTester({ languageOptions }).run(name, rule, tests);
   }
 
   function runTSRuleTester(name: string, rule: Rule, tests: TestCases) {
-    return new RuleTester({
-      languageOptions: {
-        parser: tsEslintParser,
-        parserOptions: {
-          ecmaVersion: 2022,
-          sourceType: "module",
-        },
-      } as LanguageOptions,
-    }).run(name, rule, tests);
+    const languageOptions: LanguageOptions = {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      parser: tsEslintParser,
+    };
+
+    return new RuleTester({ languageOptions }).run(name, rule, tests);
   }
 
   const test = (input: string) => `test('test', async () => { ${input} })`;

--- a/apps/oxlint/conformance/src/groups/playwright.ts
+++ b/apps/oxlint/conformance/src/groups/playwright.ts
@@ -1,0 +1,71 @@
+import { RuleTester } from "../rule_tester.ts";
+
+import type { MockFn, TestGroup } from "../index.ts";
+import type { LanguageOptions, TestCases } from "../rule_tester.ts";
+import type { Rule } from "#oxlint/plugins";
+
+type TSEslintParser = typeof import("@typescript-eslint/parser");
+
+const group: TestGroup = {
+  name: "playwright",
+
+  submoduleName: "playwright",
+  testFilesDirPath: "src/rules",
+
+  transformTestFilename(filename: string) {
+    if (!filename.endsWith(".test.ts")) return null;
+    // `rules.test.ts` is a meta-test for plugin exports/README, not a rule test.
+    if (filename === "rules.test.ts") return null;
+    return filename.slice(0, -".test.ts".length);
+  },
+
+  prepare(require: NodeJS.Require, mock: MockFn) {
+    // Load the TS-ESLint parser used by some test cases (via `runTSRuleTester`)
+    const tsEslintParser = require("@typescript-eslint/parser") as TSEslintParser;
+
+    // Mock the plugin's `src/utils/rule-tester` module.
+    // The original imports `describe` and `it` from `vitest` (ESM-only, can't be `require()`-ed)
+    // and sets `RuleTester.describe`/`.it`/`.itOnly`, which the conformance `RuleTester` prevents.
+    // So we replace the entire module with conformance-compatible wrapper functions.
+    mock("../utils/rule-tester", createRuleTesterModule(tsEslintParser));
+  },
+
+  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+
+  parsers: [{ specifier: "@typescript-eslint/parser", lang: "ts" }],
+};
+
+export default group;
+
+/**
+ * Create a module to replace the plugin's `src/utils/rule-tester` module.
+ * Provides `runRuleTester`, `runTSRuleTester`, and `test` functions
+ * that use the conformance `RuleTester`.
+ *
+ * The original module creates `RuleTester` instances with specific language options
+ * and calls `.run()`. We replicate that behavior using the conformance `RuleTester`.
+ *
+ * @param tsEslintParser - TSESLint parser module
+ * @returns Module to replace `src/utils/rule-tester` module with
+ */
+function createRuleTesterModule(tsEslintParser: TSEslintParser) {
+  function runRuleTester(name: string, rule: Rule, tests: TestCases) {
+    return new RuleTester().run(name, rule, tests);
+  }
+
+  function runTSRuleTester(name: string, rule: Rule, tests: TestCases) {
+    return new RuleTester({
+      languageOptions: {
+        parser: tsEslintParser,
+        parserOptions: {
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+      } as LanguageOptions,
+    }).run(name, rule, tests);
+  }
+
+  const test = (input: string) => `test('test', async () => { ${input} })`;
+
+  return { runRuleTester, runTSRuleTester, test };
+}


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code based on the change in #20262, reviewed and confirmed/tested/conformance tests run by me.

Adds [eslint-plugin-playwright](https://github.com/mskelton/eslint-plugin-playwright) to the conformance suite. Almost all of its tests pass, except 4.

```
### Rules

| Status            | Count | %      |
| ----------------- | ----- | ------ |
| Total rules       |    58 | 100.0% |
| Fully passing     |    57 |  98.3% |
| Partially passing |     1 |   1.7% |
| Fully failing     |     0 |   0.0% |
| Load errors       |     0 |   0.0% |
| No tests run      |     0 |   0.0% |

### Tests

| Status      | Count | %      |
| ----------- | ----- | ------ |
| Total tests |  3048 | 100.0% |
| Passing     |  3044 |  99.9% |
| Failing     |     4 |   0.1% |
| Skipped     |     0 |   0.0% |
```