### PR TITLE
refactor(estree): simplify ESTree converter for `VariableDeclarator`

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -1585,33 +1585,35 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let previousParent = parent,
-    variableDeclarator = (parent = {
+  let start,
+    end,
+    previousParent = parent,
+    node = (parent = {
       __proto__: NodeProto,
       type: "VariableDeclarator",
       id: null,
       init: null,
-      definite: false,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      range: [deserializeU32(pos), deserializeU32(pos + 4)],
-      parent: previousParent,
-    });
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
+      definite: deserializeBool(pos + 53),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
+      range: [start, end],
+      parent,
+    }),
+    pattern = deserializeBindingPattern(pos + 8);
   {
-    parent = variableDeclarator.id;
+    let previousParent = parent;
+    parent = pattern;
     let typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-    variableDeclarator.id.typeAnnotation = typeAnnotation;
     if (typeAnnotation !== null) {
-      variableDeclarator.id.end = typeAnnotation.end;
-      variableDeclarator.id.range[1] = typeAnnotation.end;
+      pattern.typeAnnotation = typeAnnotation;
+      pattern.range[1] = pattern.end = typeAnnotation.end;
     }
-    parent = variableDeclarator;
-    variableDeclarator.definite = deserializeBool(pos + 53);
+    parent = previousParent;
   }
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
+  node.id = pattern;
+  node.init = deserializeOptionExpression(pos + 32);
   parent = previousParent;
-  return variableDeclarator;
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1268,12 +1268,12 @@ pub enum VariableDeclarationKind {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
-#[estree(via = VariableDeclaratorConverter)]
 pub struct VariableDeclarator<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
     #[estree(skip)]
     pub kind: VariableDeclarationKind,
+    #[estree(via = VariableDeclaratorId)]
     pub id: BindingPattern<'a>,
     #[ts]
     #[estree(skip)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -890,7 +890,13 @@ impl ESTree for VariableDeclarationKind {
 
 impl ESTree for VariableDeclarator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::js::VariableDeclaratorConverter(self).serialize(serializer)
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("VariableDeclarator"));
+        state.serialize_field("id", &crate::serialize::js::VariableDeclaratorId(self));
+        state.serialize_field("init", &self.init);
+        state.serialize_ts_field("definite", &self.definite);
+        state.serialize_span(self.span);
+        state.end();
     }
 }
 

--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -9,57 +9,6 @@ use crate::ast::*;
 
 use super::{EmptyArray, Null};
 
-#[ast_meta]
-#[estree(raw_deser = "
-        const previousParent = parent;
-        const variableDeclarator = parent = {
-            type: 'VariableDeclarator',
-            id: null,
-            init: null,
-            ...(IS_TS && { definite: false }),
-            start: DESER[u32]( POS_OFFSET.span.start ),
-            end: DESER[u32]( POS_OFFSET.span.end ),
-            ...(RANGE && { range: [DESER[u32]( POS_OFFSET.span.start ), DESER[u32]( POS_OFFSET.span.end )] }),
-            ...(PARENT && { parent: previousParent }),
-        };
-        variableDeclarator.id = DESER[BindingPattern](POS_OFFSET.id);
-        if (IS_TS) {
-            if (PARENT) parent = variableDeclarator.id;
-            const typeAnnotation = DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.type_annotation);
-            variableDeclarator.id.typeAnnotation = typeAnnotation;
-            if (typeAnnotation !== null) {
-                variableDeclarator.id.end = typeAnnotation.end;
-                if (RANGE) variableDeclarator.id.range[1] = typeAnnotation.end;
-            }
-            if (PARENT) parent = variableDeclarator;
-            variableDeclarator.definite = DESER[bool](POS_OFFSET.definite);
-        }
-        variableDeclarator.init = DESER[Option<Expression>](POS_OFFSET.init);
-        if (PARENT) parent = previousParent;
-        variableDeclarator
-    ")]
-pub struct VariableDeclaratorConverter<'a, 'b>(pub &'b VariableDeclarator<'a>);
-
-impl ESTree for VariableDeclaratorConverter<'_, '_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "VariableDeclarator");
-        state.serialize_field(
-            "id",
-            &BindingPatternKindAndTsFields {
-                kind: &self.0.id,
-                decorators: Some(&[]),
-                optional: false,
-                type_annotation: self.0.type_annotation.as_deref(),
-                override_span: None,
-            },
-        );
-        state.serialize_field("init", &self.0.init);
-        state.serialize_ts_field("definite", &self.0.definite);
-        state.serialize_span(self.0.span);
-        state.end();
-    }
-}
 // ----------------------------------------
 // Binding patterns and function params
 // ----------------------------------------
