### PR TITLE
feat(linter): implement `vitest/prefer-strict-boolean-matchers` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4279,6 +4279,13 @@ impl RuleRunner for crate::rules::vitest::prefer_import_in_mock::PreferImportInM
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBooleanMatchers
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -685,6 +685,7 @@ pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPr
 pub use crate::rules::vitest::prefer_describe_function_title::PreferDescribeFunctionTitle as VitestPreferDescribeFunctionTitle;
 pub use crate::rules::vitest::prefer_expect_type_of::PreferExpectTypeOf as VitestPreferExpectTypeOf;
 pub use crate::rules::vitest::prefer_import_in_mock::PreferImportInMock as VitestPreferImportInMock;
+pub use crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBooleanMatchers as VitestPreferStrictBooleanMatchers;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1389,6 +1390,7 @@ pub enum RuleEnum {
     VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle),
     VitestPreferExpectTypeOf(VitestPreferExpectTypeOf),
     VitestPreferImportInMock(VitestPreferImportInMock),
+    VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -2172,7 +2174,8 @@ const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usi
 const VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_EXPECT_TYPE_OF_ID: usize = VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID + 1usize;
 const VITEST_PREFER_IMPORT_IN_MOCK_ID: usize = VITEST_PREFER_EXPECT_TYPE_OF_ID + 1usize;
-const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_IMPORT_IN_MOCK_ID + 1usize;
+const VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID: usize = VITEST_PREFER_IMPORT_IN_MOCK_ID + 1usize;
+const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
@@ -2982,6 +2985,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => VITEST_PREFER_DESCRIBE_FUNCTION_TITLE_ID,
             Self::VitestPreferExpectTypeOf(_) => VITEST_PREFER_EXPECT_TYPE_OF_ID,
             Self::VitestPreferImportInMock(_) => VITEST_PREFER_IMPORT_IN_MOCK_ID,
