### PR TITLE
fix(oxlint,oxfmt): Omit useless `| null` for `Option<T>` field from schema

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -27,20 +27,20 @@ export interface Oxfmtrc {
    *
    * - Default: `"always"`
    */
-  arrowParens?: ArrowParensConfig | null;
+  arrowParens?: ArrowParensConfig;
   /**
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
    * - Default: `false`
    */
-  bracketSameLine?: boolean | null;
+  bracketSameLine?: boolean;
   /**
    * Print spaces between brackets in object literals.
    *
    * - Default: `true`
    */
-  bracketSpacing?: boolean | null;
+  bracketSpacing?: boolean;
   /**
    * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
    *
@@ -48,7 +48,7 @@ export interface Oxfmtrc {
    *
    * - Default: `"auto"`
    */
-  embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig | null;
+  embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig;
   /**
    * Which end of line characters to apply.
    *
@@ -57,33 +57,33 @@ export interface Oxfmtrc {
    * - Default: `"lf"`
    * - Overrides `.editorconfig.end_of_line`
    */
-  endOfLine?: EndOfLineConfig | null;
+  endOfLine?: EndOfLineConfig;
   /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *
    * - Default: `"css"`
    */
-  htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig | null;
+  htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig;
   /**
    * Ignore files matching these glob patterns.
    * Patterns are based on the location of the Oxfmt configuration file.
    *
    * - Default: `[]`
    */
-  ignorePatterns?: string[] | null;
+  ignorePatterns?: string[];
   /**
    * Whether to insert a final newline at the end of the file.
    *
    * - Default: `true`
    * - Overrides `.editorconfig.insert_final_newline`
    */
-  insertFinalNewline?: boolean | null;
+  insertFinalNewline?: boolean;
   /**
    * Use single quotes instead of double quotes in JSX.
    *
    * - Default: `false`
    */
-  jsxSingleQuote?: boolean | null;
+  jsxSingleQuote?: boolean;
   /**
    * How to wrap object literals when they could fit on one line or span multiple lines.
    *
@@ -92,14 +92,14 @@ export interface Oxfmtrc {
    *
    * - Default: `"preserve"`
    */
-  objectWrap?: ObjectWrapConfig | null;
+  objectWrap?: ObjectWrapConfig;
   /**
    * File-specific overrides.
    * When a file matches multiple overrides, the later override takes precedence (array order matters).
    *
    * - Default: `[]`
    */
-  overrides?: OxfmtOverrideConfig[] | null;
+  overrides?: OxfmtOverrideConfig[];
   /**
    * Specify the line length that the printer will wrap on.
    *
@@ -108,7 +108,7 @@ export interface Oxfmtrc {
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
    */
-  printWidth?: number | null;
+  printWidth?: number;
   /**
    * How to wrap prose.
    *
@@ -118,25 +118,25 @@ export interface Oxfmtrc {
    *
    * - Default: `"preserve"`
    */
-  proseWrap?: ProseWrapConfig | null;
+  proseWrap?: ProseWrapConfig;
   /**
    * Change when properties in objects are quoted.
    *
    * - Default: `"as-needed"`
    */
-  quoteProps?: QuotePropsConfig | null;
+  quoteProps?: QuotePropsConfig;
   /**
    * Print semicolons at the ends of statements.
    *
    * - Default: `true`
    */
-  semi?: boolean | null;
+  semi?: boolean;
   /**
    * Enforce single attribute per line in HTML, Vue, and JSX.
    *
    * - Default: `false`
    */
-  singleAttributePerLine?: boolean | null;
+  singleAttributePerLine?: boolean;
   /**
    * Use single quotes instead of double quotes.
    *
@@ -144,7 +144,7 @@ export interface Oxfmtrc {
    *
    * - Default: `false`
    */
-  singleQuote?: boolean | null;
+  singleQuote?: boolean;
   /**
    * Sort import statements.
    *
@@ -153,7 +153,7 @@ export interface Oxfmtrc {
    *
    * - Default: Disabled
    */
-  sortImports?: SortImportsConfig | null;
+  sortImports?: SortImportsConfig;
   /**
    * Sort `package.json` keys.
    *
@@ -163,7 +163,7 @@ export interface Oxfmtrc {
    *
    * - Default: `true`
    */
-  sortPackageJson?: SortPackageJsonUserConfig | null;
+  sortPackageJson?: SortPackageJsonUserConfig;
   /**
    * Sort Tailwind CSS classes.
    *
@@ -173,14 +173,14 @@ export interface Oxfmtrc {
    *
    * - Default: Disabled
    */
-  sortTailwindcss?: SortTailwindcssConfig | null;
+  sortTailwindcss?: SortTailwindcssConfig;
   /**
    * Specify the number of spaces per indentation-level.
    *
    * - Default: `2`
    * - Overrides `.editorconfig.indent_size`
    */
-  tabWidth?: number | null;
+  tabWidth?: number;
   /**
    * Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
    *
@@ -188,27 +188,27 @@ export interface Oxfmtrc {
    *
    * - Default: `"all"`
    */
-  trailingComma?: TrailingCommaConfig | null;
+  trailingComma?: TrailingCommaConfig;
   /**
    * Indent lines with tabs instead of spaces.
    *
    * - Default: `false`
    * - Overrides `.editorconfig.indent_style`
    */
-  useTabs?: boolean | null;
+  useTabs?: boolean;
   /**
    * Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
    *
    * - Default: `false`
    */
-  vueIndentScriptAndStyle?: boolean | null;
+  vueIndentScriptAndStyle?: boolean;
   [k: string]: unknown;
 }
 export interface OxfmtOverrideConfig {
   /**
    * Glob patterns to exclude from this override.
    */
-  excludeFiles?: string[] | null;
+  excludeFiles?: string[];
   /**
    * Glob patterns to match files for this override.
    * All patterns are relative to the Oxfmt configuration file.
@@ -226,20 +226,20 @@ export interface FormatConfig {
    *
    * - Default: `"always"`
    */
-  arrowParens?: ArrowParensConfig | null;
+  arrowParens?: ArrowParensConfig;
   /**
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
    * - Default: `false`
    */
-  bracketSameLine?: boolean | null;
+  bracketSameLine?: boolean;
   /**
    * Print spaces between brackets in object literals.
    *
    * - Default: `true`
    */
-  bracketSpacing?: boolean | null;
+  bracketSpacing?: boolean;
   /**
    * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
    *
@@ -247,7 +247,7 @@ export interface FormatConfig {
    *
    * - Default: `"auto"`
    */
-  embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig | null;
+  embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig;
   /**
    * Which end of line characters to apply.
    *
@@ -256,26 +256,26 @@ export interface FormatConfig {
    * - Default: `"lf"`
    * - Overrides `.editorconfig.end_of_line`
    */
-  endOfLine?: EndOfLineConfig | null;
+  endOfLine?: EndOfLineConfig;
   /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *
    * - Default: `"css"`
    */
-  htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig | null;
+  htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig;
   /**
    * Whether to insert a final newline at the end of the file.
    *
    * - Default: `true`
    * - Overrides `.editorconfig.insert_final_newline`
    */
-  insertFinalNewline?: boolean | null;
+  insertFinalNewline?: boolean;
   /**
    * Use single quotes instead of double quotes in JSX.
    *
    * - Default: `false`
    */
-  jsxSingleQuote?: boolean | null;
+  jsxSingleQuote?: boolean;
   /**
    * How to wrap object literals when they could fit on one line or span multiple lines.
    *
@@ -284,7 +284,7 @@ export interface FormatConfig {
    *
    * - Default: `"preserve"`
    */
-  objectWrap?: ObjectWrapConfig | null;
+  objectWrap?: ObjectWrapConfig;
   /**
    * Specify the line length that the printer will wrap on.
    *
@@ -293,7 +293,7 @@ export interface FormatConfig {
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
    */
-  printWidth?: number | null;
+  printWidth?: number;
   /**
    * How to wrap prose.
    *
@@ -303,25 +303,25 @@ export interface FormatConfig {
    *
    * - Default: `"preserve"`
    */
-  proseWrap?: ProseWrapConfig | null;
+  proseWrap?: ProseWrapConfig;
   /**
    * Change when properties in objects are quoted.
    *
    * - Default: `"as-needed"`
    */
-  quoteProps?: QuotePropsConfig | null;
+  quoteProps?: QuotePropsConfig;
   /**
    * Print semicolons at the ends of statements.
    *
    * - Default: `true`
    */
-  semi?: boolean | null;
+  semi?: boolean;
   /**
    * Enforce single attribute per line in HTML, Vue, and JSX.
    *
    * - Default: `false`
    */
-  singleAttributePerLine?: boolean | null;
+  singleAttributePerLine?: boolean;
   /**
    * Use single quotes instead of double quotes.
    *
@@ -329,7 +329,7 @@ export interface FormatConfig {
    *
    * - Default: `false`
    */
-  singleQuote?: boolean | null;
+  singleQuote?: boolean;
   /**
    * Sort import statements.
    *
@@ -338,7 +338,7 @@ export interface FormatConfig {
    *
    * - Default: Disabled
    */
-  sortImports?: SortImportsConfig | null;
+  sortImports?: SortImportsConfig;
   /**
    * Sort `package.json` keys.
    *
@@ -348,7 +348,7 @@ export interface FormatConfig {
    *
    * - Default: `true`
    */
-  sortPackageJson?: SortPackageJsonUserConfig | null;
+  sortPackageJson?: SortPackageJsonUserConfig;
   /**
    * Sort Tailwind CSS classes.
    *
@@ -358,14 +358,14 @@ export interface FormatConfig {
    *
    * - Default: Disabled
    */
-  sortTailwindcss?: SortTailwindcssConfig | null;
+  sortTailwindcss?: SortTailwindcssConfig;
   /**
    * Specify the number of spaces per indentation-level.
    *
    * - Default: `2`
    * - Overrides `.editorconfig.indent_size`
    */
-  tabWidth?: number | null;
+  tabWidth?: number;
   /**
    * Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
    *
@@ -373,20 +373,20 @@ export interface FormatConfig {
    *
    * - Default: `"all"`
    */
-  trailingComma?: TrailingCommaConfig | null;
+  trailingComma?: TrailingCommaConfig;
   /**
    * Indent lines with tabs instead of spaces.
    *
    * - Default: `false`
    * - Overrides `.editorconfig.indent_style`
    */
-  useTabs?: boolean | null;
+  useTabs?: boolean;
   /**
    * Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
    *
    * - Default: `false`
    */
-  vueIndentScriptAndStyle?: boolean | null;
+  vueIndentScriptAndStyle?: boolean;
   [k: string]: unknown;
 }
 export interface SortImportsConfig {
@@ -404,7 +404,7 @@ export interface SortImportsConfig {
    *
    * - Default: `[]`
    */
-  customGroups?: CustomGroupItemConfig[] | null;
+  customGroups?: CustomGroupItemConfig[];
   /**
    * Specifies a list of predefined import groups for sorting.
    *
@@ -457,13 +457,13 @@ export interface SortImportsConfig {
    * Also, you can override the global `newlinesBetween` setting for specific group boundaries
    * by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
    */
-  groups?: SortGroupItemConfig[] | null;
+  groups?: SortGroupItemConfig[];
   /**
    * Specifies whether sorting should be case-sensitive.
    *
    * - Default: `true`
    */
-  ignoreCase?: boolean | null;
+  ignoreCase?: boolean;
   /**
    * Specifies a prefix for identifying internal imports.
    *
@@ -471,7 +471,7 @@ export interface SortImportsConfig {
    *
    * - Default: `["~/", "@/"]`
    */
-  internalPattern?: string[] | null;
+  internalPattern?: string[];
   /**
    * Specifies whether to add newlines between groups.
    *
@@ -479,13 +479,13 @@ export interface SortImportsConfig {
    *
    * - Default: `true`
    */
-  newlinesBetween?: boolean | null;
+  newlinesBetween?: boolean;
   /**
    * Specifies whether to sort items in ascending or descending order.
    *
    * - Default: `"asc"`
    */
-  order?: SortOrderConfig | null;
+  order?: SortOrderConfig;
   /**
    * Enables the use of comments to separate imports into logical groups.
    *
@@ -500,7 +500,7 @@ export interface SortImportsConfig {
    *
    * - Default: `false`
    */
-  partitionByComment?: boolean | null;
+  partitionByComment?: boolean;
   /**
    * Enables the empty line to separate imports into logical groups.
    *
@@ -516,7 +516,7 @@ export interface SortImportsConfig {
    *
    * - Default: `false`
    */
-  partitionByNewline?: boolean | null;
+  partitionByNewline?: boolean;
   /**
    * Specifies whether side effect imports should be sorted.
    *
@@ -524,7 +524,7 @@ export interface SortImportsConfig {
    *
    * - Default: `false`
    */
-  sortSideEffects?: boolean | null;
+  sortSideEffects?: boolean;
   [k: string]: unknown;
 }
 export interface CustomGroupItemConfig {
@@ -542,14 +542,14 @@ export interface CustomGroupItemConfig {
    *
    * Possible values: `"side_effect"`, `"type"`, `"value"`, `"default"`, `"wildcard"`, `"named"`
    */
-  modifiers?: string[] | null;
+  modifiers?: string[];
   /**
    * Selector to match the import kind.
    *
    * Possible values: `"type"`, `"side_effect_style"`, `"side_effect"`, `"style"`, `"index"`,
    * `"sibling"`, `"parent"`, `"subpath"`, `"internal"`, `"builtin"`, `"external"`, `"import"`
    */
-  selector?: string | null;
+  selector?: string;
   [k: string]: unknown;
 }
 /**
@@ -565,7 +565,7 @@ export interface SortPackageJsonConfig {
    *
    * - Default: `false`
    */
-  sortScripts?: boolean | null;
+  sortScripts?: boolean;
   [k: string]: unknown;
 }
 export interface SortTailwindcssConfig {
@@ -577,7 +577,7 @@ export interface SortTailwindcssConfig {
    * - Default: `[]`
    * - Example: `["myClassProp", ":class"]`
    */
-  attributes?: string[] | null;
+  attributes?: string[];
   /**
    * Path to your Tailwind CSS configuration file (v3).
    *
@@ -585,7 +585,7 @@ export interface SortTailwindcssConfig {
    *
    * - Default: Automatically find `"tailwind.config.js"`
    */
-  config?: string | null;
+  config?: string;
   /**
    * List of custom function names whose arguments should be sorted (exact match).
    *
@@ -594,19 +594,19 @@ export interface SortTailwindcssConfig {
    * - Default: `[]`
    * - Example: `["clsx", "cn", "cva", "tw"]`
    */
-  functions?: string[] | null;
+  functions?: string[];
   /**
    * Preserve duplicate classes.
    *
    * - Default: `false`
    */
-  preserveDuplicates?: boolean | null;
+  preserveDuplicates?: boolean;
   /**
    * Preserve whitespace around classes.
    *
    * - Default: `false`
    */
-  preserveWhitespace?: boolean | null;
+  preserveWhitespace?: boolean;
   /**
    * Path to your Tailwind CSS stylesheet (v4).
    *
@@ -614,6 +614,6 @@ export interface SortTailwindcssConfig {
    *
    * - Default: Installed Tailwind CSS's `theme.css`
    */
-  stylesheet?: string | null;
+  stylesheet?: string;
   [k: string]: unknown;
 }

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -174,43 +174,6 @@ export type CustomComponent =
  * }
  * }
  * ]
