### PR TITLE
feat(linter/eslint): implement `no-restricted-exports` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -205,6 +205,11 @@ impl RuleRunner for crate::rules::import::unambiguous::Unambiguous {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::eslint::no_restricted_exports::NoRestrictedExports {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::eslint::accessor_pairs::AccessorPairs {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -205,11 +205,6 @@ impl RuleRunner for crate::rules::import::unambiguous::Unambiguous {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
-impl RuleRunner for crate::rules::eslint::no_restricted_exports::NoRestrictedExports {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::eslint::accessor_pairs::AccessorPairs {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,
@@ -895,6 +890,15 @@ impl RuleRunner for crate::rules::eslint::no_regex_spaces::NoRegexSpaces {
         AstType::CallExpression,
         AstType::NewExpression,
         AstType::RegExpLiteral,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::eslint::no_restricted_exports::NoRestrictedExports {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ExportAllDeclaration,
+        AstType::ExportDefaultDeclaration,
+        AstType::ExportNamedDeclaration,
     ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -764,7 +764,6 @@ pub enum RuleEnum {
     ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax),
     ImportPreferDefaultExport(ImportPreferDefaultExport),
     ImportUnambiguous(ImportUnambiguous),
-    EslintNoRestrictedExports(EslintNoRestrictedExports),
     EslintAccessorPairs(EslintAccessorPairs),
     EslintArrayCallbackReturn(EslintArrayCallbackReturn),
     EslintArrowBodyStyle(EslintArrowBodyStyle),
@@ -868,6 +867,7 @@ pub enum RuleEnum {
     EslintNoPrototypeBuiltins(EslintNoPrototypeBuiltins),
     EslintNoRedeclare(EslintNoRedeclare),
     EslintNoRegexSpaces(EslintNoRegexSpaces),
+    EslintNoRestrictedExports(EslintNoRestrictedExports),
     EslintNoRestrictedGlobals(EslintNoRestrictedGlobals),
     EslintNoRestrictedImports(EslintNoRestrictedImports),
     EslintNoReturnAssign(EslintNoReturnAssign),
@@ -1484,8 +1484,7 @@ const IMPORT_NO_UNASSIGNED_IMPORT_ID: usize = IMPORT_NO_SELF_IMPORT_ID + 1usize;
 const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
 const IMPORT_PREFER_DEFAULT_EXPORT_ID: usize = IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID + 1usize;
 const IMPORT_UNAMBIGUOUS_ID: usize = IMPORT_PREFER_DEFAULT_EXPORT_ID + 1usize;
-const ESLINT_NO_RESTRICTED_EXPORTS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
-const ESLINT_ACCESSOR_PAIRS_ID: usize = ESLINT_NO_RESTRICTED_EXPORTS_ID + 1usize;
+const ESLINT_ACCESSOR_PAIRS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
 const ESLINT_ARRAY_CALLBACK_RETURN_ID: usize = ESLINT_ACCESSOR_PAIRS_ID + 1usize;
 const ESLINT_ARROW_BODY_STYLE_ID: usize = ESLINT_ARRAY_CALLBACK_RETURN_ID + 1usize;
 const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
@@ -1588,7 +1587,8 @@ const ESLINT_NO_PROTO_ID: usize = ESLINT_NO_PROMISE_EXECUTOR_RETURN_ID + 1usize;
 const ESLINT_NO_PROTOTYPE_BUILTINS_ID: usize = ESLINT_NO_PROTO_ID + 1usize;
 const ESLINT_NO_REDECLARE_ID: usize = ESLINT_NO_PROTOTYPE_BUILTINS_ID + 1usize;
 const ESLINT_NO_REGEX_SPACES_ID: usize = ESLINT_NO_REDECLARE_ID + 1usize;
-const ESLINT_NO_RESTRICTED_GLOBALS_ID: usize = ESLINT_NO_REGEX_SPACES_ID + 1usize;
+const ESLINT_NO_RESTRICTED_EXPORTS_ID: usize = ESLINT_NO_REGEX_SPACES_ID + 1usize;
+const ESLINT_NO_RESTRICTED_GLOBALS_ID: usize = ESLINT_NO_RESTRICTED_EXPORTS_ID + 1usize;
 const ESLINT_NO_RESTRICTED_IMPORTS_ID: usize = ESLINT_NO_RESTRICTED_GLOBALS_ID + 1usize;
 const ESLINT_NO_RETURN_ASSIGN_ID: usize = ESLINT_NO_RESTRICTED_IMPORTS_ID + 1usize;
 const ESLINT_NO_SCRIPT_URL_ID: usize = ESLINT_NO_RETURN_ASSIGN_ID + 1usize;
@@ -2291,7 +2291,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID,
             Self::ImportPreferDefaultExport(_) => IMPORT_PREFER_DEFAULT_EXPORT_ID,
             Self::ImportUnambiguous(_) => IMPORT_UNAMBIGUOUS_ID,
-            Self::EslintNoRestrictedExports(_) => ESLINT_NO_RESTRICTED_EXPORTS_ID,
             Self::EslintAccessorPairs(_) => ESLINT_ACCESSOR_PAIRS_ID,
             Self::EslintArrayCallbackReturn(_) => ESLINT_ARRAY_CALLBACK_RETURN_ID,
             Self::EslintArrowBodyStyle(_) => ESLINT_ARROW_BODY_STYLE_ID,
@@ -2395,6 +2394,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => ESLINT_NO_PROTOTYPE_BUILTINS_ID,
             Self::EslintNoRedeclare(_) => ESLINT_NO_REDECLARE_ID,
             Self::EslintNoRegexSpaces(_) => ESLINT_NO_REGEX_SPACES_ID,
+            Self::EslintNoRestrictedExports(_) => ESLINT_NO_RESTRICTED_EXPORTS_ID,
             Self::EslintNoRestrictedGlobals(_) => ESLINT_NO_RESTRICTED_GLOBALS_ID,
             Self::EslintNoRestrictedImports(_) => ESLINT_NO_RESTRICTED_IMPORTS_ID,
             Self::EslintNoReturnAssign(_) => ESLINT_NO_RETURN_ASSIGN_ID,
@@ -3118,7 +3118,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::NAME,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::NAME,
             Self::ImportUnambiguous(_) => ImportUnambiguous::NAME,
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::NAME,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::NAME,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::NAME,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::NAME,
@@ -3222,6 +3221,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::NAME,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::NAME,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::NAME,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::NAME,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::NAME,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::NAME,
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::NAME,
@@ -3935,7 +3935,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::CATEGORY,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::CATEGORY,
             Self::ImportUnambiguous(_) => ImportUnambiguous::CATEGORY,
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::CATEGORY,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::CATEGORY,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::CATEGORY,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::CATEGORY,
@@ -4039,6 +4038,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::CATEGORY,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::CATEGORY,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::CATEGORY,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::CATEGORY,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::CATEGORY,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::CATEGORY,
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::CATEGORY,
@@ -4801,7 +4801,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::FIX,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::FIX,
             Self::ImportUnambiguous(_) => ImportUnambiguous::FIX,
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::FIX,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::FIX,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::FIX,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::FIX,
@@ -4905,6 +4904,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::FIX,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::FIX,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::FIX,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::FIX,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::FIX,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::FIX,
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::FIX,
@@ -5623,7 +5623,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::documentation(),
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::documentation(),
             Self::ImportUnambiguous(_) => ImportUnambiguous::documentation(),
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::documentation(),
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::documentation(),
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::documentation(),
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::documentation(),
@@ -5737,6 +5736,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::documentation(),
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::documentation(),
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::documentation(),
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::documentation(),
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::documentation(),
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::documentation(),
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::documentation(),
@@ -6700,10 +6700,6 @@ impl RuleEnum {
             }
             Self::ImportUnambiguous(_) => ImportUnambiguous::config_schema(generator)
                 .or_else(|| ImportUnambiguous::schema(generator)),
-            Self::EslintNoRestrictedExports(_) => {
-                EslintNoRestrictedExports::config_schema(generator)
-                    .or_else(|| EslintNoRestrictedExports::schema(generator))
-            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::config_schema(generator)
                 .or_else(|| EslintAccessorPairs::schema(generator)),
             Self::EslintArrayCallbackReturn(_) => {
@@ -6954,6 +6950,10 @@ impl RuleEnum {
                 .or_else(|| EslintNoRedeclare::schema(generator)),
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::config_schema(generator)
                 .or_else(|| EslintNoRegexSpaces::schema(generator)),
+            Self::EslintNoRestrictedExports(_) => {
+                EslintNoRestrictedExports::config_schema(generator)
+                    .or_else(|| EslintNoRestrictedExports::schema(generator))
+            }
             Self::EslintNoRestrictedGlobals(_) => {
                 EslintNoRestrictedGlobals::config_schema(generator)
                     .or_else(|| EslintNoRestrictedGlobals::schema(generator))
@@ -8689,7 +8689,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => "import",
             Self::ImportPreferDefaultExport(_) => "import",
             Self::ImportUnambiguous(_) => "import",
-            Self::EslintNoRestrictedExports(_) => "eslint",
             Self::EslintAccessorPairs(_) => "eslint",
             Self::EslintArrayCallbackReturn(_) => "eslint",
             Self::EslintArrowBodyStyle(_) => "eslint",
@@ -8793,6 +8792,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => "eslint",
             Self::EslintNoRedeclare(_) => "eslint",
             Self::EslintNoRegexSpaces(_) => "eslint",
+            Self::EslintNoRestrictedExports(_) => "eslint",
             Self::EslintNoRestrictedGlobals(_) => "eslint",
             Self::EslintNoRestrictedImports(_) => "eslint",
             Self::EslintNoReturnAssign(_) => "eslint",
@@ -9471,9 +9471,6 @@ impl RuleEnum {
             Self::ImportUnambiguous(_) => {
                 Ok(Self::ImportUnambiguous(ImportUnambiguous::from_configuration(value)?))
             }
-            Self::EslintNoRestrictedExports(_) => Ok(Self::EslintNoRestrictedExports(
-                EslintNoRestrictedExports::from_configuration(value)?,
-            )),
             Self::EslintAccessorPairs(_) => {
                 Ok(Self::EslintAccessorPairs(EslintAccessorPairs::from_configuration(value)?))
             }
@@ -9783,6 +9780,9 @@ impl RuleEnum {
             Self::EslintNoRegexSpaces(_) => {
                 Ok(Self::EslintNoRegexSpaces(EslintNoRegexSpaces::from_configuration(value)?))
             }
+            Self::EslintNoRestrictedExports(_) => Ok(Self::EslintNoRestrictedExports(
+                EslintNoRestrictedExports::from_configuration(value)?,
+            )),
             Self::EslintNoRestrictedGlobals(_) => Ok(Self::EslintNoRestrictedGlobals(
                 EslintNoRestrictedGlobals::from_configuration(value)?,
             )),
@@ -11710,7 +11710,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.to_configuration(),
             Self::ImportPreferDefaultExport(rule) => rule.to_configuration(),
             Self::ImportUnambiguous(rule) => rule.to_configuration(),
-            Self::EslintNoRestrictedExports(rule) => rule.to_configuration(),
             Self::EslintAccessorPairs(rule) => rule.to_configuration(),
             Self::EslintArrayCallbackReturn(rule) => rule.to_configuration(),
             Self::EslintArrowBodyStyle(rule) => rule.to_configuration(),
@@ -11814,6 +11813,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.to_configuration(),
             Self::EslintNoRedeclare(rule) => rule.to_configuration(),
             Self::EslintNoRegexSpaces(rule) => rule.to_configuration(),
+            Self::EslintNoRestrictedExports(rule) => rule.to_configuration(),
             Self::EslintNoRestrictedGlobals(rule) => rule.to_configuration(),
             Self::EslintNoRestrictedImports(rule) => rule.to_configuration(),
             Self::EslintNoReturnAssign(rule) => rule.to_configuration(),
@@ -12433,7 +12433,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
             Self::ImportUnambiguous(rule) => rule.run(node, ctx),
-            Self::EslintNoRestrictedExports(rule) => rule.run(node, ctx),
             Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -12537,6 +12536,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.run(node, ctx),
             Self::EslintNoRedeclare(rule) => rule.run(node, ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run(node, ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run(node, ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run(node, ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run(node, ctx),
             Self::EslintNoReturnAssign(rule) => rule.run(node, ctx),
@@ -13152,7 +13152,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
             Self::ImportUnambiguous(rule) => rule.run_once(ctx),
-            Self::EslintNoRestrictedExports(rule) => rule.run_once(ctx),
             Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -13256,6 +13255,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_once(ctx),
             Self::EslintNoRedeclare(rule) => rule.run_once(ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run_once(ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run_once(ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_once(ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run_once(ctx),
             Self::EslintNoReturnAssign(rule) => rule.run_once(ctx),
@@ -13875,7 +13875,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
-            Self::EslintNoRestrictedExports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -13979,6 +13978,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRedeclare(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRegexSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoRestrictedImports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintNoReturnAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14690,7 +14690,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.should_run(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportUnambiguous(rule) => rule.should_run(ctx),
-            Self::EslintNoRestrictedExports(rule) => rule.should_run(ctx),
             Self::EslintAccessorPairs(rule) => rule.should_run(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.should_run(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.should_run(ctx),
@@ -14794,6 +14793,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.should_run(ctx),
             Self::EslintNoRedeclare(rule) => rule.should_run(ctx),
             Self::EslintNoRegexSpaces(rule) => rule.should_run(ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.should_run(ctx),
             Self::EslintNoRestrictedGlobals(rule) => rule.should_run(ctx),
             Self::EslintNoRestrictedImports(rule) => rule.should_run(ctx),
             Self::EslintNoReturnAssign(rule) => rule.should_run(ctx),
@@ -15415,7 +15415,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::IS_TSGOLINT_RULE,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportUnambiguous(_) => ImportUnambiguous::IS_TSGOLINT_RULE,
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::IS_TSGOLINT_RULE,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::IS_TSGOLINT_RULE,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::IS_TSGOLINT_RULE,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::IS_TSGOLINT_RULE,
@@ -15529,6 +15528,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::IS_TSGOLINT_RULE,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::IS_TSGOLINT_RULE,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::IS_TSGOLINT_RULE,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::IS_TSGOLINT_RULE,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::IS_TSGOLINT_RULE,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::IS_TSGOLINT_RULE,
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::IS_TSGOLINT_RULE,
@@ -16441,7 +16441,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::HAS_CONFIG,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::HAS_CONFIG,
             Self::ImportUnambiguous(_) => ImportUnambiguous::HAS_CONFIG,
-            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::HAS_CONFIG,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::HAS_CONFIG,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::HAS_CONFIG,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::HAS_CONFIG,
@@ -16549,6 +16548,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(_) => EslintNoPrototypeBuiltins::HAS_CONFIG,
             Self::EslintNoRedeclare(_) => EslintNoRedeclare::HAS_CONFIG,
             Self::EslintNoRegexSpaces(_) => EslintNoRegexSpaces::HAS_CONFIG,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::HAS_CONFIG,
             Self::EslintNoRestrictedGlobals(_) => EslintNoRestrictedGlobals::HAS_CONFIG,
             Self::EslintNoRestrictedImports(_) => EslintNoRestrictedImports::HAS_CONFIG,
             Self::EslintNoReturnAssign(_) => EslintNoReturnAssign::HAS_CONFIG,
@@ -17332,7 +17332,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.types_info(),
             Self::ImportPreferDefaultExport(rule) => rule.types_info(),
             Self::ImportUnambiguous(rule) => rule.types_info(),
-            Self::EslintNoRestrictedExports(rule) => rule.types_info(),
             Self::EslintAccessorPairs(rule) => rule.types_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.types_info(),
             Self::EslintArrowBodyStyle(rule) => rule.types_info(),
@@ -17436,6 +17435,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.types_info(),
             Self::EslintNoRedeclare(rule) => rule.types_info(),
             Self::EslintNoRegexSpaces(rule) => rule.types_info(),
+            Self::EslintNoRestrictedExports(rule) => rule.types_info(),
             Self::EslintNoRestrictedGlobals(rule) => rule.types_info(),
             Self::EslintNoRestrictedImports(rule) => rule.types_info(),
             Self::EslintNoReturnAssign(rule) => rule.types_info(),
@@ -18051,7 +18051,6 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_info(),
             Self::ImportPreferDefaultExport(rule) => rule.run_info(),
             Self::ImportUnambiguous(rule) => rule.run_info(),
-            Self::EslintNoRestrictedExports(rule) => rule.run_info(),
             Self::EslintAccessorPairs(rule) => rule.run_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.run_info(),
             Self::EslintArrowBodyStyle(rule) => rule.run_info(),
@@ -18155,6 +18154,7 @@ impl RuleEnum {
             Self::EslintNoPrototypeBuiltins(rule) => rule.run_info(),
             Self::EslintNoRedeclare(rule) => rule.run_info(),
             Self::EslintNoRegexSpaces(rule) => rule.run_info(),
+            Self::EslintNoRestrictedExports(rule) => rule.run_info(),
             Self::EslintNoRestrictedGlobals(rule) => rule.run_info(),
             Self::EslintNoRestrictedImports(rule) => rule.run_info(),
             Self::EslintNoReturnAssign(rule) => rule.run_info(),
@@ -18792,7 +18792,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax::default()),
         RuleEnum::ImportPreferDefaultExport(ImportPreferDefaultExport::default()),
         RuleEnum::ImportUnambiguous(ImportUnambiguous::default()),
-        RuleEnum::EslintNoRestrictedExports(EslintNoRestrictedExports::default()),
         RuleEnum::EslintAccessorPairs(EslintAccessorPairs::default()),
         RuleEnum::EslintArrayCallbackReturn(EslintArrayCallbackReturn::default()),
         RuleEnum::EslintArrowBodyStyle(EslintArrowBodyStyle::default()),
@@ -18896,6 +18895,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::EslintNoPrototypeBuiltins(EslintNoPrototypeBuiltins::default()),
         RuleEnum::EslintNoRedeclare(EslintNoRedeclare::default()),
         RuleEnum::EslintNoRegexSpaces(EslintNoRegexSpaces::default()),
+        RuleEnum::EslintNoRestrictedExports(EslintNoRestrictedExports::default()),
         RuleEnum::EslintNoRestrictedGlobals(EslintNoRestrictedGlobals::default()),
         RuleEnum::EslintNoRestrictedImports(EslintNoRestrictedImports::default()),
         RuleEnum::EslintNoReturnAssign(EslintNoReturnAssign::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -111,6 +111,7 @@ pub use crate::rules::eslint::no_proto::NoProto as EslintNoProto;
 pub use crate::rules::eslint::no_prototype_builtins::NoPrototypeBuiltins as EslintNoPrototypeBuiltins;
 pub use crate::rules::eslint::no_redeclare::NoRedeclare as EslintNoRedeclare;
 pub use crate::rules::eslint::no_regex_spaces::NoRegexSpaces as EslintNoRegexSpaces;
+pub use crate::rules::eslint::no_restricted_exports::NoRestrictedExports as EslintNoRestrictedExports;
 pub use crate::rules::eslint::no_restricted_globals::NoRestrictedGlobals as EslintNoRestrictedGlobals;
 pub use crate::rules::eslint::no_restricted_imports::NoRestrictedImports as EslintNoRestrictedImports;
 pub use crate::rules::eslint::no_return_assign::NoReturnAssign as EslintNoReturnAssign;
@@ -763,6 +764,7 @@ pub enum RuleEnum {
     ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax),
     ImportPreferDefaultExport(ImportPreferDefaultExport),
     ImportUnambiguous(ImportUnambiguous),
+    EslintNoRestrictedExports(EslintNoRestrictedExports),
     EslintAccessorPairs(EslintAccessorPairs),
     EslintArrayCallbackReturn(EslintArrayCallbackReturn),
     EslintArrowBodyStyle(EslintArrowBodyStyle),
@@ -1482,7 +1484,8 @@ const IMPORT_NO_UNASSIGNED_IMPORT_ID: usize = IMPORT_NO_SELF_IMPORT_ID + 1usize;
 const IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID: usize = IMPORT_NO_UNASSIGNED_IMPORT_ID + 1usize;
 const IMPORT_PREFER_DEFAULT_EXPORT_ID: usize = IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID + 1usize;
 const IMPORT_UNAMBIGUOUS_ID: usize = IMPORT_PREFER_DEFAULT_EXPORT_ID + 1usize;
-const ESLINT_ACCESSOR_PAIRS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
+const ESLINT_NO_RESTRICTED_EXPORTS_ID: usize = IMPORT_UNAMBIGUOUS_ID + 1usize;
+const ESLINT_ACCESSOR_PAIRS_ID: usize = ESLINT_NO_RESTRICTED_EXPORTS_ID + 1usize;
 const ESLINT_ARRAY_CALLBACK_RETURN_ID: usize = ESLINT_ACCESSOR_PAIRS_ID + 1usize;
 const ESLINT_ARROW_BODY_STYLE_ID: usize = ESLINT_ARRAY_CALLBACK_RETURN_ID + 1usize;
 const ESLINT_BLOCK_SCOPED_VAR_ID: usize = ESLINT_ARROW_BODY_STYLE_ID + 1usize;
@@ -2288,6 +2291,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => IMPORT_NO_WEBPACK_LOADER_SYNTAX_ID,
             Self::ImportPreferDefaultExport(_) => IMPORT_PREFER_DEFAULT_EXPORT_ID,
             Self::ImportUnambiguous(_) => IMPORT_UNAMBIGUOUS_ID,
+            Self::EslintNoRestrictedExports(_) => ESLINT_NO_RESTRICTED_EXPORTS_ID,
             Self::EslintAccessorPairs(_) => ESLINT_ACCESSOR_PAIRS_ID,
             Self::EslintArrayCallbackReturn(_) => ESLINT_ARRAY_CALLBACK_RETURN_ID,
             Self::EslintArrowBodyStyle(_) => ESLINT_ARROW_BODY_STYLE_ID,
@@ -3114,6 +3118,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::NAME,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::NAME,
             Self::ImportUnambiguous(_) => ImportUnambiguous::NAME,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::NAME,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::NAME,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::NAME,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::NAME,
@@ -3930,6 +3935,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::CATEGORY,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::CATEGORY,
             Self::ImportUnambiguous(_) => ImportUnambiguous::CATEGORY,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::CATEGORY,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::CATEGORY,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::CATEGORY,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::CATEGORY,
@@ -4795,6 +4801,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::FIX,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::FIX,
             Self::ImportUnambiguous(_) => ImportUnambiguous::FIX,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::FIX,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::FIX,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::FIX,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::FIX,
@@ -5616,6 +5623,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::documentation(),
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::documentation(),
             Self::ImportUnambiguous(_) => ImportUnambiguous::documentation(),
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::documentation(),
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::documentation(),
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::documentation(),
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::documentation(),
@@ -6692,6 +6700,10 @@ impl RuleEnum {
             }
             Self::ImportUnambiguous(_) => ImportUnambiguous::config_schema(generator)
                 .or_else(|| ImportUnambiguous::schema(generator)),
+            Self::EslintNoRestrictedExports(_) => {
+                EslintNoRestrictedExports::config_schema(generator)
+                    .or_else(|| EslintNoRestrictedExports::schema(generator))
+            }
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::config_schema(generator)
                 .or_else(|| EslintAccessorPairs::schema(generator)),
             Self::EslintArrayCallbackReturn(_) => {
@@ -8677,6 +8689,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => "import",
             Self::ImportPreferDefaultExport(_) => "import",
             Self::ImportUnambiguous(_) => "import",
+            Self::EslintNoRestrictedExports(_) => "eslint",
             Self::EslintAccessorPairs(_) => "eslint",
             Self::EslintArrayCallbackReturn(_) => "eslint",
             Self::EslintArrowBodyStyle(_) => "eslint",
@@ -9458,6 +9471,9 @@ impl RuleEnum {
             Self::ImportUnambiguous(_) => {
                 Ok(Self::ImportUnambiguous(ImportUnambiguous::from_configuration(value)?))
             }
+            Self::EslintNoRestrictedExports(_) => Ok(Self::EslintNoRestrictedExports(
+                EslintNoRestrictedExports::from_configuration(value)?,
+            )),
             Self::EslintAccessorPairs(_) => {
                 Ok(Self::EslintAccessorPairs(EslintAccessorPairs::from_configuration(value)?))
             }
@@ -11694,6 +11710,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.to_configuration(),
             Self::ImportPreferDefaultExport(rule) => rule.to_configuration(),
             Self::ImportUnambiguous(rule) => rule.to_configuration(),
+            Self::EslintNoRestrictedExports(rule) => rule.to_configuration(),
             Self::EslintAccessorPairs(rule) => rule.to_configuration(),
             Self::EslintArrayCallbackReturn(rule) => rule.to_configuration(),
             Self::EslintArrowBodyStyle(rule) => rule.to_configuration(),
@@ -12416,6 +12433,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run(node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run(node, ctx),
             Self::ImportUnambiguous(rule) => rule.run(node, ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run(node, ctx),
             Self::EslintAccessorPairs(rule) => rule.run(node, ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run(node, ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run(node, ctx),
@@ -13134,6 +13152,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_once(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_once(ctx),
             Self::ImportUnambiguous(rule) => rule.run_once(ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run_once(ctx),
             Self::EslintAccessorPairs(rule) => rule.run_once(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run_once(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run_once(ctx),
@@ -13856,6 +13875,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportPreferDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ImportUnambiguous(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintAccessorPairs(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::EslintArrowBodyStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14670,6 +14690,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.should_run(ctx),
             Self::ImportPreferDefaultExport(rule) => rule.should_run(ctx),
             Self::ImportUnambiguous(rule) => rule.should_run(ctx),
+            Self::EslintNoRestrictedExports(rule) => rule.should_run(ctx),
             Self::EslintAccessorPairs(rule) => rule.should_run(ctx),
             Self::EslintArrayCallbackReturn(rule) => rule.should_run(ctx),
             Self::EslintArrowBodyStyle(rule) => rule.should_run(ctx),
@@ -15394,6 +15415,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::IS_TSGOLINT_RULE,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::IS_TSGOLINT_RULE,
             Self::ImportUnambiguous(_) => ImportUnambiguous::IS_TSGOLINT_RULE,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::IS_TSGOLINT_RULE,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::IS_TSGOLINT_RULE,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::IS_TSGOLINT_RULE,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::IS_TSGOLINT_RULE,
@@ -16419,6 +16441,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(_) => ImportNoWebpackLoaderSyntax::HAS_CONFIG,
             Self::ImportPreferDefaultExport(_) => ImportPreferDefaultExport::HAS_CONFIG,
             Self::ImportUnambiguous(_) => ImportUnambiguous::HAS_CONFIG,
+            Self::EslintNoRestrictedExports(_) => EslintNoRestrictedExports::HAS_CONFIG,
             Self::EslintAccessorPairs(_) => EslintAccessorPairs::HAS_CONFIG,
             Self::EslintArrayCallbackReturn(_) => EslintArrayCallbackReturn::HAS_CONFIG,
             Self::EslintArrowBodyStyle(_) => EslintArrowBodyStyle::HAS_CONFIG,
@@ -17309,6 +17332,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.types_info(),
             Self::ImportPreferDefaultExport(rule) => rule.types_info(),
             Self::ImportUnambiguous(rule) => rule.types_info(),
+            Self::EslintNoRestrictedExports(rule) => rule.types_info(),
             Self::EslintAccessorPairs(rule) => rule.types_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.types_info(),
             Self::EslintArrowBodyStyle(rule) => rule.types_info(),
@@ -18027,6 +18051,7 @@ impl RuleEnum {
             Self::ImportNoWebpackLoaderSyntax(rule) => rule.run_info(),
             Self::ImportPreferDefaultExport(rule) => rule.run_info(),
             Self::ImportUnambiguous(rule) => rule.run_info(),
+            Self::EslintNoRestrictedExports(rule) => rule.run_info(),
             Self::EslintAccessorPairs(rule) => rule.run_info(),
             Self::EslintArrayCallbackReturn(rule) => rule.run_info(),
             Self::EslintArrowBodyStyle(rule) => rule.run_info(),
@@ -18767,6 +18792,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ImportNoWebpackLoaderSyntax(ImportNoWebpackLoaderSyntax::default()),
         RuleEnum::ImportPreferDefaultExport(ImportPreferDefaultExport::default()),
         RuleEnum::ImportUnambiguous(ImportUnambiguous::default()),
+        RuleEnum::EslintNoRestrictedExports(EslintNoRestrictedExports::default()),
         RuleEnum::EslintAccessorPairs(EslintAccessorPairs::default()),
         RuleEnum::EslintArrayCallbackReturn(EslintArrayCallbackReturn::default()),
         RuleEnum::EslintArrowBodyStyle(EslintArrowBodyStyle::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -143,6 +143,7 @@ pub(crate) mod eslint {
     pub mod no_prototype_builtins;
     pub mod no_redeclare;
     pub mod no_regex_spaces;
+    pub mod no_restricted_exports;
     pub mod no_restricted_globals;
     pub mod no_restricted_imports;
     pub mod no_return_assign;

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -1,0 +1,972 @@
+use lazy_regex::{Regex, RegexBuilder};
+use oxc_ast::{
+    AstKind,
+    ast::{Declaration, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::borrow::Borrow;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefaultExportType {
+    Direct,
+    Named,
+    DefaultFrom,
+    NamedFrom,
+    NamespaceFrom,
+}
+
+fn no_restricted_default_exports_diagnostic(
+    span: Span,
+    export_type: DefaultExportType,
+) -> OxcDiagnostic {
+    let warn = match export_type {
+        DefaultExportType::DefaultFrom => "Reexporting 'default' export is restricted.",
+        DefaultExportType::Direct => "Exporting 'default' is restricted.",
+        DefaultExportType::Named => "Exporting named value as default is restricted.",
+        DefaultExportType::NamedFrom => "Reexporting named export as default is restricted.",
+        DefaultExportType::NamespaceFrom => "Reexporting namespace as default is restricted.",
+    };
+
+    OxcDiagnostic::warn(warn).with_help("Use named export instead.").with_label(span)
+}
+
+fn no_restricted_named_exports_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("'{}' is restricted from being used as an exported name.", name))
+        .with_help("Rename this export.")
+        .with_label(span)
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct RestrictDefaultExports {
+    default_from: bool,
+    direct: bool,
+    named: bool,
+    named_from: bool,
+    namespace_from: bool,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoRestrictedExports {
+    restricted_named_exports: FxHashSet<String>,
+    #[serde(deserialize_with = "deserialize_regex_pattern")]
+    restricted_named_exports_pattern: Option<Regex>,
+    restrict_default_exports: RestrictDefaultExports,
+
+    #[serde(skip_serializing)]
+    has_default_restricted_named_export: bool,
+}
+
+fn deserialize_regex_pattern<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    Option::<String>::deserialize(deserializer)?
+        .map(|pattern| RegexBuilder::new(&pattern).build())
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
+// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule disallows specified names from being used as exported names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In a project, certain names may be disallowed from being used as exported names for various reasons.
+    ///
+    /// ### Options
+    ///
+    /// By default, this rule doesn’t disallow any names. Only the names you specify in the configuration will be disallowed.
+    ///
+    /// #### restrictedNamedExports
+    ///
+    /// This option is an array of strings, where each string is a name to be restricted.
+    ///
+    /// ```json
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictedNamedExports": ["foo", "bar"] }]}}
+    /// ```
+    ///
+    /// Example of **incorrect** code for the "restrictedNamedExports" option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictedNamedExports": ["foo"] }]}}
+    ///
+    /// export const foo = 1;
+    /// ```
+    ///
+    /// ##### Default exports
+    ///
+    /// By design, the `restrictedNamedExports` option doesn’t disallow export default declarations. If you configure `default` as a restricted name, that restriction will apply only to named export declarations.
+    ///
+    /// Examples of additional **incorrect** code for the `"restrictedNamedExports": ["default"]` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictedNamedExports": ["default"] }]}}
+    ///
+    /// function foo() {}
+    /// export { foo as default };
+    /// ```
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictedNamedExports": ["default"] }]}}
+    ///
+    /// export { default } from "some_module";
+    /// ```
+    ///
+    /// #### restrictedNamedExportsPattern
+    ///
+    /// This option is a string representing a regular expression pattern. Named exports matching this pattern will be restricted. This option does not apply to default named exports.
+    ///
+    /// Example of **incorrect** code for the "restrictedNamedExportsPattern" option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictedNamedExportsPattern": "bar$" }]}}
+    ///
+    /// export const foobar = 1;
+    /// ```
+    ///
+    /// #### restrictDefaultExports
+    ///
+    /// This option is an object option with boolean properties to restrict certain default export declarations. The option works only if the restrictedNamedExports option does not contain the "default" value.
+    ///
+    /// ##### direct
+    ///
+    /// Whether to restricts `export default` declarations.
+    ///
+    /// Example of **incorrect** code for the `"restrictDefaultExports": { "direct": true }` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictDefaultExports": { "direct": true } }]}}
+    ///
+    /// export default foo;
+    /// ```
+    ///
+    /// ##### named
+    ///
+    /// Whether to restricts `export { foo as default };` declarations.
+    ///
+    /// Example of **incorrect** code for the `"restrictDefaultExports": { "named": true }` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictDefaultExports": { "named": true } }]}}
+    ///
+    /// const foo = 123;
+    /// export { foo as default };
+    /// ```
+    ///
+    /// ##### defaultFrom
+    ///
+    /// Whether to restricts `export { default } from 'foo';` declarations.
+    ///
+    /// Example of **incorrect** code for the `"restrictDefaultExports": { "defaultFrom": true }` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictDefaultExports": { "defaultFrom": true } }]}}
+    ///
+    /// export { default } from 'foo';
+    /// ```
+    ///
+    /// ##### namedFrom
+    ///
+    /// Whether to restricts `export { foo as default } from 'foo';` declarations.
+    ///
+    /// Example of **incorrect** code for the `"restrictDefaultExports": { "namedFrom": true }` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictDefaultExports": { "namedFrom": true } }]}}
+    ///
+    /// export { foo as default } from 'foo';
+    /// ```
+    ///
+    /// ##### namespaceFrom
+    ///
+    /// Whether to restricts `export * as default from 'foo';` declarations.
+    ///
+    /// Example of **incorrect** code for the `"restrictDefaultExports": { "namespaceFrom": true }` option:
+    ///
+    /// ```js
+    /// {"rules: {"no-restricted-exports": ["error", { "restrictDefaultExports": { "namespaceFrom": true } }]}}
+    ///
+    /// export * as default from 'foo';
+    /// ```
+    NoRestrictedExports,
+    eslint,
+    nursery, // TODO: change category to `restriction`
+    config = NoRestrictedExports,
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalSpecifier {
+    NamedFrom,     // export { foo as default } from 'foo';
+    DefaultFrom,   // export { default } from 'mod';
+    NamespaceFrom, // export * as default from 'mod';
+}
+
+impl Rule for NoRestrictedExports {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let mut config = serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+            .map(DefaultRuleConfig::into_inner)?;
+
+        // Cache if "default" is in restricted_named_exports
+        config.has_default_restricted_named_export =
+            config.restricted_named_exports.contains("default");
+
+        Ok(config)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ExportAllDeclaration(export) => self.check_export_all(export, ctx),
+            AstKind::ExportDefaultDeclaration(export) => self.check_export_default(export, ctx),
+            AstKind::ExportNamedDeclaration(export) => self.check_export_named(export, ctx),
+            _ => {}
+        }
+    }
+}
+
+impl NoRestrictedExports {
+    fn check_export_all(&self, export: &ExportAllDeclaration, ctx: &LintContext) {
+        if let Some(exported) = export.exported.as_ref() {
+            // Always check for restricted named exports
+            self.check_no_restricted_named_exports(
+                ctx,
+                export.span,
+                std::iter::once(exported.name().into_string()),
+            );
+
+            // If exported name is default, also check for restricted named default export
+            if exported.name() == "default" {
+                self.check_no_restricted_named_default_exports(
+                    ctx,
+                    export.span,
+                    true,
+                    std::iter::once(LocalSpecifier::NamespaceFrom),
+                );
+            }
+        }
+    }
+
+    fn check_export_default(&self, export: &ExportDefaultDeclaration, ctx: &LintContext) {
+        self.check_no_restricted_direct_default_exports(ctx, export.span);
+    }
+
+    fn check_export_named(&self, export: &ExportNamedDeclaration, ctx: &LintContext) {
+        let (named_exports, has_default_exports, local_specifiers) = export.specifiers.iter().fold(
+            (Vec::new(), false, Vec::new()),
+            |(mut names, mut has_default, mut specifiers), spec| {
+                names.push(spec.exported.name().into_string());
+
+                if spec.exported.name() == "default" {
+                    has_default = true;
+                    let local_spec = match spec.local.name().as_str() {
+                        "default" => LocalSpecifier::DefaultFrom,
+                        _ => LocalSpecifier::NamedFrom,
+                    };
+                    specifiers.push(local_spec);
+                }
+
+                (names, has_default, specifiers)
+            },
+        );
+
+        self.check_no_restricted_named_exports(ctx, export.span, named_exports);
+
+        if has_default_exports {
+            self.check_no_restricted_named_default_exports(
+                ctx,
+                export.span,
+                export.source.is_some(),
+                local_specifiers,
+            );
+        }
+
+        if let Some(declaration) = export.declaration.as_ref() {
+            match declaration {
+                Declaration::FunctionDeclaration(_) | Declaration::ClassDeclaration(_) => {
+                    if let Some(id) = declaration.id() {
+                        self.check_no_restricted_named_exports(
+                            ctx,
+                            export.span,
+                            std::iter::once(id.name.into_string()),
+                        );
+                    }
+                }
+                Declaration::VariableDeclaration(variable) => {
+                    self.check_no_restricted_named_exports(
+                        ctx,
+                        export.span,
+                        variable.declarations.iter().flat_map(|d| {
+                            d.id.get_binding_identifiers()
+                                .into_iter()
+                                .map(|id| id.name.into_string())
+                        }),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn check_no_restricted_direct_default_exports(&self, ctx: &LintContext<'_>, span: Span) {
+        // restrict default exports option only works if the restrictedNamedExports option does not contain the "default" value.
+        if self.has_default_restricted_named_export {
+            return;
+        }
+
+        if self.restrict_default_exports.direct {
+            ctx.diagnostic(no_restricted_default_exports_diagnostic(
+                span,
+                DefaultExportType::Direct,
+            ));
+        }
+    }
+
+    fn check_no_restricted_named_default_exports<S>(
+        &self,
+        ctx: &LintContext<'_>,
+        span: Span,
+        has_source: bool,
+        specifiers: S,
+    ) where
+        S: IntoIterator,
+        S::Item: Borrow<LocalSpecifier>,
+    {
+        // restrict default exports option only works if the restrictedNamedExports option does not contain the "default" value.
+        if self.has_default_restricted_named_export {
+            return;
+        }
+
+        if let Some(type_export) = match (has_source, &self.restrict_default_exports) {
+            // Without source: check .named
+            (false, opts) => opts.named.then_some(DefaultExportType::Named),
+            // With source: check specific types
+            (true, opts) => specifiers.into_iter().find_map(|spec| match spec.borrow() {
+                LocalSpecifier::DefaultFrom => {
+                    opts.default_from.then_some(DefaultExportType::DefaultFrom)
+                }
+                LocalSpecifier::NamedFrom => {
+                    opts.named_from.then_some(DefaultExportType::NamedFrom)
+                }
+                LocalSpecifier::NamespaceFrom => {
+                    opts.namespace_from.then_some(DefaultExportType::NamespaceFrom)
+                }
+            }),
+        } {
+            ctx.diagnostic(no_restricted_default_exports_diagnostic(span, type_export));
+        };
+    }
+
+    fn check_no_restricted_named_exports<S>(&self, ctx: &LintContext<'_>, span: Span, exports: S)
+    where
+        S: IntoIterator,
+        S::Item: Borrow<String>,
+    {
+        if self.restricted_named_exports.is_empty()
+            && self.restricted_named_exports_pattern.is_none()
+        {
+            return;
+        }
+
+        for export in exports.into_iter() {
+            let export = export.borrow();
+            if self.restricted_named_exports.contains(export)
+                || (export != "default"
+                    && self
+                        .restricted_named_exports_pattern
+                        .as_ref()
+                        .is_some_and(|r| r.is_match(export)))
+            {
+                ctx.diagnostic(no_restricted_named_exports_diagnostic(span, export));
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("export var a;", None),
+        ("export function a() {}", None),
+        ("export class A {}", None),
+        ("var a; export { a };", None),
+        ("var b; export { b as a };", None),
+        ("export { a } from 'foo';", None),
+        ("export { b as a } from 'foo';", None),
+        ("export var a;", Some(serde_json::json!([{}]))),
+        ("export function a() {}", Some(serde_json::json!([{}]))),
+        ("export class A {}", Some(serde_json::json!([{}]))),
+        ("var a; export { a };", Some(serde_json::json!([{}]))),
+        ("var b; export { b as a };", Some(serde_json::json!([{}]))),
+        ("export { a } from 'foo';", Some(serde_json::json!([{}]))),
+        ("export { b as a } from 'foo';", Some(serde_json::json!([{}]))),
+        ("export var a;", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        ("export function a() {}", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        ("export class A {}", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        ("var a; export { a };", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        ("var b; export { b as a };", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        ("export { a } from 'foo';", Some(serde_json::json!([{ "restrictedNamedExports": [] }]))),
+        (
+            "export { b as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": [] }])),
+        ),
+        ("export var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        ("export let a;", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        ("export const a = 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        ("export function a() {}", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        ("export function *a() {}", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        (
+            "export async function a() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }])),
+        ),
+        (
+            "export async function *a() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }])),
+        ),
+        ("export class A {}", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        ("var a; export { a };", Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }]))),
+        (
+            "var b; export { b as a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }])),
+        ),
+        (
+            "export { a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }])),
+        ),
+        (
+            "export { b as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["x"] }])),
+        ),
+        (
+            "export { '' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["undefined"] }])),
+        ),
+        (
+            "export { '' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": [" "] }])),
+        ),
+        (
+            "export { ' ' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": [""] }])),
+        ),
+        (
+            "export { ' a', 'a ' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export var b = a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export let [b = a] = [];",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export const [b] = [a];", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export var { a: b } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export let { b = a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export const { c: b = a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export function b(a) {}", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export class A { a(){} }",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export class A extends B {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["B"] }])),
+        ),
+        (
+            "var a; export { a as b };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "var a; export { a as 'a ' };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { a as b } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { a as 'a ' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { 'a' as 'a ' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export { b } from 'a';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export * as b from 'a';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("let a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("const a = 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("function a() {}", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("class A {}", Some(serde_json::json!([{ "restrictedNamedExports": ["A"] }]))),
+        ("import a from 'foo';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "import { a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "import { b as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "var setSomething; export { setSomething };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "^get" }])),
+        ),
+        // (
+        //     "var foo, bar; export { foo, bar };",
+        //     Some(serde_json::json!([{ "restrictedNamedExportsPattern": "^(?!foo)(?!bar).+$" }])),
+        // ),
+        (
+            "var foobar; export default foobar;",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "bar$" }])),
+        ),
+        (
+            "var foobar; export default foobar;",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "export default 'default';",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "var foobar; export { foobar as default };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "var foobar; export { foobar as 'default' };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "export { default } from 'mod';",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "export { default as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "export { foobar as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        (
+            "export * as default from 'mod';",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "default" }])),
+        ),
+        ("export * from 'foo';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export * from 'a';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export default a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export default function a() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export default class A {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["A"] }])),
+        ),
+        (
+            "export default (function a() {});",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export default (class A {});",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["A"] }])),
+        ),
+        ("export default 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["default"] }]))),
+        (
+            "export { default as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["default"] }])),
+        ),
+        (
+            "export default foo;",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": false } }])),
+        ),
+        (
+            "export default 42;",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": false } }])),
+        ),
+        (
+            "export default function foo() {}",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": false } }])),
+        ),
+        (
+            "const foo = 123;
+            export { foo as default };",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "named": false } }])),
+        ),
+        (
+            "export { default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": false } }])),
+        ),
+        (
+            "export { default as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": false } }])),
+        ),
+        (
+            "export { foo as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": true } }])),
+        ),
+        (
+            "export { default } from 'mod';",
+            Some(
+                serde_json::json!([ { "restrictDefaultExports": { "named": true, "defaultFrom": false } }, ]),
+            ),
+        ),
+        (
+            "export { 'default' } from 'mod'; ",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": false } }])),
+        ),
+        (
+            "export { foo as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namedFrom": false } }])),
+        ),
+        (
+            "export { default as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namedFrom": true } }])),
+        ),
+        (
+            "export { default as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namedFrom": false } }])),
+        ),
+        (
+            "export { 'default' } from 'mod'; ",
+            Some(
+                serde_json::json!([ { "restrictDefaultExports": { "defaultFrom": false, "namedFrom": true, }, }, ]),
+            ),
+        ),
+        (
+            "export * as default from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namespaceFrom": false } }])),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "export function someFunction() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["someFunction"] }])),
+        ),
+        ("export var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export var a = 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export let a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export let a = 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export const a = 1;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export function a() {}", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export function *a() {}", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export async function a() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export async function *a() {}",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export class A {}", Some(serde_json::json!([{ "restrictedNamedExports": ["A"] }]))),
+        ("let a; export { a };", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export { a }; var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "let b; export { b as a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { b as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "let a; export { a as 'a' };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "let a; export { a as 'b' };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["b"] }])),
+        ),
+        (
+            "let a; export { a as ' b ' };",
+            Some(serde_json::json!([{ "restrictedNamedExports": [" b "] }])),
+        ),
+        (
+            "let a; export { a as '👍' };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["👍"] }])),
+        ),
+        (
+            "export { 'a' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { '' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": [""] }])),
+        ),
+        (
+            "export { ' ' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": [" "] }])),
+        ),
+        (
+            "export { b as 'a' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            r"export { b as '\u0061' } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export * as 'a' from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export var [a] = [];", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export let { a } = {};", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export const { b: a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export var [{ a }] = [];",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export let { b: { c: a = d } = e } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("var a; export var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export var a; var a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export var a = a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export let b = a, a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export const a = 1, b = a;",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export var [a] = a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export let { a: a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export const { a: b, b: a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export var { b: a, a: b } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export let a, { a: b } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export const { a: b } = {}, a = 1;",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export var [a = a] = [];",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export var { a: a = a } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export let { a } = { a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export function a(a) {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export class A { A(){} };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["A"] }])),
+        ),
+        (
+            "var a; export { a as a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "let a, b; export { a as b, b as a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "const a = 1, b = 2; export { b as a, a as b };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "var a; export { a as b, a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { a as a } from 'a';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { a as b, b as a } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { b as a, a as b } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        ("export * as a from 'a';", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export var a, b;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        ("export let b, a;", Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }]))),
+        (
+            "export const b = 1, a = 2;",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a", "b"] }])),
+        ),
+        (
+            "export var a, b, c;",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a", "c"] }])),
+        ),
+        (
+            "export let { a, b, c } = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["b", "c"] }])),
+        ),
+        (
+            "export const [a, b, c, d] = {};",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["b", "c"] }])),
+        ),
+        (
+            "export var { a, x: b, c, d, e: y } = {}, e, f = {};",
+            Some(
+                serde_json::json!([ { "restrictedNamedExports": [ "foo", "a", "b", "bar", "d", "e", "baz", ], }, ]),
+            ),
+        ),
+        (
+            "var a, b; export { a, b };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "let a, b; export { b, a };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "const a = 1, b = 1; export { a, b };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a", "b"] }])),
+        ),
+        (
+            "export { a, b, c }; var a, b, c;",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a", "c"] }])),
+        ),
+        (
+            "export { b as a, b } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a"] }])),
+        ),
+        (
+            "export { b as a, b } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["b"] }])),
+        ),
+        (
+            "export { b as a, b } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["a", "b"] }])),
+        ),
+        (
+            "export { a, b, c, d, x as e, f, g } from 'foo';",
+            Some(
+                serde_json::json!([ { "restrictedNamedExports": [ "foo", "b", "bar", "d", "e", "f", "baz", ], }, ]),
+            ),
+        ),
+        (
+            "var getSomething; export { getSomething };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "get*" }])),
+        ),
+        (
+            "var getSomethingFromUser; export { getSomethingFromUser };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "User$" }])),
+        ),
+        (
+            "var foo, ab, xy; export { foo, ab, xy };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "(b|y)$" }])),
+        ),
+        (
+            "var foo; export { foo as ab };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "(b|y)$" }])),
+        ),
+        (
+            "var privateUserEmail; export { privateUserEmail };",
+            Some(serde_json::json!([{ "restrictedNamedExportsPattern": "^privateUser" }])),
+        ),
+        // (
+        //     "export const a = 1;",
+        //     Some(serde_json::json!([{ "restrictedNamedExportsPattern": "^(?!foo)(?!bar).+$" }])),
+        // ),
+        (
+            "var a; export { a as default };",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["default"] }])),
+        ),
+        (
+            "export { default } from 'foo';",
+            Some(serde_json::json!([{ "restrictedNamedExports": ["default"] }])),
+        ),
+        (
+            "export default foo;",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": true } }])),
+        ),
+        (
+            "export default 42;",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": true } }])),
+        ),
+        (
+            "export default function foo() {}",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "direct": true } }])),
+        ),
+        (
+            "export default foo;",
+            Some(
+                serde_json::json!([ { "restrictedNamedExports": ["bar"], "restrictDefaultExports": { "direct": true }, }, ]),
+            ),
+        ),
+        (
+            "const foo = 123;
+            export { foo as default };",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "named": true } }])),
+        ),
+        (
+            "export { default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": true } }])),
+        ),
+        (
+            "export { default as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": true } }])),
+        ),
+        (
+            "export { 'default' } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "defaultFrom": true } }])),
+        ),
+        (
+            "export { foo as default } from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namedFrom": true } }])),
+        ),
+        (
+            "export * as default from 'mod';",
+            Some(serde_json::json!([{ "restrictDefaultExports": { "namespaceFrom": true } }])),
+        ),
+    ];
+
+    Tester::new(NoRestrictedExports::NAME, NoRestrictedExports::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -42,12 +42,27 @@ fn no_restricted_default_exports_diagnostic(
 }
 
 fn no_restricted_named_exports_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("'{}' is restricted from being used as an exported name.", name))
