### PR TITLE
perf(minifier): use Vec::with_capacity for inline template expressions

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -724,7 +724,7 @@ impl<'a> PeepholeOptimizations {
             return;
         }
 
-        let mut inline_exprs = Vec::new();
+        let mut inline_exprs = Vec::with_capacity(t.expressions.len());
         let new_exprs =
             ctx.ast.vec_from_iter(t.expressions.drain(..).enumerate().filter_map(|(idx, expr)| {
                 if expr.may_have_side_effects(ctx) {


### PR DESCRIPTION
## Summary
- Pre-allocate `inline_exprs` Vec based on `t.expressions.len()` to avoid incremental reallocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)