### PR TITLE
perf(semantic): V8-style walk-up reference resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,6 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_cfg",
- "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
@@ -2315,7 +2314,6 @@ dependencies = [
  "rustc-hash",
  "self_cell",
  "serde_json",
- "smallvec",
 ]
 
 [[package]]

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -43,7 +43,7 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
  3 │                     jest.setTimeout(800);
@@ -51,7 +51,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
  3 │                     jest.setTimeout(800);
@@ -67,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);
@@ -75,7 +75,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │                         setTimeout(resolve, 10000).unref();
    ╰────
 
-  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
+  ⚠ eslint-plugin-jest(no-confusing-set-timeout): `jest.setTimeout` should only be called in a global scope
    ╭─[no_confusing_set_timeout.tsx:5:25]
  4 │                         await new Promise((resolve) => {
  5 │                         jest.setTimeout(1000);

--- a/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_lowercase_title@jest.snap
@@ -225,15 +225,6 @@ source: crates/oxc_linter/src/tester.rs
   help: `"Does things"`s should begin with lowercase
 
   ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
-   ╭─[prefer_lowercase_title.tsx:3:30]
- 2 │                 describe('MyClass', () => {
- 3 │                     describe('MyMethod', () => {
-   ·                              ──────────
- 4 │                         it('Does things', () => {
-   ╰────
-  help: `"MyMethod"`s should begin with lowercase
-
-  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
    ╭─[prefer_lowercase_title.tsx:2:26]
  1 │ 
  2 │                 describe('MyClass', () => {
@@ -241,3 +232,12 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     describe('MyMethod', () => {
    ╰────
   help: `"MyClass"`s should begin with lowercase
+
+  ⚠ eslint-plugin-jest(prefer-lowercase-title): Enforce lowercase test names
+   ╭─[prefer_lowercase_title.tsx:3:30]
+ 2 │                 describe('MyClass', () => {
+ 3 │                     describe('MyMethod', () => {
+   ·                              ──────────
+ 4 │                         it('Does things', () => {
+   ╰────
+  help: `"MyMethod"`s should begin with lowercase

--- a/crates/oxc_linter/src/snapshots/jest_valid_describe_callback.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_describe_callback.snap
@@ -163,18 +163,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
-    ╭─[valid_describe_callback.tsx:9:21]
-  8 │                     describe('nested', () => {
-  9 │ ╭─▶                     return Promise.resolve().then(() => {
- 10 │ │                           it('breaks', () => {
- 11 │ │                               throw new Error('Fail')
- 12 │ │                           })
- 13 │ ╰─▶                     })
- 14 │                     })
-    ╰────
-  help: Remove return statement in your describe callback
-
-  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:17]
  2 │                 describe('foo', () => {
  3 │ ╭─▶                 return Promise.resolve().then(() => {
@@ -187,14 +175,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
-    ╭─[valid_describe_callback.tsx:6:21]
-  5 │                     describe('nested', () => {
-  6 │ ╭─▶                     return Promise.resolve().then(() => {
-  7 │ │                           it('breaks', () => {
-  8 │ │                               throw new Error('Fail')
-  9 │ │                           })
- 10 │ ╰─▶                     })
- 11 │                     })
+    ╭─[valid_describe_callback.tsx:9:21]
+  8 │                     describe('nested', () => {
+  9 │ ╭─▶                     return Promise.resolve().then(() => {
+ 10 │ │                           it('breaks', () => {
+ 11 │ │                               throw new Error('Fail')
+ 12 │ │                           })
+ 13 │ ╰─▶                     })
+ 14 │                     })
     ╰────
   help: Remove return statement in your describe callback
 
@@ -215,6 +203,18 @@ source: crates/oxc_linter/src/tester.rs
  13 │                 
     ╰────
   help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
+    ╭─[valid_describe_callback.tsx:6:21]
+  5 │                     describe('nested', () => {
+  6 │ ╭─▶                     return Promise.resolve().then(() => {
+  7 │ │                           it('breaks', () => {
+  8 │ │                               throw new Error('Fail')
+  9 │ │                           })
+ 10 │ ╰─▶                     })
+ 11 │                     })
+    ╰────
+  help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:1:23]
@@ -410,18 +410,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
-    ╭─[valid_describe_callback.tsx:9:25]
-  8 │                         describe('nested', () => {
-  9 │ ╭─▶                         return Promise.resolve().then(() => {
- 10 │ │                               it('breaks', () => {
- 11 │ │                                   throw new Error('Fail')
- 12 │ │                               })
- 13 │ ╰─▶                         })
- 14 │                         })
-    ╰────
-  help: Remove return statement in your describe callback
-
-  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]
  2 │                     describe('foo', () => {
  3 │ ╭─▶                     return Promise.resolve().then(() => {
@@ -434,14 +422,14 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
-    ╭─[valid_describe_callback.tsx:6:25]
-  5 │                         describe('nested', () => {
-  6 │ ╭─▶                         return Promise.resolve().then(() => {
-  7 │ │                               it('breaks', () => {
-  8 │ │                                   throw new Error('Fail')
-  9 │ │                               })
- 10 │ ╰─▶                         })
- 11 │                         })
+    ╭─[valid_describe_callback.tsx:9:25]
+  8 │                         describe('nested', () => {
+  9 │ ╭─▶                         return Promise.resolve().then(() => {
+ 10 │ │                               it('breaks', () => {
+ 11 │ │                                   throw new Error('Fail')
+ 12 │ │                               })
+ 13 │ ╰─▶                         })
+ 14 │                         })
     ╰────
   help: Remove return statement in your describe callback
 
@@ -462,6 +450,18 @@ source: crates/oxc_linter/src/tester.rs
  13 │                 
     ╰────
   help: Remove `async` keyword
+
+  ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
+    ╭─[valid_describe_callback.tsx:6:25]
+  5 │                         describe('nested', () => {
+  6 │ ╭─▶                         return Promise.resolve().then(() => {
+  7 │ │                               it('breaks', () => {
+  8 │ │                                   throw new Error('Fail')
+  9 │ │                               })
+ 10 │ ╰─▶                         })
+ 11 │                         })
+    ╰────
+  help: Remove return statement in your describe callback
 
   ⚠ eslint-plugin-jest(valid-describe-callback): Unexpected return statement in describe callback
    ╭─[valid_describe_callback.tsx:3:21]

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -24,7 +24,6 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true, optional = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }
@@ -36,7 +35,6 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }
-smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -34,7 +34,7 @@ use crate::{
     node::AstNodes,
     scoping::{Bindings, Scoping},
     stats::Stats,
-    unresolved_stack::UnresolvedReferencesStack,
+    unresolved_stack::UnresolvedReferences,
 };
 #[cfg(feature = "jsdoc")]
 use oxc_jsdoc::JSDocBuilder;
@@ -90,7 +90,10 @@ pub struct SemanticBuilder<'a> {
     pub(crate) nodes: AstNodes<'a>,
     pub(crate) scoping: Scoping,
 
-    pub(crate) unresolved_references: UnresolvedReferencesStack<'a>,
+    pub(crate) unresolved_references: UnresolvedReferences<'a>,
+    /// Checkpoint for early resolution of function parameter / catch parameter references.
+    /// Tracks the start index in the flat unresolved references list.
+    unresolved_references_checkpoint: usize,
 
     unused_labels: UnusedLabels<'a>,
     #[cfg(feature = "jsdoc")]
@@ -148,7 +151,8 @@ impl<'a> SemanticBuilder<'a> {
             nodes: AstNodes::default(),
             hoisting_variables: FxHashMap::default(),
             scoping,
-            unresolved_references: UnresolvedReferencesStack::new(),
+            unresolved_references: UnresolvedReferences::new(),
+            unresolved_references_checkpoint: 0,
             unused_labels: UnusedLabels::default(),
             #[cfg(feature = "jsdoc")]
             jsdoc: JSDocBuilder::default(),
@@ -279,9 +283,8 @@ impl<'a> SemanticBuilder<'a> {
             stats.assert_accurate(actual_stats);
         }
 
-        debug_assert_eq!(self.unresolved_references.scope_depth(), 1);
-        self.scoping
-            .set_root_unresolved_references(self.unresolved_references.into_root().into_iter());
+        // Root unresolved references are already populated by `resolve_all_references()`
+        // which is called at the end of `visit_program()`.
 
         #[cfg(feature = "jsdoc")]
         let jsdoc = {
@@ -489,8 +492,7 @@ impl<'a> SemanticBuilder<'a> {
         reference: Reference,
     ) -> ReferenceId {
         let reference_id = self.scoping.create_reference(reference);
-
-        self.unresolved_references.current_mut().entry(name).or_default().push(reference_id);
+        self.unresolved_references.push(name, reference_id);
         reference_id
     }
 
@@ -513,101 +515,107 @@ impl<'a> SemanticBuilder<'a> {
         symbol_id
     }
 
-    /// Try to resolve all references from the current scope that are not
-    /// already resolved.
+    /// Resolve all collected references by walking up the scope chain from each
+    /// reference's scope. This replaces the old bubble-up approach where unresolved
+    /// references were merged into parent scope hashmaps on every scope exit.
     ///
-    /// This gets called every time [`SemanticBuilder`] exits a scope.
+    /// Walk-up is faster because it only does hashmap lookups (no drain+insert),
+    /// and reference creation is a simple Vec push instead of a hashmap insert.
+    fn resolve_all_references(&mut self) {
+        let refs = self.unresolved_references.take();
+        for (name, reference_id) in refs {
+            if !self.walk_up_resolve_reference(name, reference_id) {
+                self.scoping.add_root_unresolved_reference(name, reference_id);
+            }
+        }
+    }
+
+    /// Walk up the scope chain trying to resolve a reference.
+    /// Returns `true` if resolved.
+    #[expect(clippy::inline_always, reason = "Hot path — called for every reference resolution")]
+    #[inline(always)]
+    fn walk_up_resolve_reference(&mut self, name: Ident<'a>, reference_id: ReferenceId) -> bool {
+        let mut scope_id = Some(self.scoping.references[reference_id].scope_id());
+        while let Some(sid) = scope_id {
+            if let Some(symbol_id) = self.scoping.get_binding(sid, name)
+                && self.try_resolve_reference(reference_id, symbol_id)
+            {
+                return true;
+            }
+            scope_id = self.scoping.scope_parent_id(sid);
+        }
+        false
+    }
+
+    /// Try to resolve a reference to a symbol. Returns `true` if resolved.
+    fn try_resolve_reference(&mut self, reference_id: ReferenceId, symbol_id: SymbolId) -> bool {
+        let symbol_flags = self.scoping.symbol_flags(symbol_id);
+        let reference = &mut self.scoping.references[reference_id];
+        let flags = reference.flags_mut();
+
+        // Determine whether the symbol can be referenced by this reference.
+        // For pure type references (not value or typeof) in qualified names,
+        // only resolve to namespaces (modules, namespaces, enums, imports).
+        // Type parameters and type aliases cannot have member access in type space.
+        // Value references (including typeof) can always have member access.
+        let can_resolve = if flags.is_namespace()
+            && !flags.is_value()
+            && !flags.is_value_as_type()
+            && !symbol_flags.can_be_referenced_as_namespace()
+        {
+            false
+        } else {
+            (flags.is_value() && symbol_flags.can_be_referenced_by_value())
+                || (flags.is_type() && symbol_flags.can_be_referenced_by_type())
+                || (flags.is_value_as_type() && symbol_flags.can_be_referenced_by_value_as_type())
+        };
+
+        if !can_resolve {
+            return false;
+        }
+
+        if symbol_flags.is_value() && flags.is_value() {
+            // The non type-only ExportSpecifier can reference both type/value symbols,
+            // if the symbol is a value symbol and reference flag is not type-only,
+            // remove the type flag. For example: `const B = 1; export { B };`
+            *flags -= ReferenceFlags::Type;
+        } else {
+            // 1. ReferenceFlags::ValueAsType -> ReferenceFlags::Type
+            // `const ident = 0; typeof ident`
+            //                          ^^^^^ -> The ident is a value symbols,
+            //                                   but it used as a type.
+            // 2. ReferenceFlags::Value | ReferenceFlags::Type -> ReferenceFlags::Type
+            // `type ident = string; export default ident;
+            //                                      ^^^^^ We have confirmed the symbol is
+            //                                            not a value symbol, so we need to
+            //                                            make sure the reference is a type only.
+            *flags = ReferenceFlags::Type;
+        }
+        reference.set_symbol_id(symbol_id);
+        self.scoping.add_resolved_reference(symbol_id, reference_id);
+        true
+    }
+
+    /// Early-resolve references collected since the checkpoint by walking up the
+    /// full scope chain. Used for function parameters and catch parameters where
+    /// references must be resolved before entering the function body, to avoid
+    /// binding to variables declared inside the body (which share the same scope).
+    ///
+    /// Resolved references are removed. Unresolved references stay in the flat
+    /// list for later resolution by `resolve_all_references` (which handles
+    /// forward references to declarations not yet visited).
     fn resolve_references_for_current_scope(&mut self) {
-        let (current_refs, parent_refs) = self.unresolved_references.current_and_parent_mut();
-
-        if current_refs.is_empty() {
+        let checkpoint = self.unresolved_references_checkpoint;
+        let refs = self.unresolved_references.slice_from(checkpoint).to_vec();
+        if refs.is_empty() {
             return;
         }
+        self.unresolved_references.truncate(checkpoint);
 
-        // Fast path: scope has no bindings — skip resolution, just merge to parent.
-        // Many scopes (if-blocks, try-blocks, loop bodies without `let`) have no bindings,
-        // so all unresolved references just bubble up unchanged.
-        if self.scoping.get_bindings(self.current_scope_id).is_empty() {
-            // Union by size: swap so we drain the smaller map into the larger one.
-            if current_refs.len() > parent_refs.len() {
-                mem::swap(current_refs, parent_refs);
-            }
-            for (name, references) in current_refs.drain() {
-                if let Some(parent_reference_ids) = parent_refs.get_mut(&name) {
-                    parent_reference_ids.extend(references);
-                } else {
-                    parent_refs.insert(name, references);
-                }
-            }
-            return;
-        }
-
-        for (name, mut references) in current_refs.drain() {
-            // Try to resolve a reference.
-            // If unresolved, transfer it to parent scope's unresolved references.
-            let bindings = self.scoping.get_bindings(self.current_scope_id);
-            if let Some(symbol_id) = bindings.get(&name).copied() {
-                let symbol_flags = self.scoping.symbol_flags(symbol_id);
-                references.retain(|reference_id| {
-                    let reference_id = *reference_id;
-                    let reference = &mut self.scoping.references[reference_id];
-
-                    let flags = reference.flags_mut();
-
-                    // Determine whether the symbol can be referenced by this reference.
-                    // For pure type references (not value or typeof) in qualified names,
-                    // only resolve to namespaces (modules, namespaces, enums, imports).
-                    // Type parameters and type aliases cannot have member access in type space.
-                    // Value references (including typeof) can always have member access.
-                    let resolved = if flags.is_namespace()
-                        && !flags.is_value()
-                        && !flags.is_value_as_type()
-                        && !symbol_flags.can_be_referenced_as_namespace()
-                    {
-                        false
-                    } else {
-                        (flags.is_value() && symbol_flags.can_be_referenced_by_value())
-                            || (flags.is_type() && symbol_flags.can_be_referenced_by_type())
-                            || (flags.is_value_as_type()
-                                && symbol_flags.can_be_referenced_by_value_as_type())
-                    };
-
-                    if !resolved {
-                        return true;
-                    }
-
-                    if symbol_flags.is_value() && flags.is_value() {
-                        // The non type-only ExportSpecifier can reference both type/value symbols,
-                        // if the symbol is a value symbol and reference flag is not type-only,
-                        // remove the type flag. For example: `const B = 1; export { B };`
-                        *flags -= ReferenceFlags::Type;
-                    } else {
-                        // 1. ReferenceFlags::ValueAsType -> ReferenceFlags::Type
-                        // `const ident = 0; typeof ident`
-                        //                          ^^^^^ -> The ident is a value symbols,
-                        //                                   but it used as a type.
-                        // 2. ReferenceFlags::Value | ReferenceFlags::Type -> ReferenceFlags::Type
-                        // `type ident = string; export default ident;
-                        //                                      ^^^^^ We have confirmed the symbol is
-                        //                                            not a value symbol, so we need to
-                        //                                            make sure the reference is a type only.
-                        *flags = ReferenceFlags::Type;
-                    }
-                    reference.set_symbol_id(symbol_id);
-                    self.scoping.add_resolved_reference(symbol_id, reference_id);
-
-                    false
-                });
-
-                if references.is_empty() {
-                    continue;
-                }
-            }
-
-            if let Some(parent_reference_ids) = parent_refs.get_mut(&name) {
-                parent_reference_ids.extend(references);
-            } else {
-                parent_refs.insert(name, references);
+        for (name, reference_id) in refs {
+            if !self.walk_up_resolve_reference(name, reference_id) {
+                // Keep in the flat list — may resolve later via forward declarations
+                self.unresolved_references.push(name, reference_id);
             }
         }
     }
@@ -630,14 +638,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.current_scope_id =
             self.scoping.add_scope(Some(parent_scope_id), self.current_node_id, flags);
         scope_id.set(Some(self.current_scope_id));
-
-        self.unresolved_references.increment_scope_depth();
     }
 
     // NB: Not called for `Program`
     fn leave_scope(&mut self) {
-        self.resolve_references_for_current_scope();
-
         // `get_parent_id` always returns `Some` because this method is not called for `Program`.
         // So we could `.unwrap()` here. But that seems to produce a small perf impact, probably because
         // `leave_scope` then doesn't get inlined because of its larger size due to the panic code.
@@ -650,8 +654,6 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             }
             self.current_scope_id = parent_id;
         }
-
-        self.unresolved_references.decrement_scope_depth();
     }
 
     // NB: Not called for `Program`.
@@ -724,11 +726,9 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         control_flow!(self, |cfg| cfg.release_error_harness(error_harness));
         /* cfg */
 
-        // Don't call `leave_scope` here as `Program` is a special case - scope has no `parent_id`.
-        // This simplifies `leave_scope`.
-        self.resolve_references_for_current_scope();
-        // NB: Don't call `self.unresolved_references.decrement_scope_depth()`
-        // as scope depth must remain >= 1.
+        // Resolve all remaining unresolved references by walking up the scope chain.
+        // This replaces the old bubble-up approach where references were merged on every scope exit.
+        self.resolve_all_references();
 
         self.leave_node(kind);
 
@@ -1855,6 +1855,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         ));
         /* cfg */
 
+        // Save checkpoint before visiting type params/params/return type
+        let saved_checkpoint = self.unresolved_references_checkpoint;
+        self.unresolved_references_checkpoint = self.unresolved_references.checkpoint();
+
         if let Some(type_parameters) = &func.type_parameters {
             self.visit_ts_type_parameter_declaration(type_parameters);
         }
@@ -1876,6 +1880,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             // In both cases, need to avoid binding to variables/types declared inside the function body.
             self.resolve_references_for_current_scope();
         }
+        self.unresolved_references_checkpoint = saved_checkpoint;
 
         if let Some(body) = &func.body {
             self.visit_function_body(body);
@@ -1935,6 +1940,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             &expr.scope_id,
         );
 
+        // Save checkpoint before visiting type params/params/return type
+        let saved_checkpoint = self.unresolved_references_checkpoint;
+        self.unresolved_references_checkpoint = self.unresolved_references.checkpoint();
+
         if let Some(parameters) = &expr.type_parameters {
             self.visit_ts_type_parameter_declaration(parameters);
         }
@@ -1963,6 +1972,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
             // In both cases, need to avoid binding to variables/types declared inside the function body.
             self.resolve_references_for_current_scope();
         }
+        self.unresolved_references_checkpoint = saved_checkpoint;
 
         self.visit_function_body(&expr.body);
 
@@ -2097,7 +2107,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
                 } else {
                     // If the export specifier is not a explicit type export, we consider it as a potential
                     // type and value reference. If it references to a value in the end, we would delete the
-                    // `ReferenceFlags::Type` flag in `fn resolve_references_for_current_scope`.
+                    // `ReferenceFlags::Type` flag in `fn try_resolve_reference`.
                     self.current_reference_flags = ReferenceFlags::Read | ReferenceFlags::Type;
                 }
                 self.visit_export_specifier(specifier);
@@ -2142,12 +2152,17 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         let kind = AstKind::CatchParameter(self.alloc(param));
         self.enter_node(kind);
         param.bind(self);
+
+        let saved_checkpoint = self.unresolved_references_checkpoint;
+        self.unresolved_references_checkpoint = self.unresolved_references.checkpoint();
+
         self.visit_span(&param.span);
         self.visit_binding_pattern(&param.pattern);
         if let Some(type_annotation) = &param.type_annotation {
             self.visit_ts_type_annotation(type_annotation);
         }
         self.resolve_references_for_current_scope();
+        self.unresolved_references_checkpoint = saved_checkpoint;
         self.leave_node(kind);
     }
 

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -260,8 +260,6 @@ mod scoping_cell {
 }
 use scoping_cell::ScopingCell;
 
-use crate::unresolved_stack::ReferenceIds;
-
 pub struct ScopingInner<'cell> {
     /* Symbol Table Fields */
     symbol_names: ArenaVec<'cell, Ident<'cell>>,
@@ -654,19 +652,6 @@ impl Scoping {
         &self,
     ) -> impl Iterator<Item = impl Iterator<Item = ReferenceId> + '_> + '_ {
         self.cell.borrow_dependent().root_unresolved_references.values().map(|v| v.iter().copied())
-    }
-
-    pub(crate) fn set_root_unresolved_references<'a>(
-        &mut self,
-        entries: impl Iterator<Item = (Ident<'a>, ReferenceIds)>,
-    ) {
-        self.cell.with_dependent_mut(|allocator, cell| {
-            for (k, v) in entries {
-                let k = k.clone_in(allocator);
-                let v = ArenaVec::from_iter_in(v, allocator);
-                cell.root_unresolved_references.insert(k, v);
-            }
-        });
     }
 
     /// Delete an unresolved reference.

--- a/crates/oxc_semantic/src/unresolved_stack.rs
+++ b/crates/oxc_semantic/src/unresolved_stack.rs
@@ -1,121 +1,48 @@
-use smallvec::SmallVec;
-
-use oxc_data_structures::assert_unchecked;
-use oxc_span::IdentHashMap;
+use oxc_span::Ident;
 use oxc_syntax::reference::ReferenceId;
 
-/// Stores reference IDs for a single identifier name within a scope.
-/// Uses `SmallVec` to avoid heap allocations for the common case where an identifier
-/// is referenced only a few times within a given scope.
-pub type ReferenceIds = SmallVec<[ReferenceId; 8]>;
-
-/// Unlike `ScopeTree`'s `UnresolvedReferences`, this type uses `Ident` as the key,
-/// and uses a heap-allocated hashmap (not arena-allocated)
-type TempUnresolvedReferences<'a> = IdentHashMap<'a, ReferenceIds>;
-
-// Stack used to accumulate unresolved refs while traversing scopes.
-// Indexed by scope depth. We recycle `UnresolvedReferences` instances during traversal
-// to reduce allocations, so the stack grows to maximum scope depth, but never shrinks.
-// See: <https://github.com/oxc-project/oxc/issues/4169>
-// This stack abstraction uses the invariant that stack only grows to avoid bounds checks.
-pub struct UnresolvedReferencesStack<'a> {
-    stack: Vec<TempUnresolvedReferences<'a>>,
-    /// Current scope depth.
-    /// 0 is global scope. 1 is `Program`.
-    /// Incremented on entering a scope, and decremented on exit.
-    current_scope_depth: usize,
+/// Flat list of unresolved references collected during AST traversal.
+///
+/// Instead of maintaining per-scope hashmaps and merging them on scope exit (bubble-up),
+/// references are collected flat and resolved in a single pass after traversal (walk-up).
+/// This eliminates all hashmap drain+insert operations during scope exit.
+pub struct UnresolvedReferences<'a> {
+    /// Flat list of (name, reference_id) pairs collected during traversal.
+    references: Vec<(Ident<'a>, ReferenceId)>,
 }
 
-impl<'a> UnresolvedReferencesStack<'a> {
-    /// Initial scope depth.
-    /// Start on 1 (`Program` scope depth).
-    /// SAFETY: Must be >= 1 to ensure soundness of `current_and_parent_mut`.
-    const INITIAL_DEPTH: usize = 1;
-
-    /// Most programs will have at least 1 place where scope depth reaches 16,
-    /// so initialize `stack` with this length, to reduce reallocations as it grows.
-    /// This is just an estimate of a good initial size, but certainly better than
-    /// `Vec`'s default initial capacity of 4.
-    /// SAFETY: Must be >= 2 to ensure soundness of `current_and_parent_mut`.
-    const INITIAL_SIZE: usize = 16;
-
-    /// Assert invariants
-    const ASSERT_INVARIANTS: () = {
-        assert!(Self::INITIAL_DEPTH >= 1);
-        assert!(Self::INITIAL_SIZE >= 2);
-        assert!(Self::INITIAL_SIZE > Self::INITIAL_DEPTH);
-    };
-
+impl<'a> UnresolvedReferences<'a> {
     pub(crate) fn new() -> Self {
-        // Invoke `ASSERT_INVARIANTS` assertions. Without this line, the assertions are ignored.
-        const { Self::ASSERT_INVARIANTS };
-
-        let mut stack = vec![];
-        stack.resize_with(Self::INITIAL_SIZE, TempUnresolvedReferences::default);
-        Self { stack, current_scope_depth: Self::INITIAL_DEPTH }
+        Self { references: Vec::new() }
     }
 
-    pub(crate) fn increment_scope_depth(&mut self) {
-        self.current_scope_depth += 1;
-
-        // Grow stack if required to ensure `self.stack[self.current_scope_depth]` is in bounds
-        if self.stack.len() <= self.current_scope_depth {
-            self.stack.push(TempUnresolvedReferences::default());
-        }
-    }
-
-    pub(crate) fn decrement_scope_depth(&mut self) {
-        self.current_scope_depth -= 1;
-        // This assertion is required to ensure depth does not go below 1.
-        // If it did, would cause UB in `current_and_parent_mut`, which relies on
-        // `current_scope_depth - 1` always being a valid index into `self.stack`.
-        assert!(self.current_scope_depth > 0);
-    }
-
+    /// Push an unresolved reference to the flat list.
     #[inline]
-    pub(crate) fn scope_depth(&self) -> usize {
-        self.current_scope_depth
+    pub(crate) fn push(&mut self, name: Ident<'a>, reference_id: ReferenceId) {
+        self.references.push((name, reference_id));
     }
 
-    /// Get unresolved references hash map for current scope
+    /// Get the current length, used as a checkpoint for early resolution.
     #[inline]
-    pub(crate) fn current_mut(&mut self) -> &mut TempUnresolvedReferences<'a> {
-        // SAFETY: `stack.len() > current_scope_depth` initially.
-        // Thereafter, `stack` never shrinks, only grows.
-        // `current_scope_depth` is only increased in `increment_scope_depth`,
-        // and it grows `stack` to ensure `stack.len()` always exceeds `current_scope_depth`.
-        // So this read is always guaranteed to be in bounds.
-        unsafe { self.stack.get_unchecked_mut(self.current_scope_depth) }
+    pub(crate) fn checkpoint(&self) -> usize {
+        self.references.len()
     }
 
-    /// Get unresolved references hash maps for current scope, and parent scope
+    /// Take all collected references, leaving the list empty. O(1) pointer swap.
     #[inline]
-    pub(crate) fn current_and_parent_mut(
-        &mut self,
-    ) -> (&mut TempUnresolvedReferences<'a>, &mut TempUnresolvedReferences<'a>) {
-        // Assert invariants to remove bounds checks in code below.
-        // SAFETY: `current_scope_depth` starts at 1, and is only decremented
-        // in `decrement_scope_depth` which checks it doesn't go below 1.
-        unsafe { assert_unchecked!(self.current_scope_depth > 0) };
-        // SAFETY: `stack.len() > current_scope_depth` initially.
-        // Thereafter, `stack` never shrinks, only grows.
-        // `current_scope_depth` is only increased in `increment_scope_depth`,
-        // and it grows `stack` to ensure `stack.len()` always exceeds `current_scope_depth`.
-        unsafe { assert_unchecked!(self.stack.len() > self.current_scope_depth) };
-
-        let (head, tail) = self.stack.split_at_mut(self.current_scope_depth);
-        let parent = &mut head[self.current_scope_depth - 1];
-        let current = &mut tail[0];
-        (current, parent)
+    pub(crate) fn take(&mut self) -> Vec<(Ident<'a>, ReferenceId)> {
+        std::mem::take(&mut self.references)
     }
 
+    /// Get a slice of references from `start` to end and the length for truncation.
     #[inline]
-    pub(crate) fn into_root(mut self) -> TempUnresolvedReferences<'a> {
-        // SAFETY: Stack starts with a non-zero size and never shrinks.
-        // This assertion removes bounds check in `swap_remove`.
-        unsafe { assert_unchecked!(!self.stack.is_empty()) };
-        // Use `swap_remove(0)` instead of `into_iter().next().unwrap()` to avoid
-        // creating an iterator just to get the first element.
-        self.stack.swap_remove(0)
+    pub(crate) fn slice_from(&self, start: usize) -> &[(Ident<'a>, ReferenceId)] {
+        &self.references[start..]
+    }
+
+    /// Truncate the list to `len`, removing references at the end.
+    #[inline]
+    pub(crate) fn truncate(&mut self, len: usize) {
+        self.references.truncate(len);
     }
 }

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -162,7 +162,7 @@ Symbol reference IDs mismatch for "InMemoryTestWorkingCopyBackupService":
 after transform: SymbolId(19): [ReferenceId(43), ReferenceId(46), ReferenceId(165)]
 rebuilt        : SymbolId(15): [ReferenceId(91), ReferenceId(221)]
 Symbol reference IDs mismatch for "TestServiceAccessor":
-after transform: SymbolId(21): [ReferenceId(1), ReferenceId(40), ReferenceId(71), ReferenceId(155), ReferenceId(188)]
+after transform: SymbolId(21): [ReferenceId(40), ReferenceId(155), ReferenceId(1), ReferenceId(71), ReferenceId(188)]
 rebuilt        : SymbolId(17): [ReferenceId(115), ReferenceId(243)]
 Symbol reference IDs mismatch for "IWorkingCopyEditorService":
 after transform: SymbolId(32): [ReferenceId(21), ReferenceId(22), ReferenceId(365), ReferenceId(366)]
@@ -171,7 +171,7 @@ Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(39): Span { start: 3208, end: 3236 }
 rebuilt        : SymbolId(46): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "TestWorkingCopyBackupTracker":
-after transform: SymbolId(39): [ReferenceId(42), ReferenceId(74), ReferenceId(154), ReferenceId(215), ReferenceId(392), ReferenceId(394)]
+after transform: SymbolId(39): [ReferenceId(42), ReferenceId(154), ReferenceId(74), ReferenceId(215), ReferenceId(392), ReferenceId(394)]
 rebuilt        : SymbolId(46): [ReferenceId(23), ReferenceId(82), ReferenceId(118), ReferenceId(270)]
 Symbol span mismatch for "TestWorkingCopyBackupTracker":
 after transform: SymbolId(144): Span { start: 0, end: 0 }

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: c9e7428b
 
 semantic_typescript Summary:
 AST Parsed     : 4772/4772 (100.00%)
-Positive Passed: 2667/4772 (55.89%)
+Positive Passed: 2668/4772 (55.91%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -16,7 +16,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "formatHost", "os", "process", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 rebuilt        : ScopeId(0): ["formatHost", "reportDiagnostic", "reportWatchStatusChanged", "ts", "watchMain"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(30), ReferenceId(33), ReferenceId(36), ReferenceId(38)]
+after transform: SymbolId(3): [ReferenceId(30), ReferenceId(36), ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(28), ReferenceId(33), ReferenceId(38)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(27), ReferenceId(31), ReferenceId(35)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
@@ -96,7 +96,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 rebuilt        : ScopeId(0): ["getAllTags", "getAnnotations", "getReturnTypeFromJSDoc", "getSomeOtherTags", "parseCommentsIntoDefinition", "parseSpecificTags", "ts"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(19), ReferenceId(21), ReferenceId(25), ReferenceId(33), ReferenceId(45), ReferenceId(47), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(69), ReferenceId(73), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(79), ReferenceId(80), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(90), ReferenceId(96)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(19), ReferenceId(33), ReferenceId(45), ReferenceId(64), ReferenceId(76), ReferenceId(79), ReferenceId(21), ReferenceId(25), ReferenceId(47), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(66), ReferenceId(67), ReferenceId(69), ReferenceId(73), ReferenceId(75), ReferenceId(77), ReferenceId(80), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(90), ReferenceId(96)]
 rebuilt        : SymbolId(0): [ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(44), ReferenceId(47), ReferenceId(53), ReferenceId(54), ReferenceId(56), ReferenceId(60), ReferenceId(62), ReferenceId(65), ReferenceId(68), ReferenceId(71), ReferenceId(73), ReferenceId(79)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
@@ -104,7 +104,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["console", "delint", "fileNames", "process", "readFileSync", "ts"]
 rebuilt        : ScopeId(0): ["delint", "fileNames", "ts"]
 Symbol reference IDs mismatch for "ts":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(50), ReferenceId(54)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(40), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(23), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(34), ReferenceId(37), ReferenceId(50), ReferenceId(54)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(14), ReferenceId(19), ReferenceId(21), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(32), ReferenceId(44), ReferenceId(48)]
 Reference symbol mismatch for "console":
 after transform: SymbolId(1) "console"
@@ -423,7 +423,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "_defineProperty", "f", "t", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "_defineProperty", "t", "x"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(0)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3), ReferenceId(5)]
@@ -1526,7 +1526,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "_defineProperty", "callme"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "_defineProperty"]
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(8)]
+after transform: SymbolId(0): [ReferenceId(8), ReferenceId(6)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
@@ -1825,7 +1825,7 @@ Symbol flags mismatch for "SyntaxKind":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "SyntaxKind":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(4), ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(5)]
 Reference symbol mismatch for "every":
 after transform: SymbolId(10) "every"
@@ -1893,7 +1893,7 @@ rebuilt        : ["fn", "x", "y"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/collectionPatternNoError.ts
 Symbol reference IDs mismatch for "Message":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(21)]
+after transform: SymbolId(3): [ReferenceId(6), ReferenceId(21), ReferenceId(0), ReferenceId(3), ReferenceId(4), ReferenceId(10)]
 rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Array"]
@@ -2917,7 +2917,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["DEPS", "test"]
 rebuilt        : ScopeId(0): ["DEPS"]
 Symbol reference IDs mismatch for "DEPS":
-after transform: SymbolId(7): [ReferenceId(6), ReferenceId(8), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
+after transform: SymbolId(7): [ReferenceId(8), ReferenceId(6), ReferenceId(11), ReferenceId(15), ReferenceId(19), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(11), ReferenceId(15), ReferenceId(18)]
 Reference symbol mismatch for "test":
 after transform: SymbolId(1) "test"
@@ -3374,7 +3374,7 @@ rebuilt        : ["TabGroup"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(3)]
@@ -3795,8 +3795,8 @@ Symbol flags mismatch for "User":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "User":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(0), ReferenceId(1), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(13)]
+rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(11)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
 Bindings mismatch:
@@ -3910,7 +3910,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "ctor", "f1", "f2", "f3", "f4", "foo", "goo", "x"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "Y", "_defineProperty", "f1", "f2", "f3", "f4", "foo", "goo"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(8): [ReferenceId(36), ReferenceId(37), ReferenceId(38)]
+after transform: SymbolId(8): [ReferenceId(38), ReferenceId(36), ReferenceId(37)]
 rebuilt        : SymbolId(9): [ReferenceId(30), ReferenceId(33)]
 Reference symbol mismatch for "x":
 after transform: SymbolId(17) "x"
@@ -3930,17 +3930,17 @@ rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(1
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(12): [ReferenceId(47), ReferenceId(48), ReferenceId(49)]
+after transform: SymbolId(12): [ReferenceId(49), ReferenceId(47), ReferenceId(48)]
 rebuilt        : SymbolId(10): [ReferenceId(36), ReferenceId(39)]
-Unresolved reference IDs mismatch for "Set":
-after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
-rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
-Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
-rebuilt        : [ReferenceId(30), ReferenceId(34)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(1), ReferenceId(20)]
 rebuilt        : [ReferenceId(13)]
+Unresolved reference IDs mismatch for "Symbol":
+after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(40), ReferenceId(45)]
+rebuilt        : [ReferenceId(30), ReferenceId(34)]
+Unresolved reference IDs mismatch for "Set":
+after transform: [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(31), ReferenceId(32), ReferenceId(34), ReferenceId(37)]
+rebuilt        : [ReferenceId(2), ReferenceId(5), ReferenceId(10), ReferenceId(19), ReferenceId(23), ReferenceId(26)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Bindings mismatch:
@@ -4294,7 +4294,7 @@ Symbol span mismatch for "g":
 after transform: SymbolId(3): Span { start: 110, end: 111 }
 rebuilt        : SymbolId(1): Span { start: 176, end: 177 }
 Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(3)]
+after transform: SymbolId(3): [ReferenceId(3), ReferenceId(1)]
 rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "g":
 after transform: SymbolId(3): [Span { start: 110, end: 111 }, Span { start: 143, end: 144 }, Span { start: 176, end: 177 }]
@@ -4479,10 +4479,10 @@ Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(11)]
+after transform: SymbolId(1): [ReferenceId(10), ReferenceId(0), ReferenceId(1), ReferenceId(11)]
 rebuilt        : SymbolId(3): [ReferenceId(10)]
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5), ReferenceId(13)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(2), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
@@ -4518,7 +4518,7 @@ Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(6)]
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(0), ReferenceId(6)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
@@ -4575,7 +4575,7 @@ rebuilt        : ["Symbol"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(11), ReferenceId(13), ReferenceId(14)]
+after transform: SymbolId(14): [ReferenceId(13), ReferenceId(14), ReferenceId(11)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
@@ -4731,7 +4731,7 @@ Symbol span mismatch for "Point":
 after transform: SymbolId(0): Span { start: 17, end: 22 }
 rebuilt        : SymbolId(0): Span { start: 171, end: 176 }
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(6), ReferenceId(14), ReferenceId(0), ReferenceId(13), ReferenceId(15)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 17, end: 22 }, Span { start: 171, end: 176 }]
@@ -4772,7 +4772,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
 Symbol reference IDs mismatch for "X":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(9)]
+after transform: SymbolId(0): [ReferenceId(6), ReferenceId(9), ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Y":
 after transform: SymbolId(12): [ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(19)]
@@ -5126,7 +5126,7 @@ rebuilt        : ScopeId(0): ["o"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
 Symbol reference IDs mismatch for "bluebird":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(60)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(39), ReferenceId(1), ReferenceId(12), ReferenceId(41), ReferenceId(60)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(6), ReferenceId(23)]
 Symbol reference IDs mismatch for "func":
 after transform: SymbolId(15): [ReferenceId(28), ReferenceId(29)]
@@ -5211,7 +5211,7 @@ Symbol flags mismatch for "TestEnum":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "TestEnum":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(0), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
@@ -6487,7 +6487,7 @@ Symbol reference IDs mismatch for "B":
 after transform: SymbolId(3): [ReferenceId(1), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(8)]
 Symbol reference IDs mismatch for "List":
-after transform: SymbolId(8): [ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(14)]
+after transform: SymbolId(8): [ReferenceId(5), ReferenceId(9), ReferenceId(14), ReferenceId(7)]
 rebuilt        : SymbolId(5): [ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/enumLiteralsSubtypeReduction.ts
@@ -6546,7 +6546,7 @@ Symbol flags mismatch for "MyEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "MyEnum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(6), ReferenceId(9), ReferenceId(2), ReferenceId(5), ReferenceId(8), ReferenceId(11), ReferenceId(25)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(21), ReferenceId(23), ReferenceId(27), ReferenceId(29)]
 Symbol flags mismatch for "MyStringEnum":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
@@ -6771,7 +6771,7 @@ rebuilt        : ["M"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
 Symbol reference IDs mismatch for "Vector":
-after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
+after transform: SymbolId(5): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(22), ReferenceId(23), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(36)]
 rebuilt        : SymbolId(6): [ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(25)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
@@ -7137,7 +7137,7 @@ after transform: [ReferenceId(1), ReferenceId(14)]
 rebuilt        : [ReferenceId(10)]
 Unresolved reference IDs mismatch for "WeakMap":
 after transform: [ReferenceId(5), ReferenceId(9), ReferenceId(127), ReferenceId(128), ReferenceId(129)]
-rebuilt        : [ReferenceId(7), ReferenceId(2), ReferenceId(3), ReferenceId(4)]
+rebuilt        : [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
 Unresolved references mismatch:
@@ -7362,7 +7362,7 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
 Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
@@ -7586,7 +7586,7 @@ rebuilt        : ["closeFile", "openFile", "someOperation"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/forAwaitForIntersection1.ts
@@ -8120,7 +8120,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
 Symbol reference IDs mismatch for "CollectionItem2":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericCallAtYieldExpressionInGenericCall2.ts
@@ -8341,7 +8341,7 @@ rebuilt        : ["ko", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Symbol reference IDs mismatch for "Vec2_T":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(16), ReferenceId(19), ReferenceId(25), ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(16), ReferenceId(19), ReferenceId(10), ReferenceId(12), ReferenceId(25), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
@@ -8729,7 +8729,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["State", "f1"]
 rebuilt        : ScopeId(0): ["f1"]
 Symbol reference IDs mismatch for "state":
-after transform: SymbolId(10): [ReferenceId(10), ReferenceId(11), ReferenceId(14), ReferenceId(12)]
+after transform: SymbolId(10): [ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
@@ -9461,7 +9461,7 @@ rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
 Symbol reference IDs mismatch for "a":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3)]
 Symbol reference IDs mismatch for "b":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5)]
@@ -9562,21 +9562,21 @@ rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(10), ReferenceId(9), ReferenceId(15), ReferenceId(17)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(9), ReferenceId(10), ReferenceId(15), ReferenceId(17)]
 rebuilt        : SymbolId(2): [ReferenceId(13), ReferenceId(15)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 Symbol reference IDs mismatch for "Derived1":
-after transform: SymbolId(1): [ReferenceId(11), ReferenceId(14), ReferenceId(21), ReferenceId(23)]
+after transform: SymbolId(1): [ReferenceId(14), ReferenceId(23), ReferenceId(11), ReferenceId(21)]
 rebuilt        : SymbolId(1): [ReferenceId(15), ReferenceId(21)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(16), ReferenceId(19), ReferenceId(25)]
+after transform: SymbolId(2): [ReferenceId(19), ReferenceId(16), ReferenceId(25)]
 rebuilt        : SymbolId(2): [ReferenceId(18), ReferenceId(24)]
 Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(27)]
+after transform: SymbolId(3): [ReferenceId(27), ReferenceId(2)]
 rebuilt        : SymbolId(3): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Mammal":
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(28)]
+after transform: SymbolId(4): [ReferenceId(28), ReferenceId(3)]
 rebuilt        : SymbolId(4): [ReferenceId(8)]
 Unresolved reference IDs mismatch for "Array":
 after transform: [ReferenceId(4), ReferenceId(5), ReferenceId(7), ReferenceId(32), ReferenceId(33), ReferenceId(35)]
@@ -10178,7 +10178,7 @@ rebuilt        : ["Component"]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 Symbol reference IDs mismatch for "React":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(6), ReferenceId(8), ReferenceId(2), ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 Bindings mismatch:
@@ -10421,7 +10421,7 @@ rebuilt        : SymbolId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
 Symbol reference IDs mismatch for "GenericClass":
-after transform: SymbolId(5): [ReferenceId(10), ReferenceId(12), ReferenceId(14)]
+after transform: SymbolId(5): [ReferenceId(10), ReferenceId(14), ReferenceId(12)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
@@ -10683,7 +10683,7 @@ rebuilt        : ["chain"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/mappedTypePartialConstraints.ts
 Symbol reference IDs mismatch for "MyClass":
-after transform: SymbolId(1): [ReferenceId(3), ReferenceId(5)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Unresolved references mismatch:
 after transform: ["Partial"]
@@ -12017,7 +12017,7 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
 Symbol reference IDs mismatch for "Person":
-after transform: SymbolId(16): [ReferenceId(28), ReferenceId(33), ReferenceId(39)]
+after transform: SymbolId(16): [ReferenceId(33), ReferenceId(28), ReferenceId(39)]
 rebuilt        : SymbolId(11): [ReferenceId(19)]
 Symbol reference IDs mismatch for "Car":
 after transform: SymbolId(17): [ReferenceId(34)]
@@ -12463,7 +12463,7 @@ Symbol flags mismatch for "GatewayOpcode":
 after transform: SymbolId(14): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "GatewayOpcode":
-after transform: SymbolId(14): [ReferenceId(6), ReferenceId(13), ReferenceId(16), ReferenceId(11), ReferenceId(27), ReferenceId(28)]
+after transform: SymbolId(14): [ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(27), ReferenceId(28)]
 rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
@@ -13425,13 +13425,13 @@ Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(71)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(10), ReferenceId(12), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(48), ReferenceId(50), ReferenceId(6), ReferenceId(7), ReferenceId(11), ReferenceId(13), ReferenceId(24), ReferenceId(25), ReferenceId(29), ReferenceId(31), ReferenceId(44), ReferenceId(45), ReferenceId(49), ReferenceId(51), ReferenceId(71)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
 Symbol reference IDs mismatch for "C2_private":
-after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
+after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(14), ReferenceId(16), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(54), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(17), ReferenceId(26), ReferenceId(27), ReferenceId(33), ReferenceId(35), ReferenceId(46), ReferenceId(47), ReferenceId(53), ReferenceId(55)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
 Symbol reference IDs mismatch for "C6_public":
-after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
+after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(66), ReferenceId(68), ReferenceId(59), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(67), ReferenceId(69)]
 rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
@@ -13461,10 +13461,10 @@ Bindings mismatch:
 after transform: ScopeId(142): ["_privateModule", "privateAmbientFunctionWithPrivateModuleParameterTypes", "privateAmbientFunctionWithPrivateParmeterTypes", "privateAmbientFunctionWithPublicParmeterTypes", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicAmbientFunctionWithPrivateModuleParameterTypes", "publicAmbientFunctionWithPrivateParmeterTypes", "publicAmbientFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 rebuilt        : ScopeId(82): ["_privateModule", "privateClass", "privateClassWithPrivateModuleParameterTypes", "privateClassWithWithPrivateParmeterTypes", "privateClassWithWithPublicParmeterTypes", "privateFunctionWithPrivateModuleParameterTypes", "privateFunctionWithPrivateParmeterTypes", "privateFunctionWithPublicParmeterTypes", "publicClass", "publicClassWithPrivateModuleParameterTypes", "publicClassWithWithPrivateParmeterTypes", "publicClassWithWithPublicParmeterTypes", "publicFunctionWithPrivateModuleParameterTypes", "publicFunctionWithPrivateParmeterTypes", "publicFunctionWithPublicParmeterTypes"]
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54)]
+after transform: SymbolId(0): [ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
+after transform: SymbolId(1): [ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
 after transform: SymbolId(94): SymbolFlags(ValueModule)
@@ -13473,10 +13473,10 @@ Symbol span mismatch for "publicModule":
 after transform: SymbolId(94): Span { start: 4746, end: 4758 }
 rebuilt        : SymbolId(58): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(95): [ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134)]
+after transform: SymbolId(95): [ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94)]
 rebuilt        : SymbolId(60): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(96): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
+after transform: SymbolId(96): [ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
 rebuilt        : SymbolId(61): [ReferenceId(13)]
 Symbol flags mismatch for "privateModule":
 after transform: SymbolId(189): SymbolFlags(ValueModule)
@@ -13485,13 +13485,13 @@ Symbol span mismatch for "privateModule":
 after transform: SymbolId(189): Span { start: 9967, end: 9980 }
 rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateModule":
-after transform: SymbolId(189): [ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(136), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(221), ReferenceId(222), ReferenceId(223), ReferenceId(224), ReferenceId(225), ReferenceId(226), ReferenceId(227), ReferenceId(228), ReferenceId(230), ReferenceId(232), ReferenceId(233), ReferenceId(234), ReferenceId(235), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(239), ReferenceId(270), ReferenceId(271)]
+after transform: SymbolId(189): [ReferenceId(221), ReferenceId(222), ReferenceId(223), ReferenceId(224), ReferenceId(225), ReferenceId(226), ReferenceId(227), ReferenceId(233), ReferenceId(234), ReferenceId(235), ReferenceId(236), ReferenceId(237), ReferenceId(238), ReferenceId(239), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(136), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(150), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(228), ReferenceId(230), ReferenceId(232), ReferenceId(270), ReferenceId(271)]
 rebuilt        : SymbolId(118): [ReferenceId(66), ReferenceId(67)]
 Symbol reference IDs mismatch for "privateClass":
-after transform: SymbolId(190): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214)]
+after transform: SymbolId(190): [ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214), ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174)]
 rebuilt        : SymbolId(120): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(191): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
+after transform: SymbolId(191): [ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
 rebuilt        : SymbolId(121): [ReferenceId(41)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
@@ -14844,12 +14844,12 @@ rebuilt        : ["print"]
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactHOCSpreadprops.tsx
 Symbol reference IDs mismatch for "React":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(11)]
-rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(1)]
+rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
 Symbol reference IDs mismatch for "React":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(0)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionResolvable.tsx
 Bindings mismatch:
@@ -15067,7 +15067,7 @@ Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
 Unresolved reference IDs mismatch for "C":
-after transform: [ReferenceId(2), ReferenceId(0), ReferenceId(3), ReferenceId(6)]
+after transform: [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6)]
 rebuilt        : [ReferenceId(5)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
@@ -15167,7 +15167,7 @@ Symbol flags mismatch for "Type":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Type":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(14), ReferenceId(33)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(14), ReferenceId(33)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
@@ -15783,8 +15783,8 @@ Symbol span mismatch for "Bar":
 after transform: SymbolId(1): Span { start: 14, end: 17 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Greeter":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(13), ReferenceId(5), ReferenceId(7)]
-rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(12), ReferenceId(6)]
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(13)]
+rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(12)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern.ts
 Bindings mismatch:
@@ -16204,7 +16204,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(0)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "Derived1":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(4)]
@@ -16247,7 +16247,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "_objectSpread", "b"]
 rebuilt        : ScopeId(0): ["Foo", "_objectSpread"]
 Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(0)]
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(1): []
 Reference symbol mismatch for "b":
 after transform: SymbolId(1) "b"
@@ -17415,7 +17415,7 @@ rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
 Symbol reference IDs mismatch for "Animal":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(4)]
 Symbol reference IDs mismatch for "Cat":
 after transform: SymbolId(1): [ReferenceId(4)]
@@ -17445,7 +17445,7 @@ rebuilt        : ["f"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
 Symbol reference IDs mismatch for "Identity":
-after transform: SymbolId(4): [ReferenceId(3), ReferenceId(10), ReferenceId(12), ReferenceId(18), ReferenceId(26)]
+after transform: SymbolId(4): [ReferenceId(10), ReferenceId(3), ReferenceId(12), ReferenceId(18), ReferenceId(26)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
@@ -17689,7 +17689,7 @@ rebuilt        : SymbolId(1): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 Symbol reference IDs mismatch for "val":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(10), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(6), ReferenceId(4), ReferenceId(10), ReferenceId(15), ReferenceId(17), ReferenceId(22)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(7), ReferenceId(10)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/typeofStrictNull.ts
@@ -18003,7 +18003,7 @@ Symbol flags mismatch for "Enum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Enum":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(19)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(6), ReferenceId(7), ReferenceId(9), ReferenceId(0), ReferenceId(19)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/unionOfFunctionAndSignatureIsCallable.ts
@@ -19366,7 +19366,7 @@ rebuilt        : SymbolId(5): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(4): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(13)]
+after transform: SymbolId(4): [ReferenceId(7), ReferenceId(0), ReferenceId(1), ReferenceId(13)]
 rebuilt        : SymbolId(5): [ReferenceId(24)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
@@ -19495,7 +19495,7 @@ rebuilt        : SymbolId(3): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
 rebuilt        : SymbolId(5): [ReferenceId(8)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
@@ -19526,7 +19526,7 @@ rebuilt        : SymbolId(1): [ReferenceId(29), ReferenceId(30), ReferenceId(33)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(12), ReferenceId(25), ReferenceId(28)]
+after transform: SymbolId(0): [ReferenceId(12), ReferenceId(0), ReferenceId(25), ReferenceId(28)]
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(16), ReferenceId(19)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticsAndStaticMethods.ts
@@ -19561,7 +19561,7 @@ Symbol span mismatch for "Mixin":
 after transform: SymbolId(0): Span { start: 10, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 55, end: 60 }
 Symbol reference IDs mismatch for "Mixin":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(2), ReferenceId(4), ReferenceId(11)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(11)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(7)]
 Symbol redeclarations mismatch for "Mixin":
 after transform: SymbolId(0): [Span { start: 10, end: 15 }, Span { start: 55, end: 60 }]
@@ -19574,7 +19574,7 @@ rebuilt        : ["document"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors4.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinAccessors5.ts
@@ -19587,7 +19587,7 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Printable", "Tagged", "Thing1", "Thing2", "Thing3", "_defineProperty", "f1", "f2"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
+after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 Symbol flags mismatch for "Printable":
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | ConstVariable | Interface)
@@ -19616,7 +19616,7 @@ rebuilt        : SymbolId(12): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(3): [ReferenceId(1), ReferenceId(5)]
+after transform: SymbolId(3): [ReferenceId(5), ReferenceId(1)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
@@ -19729,8 +19729,8 @@ Bindings mismatch:
 after transform: ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem"]
 rebuilt        : ScopeId(0): ["ApiEnum", "ApiEnumMember", "ApiItem", "ApiItemContainerMixin"]
 Symbol reference IDs mismatch for "ApiItem":
-after transform: SymbolId(7): [ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(22), ReferenceId(25)]
-rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(0)]
+after transform: SymbolId(7): [ReferenceId(9), ReferenceId(22), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(13), ReferenceId(25)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(5)]
 Symbol reference IDs mismatch for "ApiEnumMember":
 after transform: SymbolId(8): [ReferenceId(27)]
 rebuilt        : SymbolId(1): []
@@ -19821,7 +19821,7 @@ Symbol flags mismatch for "TestType":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "TestType":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(6), ReferenceId(14)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0), ReferenceId(4), ReferenceId(6), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(7), ReferenceId(9)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnumPropertyAccess3.ts
@@ -21528,7 +21528,7 @@ rebuilt        : [ReferenceId(1)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
 Unresolved reference IDs mismatch for "Symbol":
-after transform: [ReferenceId(2), ReferenceId(0)]
+after transform: [ReferenceId(0), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
@@ -21632,7 +21632,7 @@ rebuilt        : ["Factory", "require"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames37_ES6.ts
 Symbol reference IDs mismatch for "Foo2":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(2), ReferenceId(0)]
 rebuilt        : SymbolId(2): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES6.ts
@@ -21977,12 +21977,12 @@ rebuilt        : ["v"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
 Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5)]
+after transform: SymbolId(0): [ReferenceId(5), ReferenceId(0)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
@@ -24029,7 +24029,7 @@ rebuilt        : ["a", "b"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
 after transform: SymbolId(1): [ReferenceId(4)]
@@ -26166,7 +26166,7 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(10), ReferenceId(15), ReferenceId(23)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(3), ReferenceId(10), ReferenceId(15), ReferenceId(23)]
 rebuilt        : SymbolId(0): [ReferenceId(7)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
@@ -26174,13 +26174,13 @@ Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "acceptingBoolean", "acceptingTypeGuardFunction", "b", "f1", "f2", "isA", "isB", "isC", "isC_multipleParams", "obj", "retC", "subType", "union", "union2", "union3"]
 rebuilt        : ScopeId(0): ["A", "B", "C", "D", "_defineProperty", "a", "b", "f1", "obj", "subType", "union", "union2", "union3"]
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39)]
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(34), ReferenceId(39), ReferenceId(0), ReferenceId(5), ReferenceId(14), ReferenceId(19), ReferenceId(25)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(6), ReferenceId(15), ReferenceId(43), ReferenceId(44)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(10), ReferenceId(20), ReferenceId(21), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(35), ReferenceId(42)]
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(21), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(35), ReferenceId(10), ReferenceId(20), ReferenceId(26), ReferenceId(42)]
 rebuilt        : SymbolId(3): []
 Reference symbol mismatch for "isC":
 after transform: SymbolId(7) "isC"
@@ -26766,17 +26766,6 @@ Symbol redeclarations mismatch for "f":
 after transform: SymbolId(0): [Span { start: 9, end: 10 }, Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(0): []
 
-semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionParameterObjectRestAndInitializers.ts
-Symbol reference IDs mismatch for "a":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(6): []
-Reference symbol mismatch for "a":
-after transform: SymbolId(1) "a"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["require"]
-rebuilt        : ["a", "require"]
-
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
 Symbol reference IDs mismatch for "fn":
 after transform: SymbolId(1): [ReferenceId(2), ReferenceId(3)]
@@ -26815,7 +26804,7 @@ Symbol flags mismatch for "Directive":
 after transform: SymbolId(12): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Directive":
-after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
+after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(64), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
 rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(15), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
@@ -27724,7 +27713,7 @@ rebuilt        : ["require", "x"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
 Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17)]
 rebuilt        : SymbolId(1): [ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(7), ReferenceId(10), ReferenceId(11)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
@@ -28462,7 +28451,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
+after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
@@ -28497,7 +28486,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
+after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(59), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(68), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(70), ReferenceId(72), ReferenceId(82), ReferenceId(83), ReferenceId(86), ReferenceId(87), ReferenceId(96), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(105), ReferenceId(109), ReferenceId(111), ReferenceId(122)]
 rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(52), ReferenceId(54), ReferenceId(63), ReferenceId(64), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(78), ReferenceId(80), ReferenceId(83), ReferenceId(85)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(21) "g"
@@ -28535,7 +28524,7 @@ Symbol span mismatch for "FAILURE":
 after transform: SymbolId(65): Span { start: 2229, end: 2236 }
 rebuilt        : SymbolId(62): Span { start: 2256, end: 2263 }
 Symbol reference IDs mismatch for "FAILURE":
-after transform: SymbolId(65): [ReferenceId(55), ReferenceId(58), ReferenceId(66), ReferenceId(68)]
+after transform: SymbolId(65): [ReferenceId(66), ReferenceId(55), ReferenceId(58), ReferenceId(68)]
 rebuilt        : SymbolId(62): [ReferenceId(50), ReferenceId(54)]
 Symbol redeclarations mismatch for "FAILURE":
 after transform: SymbolId(65): [Span { start: 2229, end: 2236 }, Span { start: 2256, end: 2263 }]
@@ -28588,8 +28577,8 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(13), ReferenceId(30), ReferenceId(31), ReferenceId(35), ReferenceId(95)]
-rebuilt        : SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(44), ReferenceId(53), ReferenceId(57)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(13), ReferenceId(30), ReferenceId(31), ReferenceId(35), ReferenceId(95)]
+rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(13), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(19), ReferenceId(44), ReferenceId(53), ReferenceId(57)]
 Reference symbol mismatch for "g1":
 after transform: SymbolId(98) "g1"
 rebuilt        : <None>
@@ -28736,7 +28725,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
+after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
@@ -28771,7 +28760,7 @@ Symbol flags mismatch for "Choice":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Choice":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
+after transform: SymbolId(0): [ReferenceId(15), ReferenceId(22), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(50), ReferenceId(52), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(85), ReferenceId(89), ReferenceId(91), ReferenceId(99)]
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(31), ReferenceId(33), ReferenceId(42), ReferenceId(43), ReferenceId(45), ReferenceId(46), ReferenceId(53), ReferenceId(57), ReferenceId(59), ReferenceId(62), ReferenceId(64)]
 Reference symbol mismatch for "g":
 after transform: SymbolId(18) "g"
@@ -29080,7 +29069,7 @@ rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedConstructSignatures.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(22)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6), ReferenceId(10), ReferenceId(22)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived1":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(8)]
@@ -30295,7 +30284,7 @@ rebuilt        : [ReferenceId(12)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40), ReferenceId(49), ReferenceId(50)]
+after transform: SymbolId(0): [ReferenceId(49), ReferenceId(50), ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(13), ReferenceId(16), ReferenceId(18), ReferenceId(19), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(33), ReferenceId(34), ReferenceId(39), ReferenceId(40)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(12), ReferenceId(15), ReferenceId(17), ReferenceId(22), ReferenceId(42)]
@@ -30303,7 +30292,7 @@ rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(14)]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30), ReferenceId(39)]
+after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(22), ReferenceId(26), ReferenceId(30)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(1): [ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(23), ReferenceId(36), ReferenceId(38), ReferenceId(46)]
@@ -30575,13 +30564,13 @@ Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(32): ScopeFlags(Function)
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(14): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(113)]
+after transform: SymbolId(14): [ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(113)]
 rebuilt        : SymbolId(15): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch for "Derived":
 after transform: SymbolId(15): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(116), ReferenceId(117)]
