### PR TITLE
docs(linter): Improve formatting for 80ish rules' docs.

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -131,7 +131,7 @@ pub struct ArrayCallbackReturn {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce return statements in callbacks of array methods
+    /// Enforce return statements in callbacks of array methods.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -95,7 +95,7 @@ pub struct GroupedAccessorPairsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Require grouped accessor pairs in object literals and classes
+    /// Require grouped accessor pairs in object literals and classes.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -46,7 +46,7 @@ impl Default for MaxClassesPerFileConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce a maximum number of classes per file
+    /// Enforce a maximum number of classes per file.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -18,12 +18,12 @@ pub struct NoAlert;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow the use of alert, confirm, and prompt
+    /// Disallow the use of `alert`, `confirm`, and `prompt`.
     ///
     /// ### Why is this bad?
     ///
-    /// JavaScript’s alert, confirm, and prompt functions are widely considered to be obtrusive as UI elements and should be replaced by a more appropriate custom UI implementation.
-    /// Furthermore, alert is often used while debugging code, which should be removed before deployment to production.
+    /// JavaScript’s `alert`, `confirm`, and `prompt` functions are widely considered to be obtrusive as UI elements and should be replaced by a more appropriate custom UI implementation.
+    /// Furthermore, `alert` is often used while debugging code, which should be removed before deployment to production.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -57,7 +57,7 @@ impl std::ops::Deref for NoBitwise {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow bitwise operators
+    /// Disallow bitwise operators.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -37,7 +37,7 @@ enum NoCondAssignConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow assignment operators in conditional expressions
+    /// Disallow assignment operators in conditional expressions.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -19,7 +19,7 @@ pub struct NoConstantBinaryExpression;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow expressions where the operation doesn't affect the value
+    /// Disallow expressions where the operation doesn't affect the value.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -58,7 +58,7 @@ pub struct NoConstantCondition {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow constant expressions in conditions
+    /// Disallow constant expressions in conditions.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constructor_return.rs
@@ -21,7 +21,7 @@ pub struct NoConstructorReturn;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow returning value from constructor
+    /// Disallow returning value from constructor.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_continue.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_continue.rs
@@ -17,7 +17,7 @@ pub struct NoContinue;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `continue` statements
+    /// Disallow `continue` statements.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -17,7 +17,7 @@ pub struct NoDebugger;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Checks for usage of the `debugger` statement
+    /// Checks for usage of the `debugger` statement.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -26,7 +26,7 @@ pub struct NoDupeElseIf;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow duplicate conditions in if-else-if chains
+    /// Disallow duplicate conditions in if-else-if chains.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -17,7 +17,7 @@ pub struct NoDuplicateCase;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow duplicate case labels
+    /// Disallow duplicate case labels.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -61,7 +61,7 @@ impl Default for NoElseReturn {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `else` blocks after `return` statements in `if` statements
+    /// Disallow `else` blocks after `return` statements in `if` statements.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -27,7 +27,7 @@ pub struct NoEmpty {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallows empty block statements
+    /// Disallows empty block statements.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -23,7 +23,7 @@ pub struct NoEmptyCharacterClass;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow empty character classes in regular expressions
+    /// Disallow empty character classes in regular expressions.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -17,7 +17,7 @@ pub struct NoEmptyStaticBlock;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallows the usages of empty static blocks
+    /// Disallows the usages of empty static blocks.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -19,7 +19,7 @@ pub struct NoExAssign;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow reassigning exceptions in catch clauses
+    /// Disallow reassigning exceptions in catch clauses.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_extra_bind.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_bind.rs
@@ -22,14 +22,14 @@ pub struct NoExtraBind;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unnecessary calls to .bind()
+    /// Disallow unnecessary calls to `.bind()`.
     ///
     /// ### Why is this bad?
     ///
-    /// This rule is aimed at avoiding the unnecessary use of bind()
-    /// and as such will warn whenever an immediately-invoked function expression (IIFE) is using bind()
-    /// and doesn’t have an appropriate this value.
-    /// This rule won’t flag usage of bind() that includes function argument binding.
+    /// This rule is aimed at avoiding the unnecessary use of `bind()`
+    /// and as such will warn whenever an immediately-invoked function expression (IIFE) is using `bind()`
+    /// and doesn’t have an appropriate `this` value.
+    /// This rule won’t flag usage of `bind()` that includes function argument binding.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_lonely_if.rs
@@ -18,7 +18,7 @@ pub struct NoLonelyIf;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `if` statements as the only statement in `else` blocks
+    /// Disallow `if` statements as the only statement in `else` blocks.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -31,12 +31,12 @@ pub struct NoNewWrappers;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow `new` operators with the `String`, `Number`, and `Boolean` objects
+    /// Disallow `new` operators with the `String`, `Number`, and `Boolean` objects.
     ///
     /// ### Why is this bad?
     ///
     /// The first problem is that primitive wrapper objects are, in fact,
-    /// objects. That means typeof will return `"object"` instead of `"string"`,
+    /// objects. That means `typeof` will return `"object"` instead of `"string"`,
     /// `"number"`, or `"boolean"`.  The second problem comes with boolean
     /// objects. Every object is truthy, that means an instance of `Boolean`
     /// always resolves to `true` even when its actual value is `false`.

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -23,7 +23,7 @@ pub struct NoNonoctalDecimalEscape;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule disallows \8 and \9 escape sequences in string literals
+    /// This rule disallows \8 and \9 escape sequences in string literals.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
@@ -17,7 +17,7 @@ pub struct NoObjectConstructor;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow calls to the Object constructor without an argument
+    /// Disallow calls to the Object constructor without an argument.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -21,17 +21,17 @@ pub struct NoPrototypeBuiltins;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow calling some Object.prototype methods directly on objects
+    /// Disallow calling some `Object.prototype` methods directly on objects.
     ///
     /// ### Why is this bad?
     ///
-    /// In ECMAScript 5.1, Object.create was added, which enables the creation of objects with a specified [[Prototype]].
-    /// Object.create(null) is a common pattern used to create objects that will be used as a Map.
-    /// This can lead to errors when it is assumed that objects will have properties from Object.prototype. This rule prevents calling some Object.prototype methods directly from an object.
-    /// Additionally, objects can have properties that shadow the builtins on Object.prototype, potentially causing unintended behavior or denial-of-service security vulnerabilities.
-    /// For example, it would be unsafe for a webserver to parse JSON input from a client and call hasOwnProperty directly on the resulting object, because a malicious client could send a JSON value like {"hasOwnProperty": 1} and cause the server to crash.
+    /// In ECMAScript 5.1, `Object.create` was added, which enables the creation of objects with a specified [[Prototype]].
+    /// `Object.create(null)` is a common pattern used to create objects that will be used as a Map.
+    /// This can lead to errors when it is assumed that objects will have properties from `Object.prototype`. This rule prevents calling some `Object.prototype` methods directly from an object.
+    /// Additionally, objects can have properties that shadow the builtins on `Object.prototype`, potentially causing unintended behavior or denial-of-service security vulnerabilities.
+    /// For example, it would be unsafe for a webserver to parse JSON input from a client and call `hasOwnProperty` directly on the resulting object, because a malicious client could send a JSON value like {"hasOwnProperty": 1} and cause the server to crash.
     ///
-    /// To avoid subtle bugs like this, it’s better to always call these methods from Object.prototype. For example, foo.hasOwnProperty("bar") should be replaced with Object.prototype.hasOwnProperty.call(foo, "bar").
+    /// To avoid subtle bugs like this, it’s better to always call these methods from `Object.prototype`. For example, `foo.hasOwnProperty("bar")` should be replaced with `Object.prototype.hasOwnProperty.call(foo, "bar")`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_script_url.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_script_url.rs
@@ -18,7 +18,7 @@ pub struct NoScriptUrl;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow javascript: urls
+    /// Disallow `javascript:` URLs.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -17,7 +17,7 @@ pub struct NoSelfCompare;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow comparisons where both sides are exactly the same
+    /// Disallow comparisons where both sides are exactly the same.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
     /// var undefined = "foo";
     /// ```
     ///
-    /// Then any code used within the same scope would not get the global undefined, but rather the
+    /// Then any code used within the same scope would not get the global `undefined`, but rather the
     /// local version with a very different meaning.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -17,7 +17,7 @@ pub struct NoTernary;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow ternary operators
+    /// Disallow ternary operators.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -21,12 +21,12 @@ pub struct NoUnassignedVars;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow let or var variables that are read but never assigned
+    /// Disallow let or var variables that are read but never assigned.
     ///
     /// ### Why is this bad?
     ///
     /// This rule flags let or var declarations that are never assigned a value but are still read or used in the code.
-    /// Since these variables will always be undefined, their usage is likely a programming mistake.
+    /// Since these variables will always be `undefined`, their usage is likely a programming mistake.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -15,12 +15,12 @@ fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow the use of `undefined` as an identifier
+    /// Disallow the use of `undefined` as an identifier.
     ///
     /// ### Why is this bad?
     ///
-    /// Using undefined directly can lead to bugs, since it can be shadowed or overwritten in JavaScript.
-    /// It's safer and more intentional to use null or rely on implicit undefined (e.g., missing return) to avoid accidental issues.
+    /// Using `undefined` directly can lead to bugs, since it can be shadowed or overwritten in JavaScript.
+    /// It's safer and more intentional to use `null` or rely on implicit `undefined` (e.g., missing return) to avoid accidental issues.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unneeded_ternary.rs
@@ -45,7 +45,7 @@ impl Default for NoUnneededTernary {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow ternary operators when simpler alternatives exist
+    /// Disallow ternary operators when simpler alternatives exist.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -38,11 +38,11 @@ pub struct NoUnsafeOptionalChaining {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow use of optional chaining in contexts where the undefined value is not allowed
+    /// Disallow use of optional chaining in contexts where the `undefined` value is not allowed.
     ///
     /// ### Why is this bad?
     ///
-    /// The optional chaining (`?.`) expression can short-circuit with a return value of undefined.
+    /// The optional chaining (`?.`) expression can short-circuit with a return value of `undefined`.
     /// Therefore, treating an evaluated optional chaining expression as a function, object, number, etc.,
     /// can cause TypeError or unexpected results. For example:
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -20,7 +20,7 @@ pub struct NoUnusedPrivateClassMembers;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unused private class members
+    /// Disallow unused private class members.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -26,7 +26,7 @@ pub struct NoUselessCatch;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unnecessary catch clauses
+    /// Disallow unnecessary catch clauses.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -49,7 +49,7 @@ impl Default for NoUselessComputedKey {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow unnecessary computed property keys in objects and classes
+    /// Disallow unnecessary computed property keys in objects and classes.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_destructuring.rs
@@ -54,7 +54,7 @@ pub struct PreferDestructuring {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Require destructuring from arrays and/or objects
+    /// Require destructuring from arrays and/or objects.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -21,12 +21,12 @@ fn prefer_exponentian_operator_diagnostic(span: Span) -> OxcDiagnostic {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow the use of Math.pow in favor of the ** operator
+    /// Disallow the use of `Math.pow` in favor of the `**` operator.
     ///
     /// ### Why is this bad?
     ///
-    /// Introduced in ES2016, the infix exponentiation operator ** is an alternative for the
-    /// standard Math.pow function. Infix notation is considered to be more readable and thus more
+    /// Introduced in ES2016, the infix exponentiation operator `**` is an alternative for the
+    /// standard `Math.pow` function. Infix notation is considered to be more readable and thus more
     /// preferable than the function notation.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -34,15 +34,15 @@ fn radix_map(base: &str) -> Option<(&'static str, &'static str)> {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal
+    /// Disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal
     /// literals.
     ///
     /// ### Why is this bad?
     ///
-    /// The parseInt() and Number.parseInt() functions can be used to turn binary, octal, and
+    /// The `parseInt()` and `Number.parseInt()` functions can be used to turn binary, octal, and
     /// hexadecimal strings into integers. As binary, octal, and hexadecimal literals are supported
-    /// in ES2015, this rule encourages use of those numeric literals instead of parseInt() or
-    /// Number.parseInt().
+    /// in ES2015, this rule encourages use of those numeric literals instead of `parseInt()` or
+    /// `Number.parseInt()`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -30,8 +30,8 @@ declare_oxc_lint!(
     ///     console.log("has property foo");
     /// }
     /// ```
-    /// This is a common practice because methods on Object.prototype can sometimes be unavailable or redefined (see the no-prototype-builtins rule).
-    /// Introduced in ES2022, Object.hasOwn() is a shorter alternative to Object.prototype.hasOwnProperty.call():
+    /// This is a common practice because methods on `Object.prototype` can sometimes be unavailable or redefined (see the no-prototype-builtins rule).
+    /// Introduced in ES2022, `Object.hasOwn()` is a shorter alternative to `Object.prototype.hasOwnProperty.call()`:
     /// ```javascript
     /// if (Object.hasOwn(object, "foo")) {
     ///   console.log("has property foo")

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -26,7 +26,7 @@ pub struct PreferObjectSpread;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow using `Object.assign` with an object literal as the first argument and prefer the use of object spread instead
+    /// Disallow using `Object.assign` with an object literal as the first argument and prefer the use of object spread instead.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -68,21 +68,21 @@ impl Default for UseIsnan {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallows checking against NaN without using `isNaN()` call.
+    /// Disallows checking against `NaN` without using `isNaN()` call.
     ///
     /// ### Why is this bad?
     ///
-    /// In JavaScript, NaN is a special value of the Number type.
+    /// In JavaScript, `NaN` is a special value of the Number type.
     /// It’s used to represent any of the “not-a-number” values represented
     /// by the double-precision 64-bit format as specified by the IEEE Standard
     /// for Binary Floating-Point Arithmetic.
     ///
-    /// Because NaN is unique in JavaScript by not being equal to anything, including itself,
-    /// the results of comparisons to NaN are confusing:
+    /// Because `NaN` is unique in JavaScript by not being equal to anything, including itself,
+    /// the results of comparisons to `NaN` are confusing:
     /// - `NaN === NaN` or `NaN == NaN` evaluate to false
     /// - `NaN !== NaN` or `NaN != NaN` evaluate to true
     ///
-    /// Therefore, use `Number.isNaN()` or global `isNaN()` functions to test whether a value is NaN.
+    /// Therefore, use `Number.isNaN()` or global `isNaN()` functions to test whether a value is `NaN`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -33,7 +33,7 @@ pub struct NoConfusingSetTimeout;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow confusing usages of jest.setTimeout
+    /// Disallow confusing usages of `jest.setTimeout`.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -31,7 +31,7 @@ pub struct HtmlHasLang;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Ensures that every HTML document has a lang attribute
+    /// Ensures that every HTML document has a lang attribute.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/node/global_require.rs
+++ b/crates/oxc_linter/src/rules/node/global_require.rs
@@ -20,7 +20,7 @@ pub struct GlobalRequire;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Require `require()` calls to be placed at top-level module scope
+    /// Require `require()` calls to be placed at top-level module scope.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
+++ b/crates/oxc_linter/src/rules/oxc/uninvoked_array_callback.rs
@@ -26,7 +26,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// When the Array constructor is called with a single number argument, an array with the specified number of empty slots (not actual undefined values) is constructed.
+    /// When the Array constructor is called with a single number argument, an array with the specified number of empty slots (not actual `undefined` values) is constructed.
     /// If a callback function is passed to the function of this array, the callback function is never invoked because the array has no actual elements.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -21,7 +21,7 @@ pub struct NoNesting;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow nested then() or catch() statements.
+    /// Disallow nested `then()` or `catch()` statements.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -21,7 +21,7 @@ pub struct NoReturnInFinally;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow return statements in a finally() callback of a promise.
+    /// Disallow return statements in a `finally()` callback of a promise.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -37,7 +37,7 @@ pub struct PreferAwaitToThenConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values
+    /// Prefer `await` to `then()`/`catch()`/`finally()` for reading Promise values.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
+++ b/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
@@ -58,7 +58,7 @@ pub struct IframeMissingSandbox;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce sandbox attribute on iframe elements
+    /// Enforce sandbox attribute on iframe elements.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -81,7 +81,7 @@ impl Deref for JsxKey {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce `key` prop for elements in array
+    /// Enforce `key` prop for elements in array.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_pascal_case.rs
@@ -53,7 +53,7 @@ impl std::ops::Deref for JsxPascalCase {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce PascalCase for user-defined JSX components
+    /// Enforce PascalCase for user-defined JSX components.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spreading.rs
@@ -60,7 +60,7 @@ impl std::ops::Deref for JsxPropsNoSpreading {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow JSX prop spreading
+    /// Disallow JSX prop spreading.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -15,7 +15,7 @@ pub struct BanTslintComment;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule disallows `tslint:<rule-flag>` comments
+    /// This rule disallows `tslint:<rule-flag>` comments.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_array_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_array_delete.rs
@@ -12,7 +12,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// When using the delete operator on an array, the element is not actually removed, but instead the array slot is turned into undefined. This is usually not the intended behavior. Instead, you should use methods like Array.prototype.splice() to properly remove elements from an array.
+    /// When using the delete operator on an array, the element is not actually removed, but instead the array slot is turned into `undefined`. This is usually not the intended behavior. Instead, you should use methods like `Array.prototype.splice()` to properly remove elements from an array.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
@@ -38,11 +38,11 @@ impl Default for NoBaseToStringConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule requires toString() and toLocaleString() calls to only be called on objects which provide useful information when stringified.
+    /// This rule requires `toString()` and `toLocaleString()` calls to only be called on objects which provide useful information when stringified.
     ///
     /// ### Why is this bad?
     ///
-    /// JavaScript's toString() method returns '[object Object]' on plain objects, which is not useful information. This rule prevents toString() and toLocaleString() from being called on objects that return less useful strings.
+    /// JavaScript's `toString()` method returns '[object Object]' on plain objects, which is not useful information. This rule prevents `toString()` and `toLocaleString()` from being called on objects that return less useful strings.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_void_expression.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// The void operator is useful when you want to execute an expression while evaluating to undefined. However, it can be confusing when used in places where the return value is meaningful, particularly in arrow functions and conditional expressions.
+    /// The void operator is useful when you want to execute an expression while evaluating to `undefined`. However, it can be confusing when used in places where the return value is meaningful, particularly in arrow functions and conditional expressions.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -123,7 +123,7 @@ declare_oxc_lint!(
     /// The `{}`, or "empty object" type in TypeScript is a common source of confusion for developers unfamiliar with TypeScript's structural typing. `{}` represents any non-nullish value, including literals like 0 and "".
     /// Often, developers writing `{}` actually mean either:
     /// - object: representing any object value
-    /// - unknown: representing any value at all, including null and undefined
+    /// - unknown: representing any value at all, including `null` and `undefined`
     /// In other words, the "empty object" type {}` really means "any value that is defined". That includes arrays, class instances, functions, and primitives such as string and symbol.
     ///
     /// Note that this rule does not report on:

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// The `!` non-null assertion operator in TypeScript is used to assert that a value's type
-    /// does not include null or undefined. Using the operator any more than once on a single value
+    /// does not include `null` or `undefined`. Using the operator any more than once on a single value
     /// does nothing.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/typescript/no_implied_eval.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_implied_eval.rs
@@ -12,7 +12,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// It's considered a good practice to avoid using eval() in JavaScript. There are security and performance implications involved with doing so, which is why many linters recommend disallowing eval(). However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
+    /// It's considered a good practice to avoid using `eval()` in JavaScript. There are security and performance implications involved with doing so, which is why many linters recommend disallowing `eval()`. However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -35,7 +35,7 @@ pub struct NoInferrableTypes {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow explicit type declarations for variables or parameters initialized to a number, string, or boolean
+    /// Disallow explicit type declarations for variables or parameters initialized to a number, string, or boolean.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_meaningless_void_operator.rs
@@ -17,11 +17,11 @@ pub struct NoMeaninglessVoidOperatorConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule disallows the void operator when its argument is already of type void or undefined.
+    /// This rule disallows the void operator when its argument is already of type void or `undefined`.
     ///
     /// ### Why is this bad?
     ///
-    /// The void operator is useful when you want to execute an expression and force it to evaluate to undefined. However, using void on expressions that are already of type void or undefined is meaningless and adds unnecessary complexity to the code.
+    /// The void operator is useful when you want to execute an expression and force it to evaluate to `undefined`. However, using void on expressions that are already of type void or `undefined` is meaningless and adds unnecessary complexity to the code.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -92,7 +92,7 @@ declare_oxc_lint!(
     ///
     /// TypeScript historically allowed a form of code organization called "custom modules" (module Example {}),
     /// later renamed to "namespaces" (namespace Example). Namespaces are an outdated way to organize TypeScript code.
-    /// ES2015 module syntax is now preferred (import/export).
+    /// ES2015 module syntax is now preferred (`import`/`export`).
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -27,7 +27,7 @@ declare_oxc_lint!(
     /// ### Why is this bad?
     ///
     /// The ?? nullish coalescing runtime operator allows providing a default value when dealing
-    /// with null or undefined. Using a ! non-null assertion type operator in the left operand of
+    /// with `null` or `undefined`. Using a ! non-null assertion type operator in the left operand of
     /// a nullish coalescing operator is redundant, and likely a sign of programmer error or
     /// confusion over the two operators.
     ///

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -15,11 +15,11 @@ pub struct NoNonNullAssertion;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow non-null assertions using the ! postfix operator.
+    /// Disallow non-null assertions using the `!` postfix operator.
     ///
     /// ### Why is this bad?
     ///
-    /// TypeScript's ! non-null assertion operator asserts to the type system that an expression is non-nullable, as in not null or undefined. Using assertions to tell the type system new information is often a sign that code is not fully type-safe. It's generally better to structure program logic so that TypeScript understands when values may be nullable.
+    /// TypeScript's `!` non-null assertion operator asserts to the type system that an expression is non-nullable, as in not `null` or `undefined`. Using assertions to tell the type system new information is often a sign that code is not fully type-safe. It's generally better to structure program logic so that TypeScript understands when values may be nullable.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/non_nullable_type_assertion_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/non_nullable_type_assertion_style.rs
@@ -12,7 +12,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// When you know that a value cannot be null or undefined, you can use either a non-null assertion (`!`) or a type assertion (`as Type`). The non-null assertion is more concise and clearly communicates the intent that you're asserting the value is not null/undefined.
+    /// When you know that a value cannot be `null` or `undefined`, you can use either a non-null assertion (`!`) or a type assertion (`as Type`). The non-null assertion is more concise and clearly communicates the intent that you're asserting the value is not `null`/`undefined`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Namespaces are an outdated way to organize TypeScript code. ES2015 module syntax is now preferred (import/export).
+    /// Namespaces are an outdated way to organize TypeScript code. ES2015 module syntax is now preferred (`import`/`export`).
     /// For projects still using custom modules / namespaces, it's preferred to refer to them as namespaces.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -21,7 +21,7 @@ pub struct PreferPromiseRejectErrorsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces passing an Error object to Promise.reject().
+    /// This rule enforces passing an Error object to `Promise.reject()`.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/typescript/prefer_reduce_type_parameter.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_reduce_type_parameter.rs
@@ -8,11 +8,11 @@ pub struct PreferReduceTypeParameter;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule prefers using a type parameter for the accumulator in Array.reduce instead of casting.
+    /// This rule prefers using a type parameter for the accumulator in `Array#reduce()` instead of casting.
     ///
     /// ### Why is this bad?
     ///
-    /// Array.reduce can be called with a generic type parameter to specify the type of the accumulator. This is preferred over casting the result because it provides better type safety and is more explicit about the intended type.
+    /// `Array#reduce()` can be called with a generic type parameter to specify the type of the accumulator. This is preferred over casting the result because it provides better type safety and is more explicit about the intended type.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
+++ b/crates/oxc_linter/src/rules/typescript/require_array_sort_compare.rs
@@ -23,11 +23,11 @@ impl Default for RequireArraySortCompareConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule requires Array.sort() to be called with a comparison function.
+    /// This rule requires `Array#sort()` to be called with a comparison function.
     ///
     /// ### Why is this bad?
     ///
-    /// When Array.sort() is called without a comparison function, it converts elements to strings and sorts them lexicographically. This often leads to unexpected results, especially with numbers where `[1, 10, 2].sort()` returns `[1, 10, 2]` instead of `[1, 2, 10]`.
+    /// When `Array#sort()` is called without a comparison function, it converts elements to strings and sorts them lexicographically. This often leads to unexpected results, especially with numbers where `[1, 10, 2].sort()` returns `[1, 10, 2]` instead of `[1, 2, 10]`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -66,7 +66,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Template literals will call toString() on the interpolated values. Some types don't have meaningful string representations (like objects that become "[object Object]") or may not have a toString method at all. This rule helps ensure that only appropriate types are used in template expressions.
+    /// Template literals will call `toString()` on the interpolated values. Some types don't have meaningful string representations (like objects that become `"[object Object]"`) or may not have a `toString` method at all. This rule helps ensure that only appropriate types are used in template expressions.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/unicorn/consistent_empty_array_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_empty_array_spread.rs
@@ -16,7 +16,7 @@ pub struct ConsistentEmptyArraySpread;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// When spreading a ternary in an array, we can use both [] and '' as fallbacks,
+    /// When spreading a ternary in an array, we can use both `[]` and `''` as fallbacks,
     /// but it's better to have consistent types in both branches.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/unicorn/no_array_callback_reference.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_callback_reference.rs
@@ -24,7 +24,7 @@ pub struct NoArrayCallbackReference;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prevents passing a function reference directly to iterator methods
+    /// Prevents passing a function reference directly to iterator methods.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -17,7 +17,7 @@ pub struct NoAwaitInPromiseMethods;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Disallow using `await` in `Promise` method parameters
+    /// Disallow using `await` in `Promise` method parameters.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -35,7 +35,7 @@ pub struct PreferArraySome;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefers using [`Array#some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) over [`Array#find()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`Array#findLast()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast) with comparing to undefined,
+    /// Prefers using [`Array#some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) over [`Array#find()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), [`Array#findLast()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast) with comparing to `undefined`,
     /// or [`Array#findIndex()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex), [`Array#findLastIndex()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex)
     /// and a non-zero length check on the result of [`Array#filter()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -21,7 +21,7 @@ pub struct PreferNodeProtocol;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefer using the `node:protocol` when importing Node.js builtin modules
+    /// Prefer using the `node:protocol` when importing Node.js builtin modules.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -16,7 +16,7 @@ pub struct PreferOptionalCatchBinding;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefers omitting the catch binding parameter if it is unused
+    /// Prefers omitting the catch binding parameter if it is unused.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Set#has() is faster than Array#includes().
+    /// `Set#has()` is faster than `Array#includes()`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -20,7 +20,7 @@ pub struct PreferStringRaw;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefers use of String.raw to avoid escaping \.
+    /// Prefers use of `String.raw` to avoid escaping `\`.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -51,11 +51,11 @@ impl Deref for PreferStructuredClone {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Prefer using structuredClone to create a deep clone.
+    /// Prefer using `structuredClone` to create a deep clone.
     ///
     /// ### Why is this bad?
     ///
-    /// structuredClone is the modern way to create a deep clone of a value.
+    /// `structuredClone` is the modern way to create a deep clone of a value.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -23,12 +23,12 @@ pub struct RequireArrayJoinSeparator;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce using the separator argument with Array#join()
+    /// Enforce using the separator argument with `Array#join()`.
     ///
     /// ### Why is this bad?
     ///
-    /// It's better to make it clear what the separator is when calling Array#join(),
-    /// instead of relying on the default comma (',') separator.
+    /// It's better to make it clear what the separator is when calling `Array#join()`,
+    /// instead of relying on the default comma (`','`) separator.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
@@ -26,7 +26,7 @@ pub struct RequireModuleAttributes;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces non-empty attribute list in import/export statements and import() expressions.
+    /// This rule enforces non-empty attribute list in `import`/`export` statements and `import()` expressions.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
@@ -29,7 +29,7 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Empty import/export specifiers add no value and can be confusing.
+    /// Empty `import`/`export` specifiers add no value and can be confusing.
     /// If you want to import a module for side effects, use `import 'module'` instead.
     ///
     /// ### Examples

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -17,12 +17,12 @@ pub struct RequireNumberToFixedDigitsArgument;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce using the digits argument with Number.toFixed()
+    /// Enforce using the digits argument with `Number#toFixed()`.
     ///
     /// ### Why is this bad?
     ///
-    /// It's better to make it clear what the value of the digits argument is when calling Number.toFixed(),
-    /// instead of relying on the default value of 0.
+    /// It's better to make it clear what the value of the digits argument is when calling `Number#toFixed()`,
+    /// instead of relying on the default value of `0`.
     ///
     /// ### Examples
     ///

--- a/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_describe_function_title.rs
@@ -24,7 +24,7 @@ pub struct PreferDescribeFunctionTitle;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// When testing a specific function, this rule aims to enforce passing a named function to describe()
+    /// When testing a specific function, this rule aims to enforce passing a named function to `describe()`
     /// instead of an equivalent hardcoded string.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_import_in_mock.rs
@@ -44,7 +44,7 @@ impl Default for PreferImportInMockConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces using a dynamic import() in `vi.mock()`, which improves type information and IntelliSense for the mocked module.
+    /// This rule enforces using a dynamic `import()` in `vi.mock()`, which improves type information and IntelliSense for the mocked module.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
@@ -49,9 +49,9 @@ pub struct ValidDefineEmits;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule checks whether defineEmits compiler macro is valid.
+    /// This rule checks whether `defineEmits` compiler macro is valid.
     ///
-    /// This rule reports defineEmits compiler macros in the following cases:
+    /// This rule reports `defineEmits` compiler macros in the following cases:
     ///
     /// - `defineEmits` is referencing locally declared variables.
     /// - `defineEmits` has both a literal type and an argument. e.g. `defineEmits<(e: 'foo')=>void>(['bar'])`


### PR DESCRIPTION
Just adding backticks where it makes sense, adding period that were missing from opening sentences for rule docs, and fixing some mistakes with the formatting on method names (`Number.toFixed()` vs `Number#toFixed()` and so on).

AI Disclosure: This changeset was helped by Claude Code and then reviewed (each file was only staged after I had looked at the diff) by me.