### PR TITLE
fix(oxfmt): non idempotent formatting on comments in TS

### DIFF
--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -28,7 +28,16 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSUnionType<'a>> {
         // should be inlined and not be printed in the multi-line variant
         let should_hug = should_hug_type(self, f);
         if should_hug {
-            return format_union_types(self.types(), Span::default(), true, f);
+            // Don't take the hug shortcut when a single-member union at the type-alias level
+            // has own-line leading comments (e.g. a JSDoc block before `| 'Value'`).
+            // Those comments must be handled by the normal union formatting path so they are
+            // printed with correct indentation. See https://github.com/oxc-project/oxc/issues/20219
+            let has_alias_level_own_line_comments =
+                matches!(self.parent(), AstNodes::TSTypeAliasDeclaration(_))
+                    && f.comments().has_leading_own_line_comment(self.span().start);
+            if !has_alias_level_own_line_comments {
+                return format_union_types(self.types(), Span::default(), true, f);
+            }
         }
 
         // Find the head of the nested union type chain.

--- a/crates/oxc_formatter/src/utils/assignment_like.rs
+++ b/crates/oxc_formatter/src/utils/assignment_like.rs
@@ -364,7 +364,11 @@ impl<'a> AssignmentLike<'a, '_> {
                 };
                 if let Some(span) = type_span {
                     let comments = f.context().comments().comments_before(span.start);
-                    if comments.len() == 1 {
+                    // Only relocate inline comments (not own-line comments).
+                    // Own-line comments (e.g. JSDoc on its own line before the union)
+                    // must stay as leading comments of the union type so they get
+                    // proper indentation. See https://github.com/oxc-project/oxc/issues/20219
+                    if comments.len() == 1 && !comments[0].preceded_by_newline() {
                         write!(f, [FormatTrailingComments::Comments(comments)]);
                     }
                 }

--- a/crates/oxc_formatter/src/utils/typescript.rs
+++ b/crates/oxc_formatter/src/utils/typescript.rs
@@ -38,6 +38,12 @@ pub fn should_hug_type(node: &TSUnionType<'_>, f: &Formatter<'_, '_>) -> bool {
     let types = &node.types;
 
     if types.len() == 1 {
+        // Don't hug if there are own-line leading comments (e.g. JSDoc before the single type).
+        // They need proper indentation handling via the normal union type path.
+        // See https://github.com/oxc-project/oxc/issues/20219
+        if f.comments().has_leading_own_line_comment(node.span.start) {
+            return false;
+        }
         return true;
     }
 

--- a/crates/oxc_formatter/src/utils/typescript.rs
+++ b/crates/oxc_formatter/src/utils/typescript.rs
@@ -38,12 +38,6 @@ pub fn should_hug_type(node: &TSUnionType<'_>, f: &Formatter<'_, '_>) -> bool {
     let types = &node.types;
 
     if types.len() == 1 {
-        // Don't hug if there are own-line leading comments (e.g. JSDoc before the single type).
-        // They need proper indentation handling via the normal union type path.
-        // See https://github.com/oxc-project/oxc/issues/20219
-        if f.comments().has_leading_own_line_comment(node.span.start) {
-            return false;
-        }
         return true;
     }
 

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts
@@ -1,0 +1,19 @@
+// Issue #20219 - non-idempotent formatting: leading JSDoc comment on single union member
+export type AuditLogOrderField =
+  /** Order audit log entries by timestamp */
+  | 'CREATED_AT';
+
+// Multiple JSDoc blocks before single union member
+export type MultipleJSDocBlocks =
+  /** Comment 1 */
+  /** Comment 2 */
+  /** Comment 3 */
+  | 'CREATED_AT';
+
+// Multiline JSDoc block before single union member
+export type MultilineJSDoc =
+  /**
+   * Order audit log entries by timestamp.
+   * This is a multiline comment.
+   */
+  | 'CREATED_AT';

--- a/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/union/issue-20219.ts.snap
@@ -1,0 +1,72 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Issue #20219 - non-idempotent formatting: leading JSDoc comment on single union member
+export type AuditLogOrderField =
+  /** Order audit log entries by timestamp */
+  | 'CREATED_AT';
+
+// Multiple JSDoc blocks before single union member
+export type MultipleJSDocBlocks =
+  /** Comment 1 */
+  /** Comment 2 */
+  /** Comment 3 */
+  | 'CREATED_AT';
+
+// Multiline JSDoc block before single union member
+export type MultilineJSDoc =
+  /**
+   * Order audit log entries by timestamp.
+   * This is a multiline comment.
+   */
+  | 'CREATED_AT';
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Issue #20219 - non-idempotent formatting: leading JSDoc comment on single union member
+export type AuditLogOrderField =
+  /** Order audit log entries by timestamp */
+  "CREATED_AT";
+
+// Multiple JSDoc blocks before single union member
+export type MultipleJSDocBlocks =
+  /** Comment 1 */
+  /** Comment 2 */
+  /** Comment 3 */
+  "CREATED_AT";
+
+// Multiline JSDoc block before single union member
+export type MultilineJSDoc =
+  /**
+   * Order audit log entries by timestamp.
+   * This is a multiline comment.
+   */
+  "CREATED_AT";
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Issue #20219 - non-idempotent formatting: leading JSDoc comment on single union member
+export type AuditLogOrderField =
+  /** Order audit log entries by timestamp */
+  "CREATED_AT";
+
+// Multiple JSDoc blocks before single union member
+export type MultipleJSDocBlocks =
+  /** Comment 1 */
+  /** Comment 2 */
+  /** Comment 3 */
+  "CREATED_AT";
+
+// Multiline JSDoc block before single union member
+export type MultilineJSDoc =
+  /**
+   * Order audit log entries by timestamp.
+   * This is a multiline comment.
+   */
+  "CREATED_AT";
+
+===================== End =====================


### PR DESCRIPTION
Fixed #20219.

## Testing

Run `cargo test -p oxc_formatter "issue_20219"`.