+    OxcDiagnostic::warn(format!("'{name}' is restricted from being used as an exported name."))
         .with_help("Rename this export.")
         .with_label(span)
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct NoRestrictedExports(Box<NoRestrictedExportsConfig>);
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoRestrictedExportsConfig {
+    restricted_named_exports: FxHashSet<String>,
+    #[serde(deserialize_with = "deserialize_regex_pattern")]
+    restricted_named_exports_pattern: Option<Regex>,
+    restrict_default_exports: RestrictDefaultExports,
+
+    #[serde(skip_serializing)]
+    has_default_restricted_named_export: bool,
+}
+
+#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct RestrictDefaultExports {
     default_from: bool,
@@ -57,16 +72,18 @@ struct RestrictDefaultExports {
     namespace_from: bool,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
-pub struct NoRestrictedExports {
-    restricted_named_exports: FxHashSet<String>,
-    #[serde(deserialize_with = "deserialize_regex_pattern")]
-    restricted_named_exports_pattern: Option<Regex>,
-    restrict_default_exports: RestrictDefaultExports,
+impl std::ops::Deref for NoRestrictedExports {
+    type Target = NoRestrictedExportsConfig;
 
-    #[serde(skip_serializing)]
-    has_default_restricted_named_export: bool,
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for NoRestrictedExports {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 fn deserialize_regex_pattern<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
@@ -209,26 +226,27 @@ declare_oxc_lint!(
     NoRestrictedExports,
     eslint,
     nursery, // TODO: change category to `restriction`
-    config = NoRestrictedExports,
+    config = NoRestrictedExportsConfig,
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LocalSpecifier {
-    NamedFrom,     // export { foo as default } from 'foo';
-    DefaultFrom,   // export { default } from 'mod';
-    NamespaceFrom, // export * as default from 'mod';
+enum LocalFromSpecifier {
+    Named,     // export { foo as default } from 'foo';
+    Default,   // export { default } from 'mod';
+    Namespace, // export * as default from 'mod';
 }
 
 impl Rule for NoRestrictedExports {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut config = serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-            .map(DefaultRuleConfig::into_inner)?;
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|mut c| {
+                // Cache if "default" is in restricted_named_exports
+                c.has_default_restricted_named_export =
+                    c.restricted_named_exports.contains("default");
 
-        // Cache if "default" is in restricted_named_exports
-        config.has_default_restricted_named_export =
-            config.restricted_named_exports.contains("default");
-
-        Ok(config)
+                c
+            })
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -257,7 +275,7 @@ impl NoRestrictedExports {
                     ctx,
                     export.span,
                     true,
-                    std::iter::once(LocalSpecifier::NamespaceFrom),
+                    std::iter::once(LocalFromSpecifier::Namespace),
                 );
             }
         }
@@ -276,8 +294,8 @@ impl NoRestrictedExports {
                 if spec.exported.name() == "default" {
                     has_default = true;
                     let local_spec = match spec.local.name().as_str() {
-                        "default" => LocalSpecifier::DefaultFrom,
-                        _ => LocalSpecifier::NamedFrom,
+                        "default" => LocalFromSpecifier::Default,
+                        _ => LocalFromSpecifier::Named,
                     };
                     specifiers.push(local_spec);
                 }
@@ -346,7 +364,7 @@ impl NoRestrictedExports {
         specifiers: S,
     ) where
         S: IntoIterator,
-        S::Item: Borrow<LocalSpecifier>,
+        S::Item: Borrow<LocalFromSpecifier>,
     {
         // restrict default exports option only works if the restrictedNamedExports option does not contain the "default" value.
         if self.has_default_restricted_named_export {
@@ -358,19 +376,19 @@ impl NoRestrictedExports {
             (false, opts) => opts.named.then_some(DefaultExportType::Named),
             // With source: check specific types
             (true, opts) => specifiers.into_iter().find_map(|spec| match spec.borrow() {
-                LocalSpecifier::DefaultFrom => {
+                LocalFromSpecifier::Default => {
                     opts.default_from.then_some(DefaultExportType::DefaultFrom)
                 }
-                LocalSpecifier::NamedFrom => {
+                LocalFromSpecifier::Named => {
                     opts.named_from.then_some(DefaultExportType::NamedFrom)
                 }
-                LocalSpecifier::NamespaceFrom => {
+                LocalFromSpecifier::Namespace => {
                     opts.namespace_from.then_some(DefaultExportType::NamespaceFrom)
                 }
             }),
         } {
             ctx.diagnostic(no_restricted_default_exports_diagnostic(span, type_export));
-        };
+        }
     }
 
     fn check_no_restricted_named_exports<S>(&self, ctx: &LintContext<'_>, span: Span, exports: S)
@@ -384,7 +402,7 @@ impl NoRestrictedExports {
             return;
         }
 
-        for export in exports.into_iter() {
+        for export in exports {
             let export = export.borrow();
             if self.restricted_named_exports.contains(export)
                 || (export != "default"

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -1,4 +1,10 @@
-use lazy_regex::{Regex, RegexBuilder};
+use std::borrow::Borrow;
+
+use lazy_regex::Regex;
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{Declaration, ExportAllDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration},
@@ -6,15 +12,12 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use rustc_hash::FxHashSet;
-use schemars::JsonSchema;
-use serde::Deserialize;
-use std::borrow::Borrow;
 
 use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
+    utils::deserialize_regex_option,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +57,7 @@ pub struct NoRestrictedExports(Box<NoRestrictedExportsConfig>);
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoRestrictedExportsConfig {
     restricted_named_exports: FxHashSet<String>,
-    #[serde(deserialize_with = "deserialize_regex_pattern")]
+    #[serde(deserialize_with = "deserialize_regex_option")]
     restricted_named_exports_pattern: Option<Regex>,
     restrict_default_exports: RestrictDefaultExports,
 
@@ -84,18 +87,6 @@ impl std::ops::DerefMut for NoRestrictedExports {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
-}
-
-fn deserialize_regex_pattern<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
-
-    Option::<String>::deserialize(deserializer)?
-        .map(|pattern| RegexBuilder::new(&pattern).build())
-        .transpose()
-        .map_err(D::Error::custom)
 }
 
 declare_oxc_lint!(
@@ -243,7 +234,6 @@ impl Rule for NoRestrictedExports {
                 // Cache if "default" is in restricted_named_exports
                 c.has_default_restricted_named_export =
                     c.restricted_named_exports.contains("default");
-
                 c
             })
     }

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -98,7 +98,6 @@ where
         .map_err(D::Error::custom)
 }
 
-// See <https://github.com/oxc-project/oxc/issues/6050> for documentation details.
 declare_oxc_lint!(
     /// ### What it does
     ///

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_exports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_exports.snap
@@ -1,0 +1,711 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint(no-restricted-exports): 'someFunction' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export function someFunction() {}
+   · ─────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a;
+   · ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a = 1;
+   · ─────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let a;
+   · ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let a = 1;
+   · ─────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const a = 1;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export function a() {}
+   · ──────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export function *a() {}
+   · ───────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export async function a() {}
+   · ────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export async function *a() {}
+   · ─────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'A' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export class A {}
+   · ─────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let a; export { a };
+   ·        ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a }; var a;
+   · ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let b; export { b as a };
+   ·        ──────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a } from 'foo';
+   · ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a } from 'foo';
+   · ─────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let a; export { a as 'a' };
+   ·        ────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let a; export { a as 'b' };
+   ·        ────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): ' b ' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let a; export { a as ' b ' };
+   ·        ──────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): '👍' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ let a; export { a as '👍' };
+   ·        ─────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { 'a' } from 'foo';
+   · ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): '' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { '' } from 'foo';
+   · ─────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): ' ' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { ' ' } from 'foo';
+   · ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as 'a' } from 'foo';
+   · ───────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as '\u0061' } from 'foo';
+   · ────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export * as 'a' from 'foo';
+   · ───────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var [a] = [];
+   · ────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { a } = {};
+   · ──────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const { b: a } = {};
+   · ───────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var [{ a }] = [];
+   · ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { b: { c: a = d } = e } = {};
+   · ────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ var a; export var a;
+   ·        ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a; var a;
+   · ─────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a = a;
+   · ─────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let b = a, a;
+   · ────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const a = 1, b = a;
+   · ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var [a] = a;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { a: a } = {};
+   · ─────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const { a: b, b: a } = {};
+   · ─────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { b: a, a: b } = {};
+   · ───────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let a, { a: b } = {};
+   · ────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const { a: b } = {}, a = 1;
+   · ──────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var [a = a] = [];
+   · ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { a: a = a } = {};
+   · ─────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { a } = { a };
+   · ─────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export function a(a) {};
+   · ───────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'A' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export class A { A(){} };
+   · ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ var a; export { a as a };
+   ·        ──────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:11]
+ 1 │ let a, b; export { a as b, b as a };
+   ·           ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:21]
+ 1 │ const a = 1, b = 2; export { b as a, a as b };
+   ·                     ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ var a; export { a as b, a };
+   ·        ─────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a as a } from 'a';
+   · ───────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a as b, b as a } from 'foo';
+   · ─────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a, a as b } from 'foo';
+   · ─────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export * as a from 'a';
+   · ───────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a, b;
+   · ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let b, a;
+   · ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const b = 1, a = 2;
+   · ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const b = 1, a = 2;
+   · ──────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a, b, c;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'c' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var a, b, c;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { a, b, c } = {};
+   · ────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'c' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export let { a, b, c } = {};
+   · ────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const [a, b, c, d] = {};
+   · ───────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'c' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export const [a, b, c, d] = {};
+   · ───────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { a, x: b, c, d, e: y } = {}, e, f = {};
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { a, x: b, c, d, e: y } = {}, e, f = {};
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'd' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { a, x: b, c, d, e: y } = {}, e, f = {};
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'e' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export var { a, x: b, c, d, e: y } = {}, e, f = {};
+   · ───────────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:11]
+ 1 │ var a, b; export { a, b };
+   ·           ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:11]
+ 1 │ let a, b; export { b, a };
+   ·           ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:21]
+ 1 │ const a = 1, b = 1; export { a, b };
+   ·                     ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:21]
+ 1 │ const a = 1, b = 1; export { a, b };
+   ·                     ────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c }; var a, b, c;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'c' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c }; var a, b, c;
+   · ───────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a, b } from 'foo';
+   · ────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a, b } from 'foo';
+   · ────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'a' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a, b } from 'foo';
+   · ────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { b as a, b } from 'foo';
+   · ────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'b' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c, d, x as e, f, g } from 'foo';
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'd' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c, d, x as e, f, g } from 'foo';
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'e' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c, d, x as e, f, g } from 'foo';
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'f' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { a, b, c, d, x as e, f, g } from 'foo';
+   · ───────────────────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'getSomething' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:19]
+ 1 │ var getSomething; export { getSomething };
+   ·                   ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'getSomethingFromUser' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:27]
+ 1 │ var getSomethingFromUser; export { getSomethingFromUser };
+   ·                           ────────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'ab' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:18]
+ 1 │ var foo, ab, xy; export { foo, ab, xy };
+   ·                  ───────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'xy' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:18]
+ 1 │ var foo, ab, xy; export { foo, ab, xy };
+   ·                  ───────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'ab' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:10]
+ 1 │ var foo; export { foo as ab };
+   ·          ─────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'privateUserEmail' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:23]
+ 1 │ var privateUserEmail; export { privateUserEmail };
+   ·                       ────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'default' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:8]
+ 1 │ var a; export { a as default };
+   ·        ────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): 'default' is restricted from being used as an exported name.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { default } from 'foo';
+   · ──────────────────────────────
+   ╰────
+  help: Rename this export.
+
+  ⚠ eslint(no-restricted-exports): Exporting 'default' is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export default foo;
+   · ───────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Exporting 'default' is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export default 42;
+   · ──────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Exporting 'default' is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export default function foo() {}
+   · ────────────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Exporting 'default' is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export default foo;
+   · ───────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Exporting named values as default is restricted.
+   ╭─[no_restricted_exports.tsx:2:13]
+ 1 │ const foo = 123;
+ 2 │             export { foo as default };
+   ·             ──────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Reexporting 'default' export is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { default } from 'mod';
+   · ──────────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Reexporting 'default' export is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { default as default } from 'mod';
+   · ─────────────────────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Reexporting 'default' export is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { 'default' } from 'mod';
+   · ────────────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Reexporting named export as default is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export { foo as default } from 'mod';
+   · ─────────────────────────────────────
+   ╰────
+  help: Use named export instead.
+
+  ⚠ eslint(no-restricted-exports): Reexporting namespace as default is restricted.
+   ╭─[no_restricted_exports.tsx:1:1]
+ 1 │ export * as default from 'mod';
+   · ───────────────────────────────
+   ╰────
+  help: Use named export instead.

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_exports.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_exports.snap
@@ -667,7 +667,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Use named export instead.
 
-  ⚠ eslint(no-restricted-exports): Exporting named values as default is restricted.
+  ⚠ eslint(no-restricted-exports): Exporting named value as default is restricted.
    ╭─[no_restricted_exports.tsx:2:13]
  1 │ const foo = 123;
  2 │             export { foo as default };


### PR DESCRIPTION
- implement `no-restricted-exports` rule
- tests from original [rule](https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-restricted-exports.js) pass except the one involving look-around regex

issue https://github.com/oxc-project/oxc/issues/479