### PR TITLE
ci: remove unnecessary wasm target from NAPI compiler jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,6 @@ jobs:
           RUN_RAW_RANGE_TESTS: "true"
           RUN_RAW_TOKENS_TESTS: "true"
         run: |
-          rustup target add wasm32-wasip1-threads
           pnpm --workspace-concurrency=1 --filter "./napi/parser" --filter "./napi/minify" --filter "./napi/transform" build-test
           pnpm --workspace-concurrency=1 --filter "./napi/parser" --filter "./napi/minify" --filter "./napi/transform" test
       - if: steps.filter.outputs.changed == 'true'
@@ -312,7 +311,6 @@ jobs:
         env:
           RUN_RAW_RANGE_TESTS: "true"
         run: |
-          rustup target add wasm32-wasip1-threads
           pnpm --workspace-concurrency=1 --filter "./napi/parser" --filter "./napi/minify" --filter "./napi/transform" build-test
           pnpm --workspace-concurrency=1 --filter "./napi/parser" --filter "./napi/minify" --filter "./napi/transform" test
       - if: steps.filter.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- Remove `rustup target add wasm32-wasip1-threads` from `test-napi-compiler` and `test-napi-compiler-windows` jobs
- The WASM target is only needed by the `test-wasm32-wasip1-threads` job; NAPI compiler jobs build native modules via `napi build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)