### PR TITLE
perf(linter/plugins): reduce operations in binary search

### DIFF
--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -166,7 +166,7 @@ function getLineColumnFromOffsetUnchecked(offset: number): LineColumn {
     high = lineStartIndices.length,
     mid: number;
   do {
-    mid = ((low + high) / 2) | 0; // Use bitwise OR to floor the division
+    mid = (low + high) >>> 1;
     if (offset < lineStartIndices[mid]) {
       high = mid;
     } else {


### PR DESCRIPTION
Tiny optimization. Use 1 less operation in binary search when converting offset to line-column pair.