### PR TITLE
perf(linter/plugins): streamline getting/creating visit fn mergers

### DIFF
--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -571,17 +571,12 @@ function mergeVisitFns(visitProps: VisitProp[]): VisitFn {
     });
 
     // Get or create merger for merging `numVisitFns` functions
-    let merger: Merger | null;
-    if (mergers.length <= numVisitFns) {
-      while (mergers.length < numVisitFns) {
-        mergers.push(null);
-      }
-      merger = createMerger(numVisitFns);
-      mergers.push(merger);
-    } else {
-      merger = mergers[numVisitFns];
-      if (merger === null) merger = mergers[numVisitFns] = createMerger(numVisitFns);
+    while (mergers.length <= numVisitFns) {
+      mergers.push(null);
     }
+
+    let merger = mergers[numVisitFns];
+    if (merger === null) merger = mergers[numVisitFns] = createMerger(numVisitFns);
 
     // Merge functions.
     // Reuse a temporary array to avoid creating a new array for each merge.
@@ -688,17 +683,12 @@ function mergeCfgVisitFns(visitProps: CfgVisitProp[]): CfgVisitFn {
     // No need to sort in order of specificity, because each rule can only have 1 handler for each CFG event
 
     // Get or create merger for merging `numVisitFns` functions
-    let merger: CfgMerger | null;
-    if (cfgMergers.length <= numVisitFns) {
-      while (cfgMergers.length < numVisitFns) {
-        cfgMergers.push(null);
-      }
-      merger = createCfgMerger(numVisitFns);
-      cfgMergers.push(merger);
-    } else {
-      merger = cfgMergers[numVisitFns];
-      if (merger === null) merger = cfgMergers[numVisitFns] = createCfgMerger(numVisitFns);
+    while (cfgMergers.length <= numVisitFns) {
+      cfgMergers.push(null);
     }
+
+    let merger = cfgMergers[numVisitFns];
+    if (merger === null) merger = cfgMergers[numVisitFns] = createCfgMerger(numVisitFns);
 
     // Merge functions.
     // Reuse a temporary array to avoid creating a new array for each merge.


### PR DESCRIPTION
When compiling a visitor, visit functions from different rules which act on the same AST node (e.g. `Identifier`) need to be merged into a single function.

Functions which merge up to 5 visit function are hard-coded. If need to merge 6 or more functions, new merger functions are generated dynamically.

Simplify this logic so there's only a single call to `createMerger`. After warm-up over first few files, the `while` loop will be skipped, and the `=== null` check will fail. Can't avoid 2 branches here, but both become highly predictable after warm-up.