### PR TITLE
fix(formatter): preserve parentheses around as expression before private field access

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -897,7 +897,9 @@ fn type_cast_like_needs_parens(span: Span, parent: &AstNodes<'_>) -> bool {
         | AstNodes::SpreadElement(_)
         | AstNodes::JSXSpreadAttribute(_)
         // static member
-        | AstNodes::StaticMemberExpression(_) => true,
+        | AstNodes::StaticMemberExpression(_)
+        // private field member
+        | AstNodes::PrivateFieldExpression(_) => true,
         AstNodes::ComputedMemberExpression(member) => {
             member.object.span() == span
         }

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/as-private-field.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/as-private-field.ts
@@ -1,0 +1,8 @@
+class X {
+  #selectClause: unknown;
+
+  test(columns: unknown) {
+    (this as any).#selectClause = columns;
+  }
+}
+

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/as-private-field.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/as-private-field.ts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+class X {
+  #selectClause: unknown;
+
+  test(columns: unknown) {
+    (this as any).#selectClause = columns;
+  }
+}
+
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+class X {
+  #selectClause: unknown;
+
+  test(columns: unknown) {
+    (this as any).#selectClause = columns;
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+class X {
+  #selectClause: unknown;
+
+  test(columns: unknown) {
+    (this as any).#selectClause = columns;
+  }
+}
+
+===================== End =====================


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/20345