### PR TITLE
fix(tools): disable TypeScript in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports": "never" // let oxfmt handle import organization
   },
+  // Disable TypeScript's error checking — Oxlint handles this via the Oxc language server.
+  // VS Code's bundled TS version can disagree with Oxlint's newer TS support (via tsgolint).
+  "js/ts.validate.enabled": false,
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   }


### PR DESCRIPTION
Disable TypeScript type-checking in VS Code in this repo. It's redundant because Oxc language server runs Oxlint, which performs type-checking.

It's also annoying having TS enabled because the versions of TypeScript used by VS Code and by Oxlint sometimes disagree (e.g. on whether `RegExp.escape` exists), which produces erroneous red squiggles in some cases.

This makes #20077 redundant.