### PR TITLE
fix(formatter,oxfmt): Remove redundant space after soft_line_break_or_space

### DIFF
--- a/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/issue-20548.vue
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/js-in-vue/issue-20548.vue
@@ -1,0 +1,10 @@
+<script lang="ts">
+  // Arrow function chain: SoftOrSpace -> StartGroup -> Space
+  const fn = (a: string) => (b: number) => { return b }
+
+  // Interface extends member expression: SoftOrSpace -> StartGroup -> Space
+  interface Foo extends Bar.Baz { x: number; y: string; z: boolean; aaa: number; bbb: string; }
+
+  // Class extends member expression: SoftOrSpace -> StartGroup -> Space
+  class Foo extends Bar.Baz { x: number = 1; y: string = "hello"; z: boolean = true; aaa: number = 2; bbb: string = "world"; }
+</script>

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -1,6 +1,6 @@
 ## js-in-vue
 
-### Option 1: 423/425 (99.53%)
+### Option 1: 424/426 (99.53%)
 
 ```json
 {"printWidth":80}
@@ -11,7 +11,7 @@
 | [effects/common-ui/src/components/api-component/api-component.vue](diffs/js-in-vue/effects__common-ui__src__components__api-component__api-component.vue.md) | `<T = any,>() => {}` comma in generic param is removed even in .ts(x) file |
 | [vue/multiparser/lang-tsx.vue](diffs/js-in-vue/vue__multiparser__lang-tsx.vue.md) | `lang=tsx` is not supported |
 
-### Option 2: 423/425 (99.53%)
+### Option 2: 424/426 (99.53%)
 
 ```json
 {"printWidth":100,"vueIndentScriptAndStyle":true,"singleQuote":true}

--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -678,7 +678,6 @@ fn format_signature<'a, 'b>(
     format_with(move |f| {
         let content = format_with(|f| {
             group(&format_args!(
-                maybe_space(!is_first_in_chain),
                 arrow.r#async().then_some("async "),
                 arrow.type_parameters(),
                 arrow.params(),
@@ -693,6 +692,7 @@ fn format_signature<'a, 'b>(
             if is_first_in_chain {
                 write!(f, format_head);
             } else {
+                write!(f, [space()]);
                 let mut buffer = RemoveSoftLinesBuffer::new(f);
                 write!(buffer, format_head);
             }

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -385,12 +385,12 @@ impl<'a> Format<'a> for FormatClass<'a, '_> {
                 });
 
                 let format_extends =
-                    format_with(|f| write!(f, [space(), "extends", space(), &format_super]));
+                    format_with(|f| write!(f, ["extends", space(), &format_super]));
 
                 if group_mode {
                     write!(f, [soft_line_break_or_space(), group(&format_extends)]);
                 } else {
-                    write!(f, format_extends);
+                    write!(f, [space(), format_extends]);
                 }
             }
 

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1392,12 +1392,11 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSInterfaceDeclaration<'a>> {
                     ]
                 );
             } else {
-                let format_extends =
-                    format_with(|f| write!(f, [space(), "extends", space(), extends]));
+                let format_extends = format_with(|f| write!(f, ["extends", space(), extends]));
                 if group_mode {
                     write!(f, [soft_line_break_or_space(), group(&format_extends)]);
                 } else {
-                    write!(f, format_extends);
+                    write!(f, [space(), format_extends]);
                 }
             }
 


### PR DESCRIPTION
Fixes #20548

Remove redundant `Space` elements that immediately followed `soft_line_break_or_space()` in three places:

- Arrow function chain signatures
- `class ... extends` with member expressions
- `interface ... extends` with member expressions

This, in turn, fixes the js-in-vue issue.

---

The root cause is that `to_prettier_doc` cannot fully replicate the oxc_formatter printer's runtime behavior (e.g. deduplication of spaces).

While this commit fixes the three identified IR-level issues, there are other known divergences between the printer and `to_prettier_doc` (e.g. `Space` → `StartTag` → `Space` patterns around comments) that will be addressed separately...

TL;DR, converting between Prettier Doc and oxc_formatter IR doesn't seem to be straightforward after all. 🥲
