### PR TITLE
perf(linter/plugins): apply replace globals TSDown plugin to JS files

### DIFF
--- a/apps/oxlint/tsdown_plugins/replace_globals.ts
+++ b/apps/oxlint/tsdown_plugins/replace_globals.ts
@@ -47,8 +47,8 @@ const availableGlobals = getAvailableGlobals(GLOBALS_PATH);
 const plugin: Plugin = {
   name: "replace-globals",
   transform: {
-    // Only process TS files in `src-js` directory
-    filter: { id: /\/src-js\/.+(?<!\.d)\.ts$/ },
+    // Only process JS and TS files in `src-js` directory
+    filter: { id: /\/src-js\/.+(?<!\.d)\.[jt]s$/ },
 
     async handler(code, path, meta) {
       const magicString = meta.magicString!;


### PR DESCRIPTION
TSDown build uses a custom plugin to replace global property lookups e.g. `Object.assign` with top level vars e.g. `const ObjectAssign = Object.assign;`, and then replace the usages with those top-level vars.

The plugin was only applied to `.ts` files. Broaden the filter to include `.js` files too, so it applies to the large generated files `deserialize.js` and `walk.js`.