### PR TITLE
test(linter/plugins): Add eslint-plugin-cypress to the conformance suite for JS Plugins

### DIFF
--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -9,6 +9,7 @@ E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
 TESTING_LIBRARY_SHA="b8ef3772487a32c886cb5c338da2a144560a437b" # 7.15.4
 STORYBOOK_SHA="99aa48989f6798ae24d9867bc2b5fe6991a2e341" # v10.3.0-alpha.12
 PLAYWRIGHT_SHA="7e16bd565cfccd365a6a8f1f7f6fe29a1c868036" # v2.9.0
+CYPRESS_SHA="de98a5de648694518873ad85b41250e40a67be95" # v6.2.0
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
@@ -227,6 +228,19 @@ clone playwright https://github.com/mskelton/eslint-plugin-playwright.git "$PLAY
 
 # Install dependencies
 yarn install
+
+# Return to `submodules` directory
+cd ..
+
+###############################################################################
+# Cypress
+###############################################################################
+
+# Clone `eslint-plugin-cypress` repo into `submodules/cypress`
+clone cypress https://github.com/cypress-io/eslint-plugin-cypress.git "$CYPRESS_SHA"
+
+# Install dependencies
+npm install
 
 # Return to `submodules` directory
 cd ..

--- a/apps/oxlint/conformance/snapshots/cypress.md
+++ b/apps/oxlint/conformance/snapshots/cypress.md
@@ -1,0 +1,127 @@
+# Conformance test results - cypress
+
+## Summary
+
+### Rules
+
+| Status            | Count | %      |
+| ----------------- | ----- | ------ |
+| Total rules       |    12 | 100.0% |
+| Fully passing     |    11 |  91.7% |
+| Partially passing |     1 |   8.3% |
+| Fully failing     |     0 |   0.0% |
+| Load errors       |     0 |   0.0% |
+| No tests run      |     0 |   0.0% |
+
+### Tests
+
+| Status      | Count | %      |
+| ----------- | ----- | ------ |
+| Total tests |   150 | 100.0% |
+| Passing     |   147 |  98.0% |
+| Failing     |     3 |   2.0% |
+| Skipped     |     0 |   0.0% |
+
+## Fully Passing Rules
+
+- `assertion-before-screenshot` (18 tests)
+- `no-assigning-return-values` (19 tests)
+- `no-async-before` (8 tests)
+- `no-async-tests` (8 tests)
+- `no-chained-get` (4 tests)
+- `no-debug` (6 tests)
+- `no-force` (22 tests)
+- `no-pause` (6 tests)
+- `no-xpath` (3 tests)
+- `require-data-selectors` (22 tests)
+- `unsafe-to-chain-command` (8 tests)
+
+## Rules with Failures
+
+- `no-unnecessary-waiting` - 23 / 26 (88.5%)
+
+## Rules with Failures Detail
+
+### `no-unnecessary-waiting`
+
+Pass: 23 / 26 (88.5%)
+Fail: 3 / 26 (11.5%)
+Skip: 0 / 26 (0.0%)
+
+#### no-unnecessary-waiting > invalid
+
+```js
+function customWait (ms = 1) { cy.wait(ms) }
+```
+
+```json
+{
+  "errors": [
+    {
+      "messageId": "unexpected"
+    }
+  ]
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+
+
+#### no-unnecessary-waiting > invalid
+
+```js
+const customWait = (ms = 1) => { cy.wait(ms) }
+```
+
+```json
+{
+  "errors": [
+    {
+      "messageId": "unexpected"
+    }
+  ]
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+
+
+#### no-unnecessary-waiting > invalid
+
+```js
+const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }
+```
+
+```json
+{
+  "errors": [
+    {
+      "messageId": "unexpected"
+    }
+  ]
+}
+```
+
+AssertionError [ERR_ASSERTION]: Should have 1 error but had 0: []
+
+0 !== 1
+
+    at assertErrorCountIsCorrect (apps/oxlint/dist/plugins-dev.js)
+    at assertInvalidTestCasePasses (apps/oxlint/dist/plugins-dev.js)
+    at runInvalidTestCase (apps/oxlint/dist/plugins-dev.js)
+    at apps/oxlint/dist/plugins-dev.js
+

--- a/apps/oxlint/conformance/src/groups/cypress.ts
+++ b/apps/oxlint/conformance/src/groups/cypress.ts
@@ -1,0 +1,19 @@
+import type { TestGroup } from "../index.ts";
+
+const group: TestGroup = {
+  name: "cypress",
+
+  submoduleName: "cypress",
+  testFilesDirPath: "tests/lib/rules",
+
+  transformTestFilename(filename: string) {
+    if (!filename.endsWith(".js")) return null;
+    return filename.slice(0, -".js".length);
+  },
+
+  ruleTesters: [{ specifier: "eslint", propName: "RuleTester" }],
+
+  parsers: [],
+};
+
+export default group;

--- a/apps/oxlint/conformance/src/groups/index.ts
+++ b/apps/oxlint/conformance/src/groups/index.ts
@@ -8,6 +8,7 @@ import e18e from "./e18e.ts";
 import testingLibrary from "./testing_library.ts";
 import storybook from "./storybook.ts";
 import playwright from "./playwright.ts";
+import cypress from "./cypress.ts";
 
 export const TEST_GROUPS: TestGroup[] = [
   eslint,
@@ -18,4 +19,5 @@ export const TEST_GROUPS: TestGroup[] = [
   testingLibrary,
   storybook,
   playwright,
+  cypress,
 ];


### PR DESCRIPTION
This adds eslint-plugin-cypress, based on the same changes from the last 2 additions I've done. See the repo here: https://github.com/cypress-io/eslint-plugin-cypress

AI Disclosure: Generated with Claude Code, tested/spot-checked and verified by me (including the SHA hash, of course).

```
### Rules

| Status            | Count | %      |
| ----------------- | ----- | ------ |
| Total rules       |    12 | 100.0% |
| Fully passing     |    11 |  91.7% |
| Partially passing |     1 |   8.3% |
| Fully failing     |     0 |   0.0% |
| Load errors       |     0 |   0.0% |
| No tests run      |     0 |   0.0% |

### Tests

| Status      | Count | %      |
| ----------- | ----- | ------ |
| Total tests |   150 | 100.0% |
| Passing     |   147 |  98.0% |
| Failing     |     3 |   2.0% |
| Skipped     |     0 |   0.0% |
```