### PR TITLE
docs(linter): Add note about options to `react/jsx_key`

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -85,21 +85,26 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// React requires a `key` prop for elements in an array to help identify which items have changed, are added, or are removed.
+    /// React requires a `key` prop for elements in an array to help identify which
+    /// items have changed, are added, or are removed.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// [1, 2, 3].map(x => <App />);
-    /// [1, 2, 3]?.map(x => <BabelEslintApp />)
+    /// [1, 2, 3]?.map(x => <ListItem />)
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// [1, 2, 3].map(x => <App key={x} />);
-    /// [1, 2, 3]?.map(x => <BabelEslintApp key={x} />)
+    /// [1, 2, 3]?.map(x => <ListItem key={x} />)
     /// ```
+    ///
+    /// NOTE: This rule's option defaults differ from the defaults in the original ESLint plugin. It is recommended to keep
+    /// all options set to `true` for correctness reasons, but you may want to set them back to `false` to get behavior
+    /// parity when migrating from ESLint.
     JsxKey,
     react,
     correctness,


### PR DESCRIPTION
The default options are different on ESLint vs Oxlint, so adding a note to that effect.