### PR TITLE
fix(ast_tools): remove `NonMax32` primitive

### DIFF
--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -255,7 +255,6 @@ impl<'c> Parser<'c> {
             "&str" => primitive("&str"),
             "Atom" => primitive("Atom"),
             "Ident" => primitive("Ident"),
-            "NonMaxU32" => primitive("NonMaxU32"),
             "NodeId" => primitive("NodeId"),
             // TODO: Remove the need for this by adding
             // `#[cfg_attr(target_pointer_width = "64", repr(align(8)))]` to all AST types


### PR DESCRIPTION
Remove `NonMax32` from list of primitive types in `ast_tools`. It's not a primitive - there already exists a "foreign" struct in `oxc_syntax` crate which informs `ast_tools` of this type's layout:

https://github.com/oxc-project/oxc/blob/d176eccdbf1b69a76747a8568beee6da652270fa/crates/oxc_syntax/src/lib.rs#L35-L38
