### PR TITLE
fix(transformer/typescript): parameter property assignments before conditional super()

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use oxc_allocator::{ArenaVec, ReplaceWith, TakeIn};
 use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, ScopeId};
-use oxc_span::SPAN;
+use oxc_span::{GetSpan, SPAN};
 use oxc_str::Ident;
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::BoundIdentifier;
@@ -411,13 +411,34 @@ impl<'a> TypeScript<'a> {
             return;
         }
 
-        let params = &constructor.value.params.items;
-        let assignments = Self::convert_constructor_params(params, ctx).collect::<Vec<_>>();
+        let constructor_scope_id = constructor.value.scope_id();
+        let Function { params, body, .. } = &mut *constructor.value;
+        let params = &params.items;
+        if !params
+            .iter()
+            .any(|param| param.has_modifier() && param.pattern.get_binding_identifier().is_some())
+        {
+            return;
+        }
 
-        let constructor_body_statements = &mut constructor.value.body.as_mut().unwrap().statements;
+        let constructor_body_statements = &mut body.as_mut().unwrap().statements;
         let super_call_position = Self::get_super_call_position(constructor_body_statements);
+        if super_call_position > 0 {
+            let statement = &mut constructor_body_statements[super_call_position - 1];
+            if let Statement::IfStatement(stmt) = statement
+                && Self::can_insert_constructor_params_in_if_branches(stmt)
+            {
+                Self::insert_constructor_params_in_if_branches(
+                    stmt,
+                    params,
+                    constructor_scope_id,
+                    ctx,
+                );
+                return;
+            }
+        }
 
-        // Insert the assignments after the `super()` call
+        let assignments = Self::convert_constructor_params(params, ctx);
         constructor_body_statements.splice(super_call_position..super_call_position, assignments);
     }
 
@@ -479,19 +500,111 @@ impl<'a> TypeScript<'a> {
         Self::create_assignment(target, value, ctx)
     }
 
-    /// Find the position of the `super()` call in the constructor body, otherwise return 0.
+    /// Find the position after the `super()` call in the constructor body, otherwise return 0.
     ///
