### PR TITLE
refactor(oxlint/lsp): remove redudant range check for code actions

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -42,7 +42,7 @@ use crate::{
         },
         lsp_file_system::LspFileSystem,
         options::{LintOptions as LSPLintOptions, Run, UnusedDisableDirectives},
-        utils::normalize_path,
+        utils::{normalize_path, range_overlaps},
     },
 };
 
@@ -605,8 +605,7 @@ impl Tool for ServerLinter {
             return vec![];
         }
 
-        let actions =
-            actions.into_iter().filter(|r| r.range == *range || range_overlaps(*range, r.range));
+        let actions = actions.into_iter().filter(|r| range_overlaps(*range, r.range));
 
         // `context.only` is a special case here. ESLint behavior is if `source.fixAll` is the first element in `context.only`,
         // then only return fix all code action, and ignore other code actions, even if they are requested.
@@ -874,10 +873,6 @@ impl ServerLinter {
         }
         false
     }
-}
-
-fn range_overlaps(a: Range, b: Range) -> bool {
-    a.start <= b.end && a.end >= b.start
 }
 
 #[cfg(test)]

--- a/apps/oxlint/src/lsp/utils.rs
+++ b/apps/oxlint/src/lsp/utils.rs
@@ -1,5 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 
+use tower_lsp_server::ls_types::Range;
+
 /// Normalize a path by removing `.` and resolving `..` components,
 /// without touching the filesystem.
 pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
@@ -25,11 +27,21 @@ pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
     result
 }
 
+pub fn range_overlaps(a: Range, b: Range) -> bool {
+    a.start <= b.end && a.end >= b.start
+}
+
 #[cfg(test)]
 mod test {
     use std::path::Path;
 
-    use crate::lsp::utils::normalize_path;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    use crate::lsp::utils::{normalize_path, range_overlaps};
+
+    fn range(sl: u32, sc: u32, el: u32, ec: u32) -> Range {
+        Range::new(Position::new(sl, sc), Position::new(el, ec))
+    }
 
     #[test]
     fn test_normalize_path() {
@@ -37,5 +49,58 @@ mod test {
             normalize_path(Path::new("/root/directory/./.oxlintrc.json")),
             Path::new("/root/directory/.oxlintrc.json")
         );
+    }
+
+    #[test]
+    fn test_range_overlaps_with_equal_ranges() {
+        let range = range(1, 2, 3, 4);
+        // A range always overlaps itself.
+        assert!(range_overlaps(range, range));
+    }
+
+    #[test]
+    fn test_range_overlaps_when_touching_at_boundary() {
+        let a = range(1, 0, 1, 5);
+        let b = range(1, 5, 1, 10);
+        // End/start boundary is inclusive, so touching at one position counts as overlap.
+        assert!(range_overlaps(a, b));
+        assert!(range_overlaps(b, a));
+    }
+
+    #[test]
+    fn test_range_overlaps_when_one_contains_the_other() {
+        let outer = range(2, 0, 6, 0);
+        let inner = range(3, 4, 4, 8);
+        // Full containment is a strict overlap in either argument order.
+        assert!(range_overlaps(outer, inner));
+        assert!(range_overlaps(inner, outer));
+    }
+
+    #[test]
+    fn test_range_overlaps_when_partially_overlapping() {
+        let a = range(10, 0, 12, 0);
+        let b = range(11, 5, 14, 0);
+        // Shared interior span means they overlap.
+        assert!(range_overlaps(a, b));
+        assert!(range_overlaps(b, a));
+    }
+
+    #[test]
+    fn test_range_overlaps_when_disjoint() {
+        let a = range(1, 0, 1, 4);
+        let b = range(1, 5, 1, 10);
+        // There is a strict gap between a.end and b.start, so no overlap.
+        assert!(!range_overlaps(a, b));
+        assert!(!range_overlaps(b, a));
+    }
+
+    #[test]
+    fn test_range_overlaps_respects_line_before_character() {
+        let a = range(1, 50, 1, 200);
+        let b = range(2, 0, 2, 100);
+        // Even though character columns could look overlapping, line 2 is strictly after line 1.
+        // Position ordering is line-first, then character, so these ranges are disjoint.
+        assert!(!range_overlaps(a, b));
+        assert!(!range_overlaps(b, a));
     }
 }


### PR DESCRIPTION
> Moves `range_overlaps` from `server_linter.rs` to `utils.rs` for reusability, removes a redundant equality check (since `range_overlaps` already covers the equal-range case), and adds comprehensive unit tests.