### PR TITLE
fix(formatter): respect ignorePatterns when using `--stdin-filepath`

### DIFF
--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -84,9 +84,16 @@ impl StdinRunner {
 
         // Check if the stdin filepath matches any ignore pattern.
         // If ignored, output the source text unchanged (like Prettier).
-        if is_ignored_by_patterns(&ignore_patterns, config_resolver.config_dir(), &filepath, &cwd) {
-            utils::print_and_flush(stdout, &source_text);
-            return CliRunResult::FormatSucceeded;
+        match is_ignored_by_patterns(&ignore_patterns, config_resolver.config_dir(), &filepath, &cwd) {
+            Ok(true) => {
+                utils::print_and_flush(stdout, &source_text);
+                return CliRunResult::FormatSucceeded;
+            }
+            Err(err) => {
+                utils::print_and_flush(stderr, &format!("{err}\n"));
+                return CliRunResult::InvalidOptionConfig;
+            }
+            Ok(false) => {}
         }
 
         // Use `block_in_place()` to avoid nested async runtime access
@@ -141,28 +148,26 @@ fn is_ignored_by_patterns(
     config_dir: Option<&Path>,
     filepath: &Path,
     cwd: &Path,
-) -> bool {
+) -> Result<bool, String> {
     if ignore_patterns.is_empty() {
-        return false;
+        return Ok(false);
     }
     let Some(config_dir) = config_dir else {
-        return false;
+        return Ok(false);
     };
 
     let mut builder = GitignoreBuilder::new(config_dir);
     for pattern in ignore_patterns {
-        if builder.add_line(None, pattern).is_err() {
-            return false;
-        }
+        builder.add_line(None, pattern).map_err(|_| {
+            format!("Failed to add ignore pattern `{pattern}` from `.ignorePatterns`")
+        })?;
     }
-    let Ok(gitignore) = builder.build() else {
-        return false;
-    };
+    let gitignore = builder.build().map_err(|_| "Failed to build ignores".to_string())?;
 
     // Resolve filepath relative to cwd for matching
     let full_path =
         if filepath.is_absolute() { filepath.to_path_buf() } else { cwd.join(filepath) };
 
     let matched = gitignore.matched_path_or_any_parents(&full_path, false);
-    matched.is_ignore() && !matched.is_whitelist()
+    Ok(matched.is_ignore() && !matched.is_whitelist())
 }

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -1,8 +1,10 @@
 use std::{
     env,
     io::{self, BufWriter, Read},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
+
+use ignore::gitignore::GitignoreBuilder;
 
 use crate::cli::{CliRunResult, FormatCommand, Mode};
 use crate::core::{
@@ -72,12 +74,19 @@ impl StdinRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         };
-        match config_resolver.build_and_validate() {
-            Ok(_) => {}
+        let ignore_patterns = match config_resolver.build_and_validate() {
+            Ok(patterns) => patterns,
             Err(err) => {
                 utils::print_and_flush(stderr, &format!("Failed to parse configuration.\n{err}\n"));
                 return CliRunResult::InvalidOptionConfig;
             }
+        };
+
+        // Check if the stdin filepath matches any ignore pattern.
+        // If ignored, output the source text unchanged (like Prettier).
+        if is_ignored_by_patterns(&ignore_patterns, config_resolver.config_dir(), &filepath, &cwd) {
+            utils::print_and_flush(stdout, &source_text);
+            return CliRunResult::FormatSucceeded;
         }
 
         // Use `block_in_place()` to avoid nested async runtime access
@@ -124,4 +133,36 @@ impl StdinRunner {
             }
         }
     }
+}
+
+/// Check if a filepath should be ignored based on `ignorePatterns` from the config.
+fn is_ignored_by_patterns(
+    ignore_patterns: &[String],
+    config_dir: Option<&Path>,
+    filepath: &Path,
+    cwd: &Path,
+) -> bool {
+    if ignore_patterns.is_empty() {
+        return false;
+    }
+    let Some(config_dir) = config_dir else {
+        return false;
+    };
+
+    let mut builder = GitignoreBuilder::new(config_dir);
+    for pattern in ignore_patterns {
+        if builder.add_line(None, pattern).is_err() {
+            return false;
+        }
+    }
+    let Ok(gitignore) = builder.build() else {
+        return false;
+    };
+
+    // Resolve filepath relative to cwd for matching
+    let full_path =
+        if filepath.is_absolute() { filepath.to_path_buf() } else { cwd.join(filepath) };
+
+    let matched = gitignore.matched_path_or_any_parents(&full_path, false);
+    matched.is_ignore() && !matched.is_whitelist()
 }

--- a/apps/oxfmt/src/stdin/mod.rs
+++ b/apps/oxfmt/src/stdin/mod.rs
@@ -84,7 +84,12 @@ impl StdinRunner {
 
         // Check if the stdin filepath matches any ignore pattern.
         // If ignored, output the source text unchanged (like Prettier).
-        match is_ignored_by_patterns(&ignore_patterns, config_resolver.config_dir(), &filepath, &cwd) {
+        match is_ignored_by_patterns(
+            &ignore_patterns,
+            config_resolver.config_dir(),
+            &filepath,
+            &cwd,
+        ) {
             Ok(true) => {
                 utils::print_and_flush(stdout, &source_text);
                 return CliRunResult::FormatSucceeded;

--- a/apps/oxfmt/test/cli/stdin/__snapshots__/stdin.test.ts.snap
+++ b/apps/oxfmt/test/cli/stdin/__snapshots__/stdin.test.ts.snap
@@ -31,3 +31,17 @@ exports[`--stdin-filepath > should not report \`WouldBlock\` error on large file
   "stderr": "",
 }
 `;
+
+exports[`--stdin-filepath > should respect ignorePatterns for stdin-filepath 1`] = `
+{
+  "exitCode": 0,
+  "stdout": "const   x:number=1",
+}
+`;
+
+exports[`--stdin-filepath > should respect ignorePatterns for stdin-filepath 2`] = `
+{
+  "exitCode": 0,
+  "stdout": "const x: number = 1;",
+}
+`;

--- a/apps/oxfmt/test/cli/stdin/fixtures/ignore-patterns/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/stdin/fixtures/ignore-patterns/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["ignored/**"]
+}

--- a/apps/oxfmt/test/cli/stdin/stdin.test.ts
+++ b/apps/oxfmt/test/cli/stdin/stdin.test.ts
@@ -30,6 +30,34 @@ describe("--stdin-filepath", () => {
     }).toMatchSnapshot();
   });
 
+  it("should respect ignorePatterns for stdin-filepath", async () => {
+    const fixtureCwd = join(fixturesDir, "ignore-patterns");
+    const input = "const   x:number=1";
+
+    const ignored = await runCliStdin(input, "ignored/file.ts", {
+      cwd: fixtureCwd,
+      extraArgs: ["--config=.oxfmtrc.json"],
+    });
+
+    expect({
+      exitCode: ignored.exitCode,
+      stdout: ignored.stdout,
+    }).toMatchSnapshot();
+
+    expect(ignored.stdout).toBe(input);
+
+    const formatted = await runCliStdin(input, "src/file.ts", {
+      cwd: fixtureCwd,
+      extraArgs: ["--config=.oxfmtrc.json"],
+    });
+    expect({
+      exitCode: formatted.exitCode,
+      stdout: formatted.stdout,
+    }).toMatchSnapshot();
+
+    expect(formatted.stdout).not.toBe(input);
+  });
+
   // https://github.com/oxc-project/oxc/issues/17939
   it("should not report `WouldBlock` error on large file piped to wc", async () => {
     const largeFile = await readFile(join(fixturesDir, "parser.ts"), "utf-8");

--- a/apps/oxfmt/test/cli/stdin/stdin.test.ts
+++ b/apps/oxfmt/test/cli/stdin/stdin.test.ts
@@ -61,7 +61,7 @@ describe("--stdin-filepath", () => {
   // https://github.com/oxc-project/oxc/issues/17939
   it("should not report `WouldBlock` error on large file piped to wc", async () => {
     const largeFile = await readFile(join(fixturesDir, "parser.ts"), "utf-8");
-    const result = await runCliStdin(largeFile, "parser.ts", "wc -l");
+    const result = await runCliStdin(largeFile, "parser.ts", { pipe: "wc -l" });
 
     expect({
       exitCode: result.exitCode,

--- a/apps/oxfmt/test/cli/utils.ts
+++ b/apps/oxfmt/test/cli/utils.ts
@@ -26,16 +26,13 @@ export function runCli(cwd: string, args: string[]) {
 export function runCliStdin(
   input: string,
   filepath: string,
-  pipeOrOptions?: string | { cwd?: string; extraArgs?: string[] },
+  options?: { cwd?: string; extraArgs?: string[]; pipe?: string },
 ) {
-  const pipe = typeof pipeOrOptions === "string" ? pipeOrOptions : undefined;
-  const options = typeof pipeOrOptions === "object" ? pipeOrOptions : undefined;
-
   let cmd = `node ${CLI_PATH} --stdin-filepath=${filepath}`;
 
   if (options?.extraArgs) cmd += ` ${options.extraArgs.join(" ")}`;
 
-  if (pipe) cmd += ` | ${pipe}`;
+  if (options?.pipe) cmd += ` | ${options.pipe}`;
 
   return execa({ shell: true, reject: false, input, cwd: options?.cwd })`${cmd}`;
 }

--- a/apps/oxfmt/test/cli/utils.ts
+++ b/apps/oxfmt/test/cli/utils.ts
@@ -23,10 +23,21 @@ export function runCli(cwd: string, args: string[]) {
   });
 }
 
-export function runCliStdin(input: string, filepath: string, pipe?: string) {
+export function runCliStdin(
+  input: string,
+  filepath: string,
+  pipeOrOptions?: string | { cwd?: string; extraArgs?: string[] },
+) {
+  const pipe = typeof pipeOrOptions === "string" ? pipeOrOptions : undefined;
+  const options = typeof pipeOrOptions === "object" ? pipeOrOptions : undefined;
+
   let cmd = `node ${CLI_PATH} --stdin-filepath=${filepath}`;
+
+  if (options?.extraArgs) cmd += ` ${options.extraArgs.join(" ")}`;
+
   if (pipe) cmd += ` | ${pipe}`;
-  return execa({ shell: true, reject: false, input })`${cmd}`;
+
+  return execa({ shell: true, reject: false, input, cwd: options?.cwd })`${cmd}`;
 }
 
 // Test function for running the CLI with various arguments


### PR DESCRIPTION
Resolves #20545 

(on hold, see linked issue)