### PR TITLE
ci: more CI low-hanging fruit optimizations

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.js
+++ b/.github/scripts/generate-benchmark-matrix.js
@@ -64,6 +64,9 @@ function getFeatureForComponent(component) {
   return "compiler";
 }
 
+/** @type {Map<string, string[]>} Cache of cargo tree results keyed by feature */
+const depsCache = new Map();
+
 /**
  * Get dependencies for a specific benchmark component
  * @param {string} component - Component name
@@ -71,6 +74,12 @@ function getFeatureForComponent(component) {
  */
 function getComponentDependencies(component) {
   const feature = getFeatureForComponent(component);
+
+  const cached = depsCache.get(feature);
+  if (cached) {
+    return cached;
+  }
+
   const deps = getCrateDependencies("oxc_benchmark", {
     features: feature,
     noDefaultFeatures: true,
@@ -80,6 +89,7 @@ function getComponentDependencies(component) {
     console.error(`Warning: Could not get dependencies for ${component} (feature: ${feature})`);
   }
 
+  depsCache.set(feature, deps);
   return deps;
 }
 
@@ -107,16 +117,6 @@ function isComponentAffected(component, changedFiles) {
     }
   }
 
-  // Check benchmark and common task files
-  if (
-    changedFiles.some(
-      (file) => file.startsWith("tasks/benchmark/") || file.startsWith("tasks/common/"),
-    )
-  ) {
-    console.error(`  Component ${component} affected by benchmark/common file changes`);
-    return true;
-  }
-
   return false;
 }
 
@@ -142,6 +142,25 @@ async function determineAffectedComponents() {
       component,
       feature: getFeatureForComponent(component),
     }));
+  }
+
+  // Check benchmark and common task files - affects all components
+  if (
+    changedFiles.some(
+      (file) => file.startsWith("tasks/benchmark/") || file.startsWith("tasks/common/"),
+    )
+  ) {
+    console.error("Benchmark/common task files changed - will run all benchmarks");
+    return ALL_COMPONENTS.map((component) => ({
+      component,
+      feature: getFeatureForComponent(component),
+    }));
+  }
+
+  // If no crate files changed, no benchmarks need to run
+  if (!changedFiles.some((file) => file.startsWith("crates/"))) {
+    console.error("No crate files changed - skipping cargo tree and all benchmarks");
+    return [];
   }
 
   // Check each component individually

--- a/.github/scripts/get-changed-files.js
+++ b/.github/scripts/get-changed-files.js
@@ -49,6 +49,30 @@ function githubApi(path) {
 }
 
 /**
+ * Get all changed files for a PR, paginating through all pages
+ * @param {string} repository - Repository name (owner/repo)
+ * @param {string} prNumber - Pull request number
+ * @returns {Promise<string[]>} Array of changed file paths
+ */
+async function getPrChangedFiles(repository, prNumber) {
+  const perPage = 100;
+  const files = [];
+  let page = 1;
+  let prFiles;
+  do {
+    // oxlint-disable-next-line no-await-in-loop -- sequential pagination requires await in loop
+    prFiles = await githubApi(
+      `/repos/${repository}/pulls/${prNumber}/files?per_page=${perPage}&page=${page}`,
+    );
+    for (const f of prFiles) {
+      files.push(f.filename);
+    }
+    page++;
+  } while (prFiles.length >= perPage);
+  return files;
+}
+
+/**
  * Get changed files based on the GitHub event type
  * @returns {Promise<string[] | null>} Array of changed file paths, or null to signal "run all"
  */
@@ -75,20 +99,7 @@ async function getChangedFiles() {
     if (eventName === "pull_request" && prNumber) {
       // For PR, use GitHub API to get changed files (paginated)
       console.error(`Getting changed files for PR #${prNumber}`);
-      const perPage = 100;
-      let page = 1;
-      while (true) {
-        const prFiles = await githubApi(
-          `/repos/${repository}/pulls/${prNumber}/files?per_page=${perPage}&page=${page}`,
-        );
-        for (const f of prFiles) {
-          files.push(f.filename);
-        }
-        if (prFiles.length < perPage) {
-          break;
-        }
-        page++;
-      }
+      files = await getPrChangedFiles(repository, prNumber);
     } else if (sha && repository) {
       // For push to main, get the commit and compare with parent
       console.error(`Getting changed files for commit ${sha}`);

--- a/.github/scripts/get-changed-files.js
+++ b/.github/scripts/get-changed-files.js
@@ -73,10 +73,22 @@ async function getChangedFiles() {
 
   try {
     if (eventName === "pull_request" && prNumber) {
-      // For PR, use GitHub API to get changed files
+      // For PR, use GitHub API to get changed files (paginated)
       console.error(`Getting changed files for PR #${prNumber}`);
-      const prFiles = await githubApi(`/repos/${repository}/pulls/${prNumber}/files?per_page=100`);
-      files = prFiles.map((f) => f.filename);
+      const perPage = 100;
+      let page = 1;
+      while (true) {
+        const prFiles = await githubApi(
+          `/repos/${repository}/pulls/${prNumber}/files?per_page=${perPage}&page=${page}`,
+        );
+        for (const f of prFiles) {
+          files.push(f.filename);
+        }
+        if (prFiles.length < perPage) {
+          break;
+        }
+        page++;
+      }
     } else if (sha && repository) {
       // For push to main, get the commit and compare with parent
       console.error(`Getting changed files for commit ${sha}`);

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -7,9 +7,6 @@ on:
     types: [opened, synchronize]
     branches-ignore:
       - "**/graphite-base/**"
-    paths-ignore:
-      - "!.github/workflows/ci.yml"
-      - "!.github/actions/clone-submodules/action.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,6 @@ jobs:
         id: filter
         with:
           packages: oxc_minsize
-          paths: .github/workflows/ci.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 
@@ -502,7 +501,6 @@ jobs:
         id: filter
         with:
           packages: oxc_track_memory_allocations
-          paths: .github/workflows/ci.yml
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 
@@ -556,7 +554,7 @@ jobs:
         id: filter
         with:
           packages: oxc_linter
-          paths: tasks/linter_codegen/,.github/workflows/ci.yml
+          paths: tasks/linter_codegen/
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary

- Cache `cargo tree` results by feature in benchmark matrix script — only 2 unique features exist (`compiler` and `linter`) but 9 components call it, so 7 calls were redundant (9 → 2)
- Skip `cargo tree` entirely when no `crates/` files changed in benchmark matrix (same pattern as #20559)
- Move `tasks/benchmark/` and `tasks/common/` check earlier in `determineAffectedComponents()` for early return before any `cargo tree` calls
- Add GitHub API pagination for PR changed files — PRs with >100 files were silently truncated, potentially skipping jobs incorrectly
- Remove `.github/workflows/ci.yml` from `paths:` trigger in `minification`, `allocs`, and `lintgen` jobs — these ran unnecessarily on every CI-only PR since the `--packages` check already gates them
- Remove dead `paths-ignore` block in `autofix.yml` — GitHub Actions doesn't support `!` negation in `paths-ignore`, so the patterns were treated as literals and never matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)