### PR TITLE
feat(parser): add `Parser::new_from_bytes` for raw byte input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,7 @@ version = "0.119.0"
 dependencies = [
  "bitflags",
  "cow-utils",
+ "encoding_rs",
  "memchr",
  "num-bigint",
  "num-traits",

--- a/crates/oxc_allocator/src/file_io.rs
+++ b/crates/oxc_allocator/src/file_io.rs
@@ -1,0 +1,111 @@
+use std::{
+    alloc::Layout,
+    fs::File,
+    io::{self, Read},
+    mem::ManuallyDrop,
+    path::Path,
+    slice,
+};
+
+use crate::Allocator;
+
+/// Read file bytes directly into arena. No UTF-8 validation is performed.
+///
+/// Use with [`Parser::new_from_bytes`](https://docs.rs/oxc_parser/latest/oxc_parser/struct.Parser.html#method.new_from_bytes)
+/// for lazy encoding detection and UTF-8 validation during lexing.
+///
+/// # Parameters
+/// - `path`: The path to the file to read.
+/// - `allocator`: The [`Allocator`] into which the file contents will be allocated.
+///
+/// # Errors
+///
+/// Returns [`io::Error`] if any of:
+///
+/// - The file cannot be opened or read.
+/// - The file is larger than `isize::MAX` bytes.
+pub fn read_file_to_arena<'a>(path: &Path, allocator: &'a Allocator) -> io::Result<&'a [u8]> {
+    let file = File::open(path)?;
+
+    if let Ok(metadata) = file.metadata() {
+        read_to_arena_bytes_known_size(file, metadata.len(), allocator)
+    } else {
+        read_to_arena_bytes_unknown_size(file, allocator)
+    }
+}
+
+/// Read contents of file directly into arena when file size is known.
+fn read_to_arena_bytes_known_size(
+    file: File,
+    size: u64,
+    allocator: &Allocator,
+) -> io::Result<&[u8]> {
+    // Check file is not larger than `isize::MAX` bytes (the max size of an allocation)
+    let Ok(size) = isize::try_from(size) else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "File is larger than `isize::MAX` bytes",
+        ));
+    };
+    #[expect(clippy::cast_sign_loss)]
+    let mut size = size as usize;
+
+    // Allocate space for string in allocator.
+    // SAFETY: We checked above that `size <= isize::MAX`. `&str` has no alignment requirements.
+    let layout = unsafe { Layout::from_size_align_unchecked(size, 1) };
+    let ptr = allocator.alloc_layout(layout);
+
+    // Read contents of file into allocated space.
+    //
+    // * Create a `Vec` which pretends to own the allocation we just created in arena.
+    // * Wrap the `Vec` in `ManuallyDrop`, so it doesn't free the memory at end of the block,
+    //   or if there's a panic during reading.
+    // * Use `File::take` to obtain a reader which yields no more than `size` bytes.
+    //   This ensures it can't produce more data than we allocated space for - in case file increased
+    //   in size since the call to `file.metadata()`, or `file.metadata()` returned inaccurate size.
+    // * Use `Read::read_to_end` to fill the `Vec` from this reader.
+    //
+    // This is a hack. It's completely bananas that Rust doesn't provide a method to write into
+    // a slice of uninitialized bytes, but this seems to be the only safe way to do it on stable Rust.
+    // https://users.rust-lang.org/t/reading-c-style-structures-from-disk/70529/7
+    //
+    // I (@overlookmotel) have reviewed the code for `Read::read_to_end` and it will never grow the `Vec`,
+    // as long as it has sufficient capacity for the reader's contents to start with.
+    // If it did, that would be UB as it would free the chunk of memory backing the `Vec`,
+    // which it doesn't actually own.
+    //
+    // Unfortunately `Read::read_to_end`'s docs don't guarantee this behavior. But the code is written
+    // specifically to avoid growing the `Vec`, and there was a PR to make sure it doesn't:
+    // https://github.com/rust-lang/rust/pull/89165
+    // So I think in practice we can rely on this behavior.
+    {
+        // SAFETY: We've allocated `size` bytes starting at `ptr`.
+        // This `Vec` doesn't actually own that memory, but we immediately wrap it in `ManuallyDrop`,
+        // so it won't free the memory on drop. As long as the `Vec` doesn't grow, no UB (see above).
+        let vec = unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, size) };
+        let mut vec = ManuallyDrop::new(vec);
+        let bytes_written = file.take(size as u64).read_to_end(&mut vec)?;
+
+        debug_assert!(vec.capacity() == size);
+        debug_assert!(vec.len() == bytes_written);
+
+        // Update `size`, in case file was altered and got smaller since the call to `file.metadata()`,
+        // or `file.metadata()` reported inaccurate size
+        size = vec.len();
+    }
+
+    // SAFETY: `size` bytes were written starting at `ptr`
+    let bytes = unsafe { slice::from_raw_parts(ptr.as_ptr(), size) };
+    Ok(bytes)
+}
+
+/// Fallback for when file size is unknown.
+/// Read file contents into a `Vec`, and then copy into arena.
+fn read_to_arena_bytes_unknown_size(mut file: File, allocator: &Allocator) -> io::Result<&[u8]> {
+    // Read file into a `Vec`
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+
+    // Allocate bytes into arena
+    Ok(allocator.alloc_slice_copy(&bytes))
+}

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod bump;
 pub(crate) mod bumpalo_alloc;
 mod clone_in;
 mod convert;
