### PR TITLE
fix(transformer): use implementation signature for design:paramtypes when constructor is overloaded

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -180,7 +180,11 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecoratorMetadata<'a> {
         let should_transform = !(class.is_expression() || class.declare);
 
         let constructor = class.body.body.iter_mut().find_map(|item| match item {
-            ClassElement::MethodDefinition(method) if method.kind.is_constructor() => Some(method),
+            ClassElement::MethodDefinition(method)
+                if method.kind.is_constructor() && method.value.body.is_some() =>
+            {
+                Some(method)
+            }
             _ => None,
         });
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 87a048db
 
-Passed: 204/335
+Passed: 204/336
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -555,7 +555,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (6/86)
+# legacy-decorators (6/87)
 * oxc/class-without-name-with-decorated_class/input.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["dec"]
@@ -610,6 +610,23 @@ rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol span mismatch for "Problem":
 after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(5): Span { start: 90, end: 97 }
+
+* oxc/metadata/constructor-overload/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["MyService", "dec"]
+rebuilt        : ScopeId(0): ["MyService"]
+Symbol span mismatch for "MyService":
+after transform: SymbolId(1): Span { start: 54, end: 63 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol span mismatch for "MyService":
+after transform: SymbolId(7): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 54, end: 63 }
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["ClassDecorator", "String", "babelHelpers"]
+rebuilt        : ["String", "babelHelpers", "dec"]
 
 * oxc/metadata/enum-types/input.ts
 Bindings mismatch:

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/constructor-overload/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/constructor-overload/input.ts
@@ -1,0 +1,8 @@
+declare function dec(): ClassDecorator;
+
+@dec()
+class MyService {
+  constructor(a: string);
+  constructor(a: string, b: string);
+  constructor(a?: string, b?: string) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/constructor-overload/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/constructor-overload/output.js
@@ -1,0 +1,4 @@
+let MyService = class MyService {
+  constructor(a, b) {}
+};
+MyService = babelHelpers.decorate([dec(), babelHelpers.decorateMetadata("design:paramtypes", [String, String])], MyService);


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/20369