### PR TITLE
chore(ci): use `gh release create` instead of action

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -619,7 +619,7 @@ jobs:
         publish-oxfmt,
       ]
     permissions:
-      contents: write # for softprops/action-gh-release@v1.3.1
+      contents: write # for `gh release create`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -679,22 +679,13 @@ jobs:
           ls
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         id: release
-        with:
-          body_path: ./target/RELEASE_BODY.md
-          draft: true # Must set to true for Enable release immutability https://github.com/softprops/action-gh-release/issues/653
-          name: oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}
-          tag_name: apps_v${{ needs.check.outputs.oxlint_version }}
-          target_commitish: ${{ github.sha }}
-          fail_on_unmatched_files: true
-          files: ./release-artifacts/*
-
-      - name: Turn off draft on github release
         env:
-          OXLINT_VERSION: ${{ needs.check.outputs.oxlint_version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit apps_v${OXLINT_VERSION} --draft=false
+          GH_TOKEN: ${{ github.token }}
+          GIT_TAG: apps_v${{ needs.check.outputs.oxlint_version }}
+          GIT_TARGET: ${{ github.sha }}
+          TITLE: "oxlint v${{ needs.check.outputs.oxlint_version }} & oxfmt v${{ needs.check.outputs.oxfmt_version }}"
+        run: gh release create ${GIT_TAG} ./release-artifacts/* --title "${TITLE}" --notes-file ./target/RELEASE_BODY.md --target ${GIT_TARGET}
 
       - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
         with:

--- a/.github/workflows/release_crates.yml
+++ b/.github/workflows/release_crates.yml
@@ -53,17 +53,9 @@ jobs:
           echo "TAG=$(cat ./target/CRATES_VERSION)" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          body_path: ./target/CRATES_CHANGELOG
-          name: oxc ${{ steps.run.outputs.TAG }}
-          tag_name: ${{ steps.run.outputs.TAG }}
-          target_commitish: ${{ github.sha }}
-          draft: false
-          make_latest: false # latest is reserved for apps
-
-      # Workaround for https://github.com/softprops/action-gh-release/issues/703
-      - name: Mark release as not latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ steps.run.outputs.TAG }} --latest=false
+          GH_TOKEN: ${{ github.token }}
+          GIT_TAG: ${{ steps.run.outputs.TAG }}
+          GIT_TARGET: ${{ github.sha }}
+          TITLE: "oxc ${{ steps.run.outputs.TAG }}"
+        run: gh release create ${GIT_TAG} --latest=false --title "${TITLE}" --notes-file ./target/CRATES_CHANGELOG --target ${GIT_TARGET}


### PR DESCRIPTION
reported by: https://docs.zizmor.sh/audits/#superfluous-actions
docs: https://cli.github.com/manual/gh_release_create

Did not test it (how?) Followed the docs and hope I catched everything 🤞 