+pub mod file_io;
 #[cfg(feature = "from_raw_parts")]
 mod from_raw_parts;
 pub mod hash_map;
@@ -70,6 +71,7 @@ pub use bitset::BitSet;
 pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
+pub use file_io::read_file_to_arena;
 pub use hash_map::HashMap;
 pub use hash_set::HashSet;
 pub use ident_hasher::{IdentBuildHasher, ident_hash, pack_len_hash};

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -1,11 +1,4 @@
-use std::{
-    alloc::Layout,
-    fs::File,
-    io::{self, Read},
-    mem::ManuallyDrop,
-    path::Path,
-    slice,
-};
+use std::{io, path::Path};
 
 use oxc_allocator::Allocator;
 use oxc_span::Span;
@@ -211,94 +204,12 @@ pub fn read_to_arena_str<'alloc>(
     path: &Path,
     allocator: &'alloc Allocator,
 ) -> io::Result<&'alloc str> {
-    let file = File::open(path)?;
-
-    let bytes = if let Ok(metadata) = file.metadata() {
-        read_to_arena_bytes_known_size(file, metadata.len(), allocator)
-    } else {
-        read_to_arena_bytes_unknown_size(file, allocator)
-    }?;
+    let bytes = oxc_allocator::read_file_to_arena(path, allocator)?;
 
     // Convert to `&str`, checking contents is valid UTF-8
     simdutf8::basic::from_utf8(bytes).map_err(|_| {
         io::Error::new(io::ErrorKind::InvalidData, "stream did not contain valid UTF-8")
     })
-}
-
-/// Read contents of file directly into arena.
-fn read_to_arena_bytes_known_size(
-    file: File,
-    size: u64,
-    allocator: &Allocator,
-) -> io::Result<&[u8]> {
-    // Check file is not larger than `isize::MAX` bytes (the max size of an allocation)
-    let Ok(size) = isize::try_from(size) else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "File is larger than `isize::MAX` bytes",
-        ));
-    };
-    #[expect(clippy::cast_sign_loss)]
-    let mut size = size as usize;
-
-    // Allocate space for string in allocator.
-    // SAFETY: We checked above that `size <= isize::MAX`. `&str` has no alignment requirements.
-    let layout = unsafe { Layout::from_size_align_unchecked(size, 1) };
-    let ptr = allocator.alloc_layout(layout);
-
-    // Read contents of file into allocated space.
-    //
-    // * Create a `Vec` which pretends to own the allocation we just created in arena.
-    // * Wrap the `Vec` in `ManuallyDrop`, so it doesn't free the memory at end of the block,
-    //   or if there's a panic during reading.
-    // * Use `File::take` to obtain a reader which yields no more than `size` bytes.
-    //   This ensures it can't produce more data than we allocated space for - in case file increased
-    //   in size since the call to `file.metadata()`, or `file.metadata()` returned inaccurate size.
-    // * Use `Read::read_to_end` to fill the `Vec` from this reader.
-    //
-    // This is a hack. It's completely bananas that Rust doesn't provide a method to write into
-    // a slice of uninitialized bytes, but this seems to be the only safe way to do it on stable Rust.
-    // https://users.rust-lang.org/t/reading-c-style-structures-from-disk/70529/7
-    //
-    // I (@overlookmotel) have reviewed the code for `Read::read_to_end` and it will never grow the `Vec`,
-    // as long as it has sufficient capacity for the reader's contents to start with.
-    // If it did, that would be UB as it would free the chunk of memory backing the `Vec`,
-    // which it doesn't actually own.
-    //
-    // Unfortunately `Read::read_to_end`'s docs don't guarantee this behavior. But the code is written
-    // specifically to avoid growing the `Vec`, and there was a PR to make sure it doesn't:
-    // https://github.com/rust-lang/rust/pull/89165
-    // So I think in practice we can rely on this behavior.
-    {
-        // SAFETY: We've allocated `size` bytes starting at `ptr`.
-        // This `Vec` doesn't actually own that memory, but we immediately wrap it in `ManuallyDrop`,
-        // so it won't free the memory on drop. As long as the `Vec` doesn't grow, no UB (see above).
-        let vec = unsafe { Vec::from_raw_parts(ptr.as_ptr(), 0, size) };
-        let mut vec = ManuallyDrop::new(vec);
-        let bytes_written = file.take(size as u64).read_to_end(&mut vec)?;
-
-        debug_assert!(vec.capacity() == size);
-        debug_assert!(vec.len() == bytes_written);
-
-        // Update `size`, in case file was altered and got smaller since the call to `file.metadata()`,
-        // or `file.metadata()` reported inaccurate size
-        size = vec.len();
-    }
-
-    // SAFETY: `size` bytes were written starting at `ptr`
-    let bytes = unsafe { slice::from_raw_parts(ptr.as_ptr(), size) };
-    Ok(bytes)
-}
-
-/// Fallback for when file size is unknown.
-/// Read file contents into a `Vec`, and then copy into arena.
-fn read_to_arena_bytes_unknown_size(mut file: File, allocator: &Allocator) -> io::Result<&[u8]> {
-    // Read file into a `Vec`
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)?;
-
-    // Allocate bytes into arena
-    Ok(allocator.alloc_slice_copy(&bytes))
 }
 
 #[cfg(test)]

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -35,6 +35,7 @@ num-traits = { workspace = true }
 rustc-hash = { workspace = true }
 seq-macro = { workspace = true }
 
