### PR TITLE
ci: skip `cargo tree` in change detection when no crate files changed

### DIFF
--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -55,6 +55,22 @@ function shouldRunInclude(changedFiles, packages, paths) {
     return false;
   }
 
+  // Check additional trigger paths first (no cargo tree needed)
+  for (const file of changedFiles) {
+    for (const p of paths) {
+      if (file.startsWith(p)) {
+        console.error(`File ${file} matches trigger path ${p} - will run`);
+        return true;
+      }
+    }
+  }
+
+  // If no changed files are in crates/, cargo tree check cannot match — skip it
+  if (!changedFiles.some((file) => file.startsWith("crates/"))) {
+    console.error("No files changed in crates/ - will skip");
+    return false;
+  }
+
   // Resolve transitive dependencies via cargo tree
   let allCrates;
   try {
@@ -71,7 +87,7 @@ function shouldRunInclude(changedFiles, packages, paths) {
     return true;
   }
 
-  return checkFilesAffectCrates(changedFiles, allCrates, paths);
+  return checkFilesAffectCrates(changedFiles, allCrates);
 }
 
 /**

--- a/.github/scripts/check-conformance-changes.js
+++ b/.github/scripts/check-conformance-changes.js
@@ -63,6 +63,12 @@ function shouldRunConformance(changedFiles) {
     }
   }
 
+  // If no changed files are in crates/, cargo tree check cannot match — skip it
+  if (!changedFiles.some((file) => file.startsWith("crates/"))) {
+    console.error("No files changed in crates/ - will skip conformance");
+    return false;
+  }
+
   // Get dependencies
   const dependencies = getCoverageDependencies();
 


### PR DESCRIPTION
## Summary

- Skip the expensive `cargo tree` call (10-39s) in CI change detection scripts when no changed files are in `crates/`
- In `check-changes.js`: check trigger paths first, then early-return if no crate files changed
- In `check-conformance-changes.js`: early-return after `ALWAYS_RUN_PATHS` check if no crate files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)