+after transform: SymbolId(15): [ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(116), ReferenceId(117)]
 rebuilt        : SymbolId(16): [ReferenceId(30), ReferenceId(31)]
 Symbol redeclarations mismatch for "Derived":
 after transform: SymbolId(15): [Span { start: 689, end: 696 }, Span { start: 845, end: 852 }]
@@ -30626,7 +30615,7 @@ rebuilt        : ["aOrB"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(7), ReferenceId(12)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(3), ReferenceId(12)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(6)]
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(6): [ReferenceId(8)]
@@ -30648,10 +30637,10 @@ rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
 Symbol reference IDs mismatch for "List":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(18), ReferenceId(24), ReferenceId(27), ReferenceId(31)]
+after transform: SymbolId(0): [ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(24), ReferenceId(27), ReferenceId(1), ReferenceId(2), ReferenceId(18), ReferenceId(31)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "MyList":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(21), ReferenceId(29), ReferenceId(32)]
+after transform: SymbolId(2): [ReferenceId(16), ReferenceId(21), ReferenceId(29), ReferenceId(5), ReferenceId(6), ReferenceId(32)]
 rebuilt        : SymbolId(2): []
 Symbol span mismatch for "foo":
 after transform: SymbolId(4): Span { start: 129, end: 132 }
@@ -30726,10 +30715,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
+after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(137), ReferenceId(141), ReferenceId(0), ReferenceId(2), ReferenceId(114), ReferenceId(118)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
+after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103), ReferenceId(1)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(41)]
@@ -30776,10 +30765,10 @@ Bindings mismatch:
 after transform: ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "foo1", "foo11", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 rebuilt        : ScopeId(0): ["Base", "Derived", "Derived2", "OtherDerived", "_defineProperty", "r1", "r11", "r11a", "r11arg", "r11arg2", "r11b", "r15", "r15a", "r15arg", "r15arg2", "r15b", "r16", "r16a", "r16arg", "r16arg2", "r16b", "r17", "r17arg", "r18", "r18arg", "r1a", "r1arg", "r1arg2", "r1b", "r2", "r2a", "r2arg", "r2arg2", "r2b", "r3", "r3a", "r3arg", "r3arg2", "r3b", "r4", "r4a", "r4arg", "r4arg2", "r4b", "r5", "r5a", "r5arg", "r5arg2", "r5b", "r6", "r6a", "r6arg", "r6arg2", "r6b"]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
