### PR TITLE
perf(linter/no-const-assign): use `BindingPattern::get_symbol_ids`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -59,8 +59,8 @@ impl Rule for NoConstAssign {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(decl) if decl.kind.is_const() || decl.kind.is_using() => {
-                for ident in decl.id.get_binding_identifiers() {
-                    check_symbol_id(ident.symbol_id(), ctx);
+                for symbol_id in decl.id.get_symbol_ids() {
+                    check_symbol_id(symbol_id, ctx);
                 }
             }
             _ => {}


### PR DESCRIPTION
this should be faster as it avoids a deref to get the symbol id