### PR TITLE
perf(linter/plugins): remove bounds checks on regex tokens

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -395,10 +395,13 @@ function deserializeTokenIfNeeded(index: number): Token | null {
     }
   } else if (kind === REGEXP_KIND) {
     // Reuse cached regex descriptor object if available, otherwise create a new one.
-    // The array access is inside the `regexObjects.length > regexIndex` branch so V8 can elide the bounds check.
+    //
+    // The array access is inside the `regexIndex < regexObjects.length` branch so V8 can remove the bounds check
+    // on `regexObjects[regexIndex]`. Comparison *must* be this way around. Maglev would *not* remove bounds check
+    // if comparison was `regexObjects.length > regexIndex`, even though it's semantically equivalent.
     let regex: Regex;
     const regexIndex = tokensWithRegex.length;
-    if (regexObjects.length > regexIndex) {
+    if (regexIndex < regexObjects.length) {
       regex = regexObjects[regexIndex];
     } else {
       regexObjects.push((regex = { pattern: null!, flags: null! }));


### PR DESCRIPTION
Possibly the most absurd optimization I've ever encountered.

```diff
- if (regexObjects.length > regexIndex) {
+ if (regexIndex < regexObjects.length) {
    regex = regexObjects[regexIndex];
  }
```

There is no semantic difference whatsoever between `regexObjects.length > regexIndex` and `regexIndex < regexObjects.length`. But V8's 2nd-tier Maglev compiler treats them differently. In the`>` version, `regexObjects[regexIndex]` incurs a bounds check, whereas in the new `<` version, no bounds check.

This is a micro-optimization, but this function is extremely hot, so it may actually move the needle in code that includes a lot of regexes. The same optimization is also applied in #20480.

Claude found this oddity by reading V8's source code!