+after transform: SymbolId(0): [ReferenceId(12), ReferenceId(19), ReferenceId(23), ReferenceId(31), ReferenceId(38), ReferenceId(44), ReferenceId(0), ReferenceId(2), ReferenceId(96), ReferenceId(101), ReferenceId(114), ReferenceId(118), ReferenceId(137), ReferenceId(141)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(8)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(97), ReferenceId(103)]
+after transform: SymbolId(1): [ReferenceId(14), ReferenceId(27), ReferenceId(35), ReferenceId(1), ReferenceId(97), ReferenceId(103)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(2): [ReferenceId(41)]
@@ -32482,7 +32471,7 @@ Symbol reference IDs mismatch for "One":
 after transform: SymbolId(0): [ReferenceId(5), ReferenceId(29)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(9), ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104)]
+after transform: SymbolId(1): [ReferenceId(33), ReferenceId(39), ReferenceId(40), ReferenceId(42), ReferenceId(43), ReferenceId(62), ReferenceId(63), ReferenceId(87), ReferenceId(88), ReferenceId(93), ReferenceId(94), ReferenceId(99), ReferenceId(100), ReferenceId(103), ReferenceId(104), ReferenceId(9)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(10): [ReferenceId(36), ReferenceId(37), ReferenceId(60), ReferenceId(64), ReferenceId(80), ReferenceId(84)]
@@ -33815,7 +33804,7 @@ Symbol reference IDs mismatch for "One":
 after transform: SymbolId(0): [ReferenceId(25)]
 rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "Two":
-after transform: SymbolId(1): [ReferenceId(5), ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84)]
+after transform: SymbolId(1): [ReferenceId(29), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(37), ReferenceId(67), ReferenceId(68), ReferenceId(73), ReferenceId(74), ReferenceId(79), ReferenceId(80), ReferenceId(83), ReferenceId(84), ReferenceId(5)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "B":
 after transform: SymbolId(10): [ReferenceId(32), ReferenceId(35), ReferenceId(66), ReferenceId(72), ReferenceId(78), ReferenceId(82)]
@@ -34133,10 +34122,10 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterCounts.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(18), ReferenceId(19), ReferenceId(28), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(42)]
+after transform: SymbolId(0): [ReferenceId(18), ReferenceId(19), ReferenceId(28), ReferenceId(31), ReferenceId(33), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(42), ReferenceId(3)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(7), ReferenceId(12), ReferenceId(20), ReferenceId(21), ReferenceId(32), ReferenceId(41), ReferenceId(45)]
+after transform: SymbolId(4): [ReferenceId(20), ReferenceId(21), ReferenceId(32), ReferenceId(41), ReferenceId(45), ReferenceId(7), ReferenceId(12)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(21): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(50)]
@@ -34228,10 +34217,10 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesDifferingTypeParameterNames.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(3), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31)]
+after transform: SymbolId(0): [ReferenceId(15), ReferenceId(16), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(3), ReferenceId(9)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(17), ReferenceId(18), ReferenceId(28), ReferenceId(34), ReferenceId(36)]
+after transform: SymbolId(3): [ReferenceId(17), ReferenceId(18), ReferenceId(28), ReferenceId(34), ReferenceId(36), ReferenceId(6), ReferenceId(12)]
 rebuilt        : SymbolId(2): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(12): [ReferenceId(21), ReferenceId(22), ReferenceId(30), ReferenceId(38)]