+encoding_rs = { workspace = true }
 memchr = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -54,6 +54,11 @@ pub fn file_appears_to_be_binary() -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn invalid_utf8(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid UTF-8 byte sequence").with_label(span)
+}
+
+#[cold]
 pub fn flow(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Flow is not supported").with_label(span)
 }

--- a/crates/oxc_parser/src/encoding.rs
+++ b/crates/oxc_parser/src/encoding.rs
@@ -1,0 +1,41 @@
+use oxc_allocator::Allocator;
+
+/// Detect encoding from BOM and normalize bytes to UTF-8.
+///
+/// - `0xFF 0xFE` → UTF-16 LE: transcode to UTF-8, allocate result in arena
+/// - `0xFE 0xFF` → UTF-16 BE: transcode to UTF-8, allocate result in arena
+/// - `0xEF 0xBB 0xBF` → UTF-8 BOM: strip BOM (return `&bytes[3..]`)
+/// - Otherwise → return bytes as-is
+pub fn detect_encoding_and_normalize<'a>(allocator: &'a Allocator, bytes: &'a [u8]) -> &'a [u8] {
+    if bytes.len() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF {
+        // UTF-8 BOM — strip it
+        return &bytes[3..];
+    }
+
+    if bytes.len() >= 2 {
+        let (decoder, bom_len) = if bytes[0] == 0xFF && bytes[1] == 0xFE {
+            // UTF-16 LE BOM
+            (encoding_rs::UTF_16LE, 2)
+        } else if bytes[0] == 0xFE && bytes[1] == 0xFF {
+            // UTF-16 BE BOM
+            (encoding_rs::UTF_16BE, 2)
+        } else {
+            return bytes;
+        };
+
+        let source_after_bom = &bytes[bom_len..];
+        let (decoded, _, _) = decoder.decode(source_after_bom);
+        match decoded {
+            std::borrow::Cow::Borrowed(s) => {
+                // Already valid UTF-8 (shouldn't happen for UTF-16, but handle gracefully)
+                s.as_bytes()
+            }
+            std::borrow::Cow::Owned(s) => {
+                // Allocate transcoded bytes in arena
+                allocator.alloc_slice_copy(s.as_bytes())
+            }
+        }
+    } else {
+        bytes
+    }
+}

