### PR TITLE
feat(linter): add agent output formatter

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -255,7 +255,7 @@ pub struct WarningOptions {
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
     /// Use a specific output format. Possible values:
-    /// `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+    /// `agent`, `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
     #[bpaf(long, short, fallback_with(default_output_format), hide_usage)]
     pub format: OutputFormat,
 }
@@ -266,6 +266,8 @@ fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
         Ok(OutputFormat::Default)
     } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
         Ok(OutputFormat::Github)
+    } else if std::env::var("OXLINT_AGENT").ok().is_some() {
+        Ok(OutputFormat::Agent)
     } else {
         Ok(OutputFormat::Default)
     }

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -260,13 +260,30 @@ pub struct OutputOptions {
     pub format: OutputFormat,
 }
 
+/// Detect whether oxlint is running inside an AI agent environment.
+/// Checks the same environment variables as [unjs/std-env](https://github.com/unjs/std-env).
+fn is_agent_env() -> bool {
+    const AGENT_ENV_VARS: &[&str] = &[
+        "CLAUDECODE",
+        "CLAUDE_CODE",
+        "CURSOR_AGENT",
+        "GEMINI_CLI",
+        "CODEX_SANDBOX",
+        "CODEX_THREAD_ID",
+        "AUGMENT_AGENT",
+        "GOOSE_PROVIDER",
+        "REPL_ID",
+    ];
+    AGENT_ENV_VARS.iter().any(|var| std::env::var(var).is_ok())
+}
+
 #[expect(clippy::unnecessary_wraps)]
 fn default_output_format() -> Result<OutputFormat, std::convert::Infallible> {
     if cfg!(debug_assertions) {
         Ok(OutputFormat::Default)
     } else if std::env::var("GITHUB_ACTIONS").ok().is_some_and(|value| value == "true") {
         Ok(OutputFormat::Github)
-    } else if std::env::var("OXLINT_AGENT").ok().is_some() {
+    } else if is_agent_env() {
         Ok(OutputFormat::Agent)
     } else {
         Ok(OutputFormat::Default)

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -261,7 +261,8 @@ pub struct OutputOptions {
 }
 
 /// Detect whether oxlint is running inside an AI agent environment.
-/// Checks the same environment variables as [unjs/std-env](https://github.com/unjs/std-env).
+/// Checks env-var-presence agents from [unjs/std-env](https://github.com/unjs/std-env).
+/// Agents that require regex matching on env var values (pi, devin, kiro) are not covered.
 fn is_agent_env() -> bool {
     const AGENT_ENV_VARS: &[&str] = &[
         "CLAUDECODE",
@@ -272,6 +273,9 @@ fn is_agent_env() -> bool {
         "CODEX_THREAD_ID",
         "AUGMENT_AGENT",
         "GOOSE_PROVIDER",
+        "OPENCODE",
+        // REPL_ID is set for all Replit sessions (not just AI agents);
+        // std-env treats Replit as an agent environment.
         "REPL_ID",
     ];
     AGENT_ENV_VARS.iter().any(|var| std::env::var(var).is_ok())

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt::Write;
 
 use oxc_diagnostics::{
     Error, Severity,
@@ -37,16 +38,19 @@ impl DiagnosticReporter for AgentReporter {
         output.push('\n');
         match (errors, warnings) {
             (0, 0) => {}
-            (e, 0) => output.push_str(&format!("{e} error{}\n", if e == 1 { "" } else { "s" })),
+            (e, 0) => {
+                let _ = write!(output, "{e} error{}\n", if e == 1 { "" } else { "s" });
+            }
             (0, w) => {
-                output.push_str(&format!("{w} warning{}\n", if w == 1 { "" } else { "s" }));
+                let _ = write!(output, "{w} warning{}\n", if w == 1 { "" } else { "s" });
             }
             (e, w) => {
-                output.push_str(&format!(
+                let _ = write!(
+                    output,
                     "{e} error{}, {w} warning{}\n",
                     if e == 1 { "" } else { "s" },
                     if w == 1 { "" } else { "s" }
-                ));
+                );
             }
         }
 
@@ -81,12 +85,13 @@ fn format_agent(diagnostics: &mut Vec<Error>) -> String {
                 _ => "warning",
             };
             let rule = info.rule_id.as_deref().unwrap_or("-");
-            output.push_str(&format!(
-                "  {}:{} {} {}: {}\n",
+            let _ = writeln!(
+                output,
+                "  {}:{} {} {}: {}",
                 info.start.line, info.start.column, severity, rule, info.message
-            ));
+            );
             if let Some(help) = help {
-                output.push_str(&format!("    help: {help}\n"));
+                let _ = writeln!(output, "    help: {help}");
             }
         }
     }

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -67,7 +67,13 @@ impl DiagnosticReporter for AgentReporter {
             let _ = writeln!(
                 self.output,
                 "{}:{}:{} {} {}: {} (help: {})",
-                info.filename, info.start.line, info.start.column, severity, rule, info.message, help
+                info.filename,
+                info.start.line,
+                info.start.column,
+                severity,
+                rule,
+                info.message,
+                help
             );
         } else {
             let _ = writeln!(

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -1,0 +1,174 @@
+use std::collections::BTreeMap;
+
+use oxc_diagnostics::{
+    Error, Severity,
+    reporter::{DiagnosticReporter, DiagnosticResult, Info},
+};
+
+use crate::output_formatter::InternalFormatter;
+
+#[derive(Debug, Default)]
+pub struct AgentOutputFormatter;
+
+impl InternalFormatter for AgentOutputFormatter {
+    fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
+        Box::new(AgentReporter::default())
+    }
+}
+
+/// Reporter optimized for AI agent consumption.
+/// Groups diagnostics by filename and uses a minimal plain-text format
+/// to reduce token usage. Includes rule IDs and help text.
+#[derive(Default)]
+struct AgentReporter {
+    diagnostics: Vec<Error>,
+}
+
+impl DiagnosticReporter for AgentReporter {
+    fn finish(&mut self, result: &DiagnosticResult) -> Option<String> {
+        if self.diagnostics.is_empty() {
+            return None;
+        }
+
+        let mut output = format_agent(&mut self.diagnostics);
+
+        let errors = result.errors_count();
+        let warnings = result.warnings_count();
+        output.push('\n');
+        match (errors, warnings) {
+            (0, 0) => {}
+            (e, 0) => output.push_str(&format!("{e} error{}\n", if e == 1 { "" } else { "s" })),
+            (0, w) => {
+                output.push_str(&format!("{w} warning{}\n", if w == 1 { "" } else { "s" }));
+            }
+            (e, w) => {
+                output.push_str(&format!(
+                    "{e} error{}, {w} warning{}\n",
+                    if e == 1 { "" } else { "s" },
+                    if w == 1 { "" } else { "s" }
+                ));
+            }
+        }
+
+        Some(output)
+    }
+
+    fn render_error(&mut self, error: Error) -> Option<String> {
+        self.diagnostics.push(error);
+        None
+    }
+}
+
+fn format_agent(diagnostics: &mut Vec<Error>) -> String {
+    // Group diagnostics by filename using BTreeMap for deterministic ordering
+    let mut by_file: BTreeMap<String, Vec<(Info, Option<String>)>> = BTreeMap::new();
+
+    for error in diagnostics.drain(..) {
+        let help = error.help().map(|h| h.to_string());
+        let info = Info::new(&error);
+        by_file.entry(info.filename.clone()).or_default().push((info, help));
+    }
+
+    let mut output = String::new();
+
+    for (filename, entries) in &by_file {
+        output.push_str(filename);
+        output.push('\n');
+
+        for (info, help) in entries {
+            let severity = match info.severity {
+                Severity::Error => "error",
+                _ => "warning",
+            };
+            let rule = info.rule_id.as_deref().unwrap_or("-");
+            output.push_str(&format!(
+                "  {}:{} {} {}: {}\n",
+                info.start.line, info.start.column, severity, rule, info.message
+            ));
+            if let Some(help) = help {
+                output.push_str(&format!("    help: {help}\n"));
+            }
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod test {
+    use oxc_diagnostics::{
+        NamedSource, OxcDiagnostic,
+        reporter::{DiagnosticReporter, DiagnosticResult},
+    };
+    use oxc_span::Span;
+
+    use super::AgentReporter;
+
+    #[test]
+    fn reporter_finish_empty() {
+        let mut reporter = AgentReporter::default();
+        let result = reporter.finish(&DiagnosticResult::default());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reporter_groups_by_file() {
+        let mut reporter = AgentReporter::default();
+
+        let error1 = OxcDiagnostic::error("no debugger")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("file.js", "debugger;"));
+        let error2 = OxcDiagnostic::warn("no console")
+            .with_label(Span::new(0, 7))
+            .with_source_code(NamedSource::new("file.js", "console;"));
+
+        let _ = reporter.render_error(error1);
+        let _ = reporter.render_error(error2);
+
+        let result = reporter.finish(&DiagnosticResult::new(1, 1, false));
+
+        assert!(result.is_some());
+        let output = result.unwrap();
+        // Both diagnostics should be under the same file header
+        assert_eq!(output.matches("file.js\n").count(), 1);
+        assert!(output.contains("error"));
+        assert!(output.contains("warning"));
+        assert!(output.contains("1 error, 1 warning"));
+    }
+
+    #[test]
+    fn reporter_includes_help_text() {
+        let mut reporter = AgentReporter::default();
+
+        let error = OxcDiagnostic::warn("no debugger")
+            .with_help("Remove the `debugger` statement")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("file.js", "debugger;"));
+
+        let _ = reporter.render_error(error);
+
+        let result = reporter.finish(&DiagnosticResult::new(1, 0, false));
+
+        assert!(result.is_some());
+        let output = result.unwrap();
+        assert!(output.contains("help: Remove the `debugger` statement"));
+    }
+
+    #[test]
+    fn reporter_error() {
+        let mut reporter = AgentReporter::default();
+
+        let error = OxcDiagnostic::warn("no debugger")
+            .with_label(Span::new(0, 8))
+            .with_source_code(NamedSource::new("file.js", "debugger;"));
+
+        let _ = reporter.render_error(error);
+
+        let result = reporter.finish(&DiagnosticResult::new(1, 0, false));
+
+        assert!(result.is_some());
+        let output = result.unwrap();
+        assert!(output.contains("file.js\n"));
+        assert!(output.contains("1:1 warning"));
+    }
+}

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -39,15 +39,15 @@ impl DiagnosticReporter for AgentReporter {
         match (errors, warnings) {
             (0, 0) => {}
             (e, 0) => {
-                let _ = write!(output, "{e} error{}\n", if e == 1 { "" } else { "s" });
+                let _ = writeln!(output, "{e} error{}", if e == 1 { "" } else { "s" });
             }
             (0, w) => {
-                let _ = write!(output, "{w} warning{}\n", if w == 1 { "" } else { "s" });
+                let _ = writeln!(output, "{w} warning{}", if w == 1 { "" } else { "s" });
             }
             (e, w) => {
-                let _ = write!(
+                let _ = writeln!(
                     output,
-                    "{e} error{}, {w} warning{}\n",
+                    "{e} error{}, {w} warning{}",
                     if e == 1 { "" } else { "s" },
                     if w == 1 { "" } else { "s" }
                 );

--- a/apps/oxlint/src/output_formatter/agent.rs
+++ b/apps/oxlint/src/output_formatter/agent.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt::Write;
 
 use oxc_diagnostics::{
@@ -18,35 +17,33 @@ impl InternalFormatter for AgentOutputFormatter {
 }
 
 /// Reporter optimized for AI agent consumption.
-/// Groups diagnostics by filename and uses a minimal plain-text format
-/// to reduce token usage. Includes rule IDs and help text.
+/// Outputs one greppable line per diagnostic in the format:
+/// `file:line:col severity rule(id): message (help: ...)`
 #[derive(Default)]
 struct AgentReporter {
-    diagnostics: Vec<Error>,
+    output: String,
 }
 
 impl DiagnosticReporter for AgentReporter {
     fn finish(&mut self, result: &DiagnosticResult) -> Option<String> {
-        if self.diagnostics.is_empty() {
+        if self.output.is_empty() {
             return None;
         }
 
-        let mut output = format_agent(&mut self.diagnostics);
-
         let errors = result.errors_count();
         let warnings = result.warnings_count();
-        output.push('\n');
+        self.output.push('\n');
         match (errors, warnings) {
             (0, 0) => {}
             (e, 0) => {
-                let _ = writeln!(output, "{e} error{}", if e == 1 { "" } else { "s" });
+                let _ = writeln!(self.output, "{e} error{}", if e == 1 { "" } else { "s" });
             }
             (0, w) => {
-                let _ = writeln!(output, "{w} warning{}", if w == 1 { "" } else { "s" });
+                let _ = writeln!(self.output, "{w} warning{}", if w == 1 { "" } else { "s" });
             }
             (e, w) => {
                 let _ = writeln!(
-                    output,
+                    self.output,
                     "{e} error{}, {w} warning{}",
                     if e == 1 { "" } else { "s" },
                     if w == 1 { "" } else { "s" }
@@ -54,49 +51,34 @@ impl DiagnosticReporter for AgentReporter {
             }
         }
 
-        Some(output)
+        Some(std::mem::take(&mut self.output))
     }
 
     fn render_error(&mut self, error: Error) -> Option<String> {
-        self.diagnostics.push(error);
-        None
-    }
-}
-
-fn format_agent(diagnostics: &mut Vec<Error>) -> String {
-    // Group diagnostics by filename using BTreeMap for deterministic ordering
-    let mut by_file: BTreeMap<String, Vec<(Info, Option<String>)>> = BTreeMap::new();
-
-    for error in diagnostics.drain(..) {
         let help = error.help().map(|h| h.to_string());
         let info = Info::new(&error);
-        by_file.entry(info.filename.clone()).or_default().push((info, help));
-    }
+        let severity = match info.severity {
+            Severity::Error => "error",
+            _ => "warning",
+        };
+        let rule = info.rule_id.as_deref().unwrap_or("-");
 
-    let mut output = String::new();
-
-    for (filename, entries) in &by_file {
-        output.push_str(filename);
-        output.push('\n');
-
-        for (info, help) in entries {
-            let severity = match info.severity {
-                Severity::Error => "error",
-                _ => "warning",
-            };
-            let rule = info.rule_id.as_deref().unwrap_or("-");
+        if let Some(help) = help {
             let _ = writeln!(
-                output,
-                "  {}:{} {} {}: {}",
-                info.start.line, info.start.column, severity, rule, info.message
+                self.output,
+                "{}:{}:{} {} {}: {} (help: {})",
+                info.filename, info.start.line, info.start.column, severity, rule, info.message, help
             );
-            if let Some(help) = help {
-                let _ = writeln!(output, "    help: {help}");
-            }
+        } else {
+            let _ = writeln!(
+                self.output,
+                "{}:{}:{} {} {}: {}",
+                info.filename, info.start.line, info.start.column, severity, rule, info.message
+            );
         }
-    }
 
-    output
+        None
+    }
 }
 
 #[cfg(test)]
@@ -117,7 +99,7 @@ mod test {
     }
 
     #[test]
-    fn reporter_groups_by_file() {
+    fn reporter_one_liner_format() {
         let mut reporter = AgentReporter::default();
 
         let error1 = OxcDiagnostic::error("no debugger")
@@ -134,15 +116,14 @@ mod test {
 
         assert!(result.is_some());
         let output = result.unwrap();
-        // Both diagnostics should be under the same file header
-        assert_eq!(output.matches("file.js\n").count(), 1);
-        assert!(output.contains("error"));
-        assert!(output.contains("warning"));
+        // Each diagnostic on its own greppable line
+        assert!(output.contains("file.js:1:1 error"));
+        assert!(output.contains("file.js:1:1 warning"));
         assert!(output.contains("1 error, 1 warning"));
     }
 
     #[test]
-    fn reporter_includes_help_text() {
+    fn reporter_includes_help_inline() {
         let mut reporter = AgentReporter::default();
 
         let error = OxcDiagnostic::warn("no debugger")
@@ -156,11 +137,13 @@ mod test {
 
         assert!(result.is_some());
         let output = result.unwrap();
-        assert!(output.contains("help: Remove the `debugger` statement"));
+        // Help text should be inline, not on a separate line
+        assert!(output.contains("(help: Remove the `debugger` statement)"));
+        assert!(!output.contains("\n    help:"));
     }
 
     #[test]
-    fn reporter_error() {
+    fn reporter_greppable_line() {
         let mut reporter = AgentReporter::default();
 
         let error = OxcDiagnostic::warn("no debugger")
@@ -173,7 +156,7 @@ mod test {
 
         assert!(result.is_some());
         let output = result.unwrap();
-        assert!(output.contains("file.js\n"));
-        assert!(output.contains("1:1 warning"));
+        // Line should start with file:line:col for greppability
+        assert!(output.starts_with("file.js:1:1 warning"));
     }
 }

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -27,8 +27,8 @@ use crate::output_formatter::{default::DefaultOutputFormatter, json::JsonOutputF
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OutputFormat {
-    /// Minimal plain-text format optimized for AI agent consumption.
-    /// Groups diagnostics by file, includes help text, uses minimal tokens.
+    /// One-line-per-diagnostic format optimized for AI agent consumption.
+    /// Each line is `file:line:col severity rule: message (help: ...)` for greppability.
     Agent,
     Default,
     /// GitHub Check Annotation

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod checkstyle;
 mod default;
 mod github;
@@ -11,6 +12,7 @@ mod xml_utils;
 use std::str::FromStr;
 use std::time::Duration;
 
+use agent::AgentOutputFormatter;
 use checkstyle::CheckStyleOutputFormatter;
 use github::GithubOutputFormatter;
 use gitlab::GitlabOutputFormatter;
@@ -25,6 +27,9 @@ use crate::output_formatter::{default::DefaultOutputFormatter, json::JsonOutputF
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum OutputFormat {
+    /// Minimal plain-text format optimized for AI agent consumption.
+    /// Groups diagnostics by file, includes help text, uses minimal tokens.
+    Agent,
     Default,
     /// GitHub Check Annotation
     /// <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message>
@@ -42,6 +47,7 @@ impl FromStr for OutputFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "agent" => Ok(Self::Agent),
             "json" => Ok(Self::Json),
             "default" => Ok(Self::Default),
             "unix" => Ok(Self::Unix),
@@ -122,6 +128,7 @@ impl OutputFormatter {
 
     fn get_internal_formatter(format: OutputFormat) -> Box<dyn InternalFormatter> {
         match format {
+            OutputFormat::Agent => Box::<AgentOutputFormatter>::default(),
             OutputFormat::Json => Box::<JsonOutputFormatter>::default(),
             OutputFormat::Checkstyle => Box::<CheckStyleOutputFormatter>::default(),
             OutputFormat::Github => Box::new(GithubOutputFormatter),
@@ -160,7 +167,7 @@ mod test {
     #[test]
     fn test_output_formatter_diagnostic_formats() {
         let mut formats: Vec<&str> =
-            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
+            vec!["agent", "checkstyle", "default", "github", "junit", "stylish", "unix"];
 
         // disabled for windows
         // json will output the offset which will be different for windows
@@ -184,7 +191,7 @@ mod test {
     #[test]
     fn test_output_formatter_diagnostic_formats_success() {
         let mut formats: Vec<&str> =
-            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
+            vec!["agent", "checkstyle", "default", "github", "junit", "stylish", "unix"];
 
         // disabled for windows
         // json will output the offset which will be different for windows
@@ -211,7 +218,7 @@ mod test {
     #[test]
     fn test_output_formatter_diagnostic_formats_with_parser_error() {
         let mut formats: Vec<&str> =
-            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
+            vec!["agent", "checkstyle", "default", "github", "junit", "stylish", "unix"];
 
         // disabled for windows
         // json will output the offset which will be different for windows
@@ -236,7 +243,7 @@ mod test {
     #[test]
     fn test_output_formatter_diagnostic_formats_with_disable_directive() {
         let mut formats: Vec<&str> =
-            vec!["checkstyle", "default", "github", "junit", "stylish", "unix"];
+            vec!["agent", "checkstyle", "default", "github", "junit", "stylish", "unix"];
 
         // disabled for windows
         // json will output the offset which will be different for windows

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -5,10 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=agent --report-unused-disable-directives disable-directive.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-disable-directive.js
-  9:3 warning -: Unused eslint-disable directive (no problems were reported).
-  12:3 warning -: Unused eslint-disable directive (no problems were reported).
-  15:3 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:9:3 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:12:3 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:15:3 warning -: Unused eslint-disable directive (no problems were reported).
 
 3 warnings
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,0 +1,16 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=agent --report-unused-disable-directives disable-directive.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+disable-directive.js
+  9:3 warning -: Unused eslint-disable directive (no problems were reported).
+  12:3 warning -: Unused eslint-disable directive (no problems were reported).
+  15:3 warning -: Unused eslint-disable directive (no problems were reported).
+
+3 warnings
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent --report-unused-disable-directives disable-directive.js@oxlint.snap
@@ -1,13 +1,14 @@
 ---
 source: apps/oxlint/src/tester.rs
+assertion_line: 134
 ---
 ########## 
 arguments: --format=agent --report-unused-disable-directives disable-directive.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-disable-directive.js:9:3 warning -: Unused eslint-disable directive (no problems were reported).
-disable-directive.js:12:3 warning -: Unused eslint-disable directive (no problems were reported).
-disable-directive.js:15:3 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:9:1 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:12:1 warning -: Unused eslint-disable directive (no problems were reported).
+disable-directive.js:15:1 warning -: Unused eslint-disable directive (no problems were reported).
 
 3 warnings
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent ok.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent ok.js@oxlint.snap
@@ -1,0 +1,10 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=agent ok.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent parser-error.js@oxlint.snap
@@ -5,8 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=agent parser-error.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-parser-error.js
-  3:9 error -: Expected `;` but found `:`
+parser-error.js:3:9 error -: Expected `;` but found `:`
 
 1 error
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent parser-error.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent parser-error.js@oxlint.snap
@@ -1,0 +1,14 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=agent parser-error.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+parser-error.js
+  3:9 error -: Expected `;` but found `:`
+
+1 error
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
@@ -5,13 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=agent test.js
 working directory: fixtures/cli/output_formatter_diagnostic
 ----------
-test.js
-  5:1 error eslint(no-debugger): `debugger` statement is not allowed
-    help: Remove the debugger statement
-  1:10 warning eslint(no-unused-vars): Function 'foo' is declared but never used.
-    help: Consider removing this declaration.
-  1:17 warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
-    help: Consider removing this parameter.
+test.js:5:1 error eslint(no-debugger): `debugger` statement is not allowed (help: Remove the debugger statement)
+test.js:1:10 warning eslint(no-unused-vars): Function 'foo' is declared but never used. (help: Consider removing this declaration.)
+test.js:1:17 warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'. (help: Consider removing this parameter.)
 
 1 error, 2 warnings
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__output_formatter_diagnostic_--format=agent test.js@oxlint.snap
@@ -1,0 +1,19 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --format=agent test.js
+working directory: fixtures/cli/output_formatter_diagnostic
+----------
+test.js
+  5:1 error eslint(no-debugger): `debugger` statement is not allowed
+    help: Remove the debugger statement
+  1:10 warning eslint(no-unused-vars): Function 'foo' is declared but never used.
+    help: Consider removing this declaration.
+  1:17 warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+    help: Consider removing this parameter.
+
+1 error, 2 warnings
+----------
+CLI result: LintFoundErrors
+----------

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -120,7 +120,7 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format. Possible values: `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+  Use a specific output format. Possible values: `agent`, `checkstyle`, `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
 
 
 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -72,7 +72,7 @@ Handle Warnings
                               your project
 
 Output
-    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
+    -f, --format=ARG          Use a specific output format. Possible values: `agent`, `checkstyle`,
                               `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
 
 Miscellaneous


### PR DESCRIPTION
Add a new `agent` output format for oxlint optimized for AI agent consumption. Groups diagnostics by filename, uses plain text with minimal tokens, includes rule IDs and help text.

## Changes

- New `agent.rs` formatter implementing `InternalFormatter` + `DiagnosticReporter`
- Buffered pattern to group diagnostics by filename (BTreeMap for deterministic ordering)
- Auto-enables via `OXLINT_AGENT` env var, following the GitHub/GitLab detection pattern
- Registered in `OutputFormat` enum, `FromStr`, dispatcher, and CLI help text
- Unit tests + snapshot tests for all diagnostic fixture cases

## Output format

```
test.js
  5:1 error eslint(no-debugger): `debugger` statement is not allowed
    help: Remove the debugger statement
  1:10 warning eslint(no-unused-vars): Function 'foo' is declared but never used.
    help: Consider removing this declaration.

1 error, 1 warning
```

Design choices:
- **Grouped by file** to de-duplicate filenames and reduce tokens
- **Plain text** with no unicode decorators
- **Help text included** on indented lines when available
- **Rule IDs inline** for easy reference

Open question from the issue thread: is `OXLINT_AGENT` the right env var name for auto-detection, or should it be something more generic?

Closes #20514