### PR TITLE
fix(linter/plugins): include `loc` when call `JSON.stringify` on `Token`s and `Comment`s

### DIFF
--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -124,6 +124,14 @@ class Comment implements Span {
     return (this.#loc = computeLoc(this.start, this.end));
   }
 
+  // Include `loc` in `JSON.stringify` output.
+  // `loc` is a prototype getter, and `JSON.stringify` only serializes own properties,
+  // so without this method, `loc` would be excluded.
+  toJSON() {
+    // oxlint-disable-next-line typescript/no-misused-spread
+    return { ...this, loc: this.loc };
+  }
+
   static {
     // Defined in static block to avoid exposing this as a public method
     resetCommentLoc = (comment: Comment) => {

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -199,6 +199,14 @@ class Token {
     return (this.#loc = computeLoc(this.start, this.end));
   }
 
+  // Include `loc` in `JSON.stringify` output.
+  // `loc` is a prototype getter, and `JSON.stringify` only serializes own properties,
+  // so without this method, `loc` would be excluded.
+  toJSON() {
+    // oxlint-disable-next-line typescript/no-misused-spread
+    return { ...this, loc: this.loc };
+  }
+
   static {
     // Defined in static block to avoid exposing this as a public method
     resetLoc = (token: Token) => {

--- a/apps/oxlint/test/fixtures/comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/comments/output.snap.md
@@ -63,6 +63,34 @@
  32 | `-> const topLevelVariable7 = 7;
     `----
 
+  x test-comments(test-comments): Comment JSON.stringify:
+  | {
+  |   "type": "Line",
+  |   "value": " Line comment 1",
+  |   "start": 29,
+  |   "end": 46,
+  |   "range": [
+  |     29,
+  |     46
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 2,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 2,
+  |       "column": 17
+  |     }
+  |   }
+  | }
+   ,-[files/comments.js:2:1]
+ 1 | const topLevelVariable1 = 1;
+ 2 | // Line comment 1
+   : ^^^^^^^^^^^^^^^^^
+ 3 | const topLevelVariable2 = 2; /* Block comment 1 */
+   `----
+
   x test-comments(test-comments): VariableDeclaration(topLevelVariable2):
   | getCommentsBefore: 1 comment
   |   [0] Line: " Line comment 1" at [29, 46]
@@ -227,6 +255,33 @@
  32 | const topLevelVariable7 = 7;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
+
+  x test-comments(test-comments): Comment JSON.stringify:
+  | {
+  |   "type": "Shebang",
+  |   "value": "/usr/bin/env node",
+  |   "start": 0,
+  |   "end": 19,
+  |   "range": [
+  |     0,
+  |     19
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 19
+  |     }
+  |   }
+  | }
+   ,-[files/hashbang.js:1:1]
+ 1 | #!/usr/bin/env node
+   : ^^^^^^^^^^^^^^^^^^^
+ 2 | // Line comment after hashbang
+   `----
 
   x test-comments(test-comments): VariableDeclaration(topLevelVariable1):
   | getCommentsBefore: 3 comments
@@ -455,7 +510,7 @@
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-Found 0 warnings and 32 errors.
+Found 0 warnings and 34 errors.
 Finished in Xms on 3 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/comments/plugin.ts
+++ b/apps/oxlint/test/fixtures/comments/plugin.ts
@@ -43,6 +43,15 @@ const testCommentsRule: Rule = {
       node: ast,
     });
 
+    // Check `JSON.stringify` on comments includes `loc`
+    const firstComment = comments[0];
+    if (firstComment) {
+      context.report({
+        message: `Comment JSON.stringify:\n${JSON.stringify(firstComment, null, 2)}`,
+        node: firstComment,
+      });
+    }
+
     const [, topLevelVariable2, topLevelFunctionExport] = ast.body;
     assert(topLevelFunctionExport.type === "ExportNamedDeclaration");
     const topLevelFunction = topLevelFunctionExport.declaration;

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -10,6 +10,32 @@
    : ^
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Identifier",
+  |   "value": "a",
+  |   "start": 0,
+  |   "end": 1,
+  |   "range": [
+  |     0,
+  |     1
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 1
+  |     }
+  |   }
+  | }
+   ,-[files/bom.js:1:4]
+ 1 | ﻿a = b;
+   : ^
+   `----
+
   x tokens-plugin(tokens): Tokens and comments:
   | Identifier        loc= 1:0 - 1:1    range= 0-1     "a"
   | Punctuator        loc= 1:2 - 1:3    range= 2-3     "="
@@ -310,6 +336,34 @@
 
   x tokens-plugin(tokens): Keyword ("var")
   |   regex: undefined
+   ,-[files/escaped_idents.js:2:1]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   : ^^^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "var",
+  |   "start": 7,
+  |   "end": 10,
+  |   "range": [
+  |     7,
+  |     10
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 2,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 2,
+  |       "column": 3
+  |     }
+  |   }
+  | }
    ,-[files/escaped_idents.js:2:1]
  1 | // abc
  2 | var \u{61}b\u0063;
@@ -1043,6 +1097,33 @@
  2 |   fn: <T>(arg: T): T => {
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "const",
+  |   "start": 0,
+  |   "end": 5,
+  |   "range": [
+  |     0,
+  |     5
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 5
+  |     }
+  |   }
+  | }
+   ,-[files/generic_arrow.ts:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   fn: <T>(arg: T): T => {
+   `----
+
   x tokens-plugin(tokens): Tokens and comments:
   | Keyword           loc= 1:0 - 1:5    range= 0-5     "const"
   | Identifier        loc= 1:6 - 1:9    range= 6-9     "obj"
@@ -1453,6 +1534,34 @@
  4 | 
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "let",
+  |   "start": 20,
+  |   "end": 23,
+  |   "range": [
+  |     20,
+  |     23
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 3,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 3,
+  |       "column": 3
+  |     }
+  |   }
+  | }
+   ,-[files/index.js:3:1]
+ 2 | 
+ 3 | let x = /* inline comment */ 1;
+   : ^^^
+ 4 | 
+   `----
+
   x tokens-plugin(tokens): Identifier ("x")
   |   regex: undefined
    ,-[files/index.js:3:5]
@@ -1559,6 +1668,33 @@
 
   x tokens-plugin(tokens): Keyword ("const")
   |   regex: undefined
+   ,-[files/jsx_element.tsx:1:1]
+ 1 | const Component = () => {
+   : ^^^^^
+ 2 |   return <div className="test">Hello</div>;
+   `----
+
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "const",
+  |   "start": 0,
+  |   "end": 5,
+  |   "range": [
+  |     0,
+  |     5
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 5
+  |     }
+  |   }
+  | }
    ,-[files/jsx_element.tsx:1:1]
  1 | const Component = () => {
    : ^^^^^
@@ -1873,6 +2009,33 @@
 
   x tokens-plugin(tokens): Keyword ("const")
   |   regex: undefined
+   ,-[files/keywords.js:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "const",
+  |   "start": 0,
+  |   "end": 5,
+  |   "range": [
+  |     0,
+  |     5
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 5
+  |     }
+  |   }
+  | }
    ,-[files/keywords.js:1:1]
  1 | const obj = {
    : ^^^^^
@@ -2299,6 +2462,34 @@
  3 | 
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Keyword",
+  |   "value": "const",
+  |   "start": 91,
+  |   "end": 96,
+  |   "range": [
+  |     91,
+  |     96
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 2,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 2,
+  |       "column": 5
+  |     }
+  |   }
+  | }
+   ,-[files/ts_angle_relex.ts:2:1]
+ 1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
+ 2 | const a = n << 2;
+   : ^^^^^
+ 3 | 
+   `----
+
   x tokens-plugin(tokens): Identifier ("a")
   |   regex: undefined
    ,-[files/ts_angle_relex.ts:2:7]
@@ -2572,6 +2763,33 @@
  2 | // 😀🤪😆😎🤮
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify:
+  | {
+  |   "type": "Identifier",
+  |   "value": "a",
+  |   "start": 0,
+  |   "end": 1,
+  |   "range": [
+  |     0,
+  |     1
+  |   ],
+  |   "loc": {
+  |     "start": {
+  |       "line": 1,
+  |       "column": 0
+  |     },
+  |     "end": {
+  |       "line": 1,
+  |       "column": 1
+  |     }
+  |   }
+  | }
+   ,-[files/unicode.js:1:1]
+ 1 | a;
+   : ^
+ 2 | // 😀🤪😆😎🤮
+   `----
+
   x tokens-plugin(tokens): Tokens and comments:
   | Identifier        loc= 1:0 - 1:1    range= 0-1     "a"
   | Punctuator        loc= 1:1 - 1:2    range= 1-2     ";"
@@ -2627,7 +2845,7 @@
    :  ^
    `----
 
-Found 0 warnings and 243 errors.
+Found 0 warnings and 251 errors.
 Finished in Xms on 8 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -89,6 +89,15 @@ const rule: Rule = {
       context.report({ message, node: token });
     }
 
+    // Check `JSON.stringify` on tokens includes `loc`
+    const firstToken = ast.tokens[0];
+    if (firstToken) {
+      context.report({
+        message: `Token JSON.stringify:\n${JSON.stringify(firstToken, null, 2)}`,
+        node: firstToken,
+      });
+    }
+
     return {};
   },
 };


### PR DESCRIPTION
`loc` property of `Token`s and `Comment`s is a getter on these classes' prototypes. Add a `toJSON` method to both classes so `JSON.stringify` includes `loc` in the generated JSON.