- * }
- * });
- * ```
- *
- * `oxlint.config.ts`
- *
- * ```ts
- * import { defineConfig } from "oxlint";
- *
- * export default defineConfig({
- * plugins: ["import", "typescript", "unicorn"],
- * env: {
- * "browser": true
- * },
- * globals: {
- * "foo": "readonly"
- * },
- * settings: {
- * react: {
- * version: "18.2.0"
- * },
- * custom: { option: true }
- * },
- * rules: {
- * "eqeqeq": "warn",
- * "import/no-cycle": "error",
- * "react/self-closing-comp": ["error", { "html": false }]
- * },
- * overrides: [
- * {
- * files: ["*.test.ts", "*.spec.ts"],
- * rules: {
- * "@typescript-eslint/no-explicit-any": "off"
- * }
- * }
- * ]
- * }
  * });
  * ```
  */
@@ -218,7 +181,7 @@ export interface Oxlintrc {
   /**
    * Schema URI for editor tooling.
    */
-  $schema?: string | null;
+  $schema?: string;
   categories?: RuleCategories;
   /**
    * Environments enable and disable collections of global variables.
@@ -300,7 +263,7 @@ export interface Oxlintrc {
    * NOTE: Setting the `plugins` field will overwrite the base set of plugins.
    * The `plugins` array should reflect all of the plugins you want to use.
    */
-  plugins?: LintPlugins | null;
+  plugins?: LintPlugins;
   /**
    * Example
    *
@@ -403,25 +366,25 @@ export interface OxlintGlobals {
  */
 export interface OxlintOptions {
   /**
+   * Ensure warnings produce a non-zero exit code.
+   *
+   * Equivalent to passing `--deny-warnings` on the CLI.
+   */
+  denyWarnings?: boolean;
+  /**
+   * Specify a warning threshold. Exits with an error status if warnings exceed this value.
+   *
+   * Equivalent to passing `--max-warnings` on the CLI.
+   */
+  maxWarnings?: number;
+  /**
    * Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).
    *
    * Equivalent to passing `--report-unused-disable-directives-severity` on the CLI.
    * CLI flags take precedence over this value when both are set.
    * Only supported in the root configuration file.
    */
-  reportUnusedDisableDirectives?: AllowWarnDeny | null;
-  /**
-   * Ensure warnings produce a non-zero exit code.
-   *
-   * Equivalent to passing `--deny-warnings` on the CLI.
-   */
-  denyWarnings?: boolean | null;
-  /**
-   * Specify a warning threshold. Exits with an error status if warnings exceed this value.
-   *
-   * Equivalent to passing `--max-warnings` on the CLI.
-   */
-  maxWarnings?: number | null;
+  reportUnusedDisableDirectives?: AllowWarnDeny;
   /**
    * Enable rules that require type information.
    *
@@ -429,7 +392,7 @@ export interface OxlintOptions {
    *
    * Note that this requires the `oxlint-tsgolint` package to be installed.
    */
-  typeAware?: boolean | null;
+  typeAware?: boolean;
   /**
    * Enable experimental type checking (includes TypeScript compiler diagnostics).
    *
@@ -437,13 +400,13 @@ export interface OxlintOptions {
    *
    * Note that this requires the `oxlint-tsgolint` package to be installed.
    */
-  typeCheck?: boolean | null;
+  typeCheck?: boolean;
 }
 export interface OxlintOverride {
   /**
    * Environments enable and disable collections of global variables.
    */
-  env?: OxlintEnv | null;
+  env?: OxlintEnv;
   /**
    * A list of glob patterns to override.
    *
@@ -454,7 +417,7 @@ export interface OxlintOverride {
   /**
    * Enabled or disabled specific global variables.
    */
-  globals?: OxlintGlobals | null;
+  globals?: OxlintGlobals;
   /**
    * JS plugins for this override, allows usage of ESLint plugins with Oxlint.
    *
@@ -468,7 +431,7 @@ export interface OxlintOverride {
    * Optionally change what plugins are enabled for this override. When
    * omitted, the base config's plugins are used.
    */
-  plugins?: LintPlugins | null;
+  plugins?: LintPlugins;
   rules?: DummyRuleMap;
 }
 /**
@@ -616,7 +579,7 @@ export interface JSXA11YPluginSettings {
    * Will be treated as an `h3`. If not set, this component will be treated
    * as a `Box`.
    */
-  polymorphicPropName?: string | null;
+  polymorphicPropName?: string;
   [k: string]: unknown;
 }
 /**
@@ -728,7 +691,7 @@ export interface ReactPluginSettings {
    * }
    * ```
    */
