### PR TITLE
ci: build only the needed bench target in benchmark jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,8 +84,7 @@ jobs:
               --no-default-features --features ${{ matrix.feature }} --features codspeed
           else
             cargo build --release -p oxc_benchmark \
-              --bench lexer --bench parser --bench transformer --bench semantic \
-              --bench minifier --bench codegen --bench formatter --bench pipeline \
+              --bench ${{ matrix.component }} \
               --no-default-features --features ${{ matrix.feature }} --features codspeed
           fi
           mkdir -p target/codspeed/analysis/oxc_benchmark


### PR DESCRIPTION
## Summary

- The benchmark matrix already determines which single component to run (e.g. `parser`, `minifier`)
- Previously, non-linter jobs built all 8 bench binaries (`lexer`, `parser`, `transformer`, `semantic`, `minifier`, `codegen`, `formatter`, `pipeline`) and discarded 7 of them
- Now builds only `--bench ${{ matrix.component }}`, saving release-mode link time for 7 unused binaries per matrix job

🤖 Generated with [Claude Code](https://claude.com/claude-code)