### PR TITLE
fix(formatter,oxfmt): Sort imports should not flush Empty line

### DIFF
--- a/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
+++ b/apps/oxfmt/test/cli/js_in_xxx/__snapshots__/js_in_xxx.test.ts.snap
@@ -270,5 +270,25 @@ const count = ref(0);
   <div>{{ count }}</div>
 </template>
 
+--------------------
+
+--- FILE -----------
+no-imports.vue
+--- BEFORE ---------
+<!-- https://github.com/oxc-project/oxc/issues/20428 -->
+<script lang="ts">
+let foo = 'foo';
+
+let bar = 'bar';
+</script>
+
+--- AFTER ----------
+<!-- https://github.com/oxc-project/oxc/issues/20428 -->
+<script lang="ts">
+  let foo = "foo";
+
+  let bar = "bar";
+</script>
+
 --------------------"
 `;

--- a/apps/oxfmt/test/cli/js_in_xxx/fixtures/no-imports.vue
+++ b/apps/oxfmt/test/cli/js_in_xxx/fixtures/no-imports.vue
@@ -1,0 +1,6 @@
+<!-- https://github.com/oxc-project/oxc/issues/20428 -->
+<script lang="ts">
+let foo = 'foo';
+
+let bar = 'bar';
+</script>

--- a/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
+++ b/apps/oxfmt/test/cli/js_in_xxx/js_in_xxx.test.ts
@@ -8,13 +8,7 @@ describe("js-in-xxx", () => {
   it("should format with full-config", async () => {
     const snapshot = await runWriteModeAndSnapshot(
       fixturesDir,
-      [
-        "test.md",
-        "test.mdx",
-        // NOTE: For now, Vue files are still handled by Prettier
-        "app.vue",
-        "multi-script.vue",
-      ],
+      ["test.md", "test.mdx", "app.vue", "multi-script.vue", "no-imports.vue"],
       ["--config", "oxfmtrc-full.json"],
     );
     expect(snapshot).toMatchSnapshot();

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -125,14 +125,18 @@ impl SortImportsTransform {
 
                 // Flush current line
                 if current_line_start < idx {
+                    // Always use `Hard` for the flushed line's mode.
+                    // The outer guard guarantees `mode` is `Empty` or `Hard` here,
+                    // and the empty line semantics are already captured by the `SourceLine::Empty` pushed below.
+                    let flush_mode = LineMode::Hard;
                     let line = if is_standalone_alignable_comment {
                         // Standalone alignable comment: directly create CommentOnly
-                        SourceLine::CommentOnly(current_line_start..idx, *mode)
+                        SourceLine::CommentOnly(current_line_start..idx, flush_mode)
                     } else {
                         SourceLine::from_element_range(
                             prev_elements,
                             current_line_start..idx,
-                            *mode,
+                            flush_mode,
                         )
                     };
                     lines.push(line);


### PR DESCRIPTION
Fixes #20428

Since we're already handling the explicit `LineMode::Empty`, `LineMode::Hard` alone would have sufficed in this case.