-  version?: string | null;
+  version?: string;
   [k: string]: unknown;
 }
 /**

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -6,74 +6,53 @@
   "properties": {
     "arrowParens": {
       "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ArrowParensConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
       "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
     },
     "bracketSpacing": {
       "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
       "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
     },
     "endOfLine": {
       "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/EndOfLineConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
       "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": "array",
       "items": {
         "type": "string"
       },
@@ -81,38 +60,26 @@
     },
     "insertFinalNewline": {
       "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
     },
     "jsxSingleQuote": {
       "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
     },
     "objectWrap": {
       "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ObjectWrapConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
     },
     "overrides": {
       "description": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/OxfmtOverrideConfig"
       },
@@ -120,134 +87,95 @@
     },
     "printWidth": {
       "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": "integer",
       "format": "uint16",
       "minimum": 0.0,
       "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
     },
     "proseWrap": {
       "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ProseWrapConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
     },
     "quoteProps": {
       "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/QuotePropsConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
     },
     "semi": {
       "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
     },
     "singleAttributePerLine": {
       "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
     },
     "singleQuote": {
       "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
     },
     "sortImports": {
       "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "sortPackageJson": {
       "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
     },
     "sortTailwindcss": {
       "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortTailwindcssConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": "integer",
       "format": "uint8",
       "minimum": 0.0,
       "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
     },
     "trailingComma": {
       "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/TrailingCommaConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
     },
     "useTabs": {
       "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
     },
     "vueIndentScriptAndStyle": {
       "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
     }
   },
@@ -281,10 +209,7 @@
         },
         "modifiers": {
           "description": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic).\n\nPossible values: `\"side_effect\"`, `\"type\"`, `\"value\"`, `\"default\"`, `\"wildcard\"`, `\"named\"`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -292,10 +217,7 @@
         },
         "selector": {
           "description": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`"
         }
       }
@@ -320,226 +242,160 @@
       "properties": {
         "arrowParens": {
           "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ArrowParensConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
           "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
         },
         "bracketSpacing": {
           "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
           "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
         },
         "endOfLine": {
           "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/EndOfLineConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
           "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
           "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
         },
         "jsxSingleQuote": {
           "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
         },
         "objectWrap": {
           "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ObjectWrapConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
         },
         "printWidth": {
           "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint16",
           "minimum": 0.0,
           "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
         },
         "proseWrap": {
           "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ProseWrapConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
         },
         "quoteProps": {
           "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/QuotePropsConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
         },
         "semi": {
           "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
         },
         "singleAttributePerLine": {
           "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
         },
         "singleQuote": {
           "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
         },
         "sortImports": {
           "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortImportsConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "sortPackageJson": {
           "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortPackageJsonUserConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
         },
         "sortTailwindcss": {
           "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortTailwindcssConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint8",
           "minimum": 0.0,
           "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
         },
         "trailingComma": {
           "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/TrailingCommaConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
         },
         "useTabs": {
           "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
         },
         "vueIndentScriptAndStyle": {
           "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
         }
       }
@@ -580,10 +436,7 @@
       "properties": {
         "excludeFiles": {
           "description": "Glob patterns to exclude from this override.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -656,10 +509,7 @@
       "properties": {
         "customGroups": {
           "description": "Define your own groups for matching very specific imports.\n\nThe `customGroups` list is ordered: The first definition that matches an element will be used.\nCustom groups have a higher priority than any predefined group.\n\nIf you want a predefined group to take precedence over a custom group,\nyou must write a custom group definition that does the same as what the predefined group does, and put it first in the list.\n\nIf you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,\nall conditions must be met for an import to match the custom group (AND logic).\n\n- Default: `[]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/CustomGroupItemConfig"
           },
@@ -667,10 +517,7 @@
         },
         "groups": {
           "description": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers.\nYou may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side_effect_style` — Side effect style imports.\n- `side_effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side_effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n\n- Default: See below\n```json\n[\n\"builtin\",\n\"external\",\n[\"internal\", \"subpath\"],\n[\"parent\", \"sibling\", \"index\"],\n\"style\",\n\"unknown\"\n]\n```\n\nAlso, you can override the global `newlinesBetween` setting for specific group boundaries\nby including a `{ \"newlinesBetween\": boolean }` marker object in the `groups` list at the desired position.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/SortGroupItemConfig"
           },
@@ -678,18 +525,12 @@
         },
         "ignoreCase": {
           "description": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
           "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -697,46 +538,31 @@
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`"
         },
         "order": {
           "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortOrderConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`"
         },
         "partitionByComment": {
           "description": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "partitionByNewline": {
           "description": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "sortSideEffects": {
           "description": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
       }
@@ -753,10 +579,7 @@
       "properties": {
         "sortScripts": {
           "description": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`"
         }
       }
@@ -776,10 +599,7 @@
       "properties": {
         "attributes": {
           "description": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -787,18 +607,12 @@
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
           "description": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -806,26 +620,17 @@
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`"
         },
         "preserveWhitespace": {
           "description": "Preserve whitespace around classes.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`"
         },
         "stylesheet": {
           "description": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`"
         }
       }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -6,10 +6,7 @@
   "properties": {
     "$schema": {
       "description": "Schema URI for editor tooling.",
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": "string",
       "markdownDescription": "Schema URI for editor tooling."
     },
     "categories": {
@@ -96,12 +93,9 @@
     "plugins": {
       "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
       "default": null,
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/LintPlugins"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use."
@@ -370,10 +364,7 @@
         },
         "polymorphicPropName": {
           "description": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`.",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`."
         }
       },
@@ -496,48 +487,33 @@
       "properties": {
         "denyWarnings": {
           "description": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI."
         },
         "maxWarnings": {
           "description": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI.",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint",
           "minimum": 0.0,
           "markdownDescription": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI."
         },
         "reportUnusedDisableDirectives": {
           "description": "Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).\n\nEquivalent to passing `--report-unused-disable-directives-severity` on the CLI.\nCLI flags take precedence over this value when both are set.\nOnly supported in the root configuration file.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/AllowWarnDeny"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).\n\nEquivalent to passing `--report-unused-disable-directives-severity` on the CLI.\nCLI flags take precedence over this value when both are set.\nOnly supported in the root configuration file."
         },
         "typeAware": {
           "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         },
         "typeCheck": {
           "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         }
       },
@@ -552,12 +528,9 @@
       "properties": {
         "env": {
           "description": "Environments enable and disable collections of global variables.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/OxlintEnv"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Environments enable and disable collections of global variables."
@@ -573,12 +546,9 @@
         },
         "globals": {
           "description": "Enabled or disabled specific global variables.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/OxlintGlobals"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
@@ -602,12 +572,9 @@
         "plugins": {
           "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",
           "default": null,
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/LintPlugins"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used."
@@ -736,10 +703,7 @@
         "version": {
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
           "default": null,
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }

--- a/tasks/website_common/src/schema_json.rs
+++ b/tasks/website_common/src/schema_json.rs
@@ -1,4 +1,5 @@
-use schemars::{JsonSchema, schema_for};
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaSettings;
 use serde_json::Value;
 
 /// Generates the JSON schema for a configuration type.
@@ -11,7 +12,14 @@ use serde_json::Value;
 /// # Panics
 /// Panics if the schema generation fails.
 pub fn generate_schema_json<T: JsonSchema>() -> String {
-    let mut schema = schema_for!(T);
+    let generator = SchemaSettings::draft07()
+        .with(|s| {
+            // `Option<T>` fields are already optional (not in `required`),
+            // so adding `null` to the type is unnecessary.
+            s.option_add_null_type = false;
+        })
+        .into_generator();
+    let mut schema = generator.into_root_schema_for::<T>();
 
     // Allow comments and trailing commas for vscode-json-languageservice
     // NOTE: This is NOT part of standard JSON Schema specification

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -10,74 +10,53 @@ expression: json
   "properties": {
     "arrowParens": {
       "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ArrowParensConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
       "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
     },
     "bracketSpacing": {
       "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
       "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
     },
     "endOfLine": {
       "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/EndOfLineConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
       "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": "array",
       "items": {
         "type": "string"
       },
@@ -85,38 +64,26 @@ expression: json
     },
     "insertFinalNewline": {
       "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
     },
     "jsxSingleQuote": {
       "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
     },
     "objectWrap": {
       "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ObjectWrapConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
     },
     "overrides": {
       "description": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": "array",
       "items": {
         "$ref": "#/definitions/OxfmtOverrideConfig"
       },
@@ -124,134 +91,95 @@ expression: json
     },
     "printWidth": {
       "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": "integer",
       "format": "uint16",
       "minimum": 0.0,
       "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
     },
     "proseWrap": {
       "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/ProseWrapConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
     },
     "quoteProps": {
       "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/QuotePropsConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
     },
     "semi": {
       "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
     },
     "singleAttributePerLine": {
       "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
     },
     "singleQuote": {
       "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
     },
     "sortImports": {
       "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortImportsConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "sortPackageJson": {
       "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortPackageJsonUserConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
     },
     "sortTailwindcss": {
       "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/SortTailwindcssConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
     },
     "tabWidth": {
       "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-      "type": [
-        "integer",
-        "null"
-      ],
+      "type": "integer",
       "format": "uint8",
       "minimum": 0.0,
       "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
     },
     "trailingComma": {
       "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/TrailingCommaConfig"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
     },
     "useTabs": {
       "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
     },
     "vueIndentScriptAndStyle": {
       "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-      "type": [
-        "boolean",
-        "null"
-      ],
+      "type": "boolean",
       "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
     }
   },
@@ -285,10 +213,7 @@ expression: json
         },
         "modifiers": {
           "description": "Modifiers to match the import characteristics.\nAll specified modifiers must be present (AND logic).\n\nPossible values: `\"side_effect\"`, `\"type\"`, `\"value\"`, `\"default\"`, `\"wildcard\"`, `\"named\"`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -296,10 +221,7 @@ expression: json
         },
         "selector": {
           "description": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Selector to match the import kind.\n\nPossible values: `\"type\"`, `\"side_effect_style\"`, `\"side_effect\"`, `\"style\"`, `\"index\"`,\n`\"sibling\"`, `\"parent\"`, `\"subpath\"`, `\"internal\"`, `\"builtin\"`, `\"external\"`, `\"import\"`"
         }
       }
@@ -324,226 +246,160 @@ expression: json
       "properties": {
         "arrowParens": {
           "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ArrowParensConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
           "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
         },
         "bracketSpacing": {
           "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
           "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
         },
         "endOfLine": {
           "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/EndOfLineConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
           "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
           "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
         },
         "jsxSingleQuote": {
           "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
         },
         "objectWrap": {
           "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ObjectWrapConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
         },
         "printWidth": {
           "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint16",
           "minimum": 0.0,
           "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
         },
         "proseWrap": {
           "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ProseWrapConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
         },
         "quoteProps": {
           "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/QuotePropsConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
         },
         "semi": {
           "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
         },
         "singleAttributePerLine": {
           "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
         },
         "singleQuote": {
           "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`"
         },
         "sortImports": {
           "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortImportsConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "sortPackageJson": {
           "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortPackageJsonUserConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
         },
         "sortTailwindcss": {
           "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortTailwindcssConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\n- Default: Disabled"
         },
         "tabWidth": {
           "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint8",
           "minimum": 0.0,
           "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size`"
         },
         "trailingComma": {
           "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/TrailingCommaConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
         },
         "useTabs": {
           "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
         },
         "vueIndentScriptAndStyle": {
           "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
         }
       }
@@ -584,10 +440,7 @@ expression: json
       "properties": {
         "excludeFiles": {
           "description": "Glob patterns to exclude from this override.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -660,10 +513,7 @@ expression: json
       "properties": {
         "customGroups": {
           "description": "Define your own groups for matching very specific imports.\n\nThe `customGroups` list is ordered: The first definition that matches an element will be used.\nCustom groups have a higher priority than any predefined group.\n\nIf you want a predefined group to take precedence over a custom group,\nyou must write a custom group definition that does the same as what the predefined group does, and put it first in the list.\n\nIf you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,\nall conditions must be met for an import to match the custom group (AND logic).\n\n- Default: `[]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/CustomGroupItemConfig"
           },
@@ -671,10 +521,7 @@ expression: json
         },
         "groups": {
           "description": "Specifies a list of predefined import groups for sorting.\n\nEach import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).\nThe order of items in the `groups` option determines how groups are ordered.\n\nWithin a given group, members will be sorted according to the type, order, ignoreCase, etc. options.\n\nIndividual groups can be combined together by placing them in an array.\nThe order of groups in that array does not matter.\nAll members of the groups in the array will be sorted together as if they were part of a single group.\n\nPredefined groups are characterized by a single selector and potentially multiple modifiers.\nYou may enter modifiers in any order, but the selector must always come at the end.\n\nThe list of selectors is sorted from most to least important:\n- `type` — TypeScript type imports.\n- `side_effect_style` — Side effect style imports.\n- `side_effect` — Side effect imports.\n- `style` — Style imports.\n- `index` — Main file from the current directory.\n- `sibling` — Modules from the same directory.\n- `parent` — Modules from the parent directory.\n- `subpath` — Node.js subpath imports.\n- `internal` — Your internal modules.\n- `builtin` — Node.js Built-in Modules.\n- `external` — External modules installed in the project.\n- `import` — Any import.\n\nThe list of modifiers is sorted from most to least important:\n- `side_effect` — Side effect imports.\n- `type` — TypeScript type imports.\n- `value` — Value imports.\n- `default` — Imports containing the default specifier.\n- `wildcard` — Imports containing the wildcard (`* as`) specifier.\n- `named` — Imports containing at least one named specifier.\n\n- Default: See below\n```json\n[\n\"builtin\",\n\"external\",\n[\"internal\", \"subpath\"],\n[\"parent\", \"sibling\", \"index\"],\n\"style\",\n\"unknown\"\n]\n```\n\nAlso, you can override the global `newlinesBetween` setting for specific group boundaries\nby including a `{ \"newlinesBetween\": boolean }` marker object in the `groups` list at the desired position.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/SortGroupItemConfig"
           },
@@ -682,18 +529,12 @@ expression: json
         },
         "ignoreCase": {
           "description": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether sorting should be case-sensitive.\n\n- Default: `true`"
         },
         "internalPattern": {
           "description": "Specifies a prefix for identifying internal imports.\n\nThis is useful for distinguishing your own modules from external dependencies.\n\n- Default: `[\"~/\", \"@/\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -701,46 +542,31 @@ expression: json
         },
         "newlinesBetween": {
           "description": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether to add newlines between groups.\n\nWhen `false`, no newlines are added between groups.\n\n- Default: `true`"
         },
         "order": {
           "description": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/SortOrderConfig"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Specifies whether to sort items in ascending or descending order.\n\n- Default: `\"asc\"`"
         },
         "partitionByComment": {
           "description": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enables the use of comments to separate imports into logical groups.\n\nWhen `true`, all comments will be treated as delimiters, creating partitions.\n\n```js\nimport { b1, b2 } from 'b'\n// PARTITION\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "partitionByNewline": {
           "description": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enables the empty line to separate imports into logical groups.\n\nWhen `true`, formatter will not sort imports if there is an empty line between them.\nThis helps maintain the defined order of logically separated groups of members.\n\n```js\nimport { b1, b2 } from 'b'\n\nimport { a } from 'a'\nimport { c } from 'c'\n```\n\n- Default: `false`"
         },
         "sortSideEffects": {
           "description": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
       }
@@ -757,10 +583,7 @@ expression: json
       "properties": {
         "sortScripts": {
           "description": "Sort the `scripts` field alphabetically.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Sort the `scripts` field alphabetically.\n\n- Default: `false`"
         }
       }
@@ -780,10 +603,7 @@ expression: json
       "properties": {
         "attributes": {
           "description": "List of additional attributes to sort beyond `class` and `className` (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"myClassProp\", \":class\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -791,18 +611,12 @@ expression: json
         },
         "config": {
           "description": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Path to your Tailwind CSS configuration file (v3).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Automatically find `\"tailwind.config.js\"`"
         },
         "functions": {
           "description": "List of custom function names whose arguments should be sorted (exact match).\n\nNOTE: Regex patterns are not yet supported.\n\n- Default: `[]`\n- Example: `[\"clsx\", \"cn\", \"cva\", \"tw\"]`",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -810,26 +624,17 @@ expression: json
         },
         "preserveDuplicates": {
           "description": "Preserve duplicate classes.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Preserve duplicate classes.\n\n- Default: `false`"
         },
         "preserveWhitespace": {
           "description": "Preserve whitespace around classes.\n\n- Default: `false`",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Preserve whitespace around classes.\n\n- Default: `false`"
         },
         "stylesheet": {
           "description": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "Path to your Tailwind CSS stylesheet (v4).\n\nNOTE: Paths are resolved relative to the Oxfmt configuration file.\n\n- Default: Installed Tailwind CSS's `theme.css`"
         }
       }

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -10,10 +10,7 @@ expression: json
   "properties": {
     "$schema": {
       "description": "Schema URI for editor tooling.",
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": "string",
       "markdownDescription": "Schema URI for editor tooling."
     },
     "categories": {
@@ -100,12 +97,9 @@ expression: json
     "plugins": {
       "description": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use.",
       "default": null,
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/LintPlugins"
-        },
-        {
-          "type": "null"
         }
       ],
       "markdownDescription": "Enabled built-in plugins for Oxlint.\nYou can view the list of available plugins on\n[the website](https://oxc.rs/docs/guide/usage/linter/plugins.html#supported-plugins).\n\nNOTE: Setting the `plugins` field will overwrite the base set of plugins.\nThe `plugins` array should reflect all of the plugins you want to use."
@@ -374,10 +368,7 @@ expression: json
         },
         "polymorphicPropName": {
           "description": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`.",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "markdownDescription": "An optional setting that define the prop your code uses to create polymorphic components.\nThis setting will be used to determine the element type in rules that\nrequire semantic context.\n\nFor example, if you set the `polymorphicPropName` to `as`, then this element:\n\n```jsx\n<Box as=\"h3\">Hello</Box>\n```\n\nWill be treated as an `h3`. If not set, this component will be treated\nas a `Box`."
         }
       },
@@ -500,48 +491,33 @@ expression: json
       "properties": {
         "denyWarnings": {
           "description": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI."
         },
         "maxWarnings": {
           "description": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI.",
-          "type": [
-            "integer",
-            "null"
-          ],
+          "type": "integer",
           "format": "uint",
           "minimum": 0.0,
           "markdownDescription": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI."
         },
         "reportUnusedDisableDirectives": {
           "description": "Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).\n\nEquivalent to passing `--report-unused-disable-directives-severity` on the CLI.\nCLI flags take precedence over this value when both are set.\nOnly supported in the root configuration file.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/AllowWarnDeny"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Report unused disable directives (e.g. `// oxlint-disable-line` or `// eslint-disable-line`).\n\nEquivalent to passing `--report-unused-disable-directives-severity` on the CLI.\nCLI flags take precedence over this value when both are set.\nOnly supported in the root configuration file."
         },
         "typeAware": {
           "description": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enable rules that require type information.\n\nEquivalent to passing `--type-aware` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         },
         "typeCheck": {
           "description": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed.",
-          "type": [
-            "boolean",
-            "null"
-          ],
+          "type": "boolean",
           "markdownDescription": "Enable experimental type checking (includes TypeScript compiler diagnostics).\n\nEquivalent to passing `--type-check` on the CLI.\n\nNote that this requires the `oxlint-tsgolint` package to be installed."
         }
       },
@@ -556,12 +532,9 @@ expression: json
       "properties": {
         "env": {
           "description": "Environments enable and disable collections of global variables.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/OxlintEnv"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Environments enable and disable collections of global variables."
@@ -577,12 +550,9 @@ expression: json
         },
         "globals": {
           "description": "Enabled or disabled specific global variables.",
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/OxlintGlobals"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Enabled or disabled specific global variables."
@@ -606,12 +576,9 @@ expression: json
         "plugins": {
           "description": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used.",
           "default": null,
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/LintPlugins"
-            },
-            {
-              "type": "null"
             }
           ],
           "markdownDescription": "Optionally change what plugins are enabled for this override. When\nomitted, the base config's plugins are used."
@@ -740,10 +707,7 @@ expression: json
         "version": {
           "description": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```",
           "default": null,
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "pattern": "^[1-9]\\d*(\\.(0|[1-9]\\d*))?(\\.(0|[1-9]\\d*))?$",
           "markdownDescription": "React version to use for version-specific rules.\n\nAccepts semver versions (e.g., \"18.2.0\", \"17.0\").\n\nExample:\n\n```jsonc\n{\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n}\n}\n}\n```"
         }


### PR DESCRIPTION
Currently, fields defined as `key: Option<T>` are represented in TS as `key?: T | null`.

However, passing `null` actually just treats it as `None`, which only creates noise.