### PR TITLE
perf(linter/plugins): reuse descriptor objects for `Object.defineProperty` calls

### DIFF
--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -34,6 +34,10 @@ export const buffers: (BufferWithArrays | null)[] = [];
 // Array of `after` hooks to run after traversal. This array reused for every file.
 const afterHooks: AfterHook[] = [];
 
+// Reusable property descriptor for updating `options` value on rule context objects.
+// `value` is updated before each call. Other attributes are omitted to retain existing values.
+const OPTIONS_DESCRIPTOR: PropertyDescriptor = { value: null };
+
 /**
  * Lint a file.
  *
@@ -200,10 +204,11 @@ export function lintFileImpl(
     debugAssert(optionsId < allOptions.length, "Options ID out of bounds");
 
     // If the rule has no user-provided options, use the plugin-provided default
-    // options (which falls back to `DEFAULT_OPTIONS`)
-    Object.defineProperty(ruleDetails.context, "options", {
-      value: optionsId === DEFAULT_OPTIONS_ID ? ruleDetails.defaultOptions : allOptions[optionsId],
-    });
+    // options (which falls back to `DEFAULT_OPTIONS`).
+    // Reuse `OPTIONS_DESCRIPTOR` object to avoid unnecessarily creating a temporary object each time.
+    OPTIONS_DESCRIPTOR.value =
+      optionsId === DEFAULT_OPTIONS_ID ? ruleDetails.defaultOptions : allOptions[optionsId];
+    Object.defineProperty(ruleDetails.context, "options", OPTIONS_DESCRIPTOR);
 
     let { visitor } = ruleDetails;
     if (visitor === null) {

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -299,10 +299,21 @@ export function getNodeLoc(node: Node): Location {
   //
   // We also don't make it configurable, because deleting it wouldn't make `node.loc` evaluate to `undefined`,
   // because the access would fall through to the getter on the prototype.
-  Object.defineProperty(node, "loc", { value: loc, writable: true });
+  //
+  // Reuse `LOC_DESCRIPTOR` object to avoid unnecessarily creating a temporary object each time.
+  LOC_DESCRIPTOR.value = loc;
+  Object.defineProperty(node, "loc", LOC_DESCRIPTOR);
 
   return loc;
 }
+
+// Reusable property descriptor for `Object.defineProperty` in `getNodeLoc`.
+const LOC_DESCRIPTOR: PropertyDescriptor = {
+  value: null,
+  writable: true,
+  enumerable: false,
+  configurable: false,
+};
 
 /**
  * Compute a `Location` from `start` and `end` source offsets.


### PR DESCRIPTION
Small optimization. Don't create temporary objects repeatedly just to pass props to `Object.defineProperty`. Re-use a single object and reuse it instead.