### PR TITLE
fix(formatter,oxfmt): Handle nested `BinaryExpression` for tailwind trailing spaces

### DIFF
--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -634,6 +634,20 @@ shadow-lg\` : "font-normal"}\`} />;`;
     expect(result.errors).toStrictEqual([]);
   });
 
+  // https://github.com/oxc-project/oxc/issues/20397
+  it("should preserve trailing space in ternary inside binary concat", async () => {
+    const input = `const A = <div className={"h-fit m-1 w-full " + (flag1 ? "block " : "hidden ") + (flag2 ? "p-2" : "p-4")} />;`;
+
+    const result = await format("test.tsx", input, {
+      experimentalTailwindcss: {},
+    });
+
+    expect(result.code).toContain('"m-1 h-fit w-full "');
+    expect(result.code).toContain('"block "');
+    expect(result.code).toContain('"hidden "');
+    expect(result.errors).toStrictEqual([]);
+  });
+
   // Tests for template literals in binary expressions
   it("should sort template literal on right side of binary expression", async () => {
     const input = "const A = <div className={a + ` p-4 flex `} />;";

--- a/crates/oxc_formatter/src/utils/tailwindcss.rs
+++ b/crates/oxc_formatter/src/utils/tailwindcss.rs
@@ -188,24 +188,33 @@ where
 
     // 2. Check binary concat context (walk parent chain)
     for ancestor in ancestors {
-        let AstNodes::BinaryExpression(binary) = ancestor else {
-            break;
-        };
+        match ancestor {
+            AstNodes::BinaryExpression(binary) if binary.operator() == BinaryOperator::Addition => {
+                let left = binary.left().span();
+                let right = binary.right().span();
 
-        if binary.operator() != BinaryOperator::Addition {
-            break;
-        }
+                // Left operand needs trailing space for separation from `+ right`
+                if left.contains_inclusive(span) {
+                    collapse.end = false;
+                }
+                // Right operand needs leading space for separation from `left +`
+                if right.contains_inclusive(span) {
+                    collapse.start = false;
+                }
 
-        let left = binary.left().span();
-        let right = binary.right().span();
-
-        // Left operand needs trailing space for separation from `+ right`
-        if left.contains_inclusive(span) {
-            collapse.end = false;
-        }
-        // Right operand needs leading space for separation from `left +`
-        if right.contains_inclusive(span) {
-            collapse.start = false;
+                // Both flags are one-way latches; no need to continue once both are set.
+                if !collapse.start && !collapse.end {
+                    break;
+                }
+            }
+            // Transparent nodes: skip through to find outer BinaryExpression(+)
+            AstNodes::ConditionalExpression(_)
+            | AstNodes::ParenthesizedExpression(_)
+            | AstNodes::TSAsExpression(_)
+            | AstNodes::TSSatisfiesExpression(_)
+            | AstNodes::TSNonNullExpression(_)
+            | AstNodes::TSTypeAssertion(_) => {}
+            _ => break,
         }
     }
 


### PR DESCRIPTION
Fixes #20397

`can_collapse_whitespace()` walks the ancestor chain looking for `BinaryExpression(+)` to determine if boundary whitespace must be preserved.

The loop broke on the first non-`BinaryExpression` ancestor, so a `ConditionalExpression` (ternary) between the string and the outer `+` caused an immediate break. So, the `BinaryExpression` was never seen.

Prettier's `canCollapseWhitespaceIn()` iterates the entire ancestor path without breaking, reacting only to `BinaryExpression(+)` and `TemplateLiteral` nodes via if checks.

