### PR TITLE
fix(minifier): treat object spread of getters as having side effects

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -650,10 +650,17 @@ impl<'a> MayHaveSideEffects<'a> for ObjectPropertyKind<'a> {
                 } else {
                     match &e.argument {
                         Expression::ArrayExpression(arr) => arr.may_have_side_effects(ctx),
-                        Expression::ObjectExpression(obj) => obj
-                            .properties
-                            .iter()
-                            .any(|property| property.may_have_side_effects(ctx)),
+                        Expression::ObjectExpression(obj) => {
+                            obj.properties.iter().any(|property| match property {
+                                ObjectPropertyKind::ObjectProperty(p) => {
+                                    p.kind == PropertyKind::Get
+                                        || p.may_have_side_effects(ctx)
+                                }
+                                ObjectPropertyKind::SpreadProperty(e) => {
+                                    e.argument.may_have_side_effects(ctx)
+                                }
+                            })
+                        }
                         Expression::StringLiteral(_) => false,
                         Expression::TemplateLiteral(t) => t.may_have_side_effects(ctx),
                         _ => true,

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -653,8 +653,7 @@ impl<'a> MayHaveSideEffects<'a> for ObjectPropertyKind<'a> {
                         Expression::ObjectExpression(obj) => {
                             obj.properties.iter().any(|property| match property {
                                 ObjectPropertyKind::ObjectProperty(p) => {
-                                    p.kind == PropertyKind::Get
-                                        || p.may_have_side_effects(ctx)
+                                    p.kind == PropertyKind::Get || p.may_have_side_effects(ctx)
                                 }
                                 ObjectPropertyKind::SpreadProperty(e) => {
                                     e.argument.may_have_side_effects(ctx)

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -717,6 +717,11 @@ fn test_object_expression() {
     test("({...{a: 1}})", false);
     test("({...{a: foo()}})", true);
     test("({...{[foo()]: 1}})", true);
+    // Getters are invoked when spreading
+    test("({...{get a() {}}})", true);
+    test("({...{get a() { return 1 }}})", true);
+    // Setters are NOT invoked when spreading
+    test("({...{set a(v) {}}})", false);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Object spread (`...{ get prop() {} }`) invokes getters at runtime, so it has side effects
- The previous code only checked key/value AST nodes and missed the getter invocation
- Setters are **not** invoked by spread, so they remain side-effect-free
- Fixes the Rolldown test `rollup@function@object-spread-side-effect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)