### PR TITLE
fix(diagnostics): handle `WouldBlock` in stdout writes to prevent panic

### DIFF
--- a/apps/oxfmt/src/core/utils.rs
+++ b/apps/oxfmt/src/core/utils.rs
@@ -60,7 +60,10 @@ pub fn print_and_flush(writer: &mut dyn Write, message: &str) {
     use std::io::{Error, ErrorKind};
     fn check_for_writer_error(error: Error) -> Result<(), Error> {
         // Do not panic when the process is killed (e.g. piping into `less`).
-        if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
+        if matches!(
+            error.kind(),
+            ErrorKind::Interrupted | ErrorKind::BrokenPipe | ErrorKind::WouldBlock
+        ) {
             Ok(())
         } else {
             Err(error)

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -546,7 +546,10 @@ pub fn print_and_flush_stdout(stdout: &mut dyn Write, message: &str) {
 
 fn check_for_writer_error(error: std::io::Error) -> Result<(), std::io::Error> {
     // Do not panic when the process is killed (e.g. piping into `less`).
-    if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
+    if matches!(
+        error.kind(),
+        ErrorKind::Interrupted | ErrorKind::BrokenPipe | ErrorKind::WouldBlock
+    ) {
         Ok(())
     } else {
         Err(error)

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -235,7 +235,10 @@ impl DiagnosticService {
 
     fn check_for_writer_error(error: std::io::Error) -> Result<(), std::io::Error> {
         // Do not panic when the process is killed (e.g. piping into `less`).
-        if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
+        if matches!(
+            error.kind(),
+            ErrorKind::Interrupted | ErrorKind::BrokenPipe | ErrorKind::WouldBlock
+        ) {
             Ok(())
         } else {
             Err(error)


### PR DESCRIPTION
## Summary

- Add `ErrorKind::WouldBlock` to all three `check_for_writer_error` functions across `oxc_diagnostics`, `oxlint`, and `oxfmt`
- Prevents panic when stdout is in non-blocking mode (e.g. set by Tokio's `#[tokio::main]`), which can cause `WouldBlock` (EAGAIN) errors on macOS under high diagnostic output volume

Closes #20239

🤖 Generated with [Claude Code](https://claude.com/claude-code)