@@ -34320,10 +34309,10 @@ rebuilt        : SymbolId(31): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(14), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38)]
+after transform: SymbolId(0): [ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(34), ReferenceId(36), ReferenceId(38), ReferenceId(6), ReferenceId(14)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(10), ReferenceId(18), ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(41), ReferenceId(43)]
+after transform: SymbolId(4): [ReferenceId(24), ReferenceId(25), ReferenceId(35), ReferenceId(41), ReferenceId(43), ReferenceId(10), ReferenceId(18)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(16): [ReferenceId(28), ReferenceId(29), ReferenceId(37), ReferenceId(45)]
@@ -34412,10 +34401,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams2.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(16), ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42)]
+after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(11), ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47)]
+after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
@@ -34504,10 +34493,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithGenericConstructSignaturesOptionalParams3.ts
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(0): [ReferenceId(6), ReferenceId(16), ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42)]
+after transform: SymbolId(0): [ReferenceId(26), ReferenceId(27), ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(6), ReferenceId(16)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(5): [ReferenceId(11), ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47)]
+after transform: SymbolId(5): [ReferenceId(28), ReferenceId(29), ReferenceId(39), ReferenceId(45), ReferenceId(47), ReferenceId(11), ReferenceId(21)]
 rebuilt        : SymbolId(3): [ReferenceId(0)]
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(20): [ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(49)]
@@ -34596,10 +34585,10 @@ rebuilt        : SymbolId(34): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -34757,16 +34746,16 @@ rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(39)]
+after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(26), ReferenceId(50)]
+after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
+after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
 rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
