### PR TITLE
fix(linter): add help messages to eslint diagnostics missing them

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,9 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`")
+        .with_help("Use `void 0` instead of `undefined`, or compare with `typeof x === 'undefined'`.")
+        .with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -16,6 +16,7 @@ use crate::{
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
+        .with_help(format!("Replace the `parseInt()` call with a {prefix_name} literal for clarity and better performance."))
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -11,7 +11,7 @@ use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule}
 fn prefer_object_has_own_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`."
-    ).with_label(span)
+    ).with_help("Use `Object.hasOwn(obj, prop)` instead of `Object.prototype.hasOwnProperty.call(obj, prop)`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -24,17 +24,21 @@ fn unexpected_syntax_order_diagnostic(
     span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Expected '{curr_kind}' syntax before '{prev_kind}' syntax."))
+        .with_help("Reorder import statements so that the import kinds appear in the configured order.")
         .with_label(span)
 }
 
 fn sort_imports_alphabetically_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Imports should be sorted alphabetically.").with_label(span)
+    OxcDiagnostic::warn("Imports should be sorted alphabetically.")
+        .with_help("Sort import declarations alphabetically by their source module path.")
+        .with_label(span)
 }
 
 fn sort_members_alphabetically_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Member '{name}' of the import declaration should be sorted alphabetically."
     ))
+    .with_help("Sort the named import members alphabetically within the import declaration.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -58,7 +58,9 @@ impl Default for SortKeysOptions {
 pub struct SortKeysConfig(SortOrder, SortKeysOptions);
 
 fn sort_properties_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Object keys should be sorted").with_label(span)
+    OxcDiagnostic::warn("Object keys should be sorted")
+        .with_help("Sort the object keys in the configured order (ascending or descending).")
+        .with_label(span)
 }
 
 declare_oxc_lint!(


### PR DESCRIPTION
Add `.with_help()` to diagnostics in the following rules that were missing help text:

- `prefer_numeric_literals`
- `prefer_object_has_own`
- `no_undefined`
- `sort_imports` (3 diagnostics)
- `sort_keys`

Each help message provides actionable guidance that adds context beyond the diagnostic message itself.

Part of #19121.

> **Note:** Snapshots need updating via `cargo insta review`. Happy to update if needed.