### PR TITLE
feat(linter): add ignoreEslintDirectives config option

### DIFF
--- a/apps/oxlint/fixtures/cli/ignore_eslint_directives/.oxlintrc.json
+++ b/apps/oxlint/fixtures/cli/ignore_eslint_directives/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+    "options": {
+        "ignoreEslintDirectives": true
+    },
+    "rules": {
+        "no-console": "warn",
+        "no-debugger": "warn"
+    }
+}

--- a/apps/oxlint/fixtures/cli/ignore_eslint_directives/test.js
+++ b/apps/oxlint/fixtures/cli/ignore_eslint_directives/test.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line no-debugger -- IGNORED
+debugger;
+
+// oxlint-disable-next-line no-console -- suppressed
+console.log('suppressed by oxlint-disable-next-line');
+
+// eslint-disable-next-line no-console -- IGNORED
+console.log('not suppressed (eslint-disable-next-line ignored)');
+
+/* eslint-disable no-debugger */ // IGNORED
+debugger;
+
+/* oxlint-disable no-debugger */ // suppressed
+debugger;
+
+/* eslint-enable no-debugger */ // IGNORED (no effect)
+debugger;
+
+/* oxlint-enable no-debugger */ // re-enabled
+debugger;
+
+console.log('not suppressed (eslint-disable-line ignored)'); // eslint-disable-line no-console -- IGNORED
+
+console.log('suppressed by oxlint-disable-line'); // oxlint-disable-line no-console -- suppressed

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -372,6 +372,14 @@ export interface OxlintOptions {
    */
   denyWarnings?: boolean;
   /**
+   * Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and
+   * `eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.
+   *
+   * This is useful for projects migrating from ESLint where legacy `eslint-*` comments
+   * should no longer suppress diagnostics.
+   */
+  ignoreEslintDirectives?: boolean;
+  /**
    * Specify a warning threshold. Exits with an error status if warnings exceed this value.
    *
    * Equivalent to passing `--max-warnings` on the CLI.

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1111,6 +1111,14 @@ mod test {
     }
 
     #[test]
+    fn test_ignore_eslint_directives() {
+        let args = &["-c", ".oxlintrc.json", "test.js"];
+        Tester::new()
+            .with_cwd("fixtures/cli/ignore_eslint_directives".into())
+            .test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_report_unused_directives_cli_overrides_config() {
         // Verify that the CLI flag takes precedence over the config file value.
         // Config has `reportUnusedDisableDirectives: "warn"`, but CLI passes `off`,

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_eslint_directives_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_eslint_directives_-c .oxlintrc.json test.js@oxlint.snap
@@ -1,0 +1,59 @@
+---
+source: apps/oxlint/src/tester.rs
+assertion_line: 134
+---
+########## 
+arguments: -c .oxlintrc.json test.js
+working directory: fixtures/cli/ignore_eslint_directives
+----------
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+   ,-[test.js:2:1]
+ 1 | // eslint-disable-next-line no-debugger -- IGNORED
+ 2 | debugger;
+   : ^^^^^^^^^
+ 3 | 
+   `----
+  help: Remove the debugger statement
+
+  ! eslint(no-console): Unexpected console statement.
+   ,-[test.js:8:1]
+ 7 | // eslint-disable-next-line no-console -- IGNORED
+ 8 | console.log('not suppressed (eslint-disable-next-line ignored)');
+   : ^^^^^^^^^^^
+ 9 | 
+   `----
+  help: Delete this console statement.
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+    ,-[test.js:11:1]
+ 10 | /* eslint-disable no-debugger */ // IGNORED
+ 11 | debugger;
+    : ^^^^^^^^^
+ 12 | 
+    `----
+  help: Remove the debugger statement
+
+  ! eslint(no-debugger): `debugger` statement is not allowed
+    ,-[test.js:20:1]
+ 19 | /* oxlint-enable no-debugger */ // re-enabled
+ 20 | debugger;
+    : ^^^^^^^^^
+ 21 | 
+    `----
+  help: Remove the debugger statement
+
+  ! eslint(no-console): Unexpected console statement.
+    ,-[test.js:22:1]
+ 21 | 
+ 22 | console.log('not suppressed (eslint-disable-line ignored)'); // eslint-disable-line no-console -- IGNORED
+    : ^^^^^^^^^^^
+ 23 | 
+    `----
+  help: Delete this console statement.
+
+Found 5 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 94 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -345,6 +345,11 @@ impl ConfigStore {
         self.base.base.config.options.report_unused_disable_directives
     }
 
+    /// Whether `eslint-*` directive comments should be ignored, honoring only `oxlint-*` directives.
+    pub fn ignore_eslint_directives(&self) -> bool {
+        self.base.base.config.options.ignore_eslint_directives.unwrap_or(false)
+    }
+
     pub(crate) fn get_related_config(&self, path: &Path) -> &Config {
         if self.nested_configs.is_empty() {
             &self.base

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -1319,4 +1319,36 @@ mod test {
         let store = ConfigStore::new(base, FxHashMap::default(), ExternalPluginStore::default());
         assert_eq!(store.max_warnings(), None);
     }
+
+    #[test]
+    fn test_ignore_eslint_directives_from_config() {
+        let base = Config::new(
+            vec![],
+            vec![],
+            OxlintCategories::default(),
+            LintConfig {
+                options: OxlintOptions {
+                    ignore_eslint_directives: Some(true),
+                    ..OxlintOptions::default()
+                },
+                ..LintConfig::default()
+            },
+            ResolvedOxlintOverrides::new(vec![]),
+        );
+        let store = ConfigStore::new(base, FxHashMap::default(), ExternalPluginStore::default());
+        assert!(store.ignore_eslint_directives());
+    }
+
+    #[test]
+    fn test_ignore_eslint_directives_false_by_default() {
+        let base = Config::new(
+            vec![],
+            vec![],
+            OxlintCategories::default(),
+            LintConfig::default(),
+            ResolvedOxlintOverrides::new(vec![]),
+        );
+        let store = ConfigStore::new(base, FxHashMap::default(), ExternalPluginStore::default());
+        assert!(!store.ignore_eslint_directives());
+    }
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -57,6 +57,14 @@ pub struct OxlintOptions {
     /// Only supported in the root configuration file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub report_unused_disable_directives: Option<AllowWarnDeny>,
+    /// Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and
+    /// `eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.
+    ///
+    /// This is useful for projects migrating from ESLint where legacy `eslint-*` comments
+    /// should no longer suppress diagnostics.
+    /// Only supported in the root configuration file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_eslint_directives: Option<bool>,
 }
 
 impl OxlintOptions {
@@ -67,6 +75,7 @@ impl OxlintOptions {
             && self.deny_warnings.is_none()
             && self.max_warnings.is_none()
             && self.report_unused_disable_directives.is_none()
+            && self.ignore_eslint_directives.is_none()
     }
 
     #[must_use]
@@ -79,6 +88,9 @@ impl OxlintOptions {
             report_unused_disable_directives: self
                 .report_unused_disable_directives
                 .or(other.report_unused_disable_directives),
+            ignore_eslint_directives: self
+                .ignore_eslint_directives
+                .or(other.ignore_eslint_directives),
         }
     }
 }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -473,6 +473,7 @@ mod test {
         assert_eq!(config.options.deny_warnings, None);
         assert_eq!(config.options.max_warnings, None);
         assert_eq!(config.options.report_unused_disable_directives, None);
+        assert_eq!(config.options.ignore_eslint_directives, None);
     }
 
     #[test]
