### PR TITLE
perf(linter): eliminate Vec allocation in disable directive matching

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -191,56 +191,52 @@ impl DisableDirectives {
         // we check if any part of the diagnostic span overlaps with the disabled interval.
         // This ensures that diagnostics starting before the disable comment (like no-empty-file)
         // are still suppressed.
-        let matched_intervals = self
-            .intervals
-            .find(span.start, span.end)
-            .filter(|interval| {
-                // Check if this rule should be disabled
-                let rule_matches = match &interval.val {
-                    DisabledRule::All { .. } => true,
-                    // `rule_name` does not contain the prefix.
-                    // - `vitest/foobar` will be just `foobar`.
-                    // - `@typescript-eslint/no-var-requires` will be just `no-var-requires`
-                    //
-                    // This enables matching rules across different plugins that share the same
-                    // rule name, such as jest<->vitest rules and eslint<->typescript rules.
-                    DisabledRule::Single { rule_name: name, .. } => {
-                        if name.contains(rule_name) {
-                            return true;
-                        }
-
+        let mut has_match = false;
+        for interval in self.intervals.find(span.start, span.end) {
+            // Check if this rule should be disabled
+            let rule_matches = match &interval.val {
+                DisabledRule::All { .. } => true,
+                // `rule_name` does not contain the prefix.
+                // - `vitest/foobar` will be just `foobar`.
+                // - `@typescript-eslint/no-var-requires` will be just `no-var-requires`
+                //
+                // This enables matching rules across different plugins that share the same
+                // rule name, such as jest<->vitest rules and eslint<->typescript rules.
+                DisabledRule::Single { rule_name: name, .. } => {
+                    if name.contains(rule_name) {
+                        true
+                    } else {
                         // Special-case mapping: `vitest/no-restricted-vi-methods` is implemented by `jest/no-restricted-jest-methods`.
-                        return name == "vitest/no-restricted-vi-methods"
-                            && rule_name == "no-restricted-jest-methods";
+                        name == "vitest/no-restricted-vi-methods"
+                            && rule_name == "no-restricted-jest-methods"
                     }
-                };
-
-                if !rule_matches {
-                    return false;
                 }
+            };
 
-                // Check if the diagnostic span is covered by this interval
-                if interval.val.is_next_line() {
-                    // For next-line directives, only check if the diagnostic starts within the interval
-                    // We intentionally only check span.start (not span.end) to avoid suppressing
-                    // diagnostics for large constructs that merely contain the disabled line
-                    #[expect(clippy::suspicious_operation_groupings)]
-                    {
-                        span.start >= interval.start && span.start < interval.stop
-                    }
-                } else {
-                    // For regular disable directives, check if there's any overlap
-                    span.start < interval.stop && span.end > interval.start
+            if !rule_matches {
+                continue;
+            }
+
+            // Check if the diagnostic span is covered by this interval
+            let span_covered = if interval.val.is_next_line() {
+                // For next-line directives, only check if the diagnostic starts within the interval
+                // We intentionally only check span.start (not span.end) to avoid suppressing
+                // diagnostics for large constructs that merely contain the disabled line
+                #[expect(clippy::suspicious_operation_groupings)]
+                {
+                    span.start >= interval.start && span.start < interval.stop
                 }
-            })
-            .map(|interval| interval.val.clone())
-            .collect::<Vec<DisabledRule>>();
+            } else {
+                // For regular disable directives, check if there's any overlap
+                span.start < interval.stop && span.end > interval.start
+            };
 
-        for disable in &matched_intervals {
-            self.mark_disable_directive_used(disable.clone());
+            if span_covered {
+                self.mark_disable_directive_used(interval.val.clone());
+                has_match = true;
+            }
         }
-
-        !matched_intervals.is_empty()
+        has_match
     }
 
     pub fn disable_rule_comments(&self) -> &[DisableRuleComment] {


### PR DESCRIPTION
## Summary
- Replace collect-then-iterate pattern with a single for-loop in `contains()`
- Eliminates intermediate `Vec<DisabledRule>` allocation and double-clone per match
- Each matched rule is now cloned once instead of twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)