### PR TITLE
ci: skip `node-compat-table` submodule clone in NAPI compiler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           babel: false
           prettier: false
+          node-compat-table: false
       - if: steps.filter.outputs.changed == 'true'
         name: Run tests
         env:
@@ -304,6 +305,7 @@ jobs:
         with:
           babel: false
           prettier: false
+          node-compat-table: false
       - if: steps.filter.outputs.changed == 'true'
         name: Run tests
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
@@ -447,6 +449,8 @@ jobs:
 
       - uses: ./.github/actions/clone-submodules
         if: steps.filter.outputs.changed == 'true'
+        with:
+          node-compat-table: false
 
       - uses: oxc-project/setup-node@b8d296d30eafd1ae2968fab67aead472a1dbf6d4 # v1.0.7
         if: steps.filter.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- NAPI compiler tests don't reference `node-compat-table`, but both Linux and Windows jobs were cloning it
- Add `node-compat-table: false` to the `clone-submodules` step in `test-napi-compiler` and `test-napi-compiler-windows` jobs
- Saves ~5-15s per CI run (more on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)