### PR TITLE
test(linter/plugins): fix stack traces in conformance snapshots

### DIFF
--- a/apps/oxlint/conformance/snapshots/stylistic.md
+++ b/apps/oxlint/conformance/snapshots/stylistic.md
@@ -195,4 +195,5 @@ TypeError: Cannot read properties of undefined (reading 'end')
     at hasEmptyLines (apps/oxlint/conformance/submodules/stylistic/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.ts:63:44)
     at checkSpacing (apps/oxlint/conformance/submodules/stylistic/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.ts:71:11)
     at <anonymous> (apps/oxlint/conformance/submodules/stylistic/packages/eslint-plugin/rules/jsx-props-no-multi-spaces/jsx-props-no-multi-spaces.ts:132:11)
+    at Array.reduce (<anonymous>)
 

--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -252,7 +252,7 @@ function cleanString(str: string): string {
 }
 
 const STACK_LINE_REGEX = /^    at ([^ ]+ \()(.+)(:\d+:\d+)\)$/u;
-const STACK_LINE_REGEX2 = /^    at (.+)(:\d+:\d+)$/u;
+const STACK_LINE_REGEX2 = /^    at (.+?)(:\d+:\d+)?$/u;
 
 /**
  * Format an error for markdown output.
@@ -296,6 +296,7 @@ function formatError(err: Error | null): string {
       match = line.match(STACK_LINE_REGEX2);
       if (!match) break;
       [, path, lineCol] = match;
+      if (lineCol === undefined) lineCol = "";
       prefix = "";
       postfix = "";
     }


### PR DESCRIPTION
Fix bug in conformance test runner. It was removing some lines from stack traces where errors occur.