### PR TITLE
ci: migrate slow runners to namespace.so

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
   benchmark:
     needs: determine-matrix
     if: needs.determine-matrix.outputs.matrix != '[]'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     permissions:
       id-token: write # required for OIDC authentication with CodSpeed
     strategy:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
   benchmark:
     needs: determine-matrix
     if: needs.determine-matrix.outputs.matrix != '[]'
-    runs-on: namespace-profile-linux-x64-default
+    runs-on: ubuntu-latest
     permissions:
       id-token: write # required for OIDC authentication with CodSpeed
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test-ubuntu:
     name: Test Linux
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
@@ -49,7 +49,7 @@ jobs:
   test-mac: # Separate job to save a job on PRs
     if: ${{ github.ref_name == 'main' }}
     name: Test Mac
-    runs-on: macos-latest
+    runs-on: namespace-profile-mac-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
@@ -111,7 +111,7 @@ jobs:
   test-big-endian:
     if: ${{ github.ref_name == 'main' }}
     name: Test big-endian # s390x-unknown-linux-gnu is a big-endian
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
@@ -127,7 +127,7 @@ jobs:
   test-32bit:
     if: ${{ github.ref_name == 'main' }}
     name: Test 32-bit # armv7-unknown-linux-gnueabihf is a 32-bit target
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
@@ -141,7 +141,7 @@ jobs:
 
   test-wasm32-wasip1-threads:
     name: Test wasm32-wasip1-threads
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: ./.github/actions/check-changes
@@ -178,7 +178,7 @@ jobs:
 
   test-napi:
     name: Test NAPI
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: ./.github/actions/check-changes
@@ -273,7 +273,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
@@ -291,7 +291,7 @@ jobs:
 
   conformance:
     name: Conformance
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -326,7 +326,7 @@ jobs:
 
   minification:
     name: Minification Size
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -352,7 +352,7 @@ jobs:
 
   allocs:
     name: Allocations
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: ./.github/actions/check-changes
@@ -378,7 +378,7 @@ jobs:
 
   ast_changes:
     name: AST Changes
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
 
@@ -406,7 +406,7 @@ jobs:
 
   lintgen:
     name: Linter changes
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
       - uses: ./.github/actions/check-changes

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
   coverage:
     if: github.repository == 'oxc-project/oxc'
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - name: Checkout
         uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   miri:
     name: Miri
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     env:
       # FIXME: cargo-miri is broken on nightly-2026-02-12.
       # https://github.com/rust-lang/miri/issues/4855

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ If you are unable to contribute by code, you can still participate by:
 
 Oxc is free and open-source software licensed under the [MIT License](./LICENSE).
 
+Thank you to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.
+
 Oxc ports or copies code from other open source projects, their licenses are listed in [**Third-party library licenses**](./THIRD-PARTY-LICENSE).
 
 [discord-badge]: https://img.shields.io/discord/1079625926024900739?logo=discord&label=Discord


### PR DESCRIPTION
## Summary

- Migrate compute-heavy CI jobs from `ubuntu-latest` to `namespace-profile-linux-x64-default` and `macos-latest` to `namespace-profile-mac-default`
- Affected workflows: `ci.yml`, `benchmark.yml`, `miri.yml`, `codecov.yml`
- Lightweight jobs (`ubuntu-slim`, `windows-latest`) kept as-is
- Add namespace.so acknowledgment to README

🤖 Generated with [Claude Code](https://claude.com/claude-code)