### PR TITLE
perf(linter/plugins): cheaper `Token` creation

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -127,8 +127,8 @@ let resetLoc: (token: Token) => void;
  * All `Token` instances always have the same V8 hidden class, keeping property access monomorphic.
  */
 class Token {
-  type: TokenType["type"] = "" as TokenType["type"]; // Overwritten later
-  value: string = "";
+  type: TokenType["type"] = null!; // Overwritten later
+  value: string = null!; // Overwritten later
   regex: RegularExpressionToken["regex"] | undefined;
   start: number = 0;
   end: number = 0;


### PR DESCRIPTION
Small optimization.

Initialize `Token` class instances with `null` fields. `null` is one of the cheapest types to create as it's represented in V8 as a static 64-bit value - likely cheaper than creating a string, even an empty one. These placeholder values are immediately overwritten a few lines later, so it doesn't matter what they are initially.