### PR TITLE
fix(oxlint): Skip vite.config.ts which fails to import

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use ignore::DirEntry;
+use tracing::debug;
 
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_linter::{
@@ -496,9 +497,15 @@ impl<'a> ConfigLoader<'a> {
 
         // Fallback: check for vite.config.ts with .lint field (lowest priority)
         // If .lint field is missing, `load_root_js_config` returns `Ok(None)` to skip.
+        // If loading fails (e.g. unresolvable dependencies), skip rather than aborting config discovery.
         let vite_config_path = dir.join(VITE_CONFIG_NAME);
         if vite_config_path.is_file() {
-            return self.load_root_js_config(&vite_config_path);
+            match self.load_root_js_config(&vite_config_path) {
+                Ok(config) => return Ok(config),
+                Err(err) => {
+                    debug!("Failed to load {}: {err}, skipping", vite_config_path.display());
+                }
+            }
         }
 
         Ok(None)

--- a/apps/oxlint/test/fixtures/vite_config_load_error/files/test.js
+++ b/apps/oxlint/test/fixtures/vite_config_load_error/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/vite_config_load_error/options.json
+++ b/apps/oxlint/test/fixtures/vite_config_load_error/options.json
@@ -1,0 +1,3 @@
+{
+  "singleThread": true
+}

--- a/apps/oxlint/test/fixtures/vite_config_load_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/vite_config_load_error/output.snap.md
@@ -1,0 +1,19 @@
+# Exit code
+0
+
+# stdout
+```
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 1 warning and 0 errors.
+Finished in Xms on 1 file with 93 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/vite_config_load_error/vite.config.ts
+++ b/apps/oxlint/test/fixtures/vite_config_load_error/vite.config.ts
@@ -1,0 +1,9 @@
+import "non-existent-module";
+
+export default {
+  lint: {
+    rules: {
+      "no-debugger": "error",
+    },
+  },
+};


### PR DESCRIPTION
The same as #20326 

(It's fine to release this as scheduled one)