### PR TITLE
ci: remove unnecessary setup-node from test-big-endian job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,6 @@ jobs:
     runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
-      - uses: oxc-project/setup-node@8958a8e040102244b619c4a94fccb657a44b1c21 # v1.0.6
       - uses: oxc-project/setup-rust@4f86b5d871ae7d24bc420e578be68964ab09e5cc # v1.0.15
         with:
           save-cache: ${{ github.ref_name == 'main' }}


### PR DESCRIPTION
## Summary

- Remove `setup-node` from the `test-big-endian` job which only runs `cross test` and doesn't need Node.js
- The adjacent `test-32bit` job already correctly omits it

🤖 Generated with [Claude Code](https://claude.com/claude-code)