--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -671,17 +671,27 @@ ascii_identifier_handler!(L_Y(id_without_first_char) match id_without_first_char
 // Note: Must not use `ascii_byte_handler!` macro, as this handler is for non-ASCII chars.
 #[expect(non_snake_case)]
 fn UNI<C: Config>(lexer: &mut Lexer<'_, C>) -> Kind {
-    lexer.unicode_char_handler()
+    let kind = lexer.unicode_char_handler();
+    // If `peek_char` / `next_char` detected invalid UTF-8, emit diagnostic
+    if lexer.source.utf8_error {
+        lexer.source.utf8_error = false;
+        lexer.error(diagnostics::invalid_utf8(lexer.unterminated_range()));
+    }
+    kind
 }
 
 // UTF-8 continuation bytes (0x80 - 0xBF) (i.e. middle of a multi-byte UTF-8 sequence)
 // + and byte values which are not legal in UTF-8 strings (0xC0, 0xC1, 0xF5 - 0xFF).
-// `handle_byte()` should only be called with 1st byte of a valid UTF-8 character,
-// so something has gone wrong if we get here.
+// For `Parser::new` (valid UTF-8 input), this should never be reached.
+// For `Parser::new_from_bytes` (unvalidated input), emit an "invalid UTF-8" diagnostic.
 // https://datatracker.ietf.org/doc/html/rfc3629
 //
 // Note: Must not use `ascii_byte_handler!` macro, as this handler is for non-ASCII bytes.
 #[expect(non_snake_case)]
-fn UER<C: Config>(_lexer: &mut Lexer<'_, C>) -> Kind {
-    unreachable!();
+fn UER<C: Config>(lexer: &mut Lexer<'_, C>) -> Kind {
+    // Advance past the bad byte
+    // SAFETY: We're at a non-EOF position (byte handler was called)
+    unsafe { lexer.source.next_byte_unchecked() };
+    lexer.error(diagnostics::invalid_utf8(lexer.unterminated_range()));
+    Kind::Undetermined
 }

--- a/crates/oxc_parser/src/lexer/comment.rs
+++ b/crates/oxc_parser/src/lexer/comment.rs
@@ -169,7 +169,7 @@ impl<'a, C: Config> Lexer<'a, C> {
         // cost on files which don't. So this is the fastest solution.
         let finder = self.multi_line_comment_end_finder.get_or_insert_with(|| Finder::new("*/"));
 
-        let remaining = self.source.str_from_pos_to_end(pos).as_bytes();
+        let remaining = self.source.bytes_from_pos_to_end(pos);
         if let Some(index) = finder.find(remaining) {
             // SAFETY: `pos + index + 2` is end of `*/`, so a valid `SourcePosition`
             self.source.set_position(unsafe { pos.add(index + 2) });

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -37,9 +37,9 @@ impl<C: Config> Lexer<'_, C> {
         // Skip opening quote
         // SAFETY: Caller guarantees next byte is ASCII, so `.add(1)` is a UTF-8 char boundary
         let after_opening_quote = unsafe { self.source.position().add(1) };
-        let remaining = self.source.str_from_pos_to_end(after_opening_quote);
+        let remaining = self.source.bytes_from_pos_to_end(after_opening_quote);
 
-        let len = memchr(delimiter, remaining.as_bytes());
+        let len = memchr(delimiter, remaining);
         if let Some(len) = len {
             // SAFETY: `after_opening_quote` + `len` is position of delimiter.
             // Caller guarantees delimiter is ASCII, so 1 byte after it is a UTF-8 char boundary.

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -186,8 +186,8 @@ impl<'a, C: Config> Lexer<'a, C> {
         &self.errors
     }
 
-    /// Remaining string from `Source`
-    pub fn remaining(&self) -> &'a str {
+    /// Remaining bytes from `Source`
+    pub fn remaining(&self) -> &'a [u8] {
         self.source.remaining()
     }
 

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -34,7 +34,7 @@ impl<C: Config> Lexer<'_, C> {
                 Some(Kind::LtEq)
             }
             // `<!--` HTML comment (Annex B.1.1)
-            Some(b'!') if self.remaining().starts_with("!--") => {
+            Some(b'!') if self.remaining().starts_with(b"!--") => {
                 if self.source_type.is_module() {
                     if self.token.is_on_new_line() {
                         let span = Span::new(self.token.start(), self.token.start() + 4);

--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -71,6 +71,9 @@ pub(super) struct Source<'a> {
     /// `SEARCH_BATCH_SIZE` bytes in one go.
     /// Must be `usize`, not a pointer, as if source is very short, a pointer could be out of bounds.
     end_for_batch_search_addr: usize,
+    /// Set `true` when an invalid UTF-8 byte sequence is encountered during lexing.
+    /// Only relevant when source was created from raw bytes via `Parser::new_from_bytes`.
+    pub(super) utf8_error: bool,
     /// Marker for immutable borrow of source string
     _marker: PhantomData<&'a str>,
 }
@@ -100,7 +103,14 @@ impl<'a> Source<'a> {
         // will always test positive, and disable batch search.
         let end_for_batch_search_addr = (end as usize).saturating_sub(SEARCH_BATCH_SIZE);
 
-        Self { start, end, ptr: start, end_for_batch_search_addr, _marker: PhantomData }
+        Self {
+            start,
+            end,
+            ptr: start,
+            end_for_batch_search_addr,
+            utf8_error: false,
+            _marker: PhantomData,
+        }
     }
 
     /// Get entire source text as `&str`.
@@ -112,13 +122,11 @@ impl<'a> Source<'a> {
         unsafe { self.str_between_positions_unchecked(self.start(), self.end()) }
     }
 
-    /// Get remaining source text as `&str`.
+    /// Get remaining source bytes as `&[u8]`.
     #[inline]
-    pub(super) fn remaining(&self) -> &'a str {
-        // SAFETY:
-        // Invariant of `Source` is that `ptr` is always <= `end`, and is on a UTF-8 char boundary.
-        // `end` is pointer to end of original `&str`, so by definition on a UTF-8 char boundary.
-        unsafe { self.str_between_positions_unchecked(self.position(), self.end()) }
+    pub(super) fn remaining(&self) -> &'a [u8] {
+        // SAFETY: `ptr` is always <= `end`, both within the same allocation.
+        unsafe { slice::from_raw_parts(self.ptr, self.remaining_bytes()) }
     }
 
     /// Get number of bytes of source text remaining.
@@ -252,12 +260,15 @@ impl<'a> Source<'a> {
         unsafe { self.str_between_positions_unchecked(self.position(), pos) }
     }
 
-    /// Get string slice from a `SourcePosition` up to the end of `Source`.
+    /// Get byte slice from a `SourcePosition` up to the end of `Source`.
     #[inline]
-    pub(super) fn str_from_pos_to_end(&self, pos: SourcePosition<'a>) -> &'a str {
-        // SAFETY: Invariants of `SourcePosition` is that it cannot be after end of `Source`,
-        // and always on a UTF-8 character boundary
-        unsafe { self.str_between_positions_unchecked(pos, self.end()) }
+    pub(super) fn bytes_from_pos_to_end(&self, pos: SourcePosition<'a>) -> &'a [u8] {
+        debug_assert!(pos.ptr >= self.start && pos.ptr <= self.end);
+        // SAFETY: `pos` is within bounds of source, and `end` is the end of source.
+        unsafe {
+            let len = self.end.offset_from_unsigned(pos.ptr);
+            slice::from_raw_parts(pos.ptr, len)
+        }
     }
 
     /// Get string slice of source between 2 `SourcePosition`s, without checks.
@@ -392,22 +403,23 @@ impl<'a> Source<'a> {
     #[expect(clippy::unnecessary_wraps)]
     #[cold] // Unicode is rare
     unsafe fn next_unicode_char(&mut self) -> Option<char> {
-        // Create a `Chars` iterator, get next char from it, and then update `self.ptr`
-        // to match `Chars` iterator's updated pointer afterwards.
-        // `Chars` iterator upholds same invariants as `Source`, so its pointer is guaranteed
-        // to be valid as `self.ptr`.
-        let remaining = self.remaining();
-        // Inform compiler that next char in `Source` is non-ASCII, so it can remove some branches from
-        // `chars.next().unwrap()`. Compiler will not be aware of these invariants if this function is not inlined.
-        // SAFETY: Caller guarantees these invariants.
-        unsafe {
-            assert_unchecked!(!remaining.is_empty());
-            assert_unchecked!(!remaining.as_bytes()[0].is_ascii());
+        let remaining_len = self.remaining_bytes();
+        // SAFETY: Caller guarantees `Source` is not empty
+        unsafe { assert_unchecked!(remaining_len > 0) };
+        match decode_utf8_char_non_ascii(self.ptr, remaining_len) {
+            Ok((c, char_len)) => {
+                // SAFETY: `char_len` bytes have been validated
+                self.ptr = unsafe { self.ptr.add(char_len) };
+                Some(c)
+            }
+            Err(error_len) => {
+                self.utf8_error = true;
+                // Advance past the bad byte(s)
+                // SAFETY: `error_len` is at least 1 and <= remaining_len
+                self.ptr = unsafe { self.ptr.add(error_len) };
+                Some(char::REPLACEMENT_CHARACTER)
+            }
         }
-        let mut chars = remaining.chars();
-        let c = chars.next().unwrap();
-        self.ptr = chars.as_str().as_ptr();
-        Some(c)
     }
 
     /// Get next 2 chars of source, and advance position to after them.
@@ -437,19 +449,26 @@ impl<'a> Source<'a> {
     /// `Source` must not be empty.
     #[cold] // Unicode is rare
     unsafe fn next_2_unicode_chars(&mut self) -> Option<[char; 2]> {
-        // Create a `Chars` iterator, get next 2 chars from it, and then update `self.ptr`
-        // to match `Chars` iterator's updated pointer afterwards.
-        // `Chars` iterator upholds same invariants as `Source`, so its pointer is guaranteed
-        // to be valid as `self.ptr`.
-        let remaining = self.remaining();
-        // Inform compiler that `Source` is not empty, to remove check from `chars.next().unwrap()`.
-        // Compiler will not be aware of this invariant if this function is not inlined.
-        // SAFETY: Caller guarantees `Source` is not empty.
-        unsafe { assert_unchecked!(!remaining.is_empty()) };
-        let mut chars = remaining.chars();
-        let c1 = chars.next().unwrap();
-        let c2 = chars.next()?;
-        self.ptr = chars.as_str().as_ptr();
+        let remaining_len = self.remaining_bytes();
+        // SAFETY: Caller guarantees `Source` is not empty
+        unsafe { assert_unchecked!(remaining_len > 0) };
+
+        // Decode first char
+        let (c1, len1) = self.decode_or_replacement(self.ptr, remaining_len);
+
+        if len1 >= remaining_len {
+            // Only one char remaining
+            self.ptr = self.end;
+            return None;
+        }
+
+        // Decode second char
+        // SAFETY: `len1 < remaining_len`, so `ptr + len1` is in bounds
+        let ptr2 = unsafe { self.ptr.add(len1) };
+        let (c2, len2) = self.decode_or_replacement(ptr2, remaining_len - len1);
+
+        // SAFETY: `len1 + len2 <= remaining_len`
+        self.ptr = unsafe { self.ptr.add(len1 + len2) };
         Some([c1, c2])
     }
 
@@ -554,21 +573,16 @@ impl<'a> Source<'a> {
     #[expect(clippy::unnecessary_wraps)]
     #[cold] // Unicode is rare
     unsafe fn peek_unicode_char(&self) -> Option<char> {
-        // Create a `Chars` iterator, and get next char from it.
-        let remaining = self.remaining();
-        // Inform compiler that next char in `Source` is non-ASCII, so it can remove some branches from
-        // `chars.next().unwrap()`. Compiler will not be aware of these invariants if this function is not inlined.
-        // SAFETY: Caller guarantees these invariants.
-        unsafe {
-            assert_unchecked!(!remaining.is_empty());
-            assert_unchecked!(!remaining.as_bytes()[0].is_ascii());
+        let remaining_len = self.remaining_bytes();
+        // SAFETY: Caller guarantees `Source` is not empty
+        unsafe { assert_unchecked!(remaining_len > 0) };
+        match decode_utf8_char_non_ascii(self.ptr, remaining_len) {
+            Ok((c, _)) => Some(c),
+            // Note: We can't set `utf8_error` here because `self` is `&self`.
+            // The error will be caught when `next_char` / `next_unicode_char` is called,
+            // or in the UNI/UER byte handler.
+            Err(_) => Some(char::REPLACEMENT_CHARACTER),
         }
-        let mut chars = remaining.chars();
-        // We know that there's a byte to be consumed, so `chars.next()` must return `Some(_)`.
-        // Could just return `chars.next()` here, but making it clear to compiler that this branch
-        // always returns `Some(_)` may help it optimize the caller.
-        let c = chars.next().unwrap();
-        Some(c)
     }
 
     /// Peek next byte of source without consuming it.
@@ -824,6 +838,117 @@ impl PartialOrd for SourcePosition<'_> {
     fn ge(&self, other: &Self) -> bool {
         self.offset_from_signed(*other) >= 0
     }
+}
+
+impl Source<'_> {
+    /// Decode a character at `ptr` with `remaining_len` bytes available,
+    /// returning the char and its byte length. On error, sets `utf8_error` flag
+    /// and returns `REPLACEMENT_CHARACTER`.
+    fn decode_or_replacement(&mut self, ptr: *const u8, remaining_len: usize) -> (char, usize) {
+        // SAFETY: `ptr` is valid for `remaining_len` bytes
+        let byte = unsafe { *ptr };
+        if byte.is_ascii() {
+            return (byte as char, 1);
+        }
+        match decode_utf8_char_non_ascii(ptr, remaining_len) {
+            Ok((c, len)) => (c, len),
+            Err(error_len) => {
+                self.utf8_error = true;
+                (char::REPLACEMENT_CHARACTER, error_len)
+            }
+        }
+    }
+}
+
+/// Decode one multi-byte UTF-8 character from a raw pointer.
+///
+/// Returns `Ok((char, byte_length))` on success, or `Err(error_length)` if the bytes
+/// do not form a valid UTF-8 sequence. `error_length` is the number of bytes to skip
+/// past the invalid sequence (at least 1).
+///
+/// # Safety
+/// The first byte at `ptr` must NOT be ASCII (i.e. >= 0x80).
+/// `remaining` must be > 0.
+/// `ptr` must be valid for reading up to `remaining` bytes.
+#[cold]
+fn decode_utf8_char_non_ascii(ptr: *const u8, remaining: usize) -> Result<(char, usize), usize> {
+    debug_assert!(remaining > 0);
+
+    // SAFETY: Caller guarantees `ptr` is valid for `remaining` bytes
+    let b0 = unsafe { *ptr };
+    debug_assert!(!b0.is_ascii());
+
+    // 2-byte sequence: 110xxxxx 10xxxxxx
+    if (0xC2..=0xDF).contains(&b0) {
+        if remaining < 2 {
+            return Err(1);
+        }
+        // SAFETY: `remaining >= 2`, so `ptr.add(1)` is in bounds
+        let b1 = unsafe { *ptr.add(1) };
+        if !is_utf8_cont_byte(b1) {
+            return Err(1);
+        }
+        let code_point = (u32::from(b0 & 0x1F) << 6) | u32::from(b1 & 0x3F);
+        // SAFETY: 2-byte sequences starting with 0xC2..=0xDF always produce valid code points
+        let c = unsafe { char::from_u32_unchecked(code_point) };
+        return Ok((c, 2));
+    }
+
+    // 3-byte sequence: 1110xxxx 10xxxxxx 10xxxxxx
+    if (0xE0..=0xEF).contains(&b0) {
+        if remaining < 3 {
+            return Err(remaining.clamp(1, 2));
+        }
+        // SAFETY: `remaining >= 3`, so `ptr.add(1)` and `ptr.add(2)` are in bounds
+        let (b1, b2) = unsafe { (*ptr.add(1), *ptr.add(2)) };
+        if !is_utf8_cont_byte(b1) {
+            return Err(1);
+        }
+        if !is_utf8_cont_byte(b2) {
+            return Err(2);
+        }
+        let code_point =
+            (u32::from(b0 & 0x0F) << 12) | (u32::from(b1 & 0x3F) << 6) | u32::from(b2 & 0x3F);
+        // Check for overlong encoding and surrogates
+        if code_point < 0x800 || (0xD800..=0xDFFF).contains(&code_point) {
+            return Err(3);
+        }
+        // SAFETY: We checked the code point is valid (not surrogate, not overlong)
+        let c = unsafe { char::from_u32_unchecked(code_point) };
+        return Ok((c, 3));
+    }
+
+    // 4-byte sequence: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+    if (0xF0..=0xF4).contains(&b0) {
+        if remaining < 4 {
+            return Err(remaining.clamp(1, 3));
+        }
+        // SAFETY: `remaining >= 4`, so `ptr.add(1..3)` are in bounds
+        let (b1, b2, b3) = unsafe { (*ptr.add(1), *ptr.add(2), *ptr.add(3)) };
+        if !is_utf8_cont_byte(b1) {
+            return Err(1);
+        }
+        if !is_utf8_cont_byte(b2) {
+            return Err(2);
+        }
+        if !is_utf8_cont_byte(b3) {
+            return Err(3);
+        }
+        let code_point = (u32::from(b0 & 0x07) << 18)
+            | (u32::from(b1 & 0x3F) << 12)
+            | (u32::from(b2 & 0x3F) << 6)
+            | u32::from(b3 & 0x3F);
+        // Check for overlong encoding and max code point
+        if !(0x10000..=0x10_FFFF).contains(&code_point) {
+            return Err(4);
+        }
+        // SAFETY: We checked the code point is in valid range
+        let c = unsafe { char::from_u32_unchecked(code_point) };
+        return Ok((c, 4));
+    }
+
+    // Invalid leading byte (0x80-0xBF, 0xC0-0xC1, 0xF5-0xFF)
+    Err(1)
 }
 
 /// Return if byte is a UTF-8 continuation byte.

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -77,6 +77,7 @@ mod jsx;
 mod ts;
 
 mod diagnostics;
+mod encoding;
 
 // Expose lexer only in benchmarks
 #[cfg(not(feature = "benchmarking"))]
@@ -260,6 +261,34 @@ impl<'a> Parser<'a> {
     /// - `source_text`: Source code to parse
     /// - `source_type`: Source type (e.g. JavaScript, TypeScript, JSX, ESM Module, Script)
     pub fn new(allocator: &'a Allocator, source_text: &'a str, source_type: SourceType) -> Self {
+        let options = ParseOptions::default();
+        Self { allocator, source_text, source_type, options, config: NoTokensParserConfig }
+    }
+
+    /// Create a new [`Parser`] from raw bytes, without requiring upfront UTF-8 validation.
+    ///
+    /// This accepts raw bytes and handles encoding detection internally:
+    /// - UTF-16 LE/BE BOM: transcodes to UTF-8 in the arena
+    /// - UTF-8 BOM: strips the BOM
+    /// - Otherwise: uses bytes as-is
+    ///
+    /// The lexer validates UTF-8 incrementally on non-ASCII bytes during lexing.
+    /// Invalid UTF-8 sequences produce diagnostic errors.
+    ///
+    /// # Parameters
+    /// - `allocator`: [Memory arena](oxc_allocator::Allocator) for allocating AST nodes
+    /// - `source_bytes`: Raw source bytes to parse (no UTF-8 validation required)
+    /// - `source_type`: Source type (e.g. JavaScript, TypeScript, JSX, ESM Module, Script)
+    pub fn new_from_bytes(
+        allocator: &'a Allocator,
+        source_bytes: &'a [u8],
+        source_type: SourceType,
+    ) -> Self {
+        let bytes = encoding::detect_encoding_and_normalize(allocator, source_bytes);
+        // SAFETY: The lexer validates UTF-8 on non-ASCII bytes as it lexes.
+        // All `&str` operations during parsing use spans from lexed tokens (validated regions).
+        // For transcoded UTF-16, bytes are already valid UTF-8.
+        let source_text = unsafe { std::str::from_utf8_unchecked(bytes) };
         let options = ParseOptions::default();
         Self { allocator, source_text, source_type, options, config: NoTokensParserConfig }
     }
@@ -971,5 +1000,65 @@ mod test {
         assert!(!ret.panicked);
         assert!(ret.errors.is_empty());
         assert_eq!(ret.program.body.len(), 2);
+    }
+
+    #[test]
+    fn new_from_bytes_valid_utf8() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        let source = b"const x = 1;";
+        let ret = Parser::new_from_bytes(&allocator, source, source_type).parse();
+        assert!(!ret.program.is_empty());
+        assert!(ret.errors.is_empty());
+    }
+
+    #[test]
+    fn new_from_bytes_invalid_utf8() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        // 0xFF is not valid UTF-8
+        let source: &[u8] = &[b'v', b'a', b'r', b' ', 0xFF, b';'];
+        let ret = Parser::new_from_bytes(&allocator, source, source_type).parse();
+        assert!(!ret.errors.is_empty());
+        assert!(ret.errors.iter().any(|e| e.to_string().contains("Invalid UTF-8")));
+    }
+
+    #[test]
+    fn new_from_bytes_utf8_bom() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        // UTF-8 BOM followed by valid JS
+        let source: &[u8] = &[0xEF, 0xBB, 0xBF, b'v', b'a', b'r', b' ', b'x', b';'];
+        let ret = Parser::new_from_bytes(&allocator, source, source_type).parse();
+        assert!(!ret.program.is_empty());
+        assert!(ret.errors.is_empty());
+    }
+
+    #[test]
+    fn new_from_bytes_utf16_le() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        // UTF-16 LE BOM + "var x;" encoded as UTF-16 LE
+        let source: &[u8] = &[
+            0xFF, 0xFE, // BOM
+            b'v', 0, b'a', 0, b'r', 0, b' ', 0, b'x', 0, b';', 0,
+        ];
+        let ret = Parser::new_from_bytes(&allocator, source, source_type).parse();
+        assert!(!ret.program.is_empty());
+        assert!(ret.errors.is_empty());
+    }
+
+    #[test]
+    fn new_from_bytes_utf16_be() {
+        let allocator = Allocator::default();
+        let source_type = SourceType::default();
+        // UTF-16 BE BOM + "var x;" encoded as UTF-16 BE
+        let source: &[u8] = &[
+            0xFE, 0xFF, // BOM
+            0, b'v', 0, b'a', 0, b'r', 0, b' ', 0, b'x', 0, b';',
+        ];
+        let ret = Parser::new_from_bytes(&allocator, source, source_type).parse();
+        assert!(!ret.program.is_empty());
+        assert!(ret.errors.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `Parser::new_from_bytes(allocator, &[u8], source_type)` that accepts raw bytes, eliminating upfront UTF-8 validation and the intermediate `String` allocation
- BOM detection: handles UTF-8 BOM (strips it), UTF-16 LE/BE (transcodes to UTF-8 in arena via `encoding_rs`)
- Lexer validates UTF-8 incrementally on non-ASCII bytes — invalid sequences emit `invalid_utf8` diagnostics instead of panicking
- Rewrite `Source`'s unicode char methods (`next_unicode_char`, `peek_unicode_char`, `next_2_unicode_chars`) to use manual UTF-8 decoding from raw pointers instead of `str::chars()`
- Change `Source::remaining()` → `&[u8]` and `str_from_pos_to_end` → `bytes_from_pos_to_end` since callers only need bytes
- Change `UER` byte handler from `unreachable!()` to emit diagnostic (supports `new_from_bytes` path with unvalidated input)
- Move `read_to_arena_bytes` utilities from `oxc_linter` to `oxc_allocator::file_io::read_file_to_arena`

Closes https://github.com/oxc-project/backlog/issues/201

🤖 Generated with [Claude Code](https://claude.com/claude-code)