### PR TITLE
ci: eliminate redundant network round-trip in clone-parallel.mjs

### DIFF
--- a/.github/scripts/clone-parallel.mjs
+++ b/.github/scripts/clone-parallel.mjs
@@ -88,22 +88,18 @@ async function cloneRepo(shouldClone, repo, path, ref, name) {
     }
 
     if (existsSync(gitDir)) {
-      // Directory exists with git repo - update it
-    } else if (existsSync(fullPath)) {
-      // Directory exists but no git repo - initialize it
-      await runGit(["init", "--quiet"], fullPath);
+      // Directory exists with git repo - ensure origin URL is correct
+      try {
+        await runGit(["remote", "set-url", "origin", repoUrl], fullPath);
+      } catch {
+        await runGit(["remote", "add", "origin", repoUrl], fullPath);
+      }
     } else {
-      // Directory doesn't exist - clone it
-      await runGit(
-        ["clone", "--quiet", "--no-progress", "--single-branch", "--depth", "1", repoUrl, fullPath],
-        repoRoot,
-      );
-    }
-
-    // Check if origin exists and update or add it
-    try {
-      await runGit(["remote", "set-url", "origin", repoUrl], fullPath);
-    } catch {
+      // Directory doesn't exist or has no git repo - initialize it
+      if (!existsSync(fullPath)) {
+        mkdirSync(fullPath, { recursive: true });
+      }
+      await runGit(["init", "--quiet"], fullPath);
       await runGit(["remote", "add", "origin", repoUrl], fullPath);
     }
 


### PR DESCRIPTION
## Summary

- Replace `git clone --depth 1` with `git init` + `git remote add` for fresh submodule directories, so `git fetch --depth 1 origin <sha>` is the only network operation
- Remove redundant `remote set-url` that ran after a fresh clone (the URL was already correct from the clone command)
- Merge the "directory exists but no .git" and "directory doesn't exist" branches into a single code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)