@@ -134,6 +83,46 @@ impl ESTree for BindingPatternKindAndTsFields<'_, '_> {
         state.serialize_span(span);
 
         state.end();
+    }
+}
+
+/// Converter for `id` field of [`VariableDeclarator`].
+///
+/// Merges `type_annotation` from the parent into the binding pattern.
+#[ast_meta]
+#[estree(
+    ts_type = "BindingPattern",
+    raw_deser = "
+        const pattern = DESER[BindingPattern](POS_OFFSET.id);
+        if (IS_TS) {
+            const previousParent = parent;
+            if (PARENT) parent = pattern;
+            const typeAnnotation = DESER[Option<Box<TSTypeAnnotation>>](POS_OFFSET.type_annotation);
+            if (typeAnnotation !== null) {
+                pattern.typeAnnotation = typeAnnotation;
+                if (RANGE) {
+                    pattern.range[1] = pattern.end = typeAnnotation.end;
+                } else {
+                    pattern.end = typeAnnotation.end;
+                }
+            }
+            if (PARENT) parent = previousParent;
+        }
+        pattern
+    "
+)]
+pub struct VariableDeclaratorId<'a, 'b>(pub &'b VariableDeclarator<'a>);
+
+impl ESTree for VariableDeclaratorId<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        BindingPatternKindAndTsFields {
+            kind: &self.0.id,
+            decorators: Some(&[]),
+            optional: false,
+            type_annotation: self.0.type_annotation.as_deref(),
+            override_span: None,
+        }
+        .serialize(serializer);
     }
 }
 

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -1218,16 +1218,16 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let variableDeclarator = {
+  let node = {
     type: "VariableDeclarator",
     id: null,
     init: null,
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
-  return variableDeclarator;
+  node.id = deserializeBindingPattern(pos + 8);
+  node.init = deserializeOptionExpression(pos + 32);
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -1351,18 +1351,18 @@ function deserializeVariableDeclarationKind(pos) {
 
 function deserializeVariableDeclarator(pos) {
   let previousParent = parent,
-    variableDeclarator = (parent = {
+    node = (parent = {
       type: "VariableDeclarator",
       id: null,
       init: null,
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
-      parent: previousParent,
+      parent,
     });
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
+  node.id = deserializeBindingPattern(pos + 8);
+  node.init = deserializeOptionExpression(pos + 32);
   parent = previousParent;
-  return variableDeclarator;
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -1333,17 +1333,19 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let variableDeclarator = {
-    type: "VariableDeclarator",
-    id: null,
-    init: null,
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    range: [deserializeU32(pos), deserializeU32(pos + 4)],
-  };
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
-  return variableDeclarator;
+  let start,
+    end,
+    node = {
+      type: "VariableDeclarator",
+      id: null,
+      init: null,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
+      range: [start, end],
+    };
+  node.id = deserializeBindingPattern(pos + 8);
+  node.init = deserializeOptionExpression(pos + 32);
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -1468,20 +1468,22 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let previousParent = parent,
-    variableDeclarator = (parent = {
+  let start,
+    end,
+    previousParent = parent,
+    node = (parent = {
       type: "VariableDeclarator",
       id: null,
       init: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      range: [deserializeU32(pos), deserializeU32(pos + 4)],
-      parent: previousParent,
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
+      range: [start, end],
+      parent,
     });
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
+  node.id = deserializeBindingPattern(pos + 8);
+  node.init = deserializeOptionExpression(pos + 32);
   parent = previousParent;
-  return variableDeclarator;
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -1301,23 +1301,25 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let variableDeclarator = {
-    type: "VariableDeclarator",
-    id: null,
-    init: null,
-    definite: false,
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-  };
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
+  let node = {
+      type: "VariableDeclarator",
+      id: null,
+      init: null,
+      definite: deserializeBool(pos + 53),
+      start: deserializeU32(pos),
+      end: deserializeU32(pos + 4),
+    },
+    pattern = deserializeBindingPattern(pos + 8);
   {
     let typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-    variableDeclarator.id.typeAnnotation = typeAnnotation;
-    typeAnnotation !== null && (variableDeclarator.id.end = typeAnnotation.end);
-    variableDeclarator.definite = deserializeBool(pos + 53);
+    if (typeAnnotation !== null) {
+      pattern.typeAnnotation = typeAnnotation;
+      pattern.end = typeAnnotation.end;
+    }
   }
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
-  return variableDeclarator;
+  node.id = pattern;
+  node.init = deserializeOptionExpression(pos + 32);
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -1430,27 +1430,30 @@ function deserializeVariableDeclarationKind(pos) {
 
 function deserializeVariableDeclarator(pos) {
   let previousParent = parent,
-    variableDeclarator = (parent = {
+    node = (parent = {
       type: "VariableDeclarator",
       id: null,
       init: null,
-      definite: false,
+      definite: deserializeBool(pos + 53),
       start: deserializeU32(pos),
       end: deserializeU32(pos + 4),
-      parent: previousParent,
-    });
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
+      parent,
+    }),
+    pattern = deserializeBindingPattern(pos + 8);
   {
-    parent = variableDeclarator.id;
+    let previousParent = parent;
+    parent = pattern;
     let typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-    variableDeclarator.id.typeAnnotation = typeAnnotation;
-    typeAnnotation !== null && (variableDeclarator.id.end = typeAnnotation.end);
-    parent = variableDeclarator;
-    variableDeclarator.definite = deserializeBool(pos + 53);
+    if (typeAnnotation !== null) {
+      pattern.typeAnnotation = typeAnnotation;
+      pattern.end = typeAnnotation.end;
+    }
+    parent = previousParent;
   }
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
+  node.id = pattern;
+  node.init = deserializeOptionExpression(pos + 32);
   parent = previousParent;
-  return variableDeclarator;
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -1420,27 +1420,28 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let variableDeclarator = {
-    type: "VariableDeclarator",
-    id: null,
-    init: null,
-    definite: false,
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    range: [deserializeU32(pos), deserializeU32(pos + 4)],
-  };
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
+  let start,
+    end,
+    node = {
+      type: "VariableDeclarator",
+      id: null,
+      init: null,
+      definite: deserializeBool(pos + 53),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
+      range: [start, end],
+    },
+    pattern = deserializeBindingPattern(pos + 8);
   {
     let typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-    variableDeclarator.id.typeAnnotation = typeAnnotation;
     if (typeAnnotation !== null) {
-      variableDeclarator.id.end = typeAnnotation.end;
-      variableDeclarator.id.range[1] = typeAnnotation.end;
+      pattern.typeAnnotation = typeAnnotation;
+      pattern.range[1] = pattern.end = typeAnnotation.end;
     }
-    variableDeclarator.definite = deserializeBool(pos + 53);
   }
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
-  return variableDeclarator;
+  node.id = pattern;
+  node.init = deserializeOptionExpression(pos + 32);
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -1547,32 +1547,34 @@ function deserializeVariableDeclarationKind(pos) {
 }
 
 function deserializeVariableDeclarator(pos) {
-  let previousParent = parent,
-    variableDeclarator = (parent = {
+  let start,
+    end,
+    previousParent = parent,
+    node = (parent = {
       type: "VariableDeclarator",
       id: null,
       init: null,
-      definite: false,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
-      range: [deserializeU32(pos), deserializeU32(pos + 4)],
-      parent: previousParent,
-    });
-  variableDeclarator.id = deserializeBindingPattern(pos + 8);
+      definite: deserializeBool(pos + 53),
+      start: (start = deserializeU32(pos)),
+      end: (end = deserializeU32(pos + 4)),
+      range: [start, end],
+      parent,
+    }),
+    pattern = deserializeBindingPattern(pos + 8);
   {
-    parent = variableDeclarator.id;
+    let previousParent = parent;
+    parent = pattern;
     let typeAnnotation = deserializeOptionBoxTSTypeAnnotation(pos + 24);
-    variableDeclarator.id.typeAnnotation = typeAnnotation;
     if (typeAnnotation !== null) {
-      variableDeclarator.id.end = typeAnnotation.end;
-      variableDeclarator.id.range[1] = typeAnnotation.end;
+      pattern.typeAnnotation = typeAnnotation;
+      pattern.range[1] = pattern.end = typeAnnotation.end;
     }
-    parent = variableDeclarator;
-    variableDeclarator.definite = deserializeBool(pos + 53);
+    parent = previousParent;
   }
-  variableDeclarator.init = deserializeOptionExpression(pos + 32);
+  node.id = pattern;
+  node.init = deserializeOptionExpression(pos + 32);
   parent = previousParent;
-  return variableDeclarator;
+  return node;
 }
 
 function deserializeEmptyStatement(pos) {


### PR DESCRIPTION
Belated follow-on after #15925.

`VariableDeclarator` doesn't need a whole-struct ESTree converter. Switch to a converter just for the `id` field, to reduce custom conversion code.