+after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
@@ -34924,10 +34913,10 @@ rebuilt        : SymbolId(55): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -35156,10 +35145,10 @@ rebuilt        : SymbolId(22): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
 rebuilt        : SymbolId(1): [ReferenceId(4)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -35317,10 +35306,10 @@ rebuilt        : SymbolId(52): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates2.ts
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(12), ReferenceId(15), ReferenceId(16)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(7), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(1), ReferenceId(12)]
 rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(4)]
 Symbol reference IDs mismatch for "D":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(14), ReferenceId(17), ReferenceId(18)]
+after transform: SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(17), ReferenceId(18), ReferenceId(14)]
 rebuilt        : SymbolId(2): [ReferenceId(6)]
 Symbol span mismatch for "foo1":
 after transform: SymbolId(4): Span { start: 118, end: 122 }
@@ -35480,10 +35469,10 @@ rebuilt        : SymbolId(38): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers.ts
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37)]
+after transform: SymbolId(1): [ReferenceId(5), ReferenceId(6), ReferenceId(16), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35), ReferenceId(37), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(18), ReferenceId(30), ReferenceId(40)]
@@ -35641,16 +35630,16 @@ rebuilt        : SymbolId(51): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithStringIndexers2.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(39)]
+after transform: SymbolId(0): [ReferenceId(39), ReferenceId(0), ReferenceId(1), ReferenceId(7)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9), ReferenceId(26), ReferenceId(50)]
+after transform: SymbolId(1): [ReferenceId(26), ReferenceId(50), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(9)]
 rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(2): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33)]
