### PR TITLE
fix(linter): add help text to diagnostics missing it

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`").with_help("Use `void 0` if you need the `undefined` value, or remove the reference entirely.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -16,7 +16,7 @@ use crate::{
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
-        .with_label(span)
+        .with_help("Replace the `parseInt()` call with the equivalent numeric literal (e.g. `0xFF`, `0o77`, `0b1010`).").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -11,7 +11,7 @@ use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule}
 fn prefer_object_has_own_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`."
-    ).with_label(span)
+    ).with_help("Use `Object.hasOwn(obj, prop)` instead.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -24,11 +24,12 @@ fn unexpected_syntax_order_diagnostic(
     span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Expected '{curr_kind}' syntax before '{prev_kind}' syntax."))
+        .with_help("Reorder your import statements so that import kinds appear in the expected order.")
         .with_label(span)
 }
 
 fn sort_imports_alphabetically_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span)
+    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_help("Sort import declarations alphabetically by their source module.")..with_label(span)
 }
 
 fn sort_members_alphabetically_diagnostic(name: &str, span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -58,7 +58,7 @@ impl Default for SortKeysOptions {
 pub struct SortKeysConfig(SortOrder, SortKeysOptions);
 
 fn sort_properties_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Object keys should be sorted").with_label(span)
+    OxcDiagnostic::warn("Object keys should be sorted").with_help("Reorder object keys to be sorted alphabetically.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -9,16 +9,15 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule, utils::BUILT_IN_ERRORS};
 
 fn missing_message(ctor_name: &str, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Pass a message to the {ctor_name:1} constructor."))
-        .with_label(span)
+    OxcDiagnostic::warn(format!("Pass a message to the {ctor_name:1} constructor.")).with_help("Provide a descriptive error message as the first argument.").with_label(span)
 }
 
 fn empty_message(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should not be an empty string.").with_label(span)
+    OxcDiagnostic::warn("Error message should not be an empty string.").with_help("Provide a meaningful, non-empty error message.").with_label(span)
 }
 
 fn not_string(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Error message should be a string.").with_label(span)
+    OxcDiagnostic::warn("Error message should be a string.").with_help("Pass a string literal or string variable as the error message.").with_label(span)
 }
 
 #[derive(Default, Debug, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -6,8 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_static_only_class_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Use an object instead of a `class` with only `static` members.")
-        .with_label(span)
+    OxcDiagnostic::warn("Use an object instead of a `class` with only `static` members.").with_help("Replace the class with a plain object or individual named exports.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 fn no_typeof_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.")
+    OxcDiagnostic::warn("Compare with `undefined` directly instead of using `typeof`.").with_help("Use `x === undefined` instead of `typeof x === \"undefined\"`.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -7,7 +7,7 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_unreadable_array_destructuring_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Array destructuring may not contain consecutive ignored values.")
+    OxcDiagnostic::warn("Array destructuring may not contain consecutive ignored values.").with_help("Use a single `.slice()` or index access instead of skipping multiple elements.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -6,7 +6,7 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_add_event_listener_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.")
+    OxcDiagnostic::warn("Prefer `addEventListener()` over their `on`-function counterparts.").with_help("Use `addEventListener(event, handler)` instead of assigning to `on<event>` properties.")
         .with_label(span)
 }
 


### PR DESCRIPTION
Adds .with_help() to 13 diagnostics across 10 rule files that were only producing a message without actionable guidance.

**eslint rules:**
- \
o_undefined\
- \prefer_numeric_literals\
- \prefer_object_has_own\
- \sort_imports\ (3 diagnostics)
- \sort_keys\

**unicorn rules:**
- \rror_message\ (3 diagnostics)
- \
o_static_only_class\
- \
o_typeof_undefined\
- \
o_unreadable_array_destructuring\
- \prefer_add_event_listener\

Each help message gives users a concrete action to resolve the diagnostic.

Partially addresses #19121.