### PR TITLE
ci: use `nscloud-checkout-action` on Namespace runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test Linux
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: oxc-project/setup-node@b8d296d30eafd1ae2968fab67aead472a1dbf6d4 # v1.0.7
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
@@ -51,7 +51,7 @@ jobs:
     name: Test Mac
     runs-on: namespace-profile-mac-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: oxc-project/setup-node@b8d296d30eafd1ae2968fab67aead472a1dbf6d4 # v1.0.7
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
@@ -113,7 +113,7 @@ jobs:
     name: Test big-endian # s390x-unknown-linux-gnu is a big-endian
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
           save-cache: ${{ github.ref_name == 'main' }}
@@ -128,7 +128,7 @@ jobs:
     name: Test 32-bit # armv7-unknown-linux-gnueabihf is a 32-bit target
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
           save-cache: ${{ github.ref_name == 'main' }}
@@ -142,7 +142,7 @@ jobs:
     name: Test wasm32-wasip1-threads
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:
@@ -179,7 +179,7 @@ jobs:
     name: Test NAPI Compiler
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:
@@ -220,7 +220,7 @@ jobs:
     name: Test NAPI Oxlint
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:
@@ -247,7 +247,7 @@ jobs:
     name: Test NAPI Oxfmt
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:
@@ -418,7 +418,7 @@ jobs:
     name: Lint
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: oxc-project/setup-node@b8d296d30eafd1ae2968fab67aead472a1dbf6d4 # v1.0.7
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
         with:
@@ -436,7 +436,7 @@ jobs:
     name: Conformance
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - name: Check if conformance should run
         id: filter
@@ -473,7 +473,7 @@ jobs:
     name: Minification Size
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - uses: ./.github/actions/check-changes
         id: filter
@@ -498,7 +498,7 @@ jobs:
     name: Allocations
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:
@@ -523,7 +523,7 @@ jobs:
     name: AST Changes
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -551,7 +551,7 @@ jobs:
     name: Linter changes
     runs-on: namespace-profile-linux-x64-default
     steps:
-      - uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+      - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
       - uses: ./.github/actions/check-changes
         id: filter
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: namespace-profile-linux-x64-default
     steps:
       - name: Checkout
-        uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - name: Clone submodules
         uses: ./.github/actions/clone-submodules

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -40,7 +40,7 @@ jobs:
       MIRI_TOOLCHAIN: nightly-2026-02-11
     steps:
       - name: Checkout
-        uses: taiki-e/checkout-action@83ed61bfbe2b8abbb3c66e8b65b1335484c70009 # v1.4.1
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - uses: ./.github/actions/check-changes
         id: filter


### PR DESCRIPTION
## Summary

- Replace `taiki-e/checkout-action` with `namespacelabs/nscloud-checkout-action@v8.1.1` on all jobs running on Namespace Cloud runners
- This leverages Namespace's Git mirror cache for faster checkouts
- Non-Namespace runner jobs (ubuntu, windows, ARM) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)