### PR TITLE
fix(parser): report syntax error for `new super()`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -491,6 +491,11 @@ pub fn new_dynamic_import(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn new_super(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("'new super()' is not allowed").with_label(span)
+}
+
+#[cold]
 pub fn private_name_constructor(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Classes can't have an element named '#constructor'").with_label(span)
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -996,6 +996,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::new_dynamic_import(self.end_span(rhs_span)));
         }
 
+        if matches!(callee, Expression::Super(_)) {
+            self.error(diagnostics::new_super(self.end_span(rhs_span)));
+        }
+
         let span = self.end_span(span);
 
         if optional {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -9957,6 +9957,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Replace with `super()` or `super.prop` or `super[prop]`
 
+  × 'new super()' is not allowed
+   ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-super-property/invalid_super_id/input.js:2:17]
+ 1 │ class A {
+ 2 │     foo() { new super + 3 }
+   ·                 ─────
+ 3 │ }
+   ╰────
+
   × TS(2337): Super calls are not permitted outside constructors or in nested functions inside constructors.
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/es2015-super-property/invalid_super_id/input.js:2:13]
  1 │ class A {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: c9e7428b
 parser_typescript Summary:
 AST Parsed     : 9828/9831 (99.97%)
 Positive Passed: 9817/9831 (99.86%)
-Negative Passed: 1532/2587 (59.22%)
+Negative Passed: 1533/2587 (59.26%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -881,8 +881,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallIns
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassExpression.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superInConstructorParam1.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess2.ts
 
@@ -11822,6 +11820,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  52 │                 super.method();
     ·                 ─────
  53 │             },
+    ╰────
+
+  × 'new super()' is not allowed
+    ╭─[typescript/tests/cases/compiler/superNewCall1.ts:9:13]
+  8 │     constructor() {
+  9 │         new super(value => String(value));
+    ·             ─────────────────────────────
+ 10 │     }
     ╰────
 
   × 'super' can only be used with function calls or in property accesses


### PR DESCRIPTION
## Summary

- Report a syntax error for `new super()` per the ECMAScript spec grammar
- `MemberExpression` includes `SuperProperty` (`super.x`, `super[x]`) but NOT bare `super`, so `new super()` is invalid
- `new super.method()` and `new super[x]()` remain valid

Closes #20306

🤖 Generated with [Claude Code](https://claude.com/claude-code)