+            Self::VitestPreferStrictBooleanMatchers(_) => VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID,
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
@@ -3781,6 +3785,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::NAME,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::NAME,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::NAME,
+            Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -4624,6 +4629,9 @@ impl RuleEnum {
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::CATEGORY,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::CATEGORY,
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                VitestPreferStrictBooleanMatchers::CATEGORY
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -5426,6 +5434,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => VitestPreferDescribeFunctionTitle::FIX,
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::FIX,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::FIX,
+            Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -6422,6 +6431,9 @@ impl RuleEnum {
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::documentation(),
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::documentation(),
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                VitestPreferStrictBooleanMatchers::documentation()
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -8364,6 +8376,10 @@ impl RuleEnum {
                 .or_else(|| VitestPreferExpectTypeOf::schema(generator)),
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::config_schema(generator)
                 .or_else(|| VitestPreferImportInMock::schema(generator)),
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                VitestPreferStrictBooleanMatchers::config_schema(generator)
+                    .or_else(|| VitestPreferStrictBooleanMatchers::schema(generator))
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -9116,6 +9132,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(_) => "vitest",
             Self::VitestPreferExpectTypeOf(_) => "vitest",
             Self::VitestPreferImportInMock(_) => "vitest",
+            Self::VitestPreferStrictBooleanMatchers(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -11306,6 +11323,11 @@ impl RuleEnum {
             Self::VitestPreferImportInMock(_) => Ok(Self::VitestPreferImportInMock(
                 VitestPreferImportInMock::from_configuration(value)?,
             )),
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                Ok(Self::VitestPreferStrictBooleanMatchers(
+                    VitestPreferStrictBooleanMatchers::from_configuration(value)?,
+                ))
+            }
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -12069,6 +12091,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.to_configuration(),
             Self::VitestPreferExpectTypeOf(rule) => rule.to_configuration(),
             Self::VitestPreferImportInMock(rule) => rule.to_configuration(),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -12774,6 +12797,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run(node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run(node, ctx),
             Self::VitestPreferImportInMock(rule) => rule.run(node, ctx),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -13477,6 +13501,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_once(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_once(ctx),
             Self::VitestPreferImportInMock(rule) => rule.run_once(ctx),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -14278,6 +14303,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferImportInMock(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14983,6 +15009,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.should_run(ctx),
             Self::VitestPreferExpectTypeOf(rule) => rule.should_run(ctx),
             Self::VitestPreferImportInMock(rule) => rule.should_run(ctx),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -15976,6 +16003,9 @@ impl RuleEnum {
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::IS_TSGOLINT_RULE,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::IS_TSGOLINT_RULE,
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                VitestPreferStrictBooleanMatchers::IS_TSGOLINT_RULE
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -16848,6 +16878,9 @@ impl RuleEnum {
             }
             Self::VitestPreferExpectTypeOf(_) => VitestPreferExpectTypeOf::HAS_CONFIG,
             Self::VitestPreferImportInMock(_) => VitestPreferImportInMock::HAS_CONFIG,
+            Self::VitestPreferStrictBooleanMatchers(_) => {
+                VitestPreferStrictBooleanMatchers::HAS_CONFIG
+            }
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -17555,6 +17588,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.types_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.types_info(),
             Self::VitestPreferImportInMock(rule) => rule.types_info(),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -18258,6 +18292,7 @@ impl RuleEnum {
             Self::VitestPreferDescribeFunctionTitle(rule) => rule.run_info(),
             Self::VitestPreferExpectTypeOf(rule) => rule.run_info(),
             Self::VitestPreferImportInMock(rule) => rule.run_info(),
+            Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -19077,6 +19112,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferDescribeFunctionTitle(VitestPreferDescribeFunctionTitle::default()),
         RuleEnum::VitestPreferExpectTypeOf(VitestPreferExpectTypeOf::default()),
         RuleEnum::VitestPreferImportInMock(VitestPreferImportInMock::default()),
+        RuleEnum::VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -713,6 +713,7 @@ pub(crate) mod vitest {
     pub mod prefer_describe_function_title;
     pub mod prefer_expect_type_of;
     pub mod prefer_import_in_mock;
+    pub mod prefer_strict_boolean_matchers;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/vitest/prefer_strict_boolean_matchers.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_strict_boolean_matchers.rs
@@ -1,0 +1,168 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{PossibleJestNode, parse_expect_and_typeof_vitest_fn_call},
+};
+
+fn prefer_strict_boolean_matchers_diagnostic(span: Span, value: bool) -> OxcDiagnostic {
+    let (matcher_name, to_be_literal) =
+        if value { ("toBeTruthy", "toBe(true)") } else { ("toBeFalsy", "toBe(false)") };
+
+    OxcDiagnostic::warn(format!("Use `{to_be_literal}` instead of `{matcher_name}`."))
+        .with_help("Use strict boolean comparison instead of truthy/falsy coercion.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferStrictBooleanMatchers;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce using `toBe(true)` and `toBe(false)` over matchers that coerce types to boolean.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Truthy/falsy matchers coerce values to boolean and can hide type mistakes.
+    /// Strict boolean assertions make intent explicit and avoid accidental coercion.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// expect(foo).toBeTruthy()
+    /// expectTypeOf(foo).toBeTruthy()
+    /// expect(foo).toBeFalsy()
+    /// expectTypeOf(foo).toBeFalsy()
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(foo).toBe(true)
+    /// expectTypeOf(foo).toBe(true)
+    /// expect(foo).toBe(false)
+    /// expectTypeOf(foo).toBe(false)
+    /// ```
+    PreferStrictBooleanMatchers,
+    vitest,
+    style,
+    fix
+);
+
+impl Rule for PreferStrictBooleanMatchers {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        possible_vitest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let AstKind::CallExpression(call_expr) = possible_vitest_node.node.kind() else {
+            return;
+        };
+
+        let Some(vitest_expect_fn_call) =
+            parse_expect_and_typeof_vitest_fn_call(call_expr, possible_vitest_node, ctx)
+        else {
+            return;
+        };
+        let Some(matcher) = vitest_expect_fn_call.matcher() else {
+            return;
+        };
+
+        let Some(value) = (if matcher.is_name_equal("toBeTruthy") {
+            Some(true)
+        } else if matcher.is_name_equal("toBeFalsy") {
+            Some(false)
+        } else {
+            None
+        }) else {
+            return;
+        };
+
+        let is_cmp_mem_expr = match matcher.parent {
+            Some(Expression::ComputedMemberExpression(_)) => true,
+            Some(Expression::StaticMemberExpression(_) | Expression::PrivateFieldExpression(_)) => {
+                false
+            }
+            _ => return,
+        };
+
+        let span = Span::new(matcher.span.start, call_expr.span.end);
+        ctx.diagnostic_with_fix(prefer_strict_boolean_matchers_diagnostic(span, value), |fixer| {
+            let call_name = if is_cmp_mem_expr { "\"toBe\"]" } else { "toBe" };
+            fixer.replace(span, format!("{call_name}({value})"))
+        });
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "[].push(true)",
+        "[].push(false)",
+        r#"expect("something");"#,
+        "expect(true).toBe(true);",
+        "expect(true).toBe(false);",
+        "expect(false).toBe(true);",
+        "expect(false).toBe(false);",
+        "expect(fal,se).toBe(true);",
+        "expect(fal,se).toBe(false);",
+        "expect(value).toEqual();",
+        "expect(value).not.toBe(true);",
+        "expect(value).not.toBe(false);",
+        "expect(value).not.toEqual();",
+        "expect(value).toBe(undefined);",
+        "expect(value).not.toBe(undefined);",
+        "expect(value).toBe();",
+        "expect(true).toMatchSnapshot();",
+        r#"expect("a string").toMatchSnapshot(true);"#,
+        r#"expect("a string").toMatchSnapshot(false);"#,
+        r#"expect("a string").not.toMatchSnapshot();"#,
+        r#"expect(value)["toBe"](true);"#,
+        r#"expect(value)["toBe"](false);"#,
+        "expect(something).toEqual('a string');",
+        "expect(true).toBe",
+        "expectTypeOf(true).toBe()",
+    ];
+
+    let fail = vec![
+        "expect(false).toBeTruthy();",
+        "expect(false).toBeFalsy();",
+        "expectTypeOf(false).toBeTruthy();",
+        "expectTypeOf(false).toBeFalsy();",
+        "expect(wasSuccessful).toBeTruthy();",
+        "expect(wasSuccessful).toBeFalsy();",
+        r#"expect("a string").not.toBeTruthy();"#,
+        r#"expect("a string").not.toBeFalsy();"#,
+        r#"expect(value)["toBeTruthy"]();"#,
+        r#"expect(value)["toBeFalsy"]();"#,
+        r#"expect(value).not["toBeTruthy"]();"#,
+        r#"expect(value).not["toBeFalsy"]();"#,
+    ];
+
+    let fix = vec![
+        ("expect(false).toBeTruthy();", "expect(false).toBe(true);"),
+        ("expect(false).toBeFalsy();", "expect(false).toBe(false);"),
+        ("expectTypeOf(false).toBeTruthy();", "expectTypeOf(false).toBe(true);"),
+        ("expectTypeOf(false).toBeFalsy();", "expectTypeOf(false).toBe(false);"),
+        ("expect(wasSuccessful).toBeTruthy();", "expect(wasSuccessful).toBe(true);"),
+        ("expect(wasSuccessful).toBeFalsy();", "expect(wasSuccessful).toBe(false);"),
+        (r#"expect("a string").not.toBeTruthy();"#, r#"expect("a string").not.toBe(true);"#),
+        (r#"expect("a string").not.toBeFalsy();"#, r#"expect("a string").not.toBe(false);"#),
+        (r#"expect(value)["toBeTruthy"]();"#, r#"expect(value)["toBe"](true);"#),
+        (r#"expect(value)["toBeFalsy"]();"#, r#"expect(value)["toBe"](false);"#),
+        (r#"expect(value).not["toBeTruthy"]();"#, r#"expect(value).not["toBe"](true);"#),
+        (r#"expect(value).not["toBeFalsy"]();"#, r#"expect(value).not["toBe"](false);"#),
+    ];
+
+    Tester::new(PreferStrictBooleanMatchers::NAME, PreferStrictBooleanMatchers::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_strict_boolean_matchers.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_strict_boolean_matchers.snap
@@ -1,0 +1,88 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:15]
+ 1 │ expect(false).toBeTruthy();
+   ·               ────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:15]
+ 1 │ expect(false).toBeFalsy();
+   ·               ───────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:21]
+ 1 │ expectTypeOf(false).toBeTruthy();
+   ·                     ────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:21]
+ 1 │ expectTypeOf(false).toBeFalsy();
+   ·                     ───────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:23]
+ 1 │ expect(wasSuccessful).toBeTruthy();
+   ·                       ────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:23]
+ 1 │ expect(wasSuccessful).toBeFalsy();
+   ·                       ───────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:24]
+ 1 │ expect("a string").not.toBeTruthy();
+   ·                        ────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:24]
+ 1 │ expect("a string").not.toBeFalsy();
+   ·                        ───────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:15]
+ 1 │ expect(value)["toBeTruthy"]();
+   ·               ───────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:15]
+ 1 │ expect(value)["toBeFalsy"]();
+   ·               ──────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(true)` instead of `toBeTruthy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:19]
+ 1 │ expect(value).not["toBeTruthy"]();
+   ·                   ───────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.
+
+  ⚠ eslint-plugin-vitest(prefer-strict-boolean-matchers): Use `toBe(false)` instead of `toBeFalsy`.
+   ╭─[prefer_strict_boolean_matchers.tsx:1:19]
+ 1 │ expect(value).not["toBeFalsy"]();
+   ·                   ──────────────
+   ╰────
+  help: Use strict boolean comparison instead of truthy/falsy coercion.


### PR DESCRIPTION
This PR adds `vitest/prefer-strict-boolean-matchers` rule. 
Passes all [original tests ](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/prefer-strict-boolean-matchers.test.ts)with added extra tests for cases like this: `expect(value)["toBeFalsy"]();`

issue #4656