### PR TITLE
ci: add "needs reproduction" workflow for issues

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -1,0 +1,21 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'oxc-project/oxc'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: needs reproduction
+        uses: actions-cool/issues-helper@71b62d7da76e59ff7b193904feb6e77d4dbb2777 # v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "needs reproduction"
+          inactive-day: 3

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,0 +1,44 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'oxc-project/oxc'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: contribution welcome
+        if: github.event.label.name == 'good first issue' || github.event.label.name == 'E-Help Wanted'
+        uses: actions-cool/issues-helper@71b62d7da76e59ff7b193904feb6e77d4dbb2777 # v3
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "pending triage, needs reproduction"
+
+      - name: needs reproduction
+        if: github.event.label.name == 'needs reproduction'
+        uses: actions-cool/issues-helper@71b62d7da76e59ff7b193904feb6e77d4dbb2777 # v3
+        with:
+          actions: "create-comment, remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "pending triage"
+          body: |
+            Hello @${{ github.event.issue.user.login }}
+
+            Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or a link to the [Oxc Playground](https://playground.oxc.rs). This helps us understand and resolve your issue much faster.
+
+            **A good reproduction should be:**
+            - **Minimal** - include only the code necessary to demonstrate the issue
+            - **Complete** - contain everything needed to run and observe the problem
+            - **Reproducible** - consistently show the issue with clear steps
+
+            If no reproduction is provided, issues labeled `needs reproduction` will be closed after 3 days of inactivity.
+
+            For more context on why this is required, please read: https://antfu.me/posts/why-reproductions-are-required


### PR DESCRIPTION
## Summary

- Add `issue-close-require.yml`: daily cron that auto-closes issues labeled `needs reproduction` after 3 days of inactivity
- Add `issue-labeled.yml`: when `needs reproduction` label is applied, posts a comment asking for a minimal reproduction (with link to Oxc Playground) and removes `pending triage` label; also handles `good first issue`/`E-Help Wanted` labels

Adapted from [vite-plus](https://github.com/voidzero-dev/vite-plus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)