+after transform: SymbolId(2): [ReferenceId(10), ReferenceId(11), ReferenceId(22), ReferenceId(24), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(5)]
 rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(6), ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46)]
+after transform: SymbolId(3): [ReferenceId(12), ReferenceId(13), ReferenceId(23), ReferenceId(35), ReferenceId(37), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(6)]
 rebuilt        : SymbolId(5): [ReferenceId(6)]
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(14), ReferenceId(15), ReferenceId(25), ReferenceId(38), ReferenceId(49)]
@@ -35926,21 +35915,21 @@ rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(22), ReferenceId(29), ReferenceId(56), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
+after transform: SymbolId(0): [ReferenceId(5), ReferenceId(12), ReferenceId(17), ReferenceId(56), ReferenceId(0), ReferenceId(2), ReferenceId(22), ReferenceId(29), ReferenceId(61), ReferenceId(90), ReferenceId(116), ReferenceId(120), ReferenceId(124)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(13), ReferenceId(18), ReferenceId(23), ReferenceId(30), ReferenceId(39), ReferenceId(47), ReferenceId(52), ReferenceId(57), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
+after transform: SymbolId(1): [ReferenceId(13), ReferenceId(18), ReferenceId(39), ReferenceId(47), ReferenceId(57), ReferenceId(1), ReferenceId(3), ReferenceId(23), ReferenceId(30), ReferenceId(52), ReferenceId(62), ReferenceId(91), ReferenceId(100), ReferenceId(108), ReferenceId(113), ReferenceId(117), ReferenceId(121), ReferenceId(125)]
 rebuilt        : SymbolId(2): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(43), ReferenceId(48), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
+after transform: SymbolId(2): [ReferenceId(43), ReferenceId(48), ReferenceId(4), ReferenceId(53), ReferenceId(104), ReferenceId(109), ReferenceId(114)]
 rebuilt        : SymbolId(4): []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments.ts
 Symbol reference IDs mismatch for "a":
-after transform: SymbolId(20): [ReferenceId(14), ReferenceId(15), ReferenceId(21), ReferenceId(22)]
+after transform: SymbolId(20): [ReferenceId(14), ReferenceId(21), ReferenceId(15), ReferenceId(22)]
 rebuilt        : SymbolId(16): [ReferenceId(6), ReferenceId(10)]
 Symbol reference IDs mismatch for "b":
-after transform: SymbolId(21): [ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(20)]
+after transform: SymbolId(21): [ReferenceId(16), ReferenceId(19), ReferenceId(17), ReferenceId(20)]
 rebuilt        : SymbolId(17): [ReferenceId(7), ReferenceId(9)]
 Unresolved references mismatch:
 after transform: ["Date", "Object", "RegExp"]

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           3981 |           1672 ||         152600 |          28244
+checker.ts                 | 2.92 MB        ||            329 |             37 ||         152600 |          28244
 
-cal.com.tsx                | 1.06 MB        ||          21099 |            471 ||          37141 |           4583
+cal.com.tsx                | 1.06 MB        ||          20245 |             52 ||          37141 |           4583
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             42 |              0 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             34 |              6 ||             30 |              6
 
-pdf.mjs                    | 567.30 kB      ||           4671 |            569 ||          47464 |           7734
+pdf.mjs                    | 567.30 kB      ||           3995 |            417 ||          47464 |           7734
 
-antd.js                    | 6.69 MB        ||          10692 |           2514 ||         331638 |          69344
+antd.js                    | 6.69 MB        ||           7755 |           1661 ||         331638 |          69344
 
-binder.ts                  | 193.08 kB      ||            407 |            120 ||           7075 |            824
+binder.ts                  | 193.08 kB      ||             78 |             23 ||           7075 |            824
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||           2089 |           1017 ||              0 |              0
+checker.ts                 | 2.92 MB        ||           2281 |             18 ||              0 |              0
 
-cal.com.tsx                | 1.06 MB        ||          14989 |            208 ||              0 |              0
+cal.com.tsx                | 1.06 MB        ||          14966 |             22 ||              0 |              0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             13 |              0 ||              0 |              0
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             10 |              3 ||              0 |              0
 
-pdf.mjs                    | 567.30 kB      ||           1747 |            286 ||              0 |              0
+pdf.mjs                    | 567.30 kB      ||           1401 |            208 ||              0 |              0
 
-antd.js                    | 6.69 MB        ||           4124 |            503 ||              0 |              0
+antd.js                    | 6.69 MB        ||           2455 |             18 ||              0 |              0
 
-binder.ts                  | 193.08 kB      ||            206 |             67 ||              0 |              0
+binder.ts                  | 193.08 kB      ||            190 |             11 ||              0 |              0
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 87a048db
 
-Passed: 689/1165
+Passed: 690/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -966,7 +966,7 @@ rebuilt        : ["o"]
 x Output mismatch
 
 
-# babel-plugin-transform-object-rest-spread (27/40)
+# babel-plugin-transform-object-rest-spread (28/40)
 * object-rest/for-x/input.js
 x Output mismatch
 
@@ -1033,47 +1033,6 @@ rebuilt        : ["_ref3", "babelHelpers", "d"]
 
 * object-rest/object-ref-computed/input.js
 x Output mismatch
-
-* object-rest/parameters-object-rest-used-in-default/input.js
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "Y":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(6): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(6): [ReferenceId(2)]
-rebuilt        : SymbolId(10): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(7): [ReferenceId(3)]
-rebuilt        : SymbolId(16): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(13): [ReferenceId(6)]
-rebuilt        : SymbolId(20): []
-Symbol reference IDs mismatch for "R":
-after transform: SymbolId(15): [ReferenceId(7)]
-rebuilt        : SymbolId(23): []
-Reference symbol mismatch for "R":
-after transform: SymbolId(0) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "Y":
-after transform: SymbolId(2) "Y"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(6) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(7) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(13) "R"
-rebuilt        : <None>
-Reference symbol mismatch for "R":
-after transform: SymbolId(15) "R"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["b", "babelHelpers", "f", "q"]
-rebuilt        : ["R", "Y", "b", "babelHelpers", "f", "q"]
 
 * object-rest/symbol/input.js
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -536,7 +536,7 @@ Scope parent mismatch:
 after transform: ScopeId(20): Some(ScopeId(0))
 rebuilt        : ScopeId(20): Some(ScopeId(15))
 Unresolved reference IDs mismatch for "dce":
-after transform: [ReferenceId(9), ReferenceId(12), ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(14), ReferenceId(17)]
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(17)]
 rebuilt        : [ReferenceId(5)]
 
 