@@ -542,6 +543,16 @@ mod test {
         )
         .unwrap();
         assert_eq!(config.options.report_unused_disable_directives, Some(AllowWarnDeny::Allow));
+
+        let config: Oxlintrc =
+            serde_json::from_value(json!({ "options": { "ignoreEslintDirectives": true } }))
+                .unwrap();
+        assert_eq!(config.options.ignore_eslint_directives, Some(true));
+
+        let config: Oxlintrc =
+            serde_json::from_value(json!({ "options": { "ignoreEslintDirectives": false } }))
+                .unwrap();
+        assert_eq!(config.options.ignore_eslint_directives, Some(false));
     }
 
     #[test]
@@ -607,6 +618,28 @@ mod test {
         base.path = PathBuf::from("/root/base.json");
         let merged = root.merge(base);
         assert_eq!(merged.options.report_unused_disable_directives, Some(AllowWarnDeny::Warn));
+
+        // root wins over base for ignoreEslintDirectives
+        let mut root: Oxlintrc =
+            serde_json::from_value(json!({ "options": { "ignoreEslintDirectives": true } }))
+                .unwrap();
+        root.path = PathBuf::from("/root/.oxlintrc.json");
+        let mut base: Oxlintrc =
+            serde_json::from_value(json!({ "options": { "ignoreEslintDirectives": false } }))
+                .unwrap();
+        base.path = PathBuf::from("/root/base.json");
+        let merged = root.merge(base);
+        assert_eq!(merged.options.ignore_eslint_directives, Some(true));
+
+        // base value propagates when root does not set ignoreEslintDirectives
+        let mut root: Oxlintrc = serde_json::from_value(json!({})).unwrap();
+        root.path = PathBuf::from("/root/.oxlintrc.json");
+        let mut base: Oxlintrc =
+            serde_json::from_value(json!({ "options": { "ignoreEslintDirectives": true } }))
+                .unwrap();
+        base.path = PathBuf::from("/root/base.json");
+        let merged = root.merge(base);
+        assert_eq!(merged.options.ignore_eslint_directives, Some(true));
     }
 
     #[test]

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -57,6 +57,7 @@ impl<'a> ContextSubHost<'a> {
             source_text_offset,
             FrameworkOptions::Default,
             ArenaBox::new_empty_boxed_slice(),
+            false,
         )
     }
 
