### PR TITLE
perf(linter): remove unnecessary clone of owned String in drain loop

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -557,12 +557,7 @@ impl DisableDirectivesBuilder {
             self.add_interval(
                 start,
                 source_len,
-                DisabledRule::Single {
-                    rule_name: rule_name.clone(),
-                    name_span,
-                    comment_span,
-                    is_next_line: false,
-                },
+                DisabledRule::Single { rule_name, name_span, comment_span, is_next_line: false },
             );
         }
 


### PR DESCRIPTION
## Summary
- After `drain()`, `rule_name` is already an owned `String` that can be moved directly
- Remove the unnecessary `.clone()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)