### PR TITLE
chore(rust): bump `cargo-shear` to 1.11.2

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           restore-cache: true
           cache-key: warm
-          tools: just,cargo-shear@1.10.0
+          tools: just,cargo-shear@1.11.2
           components: rustfmt
 
       - name: cargo-shear

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           cache-key: warm
           save-cache: false
-          tools: just,cargo-insta,typos-cli,cargo-shear@1.10.0,ast-grep
+          tools: just,cargo-insta,typos-cli,cargo-shear@1.11.2,ast-grep
           components: clippy rust-docs rustfmt rust-analyzer
 
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = true
+doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -16,9 +16,10 @@ description.workspace = true
 [lints]
 workspace = true
 
-[lib]
-
 [dependencies]
 cow-utils = { workspace = true }
 miette = { workspace = true }
 percent-encoding = { workspace = true }
+
+[lib]
+doctest = false

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -15,8 +15,6 @@ description.workspace = true
 [lints]
 workspace = true
 
-[lib]
-
 [dependencies]
 oxc_data_structures = { workspace = true, features = [
   "code_buffer",
@@ -30,3 +28,6 @@ itoa = { workspace = true, optional = true }
 [features]
 default = []
 serialize = ["dep:oxc_data_structures", "dep:itoa", "dep:dragonbox_ecma"]
+
+[lib]
+doctest = false

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -16,8 +16,6 @@ description.workspace = true
 [lints]
 workspace = true
 
-[lib]
-
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
@@ -48,3 +46,6 @@ oxc_span = { workspace = true }
 [features]
 default = []
 detect_code_removal = ["dep:oxc_semantic"]
+
+[lib]
+doctest = false

--- a/crates/oxc_macros/Cargo.toml
+++ b/crates/oxc_macros/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 [lib]
 proc-macro = true
 test = false
+doctest = false
 
 [dependencies]
 convert_case = { workspace = true }

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [lib]
 test = true
+doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ alias f := fix
 # Initialize the project by installing all necessary tools
 init:
   # Rust related init
-  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.10.0 -y
+  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.11.2 -y
   # Node.js related init
   pnpm install
 


### PR DESCRIPTION
## Summary
- Bump `cargo-shear` from 1.10.0 to 1.11.2 in justfile and CI workflows
- Apply `cargo shear --fix`: set `doctest = false` on 6 crates with no doc tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)