### PR TITLE
perf(ast): mark `AstKind::span` as `#[inline]`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -822,6 +822,9 @@ impl AstKind<'_> {
 }
 
 impl GetSpan for AstKind<'_> {
+    /// Get [`Span`] of an [`AstKind`].
+    // `span` field is in consistent position in all AST structs, so this boils down to 1 instruction.
+    #[inline]
     fn span(&self) -> Span {
         match self {
             Self::Program(it) => it.span(),

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -211,6 +211,10 @@ impl Generator for AstKindGenerator {
 
             ///@@line_break
             impl GetSpan for AstKind<'_> {
+                ///@@line_break
+                /// Get [`Span`] of an [`AstKind`].
+                ///@ `span` field is in consistent position in all AST structs, so this boils down to 1 instruction.
+                #[inline]
                 fn span(&self) -> Span {
                     match self {
                         #span_match_arms


### PR DESCRIPTION
Now that `AstKind`'s variants are all structs (no enums any more), and #20584 has ensured that `Span` is in a consistent position in all structs, `AstKind::span` should boil down to a single operation - a pointer read. Therefore, mark it `#[inline]`.

Note: `Span` was already in a consistent position prior to #20584, but that was more by accident than anything else. Now it's guaranteed. But this change won't make a difference to perf, it just guards against a perf regression in future.