@@ -68,6 +69,7 @@ impl<'a> ContextSubHost<'a> {
         source_text_offset: u32,
         frameworks_options: FrameworkOptions,
         parser_tokens: ArenaBox<'a, [Token]>,
+        ignore_eslint_directives: bool,
     ) -> Self {
         // We should always check for `semantic.cfg()` being `Some` since we depend on it and it is
         // unwrapped without any runtime checks after construction.
@@ -76,8 +78,11 @@ impl<'a> ContextSubHost<'a> {
             "`LintContext` depends on `Semantic::cfg`, Build your semantic with cfg enabled(`SemanticBuilder::with_cfg`)."
         );
 
-        let disable_directives =
-            DisableDirectivesBuilder::new().build(semantic.source_text(), semantic.comments());
+        let disable_directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            ignore_eslint_directives,
+        );
 
         Self {
             semantic,

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -334,8 +334,13 @@ impl DisableDirectivesBuilder {
         }
     }
 
-    pub fn build(mut self, source_text: &str, comments: &[Comment]) -> DisableDirectives {
-        self.build_impl(source_text, comments);
+    pub fn build(
+        mut self,
+        source_text: &str,
+        comments: &[Comment],
+        ignore_eslint_directives: bool,
+    ) -> DisableDirectives {
+        self.build_impl(source_text, comments, ignore_eslint_directives);
 
         DisableDirectives {
             intervals: self.intervals,
@@ -350,7 +355,12 @@ impl DisableDirectivesBuilder {
     }
 
     #[expect(clippy::cast_possible_truncation)] // for `as u32`
-    fn build_impl(&mut self, source_text: &str, comments: &[Comment]) {
+    fn build_impl(
+        &mut self,
+        source_text: &str,
+        comments: &[Comment],
+        ignore_eslint_directives: bool,
+    ) {
         let source_len = source_text.len() as u32;
         // This algorithm iterates through the comments and builds all intervals
         // for matching disable and enable pairs.
@@ -370,9 +380,9 @@ impl DisableDirectivesBuilder {
             let text = text_source.trim_start();
             let mut rule_name_start = comment_span.start + (text_source.len() - text.len()) as u32;
 
-            if let Some(text) =
-                text.strip_prefix("eslint-disable").or_else(|| text.strip_prefix("oxlint-disable"))
-            {
+            if let Some(text) = text.strip_prefix("oxlint-disable").or_else(|| {
+                if ignore_eslint_directives { None } else { text.strip_prefix("eslint-disable") }
+            }) {
                 rule_name_start += 14; // eslint-disable and oxlint-disable are each 14 bytes
                 // `eslint-disable`
                 if text.trim().is_empty() {
@@ -507,9 +517,9 @@ impl DisableDirectivesBuilder {
                 }
             }
 
-            if let Some(text) =
-                text.strip_prefix("eslint-enable").or_else(|| text.strip_prefix("oxlint-enable"))
-            {
+            if let Some(text) = text.strip_prefix("oxlint-enable").or_else(|| {
+                if ignore_eslint_directives { None } else { text.strip_prefix("eslint-enable") }
+            }) {
                 rule_name_start += 13; // eslint-enable is 13 bytes
                 // `eslint-enable`
                 if text.trim().is_empty() {
@@ -1107,7 +1117,7 @@ mod tests {
             let semantic = process_source(&allocator, &source_text);
             let comments = semantic.comments();
             let directives =
-                DisableDirectivesBuilder::new().build(semantic.source_text(), comments);
+                DisableDirectivesBuilder::new().build(semantic.source_text(), comments, false);
             test(comments, directives);
         }
     }
@@ -1115,8 +1125,11 @@ mod tests {
     fn test_directive_span(source_text: &str, expected_start: u32, expected_stop: u32) {
         let allocator = Allocator::default();
         let semantic = process_source(&allocator, source_text);
-        let directives =
-            DisableDirectivesBuilder::new().build(semantic.source_text(), semantic.comments());
+        let directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            false,
+        );
         let interval = &directives.intervals.intervals[0];
 
         assert_eq!(interval.start, expected_start);
@@ -1360,8 +1373,11 @@ function test() {
 ";
         let allocator = Allocator::default();
         let semantic = process_source(&allocator, source_text);
-        let directives =
-            DisableDirectivesBuilder::new().build(semantic.source_text(), semantic.comments());
+        let directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            false,
+        );
 
         // The function spans from line 2 to line 6 (positions 1 to 138)
         let function_span = Span::new(1, 138);

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1407,4 +1407,96 @@ function test() {
             "eslint-disable-next-line should NOT suppress diagnostics on lines after the next line"
         );
     }
+
+    #[test]
+    fn ignore_eslint_directives_skips_eslint_comments() {
+        let source_text = "// eslint-disable-next-line no-debugger\ndebugger;\n// oxlint-disable-next-line no-console\nconsole.log('suppressed');\n";
+        let allocator = Allocator::default();
+        let semantic = process_source(&allocator, source_text);
+        let directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            true,
+        );
+
+        let debugger_start = source_text.find("\ndebugger").unwrap() as u32 + 1;
+        let debugger_span = Span::new(debugger_start, debugger_start + 8);
+        assert_eq!(debugger_span.source_text(source_text), "debugger");
+        assert!(
+            !directives.contains("no-debugger", debugger_span),
+            "eslint-disable-next-line should be ignored when ignore_eslint_directives is true"
+        );
+
+        let console_start = source_text.find("console.log").unwrap() as u32;
+        let console_span = Span::new(console_start, console_start + 11);
+        assert_eq!(console_span.source_text(source_text), "console.log");
+        assert!(
+            directives.contains("no-console", console_span),
+            "oxlint-disable-next-line should still suppress when ignore_eslint_directives is true"
+        );
+    }
+
+    #[test]
+    fn ignore_eslint_directives_skips_eslint_enable() {
+        let source_text = "/* oxlint-disable no-debugger */\ndebugger;\n/* eslint-enable no-debugger */\ndebugger;\n/* oxlint-enable no-debugger */\ndebugger;\n";
+        let allocator = Allocator::default();
+        let semantic = process_source(&allocator, source_text);
+        let directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            true,
+        );
+
+        let mut debugger_positions = vec![];
+        let mut start = 0;
+        while let Some(pos) = source_text[start..].find("\ndebugger") {
+            debugger_positions.push((start + pos + 1) as u32);
+            start += pos + 9;
+        }
+        assert_eq!(debugger_positions.len(), 3);
+
+        // First debugger: inside oxlint-disable, should be suppressed
+        let first = Span::new(debugger_positions[0], debugger_positions[0] + 8);
+        assert_eq!(first.source_text(source_text), "debugger");
+        assert!(
+            directives.contains("no-debugger", first),
+            "first debugger should be suppressed by oxlint-disable"
+        );
+
+        // Second debugger: eslint-enable should have been ignored, still suppressed
+        let second = Span::new(debugger_positions[1], debugger_positions[1] + 8);
+        assert_eq!(second.source_text(source_text), "debugger");
+        assert!(
+            directives.contains("no-debugger", second),
+            "eslint-enable should be ignored, second debugger should still be suppressed"
+        );
+
+        // Third debugger: oxlint-enable re-enabled the rule, should NOT be suppressed
+        let third = Span::new(debugger_positions[2], debugger_positions[2] + 8);
+        assert_eq!(third.source_text(source_text), "debugger");
+        assert!(
+            !directives.contains("no-debugger", third),
+            "oxlint-enable should re-enable the rule, third debugger should not be suppressed"
+        );
+    }
+
+    #[test]
+    fn ignore_eslint_directives_false_honors_eslint_comments() {
+        let source_text = "// eslint-disable-next-line no-debugger\ndebugger;\n";
+        let allocator = Allocator::default();
+        let semantic = process_source(&allocator, source_text);
+        let directives = DisableDirectivesBuilder::new().build(
+            semantic.source_text(),
+            semantic.comments(),
+            false,
+        );
+
+        let debugger_start = source_text.find("\ndebugger").unwrap() as u32 + 1;
+        let debugger_span = Span::new(debugger_start, debugger_start + 8);
+        assert_eq!(debugger_span.source_text(source_text), "debugger");
+        assert!(
+            directives.contains("no-debugger", debugger_span),
+            "eslint-disable-next-line should suppress when ignore_eslint_directives is false"
+        );
+    }
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -153,6 +153,10 @@ impl Linter {
         &self.options
     }
 
+    pub(crate) fn config(&self) -> &ConfigStore {
+        &self.config
+    }
+
     /// Returns the number of rules that will are being used, unless there
     /// nested configurations in use, in which case it returns `None` since the
     /// number of rules depends on which file is being linted.

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -605,6 +605,8 @@ impl Runtime {
                         let mut new_source_text = Cow::from(dep.source_text);
 
                         let path = Path::new(&module_to_lint.path);
+                        let ignore_eslint_directives =
+                            me.linter.config().ignore_eslint_directives();
 
                         assert_eq!(
                             module_to_lint.section_module_records.len(),
@@ -623,6 +625,7 @@ impl Runtime {
                                         section.source.start,
                                         section.source.framework_options,
                                         section.parser_tokens,
+                                        ignore_eslint_directives,
                                     ))
                                 }
                                 Err(messages) => {
@@ -731,6 +734,9 @@ impl Runtime {
                             section_contents.len()
                         );
 
+                        let ignore_eslint_directives =
+                            me.linter.config().ignore_eslint_directives();
+
                         let context_sub_hosts: Vec<ContextSubHost<'_>> = module_to_lint
                             .section_module_records
                             .into_iter()
@@ -743,6 +749,7 @@ impl Runtime {
                                         section.source.start,
                                         section.source.framework_options,
                                         section.parser_tokens,
+                                        ignore_eslint_directives,
                                     ))
                                 }
                                 Err(diagnostics) => {
@@ -807,6 +814,9 @@ impl Runtime {
                     |allocator_guard, ModuleContentDependent { source_text: _, section_contents }| {
                         assert_eq!(module.section_module_records.len(), section_contents.len());
 
+                        let ignore_eslint_directives =
+                            me.linter.config().ignore_eslint_directives();
+
                         let context_sub_hosts: Vec<ContextSubHost<'_>> = module
                             .section_module_records
                             .into_iter()
@@ -818,6 +828,7 @@ impl Runtime {
                                     section.source.start,
                                     section.source.framework_options,
                                     section.parser_tokens,
+                                    ignore_eslint_directives,
                                 )),
                                 Err(errors) => {
                                     if !errors.is_empty() {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -490,6 +490,11 @@
           "type": "boolean",
           "markdownDescription": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI."
         },
+        "ignoreEslintDirectives": {
+          "description": "Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and\n`eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.\n\nThis is useful for projects migrating from ESLint where legacy `eslint-*` comments\nshould no longer suppress diagnostics.\nOnly supported in the root configuration file.",
+          "type": "boolean",
+          "markdownDescription": "Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and\n`eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.\n\nThis is useful for projects migrating from ESLint where legacy `eslint-*` comments\nshould no longer suppress diagnostics.\nOnly supported in the root configuration file."
+        },
         "maxWarnings": {
           "description": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI.",
           "type": "integer",

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1,5 +1,6 @@
 ---
 source: tasks/website_linter/src/json_schema.rs
+assertion_line: 22
 expression: json
 ---
 {
@@ -493,6 +494,11 @@ expression: json
           "description": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI.",
           "type": "boolean",
           "markdownDescription": "Ensure warnings produce a non-zero exit code.\n\nEquivalent to passing `--deny-warnings` on the CLI."
+        },
+        "ignoreEslintDirectives": {
+          "description": "Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and\n`eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.\n\nThis is useful for projects migrating from ESLint where legacy `eslint-*` comments\nshould no longer suppress diagnostics.\nOnly supported in the root configuration file.",
+          "type": "boolean",
+          "markdownDescription": "Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and\n`eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.\n\nThis is useful for projects migrating from ESLint where legacy `eslint-*` comments\nshould no longer suppress diagnostics.\nOnly supported in the root configuration file."
         },
         "maxWarnings": {
           "description": "Specify a warning threshold. Exits with an error status if warnings exceed this value.\n\nEquivalent to passing `--max-warnings` on the CLI.",

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -1,5 +1,6 @@
 ---
 source: tasks/website_linter/src/json_schema.rs
+assertion_line: 30
 expression: snapshot
 ---
 ---
@@ -341,6 +342,19 @@ type: `boolean`
 Ensure warnings produce a non-zero exit code.
 
 Equivalent to passing `--deny-warnings` on the CLI.
+
+
+### options.ignoreEslintDirectives
+
+type: `boolean`
+
+
+Ignore `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and
+`eslint-enable` directive comments. When enabled, only `oxlint-*` directives are honored.
+
+This is useful for projects migrating from ESLint where legacy `eslint-*` comments
+should no longer suppress diagnostics.
+Only supported in the root configuration file.
 
 
 ### options.maxWarnings


### PR DESCRIPTION
Made with AI, I am not familiar with this codebase, but visual inspection looks pretty reasonable to me.

Closes #20375

## Summary

Adds a new `ignoreEslintDirectives` option to `OxlintOptions` that causes the linter to skip
`eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, and `eslint-enable` directive comments, while continuing to honor `oxlint-*` equivalents. This is useful for projects migrating from ESLint where legacy `eslint-*` comments should no longer suppress diagnostics. Only supported for root config, similar to the `reportUnusedDisableDirectives` config.

### Usage

```json
{
  "options": {
    "ignoreEslintDirectives": true
  }
}
```

## Changes
- `oxlintrc.rs` — Add ignore_eslint_directives: Option<bool> to OxlintOptions with serde, is_empty, and merge support
- `config_store.rs` — Expose ignore_eslint_directives() on ConfigStore, defaulting to false
- `lib.rs` — Add pub(crate) config() accessor on Linter so runtime can read the resolved config
- `disable_directives.rs` — DisableDirectivesBuilder::build / build_impl accept ignore_eslint_directives: bool; when true, eslint-disable and eslint-enable prefixes are skipped
- `host.rs` — Thread the flag through ContextSubHost::new_with_framework_options
- `runtime.rs` — Resolve the option from ConfigStore and pass it at all three ContextSubHost creation sites
- Schema / generated types — Regenerated configuration_schema.json, schema snapshots, and config.generated.ts

## Tests
- `oxlintrc.rs` — Deserialization (true/false/absent) and merge (root wins, base propagates)
- `config_store.rs` — ignore_eslint_directives from config and default-false behavior
- `disable_directives.rs` — Three unit tests covering: eslint directives skipped while oxlint honored, eslint-enable ignored while oxlint-enable works, and default false preserves existing behavior
- CLI snapshot test with fixture (`fixtures/cli/ignore_eslint_directives/`)