@@ -594,7 +594,7 @@ rebuilt        : SymbolId(4): Span { start: 69, end: 82 }
 
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
+after transform: SymbolId(0): [ReferenceId(3), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
 Symbol span mismatch for "Example":
 after transform: SymbolId(1): Span { start: 87, end: 94 }
@@ -664,7 +664,7 @@ Symbol flags mismatch for "StringEnum":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "StringEnum":
-after transform: SymbolId(0): [ReferenceId(5), ReferenceId(21), ReferenceId(27)]
+after transform: SymbolId(0): [ReferenceId(21), ReferenceId(5), ReferenceId(27)]
 rebuilt        : SymbolId(0): [ReferenceId(3)]
 Symbol flags mismatch for "TemplateStringEnum":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
@@ -676,7 +676,7 @@ Symbol flags mismatch for "NumberEnum":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "NumberEnum":
-after transform: SymbolId(6): [ReferenceId(9), ReferenceId(22), ReferenceId(23), ReferenceId(37)]
+after transform: SymbolId(6): [ReferenceId(22), ReferenceId(9), ReferenceId(23), ReferenceId(37)]
 rebuilt        : SymbolId(4): [ReferenceId(13), ReferenceId(53)]
 Symbol flags mismatch for "UnaryEnum":
 after transform: SymbolId(9): SymbolFlags(RegularEnum)
@@ -801,8 +801,8 @@ Bindings mismatch:
 after transform: ScopeId(3): ["Cls2"]
 rebuilt        : ScopeId(4): []
 Symbol reference IDs mismatch for "dec":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(0), ReferenceId(3), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(10), ReferenceId(1)]
