### PR TITLE
chore(tasks): track transformer memory allocations separately

### DIFF
--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,0 +1,14 @@
+File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
+-------------------------------------------------------------------------------------------------------------------------------------------
+checker.ts                 | 2.92 MB        ||             61 |              1 ||           4398 |             64
+
+cal.com.tsx                | 1.06 MB        ||             42 |              3 ||          38933 |           3515
+
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             22 |              3 ||            264 |             24
+
+pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
+
+antd.js                    | 6.69 MB        ||             15 |              0 ||              2 |              0
+
+binder.ts                  | 193.08 kB      ||             23 |              1 ||            379 |              6
+

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -129,6 +129,7 @@ pub fn run() -> Result<(), io::Error> {
 
     let mut parser_out = table_header.clone();
     let mut semantic_out = table_header.clone();
+    let mut transformer_out = table_header.clone();
     let mut minifier_out = table_header;
 
     let mut allocator = Allocator::default();
@@ -194,9 +195,22 @@ pub fn run() -> Result<(), io::Error> {
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let transform_options = TransformOptions::from_target("esnext").unwrap();
-        let _ =
-            Transformer::new(&allocator, std::path::Path::new(&file.file_name), &transform_options)
-                .build_with_scoping(scoping, &mut parsed.program);
+        let ((), transformer_stats) = record_stats_in(&allocator, || {
+            let _ = Transformer::new(
+                &allocator,
+                std::path::Path::new(&file.file_name),
+                &transform_options,
+            )
+            .build_with_scoping(scoping, &mut parsed.program);
+        });
+
+        transformer_out.push_str(&format_table_row(
+            file.file_name.as_str(),
+            file.source_text.len(),
+            &transformer_stats,
+            fixture_width,
+            width,
+        ));
 
         let ((), minifier_stats) = record_stats_in(&allocator, || {
             Minifier::new(minifier_options).minify(&allocator, &mut parsed.program);
@@ -213,6 +227,7 @@ pub fn run() -> Result<(), io::Error> {
 
     write_snapshot("tasks/track_memory_allocations/allocs_parser.snap", &parser_out)?;
     write_snapshot("tasks/track_memory_allocations/allocs_semantic.snap", &semantic_out)?;
+    write_snapshot("tasks/track_memory_allocations/allocs_transformer.snap", &transformer_out)?;
     write_snapshot("tasks/track_memory_allocations/allocs_minifier.snap", &minifier_out)?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- Transformer allocations were previously invisible — they ran between semantic and minifier measurement, attributed to neither
- Adds a dedicated `allocs_transformer.snap` snapshot to `tasks/track_memory_allocations`
- Reveals that JSX/TSX transformation is allocation-heavy (e.g. cal.com.tsx: 38,933 arena allocs) while pure JS files have near-zero transformer work

🤖 Generated with [Claude Code](https://claude.com/claude-code)