-    /// Don't need to handle nested `super()` call because `TypeScript` doesn't allow it.
+    /// If `super()` is nested inside a top-level control flow statement, return the position after
+    /// the containing statement.
     pub fn get_super_call_position(statements: &[Statement<'a>]) -> usize {
-        // Find the position of the `super()` call in the constructor body.
-        // Don't need to handle nested `super()` call because `TypeScript` doesn't allow it.
-        statements
-            .iter()
-            .position(|stmt| {
-                matches!(stmt, Statement::ExpressionStatement(stmt)
-                        if stmt.expression.is_super_call_expression())
-            })
-            .map_or(0, |pos| pos + 1)
+        statements.iter().position(Self::statement_contains_super_call).map_or(0, |pos| pos + 1)
+    }
+
+    fn statement_contains_super_call(stmt: &Statement<'a>) -> bool {
+        if Self::statement_contains_direct_super_call(stmt) {
+            return true;
+        }
+
+        match stmt {
+            Statement::BlockStatement(stmt) => {
+                stmt.body.iter().any(Self::statement_contains_super_call)
+            }
+            Statement::IfStatement(stmt) => {
+                Self::statement_contains_super_call(&stmt.consequent)
+                    || stmt.alternate.as_ref().is_some_and(Self::statement_contains_super_call)
+            }
+            Statement::SwitchStatement(stmt) => stmt
+                .cases
+                .iter()
+                .any(|case| case.consequent.iter().any(Self::statement_contains_super_call)),
+            Statement::TryStatement(stmt) => {
+                stmt.block.body.iter().any(Self::statement_contains_super_call)
+                    || stmt.handler.as_ref().is_some_and(|handler| {
+                        handler.body.body.iter().any(Self::statement_contains_super_call)
+                    })
+                    || stmt.finalizer.as_ref().is_some_and(|block| {
+                        block.body.iter().any(Self::statement_contains_super_call)
+                    })
+            }
+            Statement::LabeledStatement(stmt) => Self::statement_contains_super_call(&stmt.body),
+            _ => false,
+        }
+    }
+
+    fn can_insert_constructor_params_in_if_branches(stmt: &IfStatement<'a>) -> bool {
+        Self::can_insert_constructor_params_in_if_branch(&stmt.consequent)
+            && stmt.alternate.as_ref().is_some_and(Self::can_insert_constructor_params_in_if_branch)
+    }
+
+    fn can_insert_constructor_params_in_if_branch(stmt: &Statement<'a>) -> bool {
+        Self::statement_contains_direct_super_call(stmt)
+            || matches!(stmt, Statement::BlockStatement(block)
+                if block.body.iter().any(Self::statement_contains_direct_super_call))
+    }
+
+    fn insert_constructor_params_in_if_branches(
+        stmt: &mut IfStatement<'a>,
+        params: &ArenaVec<'a, FormalParameter<'a>>,
+        constructor_scope_id: ScopeId,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        Self::insert_constructor_params_in_if_branch(
+            &mut stmt.consequent,
+            params,
+            constructor_scope_id,
+            ctx,
+        );
+        Self::insert_constructor_params_in_if_branch(
+            stmt.alternate.as_mut().unwrap(),
+            params,
+            constructor_scope_id,
+            ctx,
+        );
+    }
+
+    fn insert_constructor_params_in_if_branch(
+        stmt: &mut Statement<'a>,
+        params: &ArenaVec<'a, FormalParameter<'a>>,
+        constructor_scope_id: ScopeId,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        match stmt {
+            Statement::BlockStatement(stmt) => {
+                let position =
+                    stmt.body.iter().position(Self::statement_contains_direct_super_call).unwrap()
+                        + 1;
+                stmt.body.splice(position..position, Self::convert_constructor_params(params, ctx));
+            }
+            _ if Self::statement_contains_direct_super_call(stmt) => {
+                let scope_id = ctx.insert_scope_below_statement_from_scope_id(
+                    stmt,
+                    constructor_scope_id,
+                    ScopeFlags::empty(),
+                );
+                let span = stmt.span();
+                let mut body = ArenaVec::from_array_in([stmt.take_in(ctx)], ctx);
+                body.extend(Self::convert_constructor_params(params, ctx));
+                *stmt = Statement::new_block_statement_with_scope_id(span, body, scope_id, ctx);
+            }
+            _ => {}
+        }
+    }
+
+    fn statement_contains_direct_super_call(stmt: &Statement<'a>) -> bool {
+        matches!(stmt, Statement::ExpressionStatement(stmt) if match &stmt.expression {
+            Expression::SequenceExpression(seq) => {
+                seq.expressions.iter().any(Expression::is_super_call_expression)
+            }
+            expr => expr.is_super_call_expression(),
+        })
     }
 
     /// Convert computed key to sequence expression if there are assignments.

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-late-super/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/class/parameter-properties-late-super/output.js
@@ -1,0 +1,13 @@
+class B extends A {
+  p;
+  constructor(p) {
+    console.log("anything before super");
+    if (p) {
+      super();
+      this.p = p;
+    } else {
+      super();
+      this.p = p;
+    }
+  }
+}

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: c86e9e4b
 
-Passed: 771/1164
+Passed: 772/1164
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1055,7 +1055,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (115/157)
+# babel-plugin-transform-typescript (116/157)
 * class/accessor-allowDeclareFields-false/input.ts
 
   x TS(18010): An accessibility modifier cannot be used with a private
@@ -1105,9 +1105,6 @@ x Output mismatch
   help: Allowed modifiers are: private, protected, public, static, abstract,
         override
 
-
-* class/parameter-properties-late-super/input.ts
-x Output mismatch
 
 * class/private-method-override-transform-private/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: c86e9e4b
 
-Passed: 270/398
+Passed: 271/399
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -48,7 +48,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (41/60)
+# babel-plugin-transform-typescript (42/61)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-conditional-super/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-conditional-super/input.ts
@@ -1,0 +1,66 @@
+class MyError extends Error {
+  constructor(
+    public code: string,
+    public description?: string,
+  ) {
+    if (description) {
+      super(code + ': ' + description);
+    } else {
+      super(code);
+    }
+    this.name = 'MyError';
+  }
+}
+
+class MyError2 extends Error {
+  constructor(
+    public code: string,
+  ) {
+    switch (code) {
+      case 'A':
+        super('Error A');
+        break;
+      default:
+        super(code);
+    }
+  }
+}
+
+class MyError3 extends Error {
+  constructor(
+    public code: string,
+  ) {
+    super(code), init(this);
+  }
+}
+
+class Unbraced extends Error {
+  constructor(public code: string, useCode: boolean) {
+    if (useCode) super(code), init(this);
+    else super();
+  }
+}
+
+class NestedConditional extends Error {
+  constructor(public code: string, first: boolean, second: boolean) {
+    if (first) {
+      if (second) super(code);
+      return {};
+    } else {
+      super(code);
+    }
+  }
+}
+
+class OneSuperBranch extends Error {
+  constructor(public code: string, skip: boolean) {
+    if (skip) return {};
+    else super(code);
+  }
+}
+
+class MissingElse extends Error {
+  constructor(public code: string, initialize: boolean) {
+    if (initialize) super(code);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-conditional-super/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments-conditional-super/output.js
@@ -1,0 +1,81 @@
+class MyError extends Error {
+  code;
+  description;
+  constructor(code, description) {
+    if (description) {
+      super(code + ': ' + description);
+      this.code = code;
+      this.description = description;
+    } else {
+      super(code);
+      this.code = code;
+      this.description = description;
+    }
+    this.name = 'MyError';
+  }
+}
+
+class MyError2 extends Error {
+  code;
+  constructor(code) {
+    switch (code) {
+      case 'A':
+        super('Error A');
+        break;
+      default:
+        super(code);
+    }
+    this.code = code;
+  }
+}
+
+class MyError3 extends Error {
+  code;
+  constructor(code) {
+    super(code), init(this);
+    this.code = code;
+  }
+}
+
+class Unbraced extends Error {
+  code;
+  constructor(code, useCode) {
+    if (useCode) {
+      super(code), init(this);
+      this.code = code;
+    } else {
+      super();
+      this.code = code;
+    }
+  }
+}
+
+class NestedConditional extends Error {
+  code;
+  constructor(code, first, second) {
+    if (first) {
+      if (second) super(code);
+      return {};
+    } else {
+      super(code);
+    }
+    this.code = code;
+  }
+}
+
+class OneSuperBranch extends Error {
+  code;
+  constructor(code, skip) {
+    if (skip) return {};
+    else super(code);
+    this.code = code;
+  }
+}
+
+class MissingElse extends Error {
+  code;
+  constructor(code, initialize) {
+    if (initialize) super(code);
+    this.code = code;
+  }
+}


### PR DESCRIPTION
Closes #20527

`get_super_call_position` only looked for `super()` as a direct top-level `ExpressionStatement`. When `super()` was inside an `if/else` or `switch`, it was not found, so parameter property assignments (`this.x = x`) were inserted at position 0 — before `super()`. This causes a runtime `ReferenceError`.

The fix makes `get_super_call_position` walk into top-level control flow statements (`if`, `switch`, `try`, `labeled`, blocks) to find the containing statement, and inserts assignments after it.