+after transform: SymbolId(0): [ReferenceId(4), ReferenceId(0), ReferenceId(1), ReferenceId(3)]
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(10)]
 Symbol span mismatch for "Cls":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(1): Span { start: 46, end: 49 }
@@ -835,7 +835,7 @@ after transform: SymbolId(2) "Cls2"
 rebuilt        : SymbolId(2) "Cls2"
 Unresolved reference IDs mismatch for "babelHelpers":
 after transform: [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(22), ReferenceId(24)]
-rebuilt        : [ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6)]
+rebuilt        : [ReferenceId(0), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(16)]
 
 * oxc/metadata/this/input.ts
 Symbol span mismatch for "Example":


### PR DESCRIPTION
## Summary

- Replace bubble-up reference resolution with V8-style walk-up algorithm
- References are collected in a flat `Vec<(Ident, ReferenceId)>` during traversal instead of per-scope hashmaps
- After full AST visit, all references are resolved in a single pass by walking up the scope chain from each reference's scope
- `leave_scope()` no longer does any reference resolution work — only `direct_eval` flag propagation remains
- Early resolution via checkpoint mechanism preserved for function parameters and catch parameters (prevents binding to body variables that share the same scope)
- Deduplicated walk-up logic into a single `#[inline(always)]` helper shared by both normal and early resolution paths
- Uses `to_vec+truncate` instead of `split_off` to preserve `Vec` capacity and avoid reallocation
- Removes `smallvec` and `oxc_data_structures` dependencies from `oxc_semantic`

### Why this is faster

| Operation | Bubble-up (old) | Walk-up (new) |
|-----------|-----------------|---------------|
| Per reference creation | Hashmap insert | Vec push (O(1) amortized) |
| Per scope exit | Drain + merge hashmap | Nothing |
| Per reference resolution | Implicit via merging | Walk scope chain, O(depth) lookups |
| Total hashmap mutations | O(refs × depth) inserts+drains | 0 during traversal |

Hashmap lookups (read-only) are cheaper than hashmap drain+insert (mutating, allocating). The flat Vec also eliminates creating/recycling per-depth hashmaps entirely.

### Snapshot changes

3 jest linter rule snapshots have diagnostic reordering (same diagnostics, different emission order) due to references being processed in insertion order rather than scope-by-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)