### PR TITLE
chore(oxlint,oxfmt): Handle tsdown@0.21.2 warnings

### DIFF
--- a/apps/oxfmt/tsdown.config.ts
+++ b/apps/oxfmt/tsdown.config.ts
@@ -43,6 +43,6 @@ export default defineConfig({
     ],
     // tsdown warns about final bundled modules by `alwaysBundle`.
     // But we know what we are doing, just suppress the warnings.
-    onlyAllowBundle: false,
+    onlyBundle: false,
   },
 });

--- a/apps/oxlint/tsdown.config.ts
+++ b/apps/oxlint/tsdown.config.ts
@@ -32,7 +32,7 @@ const commonConfig = defineConfig({
   deps: {
     // tsdown warns about final bundled modules by `unbundle` + `deps.neverBundle`.
     // But we know what we are doing, just suppress the warnings.
-    onlyAllowBundle: false,
+    onlyBundle: false,
   },
 });
 


### PR DESCRIPTION
https://github.com/rolldown/tsdown/releases/tag/v0.21.2

It seems to be just a rename, so I'll merge soon.
