### PR TITLE
perf(linter/plugins): share empty `Uint32Array` across multiple places

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -14,6 +14,7 @@ import {
 } from "../generated/constants.ts";
 import { computeLoc } from "./location.ts";
 import { FLAG_NOT_DESERIALIZED, FLAG_DESERIALIZED } from "./tokens.ts";
+import { EMPTY_UINT8_ARRAY, EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Location, Span } from "./location.ts";
@@ -67,7 +68,7 @@ let activeCommentsWithLocCount = 0;
 // If all comments have been deserialized (`allCommentsDeserialized === true`), `deserializedCommentsLen` is 0,
 // and no further indexes are written to `deserializedCommentIndexes`. `resetComments` will reset all comments,
 // up to `commentsLen`.
-let deserializedCommentIndexes = new Uint32Array(0);
+let deserializedCommentIndexes = EMPTY_UINT32_ARRAY;
 let deserializedCommentsLen = 0;
 
 // Minimum capacity (in `u32`s) of `deserializedCommentIndexes`, when not empty.
@@ -77,10 +78,6 @@ const DESERIALIZED_COMMENT_INDEXES_MIN_CAPACITY = 16;
 // Empty comments array.
 // Reused for all files which don't have any comments. Frozen to avoid rules mutating it.
 const EMPTY_COMMENTS: CommentType[] = Object.freeze([]) as unknown as CommentType[];
-
-// Empty typed arrays, reused for files with no comments.
-const EMPTY_UINT8_ARRAY = new Uint8Array(0);
-const EMPTY_UINT32_ARRAY = new Uint32Array(0);
 
 const COMMENT_SIZE_SHIFT = 4; // 1 << 4 == 16 bytes, the size of `Comment` in Rust
 debugAssert(COMMENT_SIZE === 1 << COMMENT_SIZE_SHIFT);

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -10,6 +10,7 @@ import {
   TOKENS_OFFSET_POS_32,
   TOKENS_LEN_POS_32,
 } from "../generated/constants.ts";
+import { EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Location, Span } from "./location.ts";
@@ -130,7 +131,7 @@ const regexObjects: Regex[] = [];
 // `Uint32Array` rather than `Array` to avoid GC tracing and write barriers.
 // `activeTokensWithRegexCount` also serves as the index into `regexObjects`
 // for the next regex descriptor object which can be reused.
-let tokensWithRegexIndexes = new Uint32Array(0);
+let tokensWithRegexIndexes = EMPTY_UINT32_ARRAY;
 let activeTokensWithRegexCount = 0;
 
 // Minimum capacity of `tokensWithRegexIndexes` array when not empty.
@@ -147,7 +148,7 @@ const REGEX_INDEXES_MIN_CAPACITY = 16;
 // If all tokens have been deserialized (`allTokensDeserialized === true`), `deserializedTokensLen` is 0,
 // and no further indexes are written to `deserializedTokenIndexes`. `resetTokens` will reset all tokens,
 // up to `tokensLen`.
-let deserializedTokenIndexes = new Uint32Array(0);
+let deserializedTokenIndexes = EMPTY_UINT32_ARRAY;
 let deserializedTokensLen = 0;
 
 // Minimum capacity (in `u32`s) of `deserializedTokenIndexes`, when not empty.

--- a/apps/oxlint/src-js/plugins/tokens_and_comments.ts
+++ b/apps/oxlint/src-js/plugins/tokens_and_comments.ts
@@ -25,6 +25,7 @@ import {
   tokensUint32,
 } from "./tokens.ts";
 import { COMMENT_SIZE } from "../generated/constants.ts";
+import { EMPTY_UINT32_ARRAY } from "../utils/typed_arrays.ts";
 import { debugAssert, debugAssertIsNonNull } from "../utils/asserts.ts";
 
 import type { Comment } from "./comments.ts";
@@ -90,7 +91,7 @@ export let tokensAndCommentsLen = 0;
 // Backing buffer reused across files.
 // Grows when needed (doubled), never shrinks.
 // `tokensAndCommentsUint32` is a view over this buffer's prefix.
-let tokensAndCommentsBackingUint32 = new Uint32Array(0);
+let tokensAndCommentsBackingUint32 = EMPTY_UINT32_ARRAY;
 
 // Minimum capacity (in `u32`s) of `tokensAndCommentsBackingUint32`, when not empty.
 // 256 elements = 1 KiB.

--- a/apps/oxlint/src-js/utils/typed_arrays.ts
+++ b/apps/oxlint/src-js/utils/typed_arrays.ts
@@ -1,0 +1,7 @@
+// Empty `Uint32Array`, used for all vars which begin as an empty `Uint8Array`.
+// Avoids pointlessly creating multiple `Uint8Array`s.
+export const EMPTY_UINT8_ARRAY = new Uint8Array(0);
+
+// Empty `Uint32Array`, used for all vars which begin as an empty `Uint32Array`.
+// Avoids pointlessly creating multiple `Uint32Array`s.
+export const EMPTY_UINT32_ARRAY = new Uint32Array(0);


### PR DESCRIPTION
Tiny optimization. Various vars are initialized as an empty `Uint32Array`. Use a single empty array for all of them.