### PR TITLE
fix(linter/plugins): remove `hashbang` property from AST

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -58,7 +58,6 @@ function deserializeProgram(pos) {
       type: "Program",
       body: null,
       sourceType: deserializeModuleKind(pos + 137),
-      hashbang: null,
       get comments() {
         comments === null && initComments();
         return comments;
@@ -71,9 +70,8 @@ function deserializeProgram(pos) {
       end,
       range: [0, end],
       parent: null,
-    });
-  program.hashbang = deserializeOptionHashbang(pos + 48);
-  let body = (program.body = deserializeVecDirective(pos + 80));
+    }),
+    body = (program.body = deserializeVecDirective(pos + 80));
   body.push(...deserializeVecStatement(pos + 104));
   {
     let start;
@@ -1504,19 +1502,6 @@ function deserializeDirective(pos) {
   node.expression = deserializeStringLiteral(pos + 8);
   parent = previousParent;
   return node;
-}
-
-function deserializeHashbang(pos) {
-  let start, end;
-  return {
-    __proto__: NodeProto,
-    type: "Hashbang",
-    value: deserializeStr(pos + 8),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
-    range: [start, end],
-    parent,
-  };
 }
 
 function deserializeBlockStatement(pos) {
@@ -5902,11 +5887,6 @@ function deserializeStr(pos) {
     }
   } while (pos < end);
   return out;
-}
-
-function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -11,7 +11,6 @@ export interface Program extends Span {
   type: "Program";
   body: Array<Directive | Statement>;
   sourceType: ModuleKind;
-  hashbang: Hashbang | null;
   comments: Comment[];
   tokens: Token[];
   parent: null;

--- a/apps/oxlint/test/fixtures/sourceCode/plugin.ts
+++ b/apps/oxlint/test/fixtures/sourceCode/plugin.ts
@@ -39,6 +39,9 @@ const createRule: Rule = {
     const { id } = stmt.declarations[0];
     assert.strictEqual(id.type, "Identifier");
 
+    // Check AST has no `hashbang` property
+    assert.strictEqual("hashbang" in ast, false);
+
     context.report({
       message:
         "create:\n" +

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -128,7 +128,9 @@ impl Program<'_> {
         type: 'Program',
         body: null,
         sourceType: DESER[ModuleKind](POS_OFFSET.source_type.module_kind),
+        /* IF !LINTER */
         hashbang: null,
+        /* END_IF */
         /* IF LINTER */
         get comments() {
             if (comments === null) initComments();
@@ -145,7 +147,7 @@ impl Program<'_> {
         ...(PARENT && { parent: null }),
     };
 
-    program.hashbang = DESER[Option<Hashbang>](POS_OFFSET.hashbang);
+    if (!LINTER) program.hashbang = DESER[Option<Hashbang>](POS_OFFSET.hashbang);
 
     const body = program.body = DESER[Vec<Directive>](POS_OFFSET.directives);
     body.push(...DESER[Vec<Statement>](POS_OFFSET.body));

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -477,13 +477,14 @@ fn amend_oxlint_types(code: &str) -> String {
         }
     }
 
-    let mut code = SPAN_REGEX.replace(code, SpanReplacer).into_owned();
+    let code = SPAN_REGEX.replace(code, SpanReplacer).into_owned();
 
-    // Add `comments` and `tokens` fields to `Program`
-    #[expect(clippy::items_after_statements)]
-    const HASHBANG_FIELD: &str = "hashbang: Hashbang | null;";
-    let index = code.find(HASHBANG_FIELD).unwrap();
-    code.insert_str(index + HASHBANG_FIELD.len(), "comments: Comment[]; tokens: Token[];");
+    // Replace `hashbang` field in `Program` with `comments` and `tokens` fields
+    let old_len = code.len();
+    #[expect(clippy::disallowed_methods, reason = "always results in replacement")]
+    let code =
+        code.replacen("hashbang: Hashbang | null;", "comments: Comment[]; tokens: Token[];", 1);
+    assert!(code.len() != old_len); // Check replacement was made
 
     // Make `parent` fields non-optional
     #[expect(clippy::disallowed_methods)]


### PR DESCRIPTION
#20364 removed the reliance internally on `hashbang` property being present on `Program`. Now we can remove this field.

It's not part of ESTree standard. We include it in `oxc-parser` as a non-standard extension as it can be useful, but in the case of Oxlint, rules written with the alternative `createOnce` API are meant to also be compatible with ESLint, so we can't provided APIs which ESLint doesn't support.