### PR TITLE
test(linter/plugins): Include a repo link and SHA/version in the JS Plugin conformance markdown files.

### DIFF
--- a/apps/oxlint/conformance/README.md
+++ b/apps/oxlint/conformance/README.md
@@ -32,9 +32,22 @@ pnpm run init-conformance
 pnpm run conformance
 ```
 
+## Updating a pinned repo version
+
+All upstream repo URLs, commit SHAs, and version labels are stored in `repos.json`.
+Both `init.sh` and the TypeScript test groups read from this single file.
+
+To update a repo to a newer version:
+
+1. Edit `repos.json` — update the `commitSha` and `version` for the repo.
+2. Re-initialize submodules: `pnpm run init-conformance`
+3. Re-run the conformance tests: `pnpm run conformance`
+4. Commit the updated `repos.json` and snapshot files.
+
 ## Adding a plugin to conformance tests
 
-- Add code to `init.sh` to clone the plugin's repo.
+- Add an entry to `repos.json` with the repo's URL, commit SHA, and version.
+- Add code to `init.sh` to clone and set up the plugin's repo.
 - Add a file to `src/groups` directory (copy pattern used for other plugins).
 - Add the group to `src/groups/index.ts`.
 

--- a/apps/oxlint/conformance/init.sh
+++ b/apps/oxlint/conformance/init.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 set -e
 
-ESLINT_SHA="4e6c4ac042e321da8fc29ce53ed03c86dcaa44a7" # 10.0.0
-REACT_SHA="612e371fb215498edde4c853bd1e0c8e9203808f" # 19.2.3
-STYLISTIC_SHA="5c4b512a225a314fa5f41eead9fdc4d51fc243d7" # 5.7.1
-SONAR_SHA="8852e2593390e00f9d9aea764b0b0b9a503d1f08" # 3.0.6
-E18E_SHA="1dc399be6eb9dcee207e5cd63ef184bd6c902492" # 0.1.4
-TESTING_LIBRARY_SHA="b8ef3772487a32c886cb5c338da2a144560a437b" # 7.15.4
-STORYBOOK_SHA="99aa48989f6798ae24d9867bc2b5fe6991a2e341" # v10.3.0-alpha.12
-PLAYWRIGHT_SHA="7e16bd565cfccd365a6a8f1f7f6fe29a1c868036" # v2.9.0
-CYPRESS_SHA="c7d6a7da5a7f0063f6b1abc15ae9711d34f529c5" # v6.3.1
-MOCHA_SHA="1e5a3a1a9597ab54e5cc3d3fc58071009d0335d3" # v11.1.0
-REGEXP_SHA="788787a7e9e820c40321fe2f1095d00d4a486866" # v3.1.0
+# Path to repos.json (resolved before any `cd` changes the working directory)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPOS_JSON="$SCRIPT_DIR/repos.json"
+
+# Read a field from repos.json for a given repo key.
+# Usage: repo_field <key> <field>
+# e.g. `repo_field eslint commitSha`
+repo_field() {
+  node -p "require('$REPOS_JSON')['$1'].$2"
+}
 
 # Shallow clone a repo at a specific commit, and `cd` into the cloned directory.
+# Reads the repo URL and commit SHA from repos.json using the given key.
 # Git commands copied from `.github/scripts/clone-parallel.mjs`.
-clone() {
+clone_repo() {
   local dir="$1"
-  local url="$2"
-  local ref="$3"
+  local url="$(repo_field "$dir" repoUrl).git"
+  local ref="$(repo_field "$dir" commitSha)"
 
   git clone --single-branch --depth 1 "$url" "$dir"
   cd "$dir"
@@ -37,7 +37,7 @@ cd submodules
 ###############################################################################
 
 # Clone ESLint repo into `submodules/eslint`
-clone eslint https://github.com/eslint/eslint.git "$ESLINT_SHA"
+clone_repo eslint
 
 # Install dependencies
 pnpm install --ignore-workspace
@@ -50,7 +50,7 @@ cd ..
 ###############################################################################
 
 # Clone React repo into `submodules/react`
-clone react https://github.com/facebook/react.git "$REACT_SHA"
+clone_repo react
 
 # Install dependencies
 yarn
@@ -82,7 +82,7 @@ cd ..
 ###############################################################################
 
 # Clone ESLint Stylistic repo into `submodules/stylistic`
-clone stylistic https://github.com/eslint-stylistic/eslint-stylistic.git "$STYLISTIC_SHA"
+clone_repo stylistic
 
 # Install dependencies.
 # No `--ignore-workspace` because `eslint-stylistic` has its own `pnpm-workspace.yaml`.
@@ -141,7 +141,7 @@ cd ..
 ###############################################################################
 
 # Clone SonarJS repo into `submodules/sonarjs`
-clone sonarjs https://github.com/SonarSource/SonarJS.git "$SONAR_SHA"
+clone_repo sonarjs
 
 # Install dependencies
 pnpm install --ignore-workspace
@@ -187,7 +187,7 @@ cd ..
 ###############################################################################
 
 # Clone E18E ESLint plugin repo into `submodules/e18e`
-clone e18e https://github.com/e18e/eslint-plugin.git "$E18E_SHA"
+clone_repo e18e
 
 # Install dependencies
 pnpm install --ignore-workspace
@@ -200,7 +200,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-testing-library` repo into `submodules/testing_library`
-clone testing_library https://github.com/testing-library/eslint-plugin-testing-library.git "$TESTING_LIBRARY_SHA"
+clone_repo testing_library
 
 # Install dependencies
 pnpm install --ignore-workspace
@@ -213,7 +213,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-storybook` repo into `submodules/storybook`
-clone storybook https://github.com/storybookjs/storybook.git "$STORYBOOK_SHA"
+clone_repo storybook
 
 # Install dependencies
 yarn install
@@ -226,7 +226,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-playwright` repo into `submodules/playwright`
-clone playwright https://github.com/mskelton/eslint-plugin-playwright.git "$PLAYWRIGHT_SHA"
+clone_repo playwright
 
 # Install dependencies
 yarn install
@@ -239,7 +239,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-cypress` repo into `submodules/cypress`
-clone cypress https://github.com/cypress-io/eslint-plugin-cypress.git "$CYPRESS_SHA"
+clone_repo cypress
 
 # Install dependencies
 npm install
@@ -252,7 +252,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-mocha` repo into `submodules/mocha`
-clone mocha https://github.com/lo1tuma/eslint-plugin-mocha.git "$MOCHA_SHA"
+clone_repo mocha
 
 # Install dependencies
 npm install
@@ -265,7 +265,7 @@ cd ..
 ###############################################################################
 
 # Clone `eslint-plugin-regexp` repo into `submodules/regexp`
-clone regexp https://github.com/ota-meshi/eslint-plugin-regexp.git "$REGEXP_SHA"
+clone_repo regexp
 
 # Install dependencies
 npm install

--- a/apps/oxlint/conformance/repos.json
+++ b/apps/oxlint/conformance/repos.json
@@ -1,0 +1,57 @@
+{
+  "eslint": {
+    "repoUrl": "https://github.com/eslint/eslint",
+    "commitSha": "4e6c4ac042e321da8fc29ce53ed03c86dcaa44a7",
+    "version": "10.0.0"
+  },
+  "react": {
+    "repoUrl": "https://github.com/facebook/react",
+    "commitSha": "612e371fb215498edde4c853bd1e0c8e9203808f",
+    "version": "19.2.3"
+  },
+  "stylistic": {
+    "repoUrl": "https://github.com/eslint-stylistic/eslint-stylistic",
+    "commitSha": "5c4b512a225a314fa5f41eead9fdc4d51fc243d7",
+    "version": "5.7.1"
+  },
+  "sonarjs": {
+    "repoUrl": "https://github.com/SonarSource/SonarJS",
+    "commitSha": "8852e2593390e00f9d9aea764b0b0b9a503d1f08",
+    "version": "3.0.6"
+  },
+  "e18e": {
+    "repoUrl": "https://github.com/e18e/eslint-plugin",
+    "commitSha": "1dc399be6eb9dcee207e5cd63ef184bd6c902492",
+    "version": "0.1.4"
+  },
+  "testing_library": {
+    "repoUrl": "https://github.com/testing-library/eslint-plugin-testing-library",
+    "commitSha": "b8ef3772487a32c886cb5c338da2a144560a437b",
+    "version": "7.15.4"
+  },
+  "storybook": {
+    "repoUrl": "https://github.com/storybookjs/storybook",
+    "commitSha": "99aa48989f6798ae24d9867bc2b5fe6991a2e341",
+    "version": "v10.3.0-alpha.12"
+  },
+  "playwright": {
+    "repoUrl": "https://github.com/mskelton/eslint-plugin-playwright",
+    "commitSha": "7e16bd565cfccd365a6a8f1f7f6fe29a1c868036",
+    "version": "v2.9.0"
+  },
+  "cypress": {
+    "repoUrl": "https://github.com/cypress-io/eslint-plugin-cypress",
+    "commitSha": "c7d6a7da5a7f0063f6b1abc15ae9711d34f529c5",
+    "version": "v6.3.1"
+  },
+  "mocha": {
+    "repoUrl": "https://github.com/lo1tuma/eslint-plugin-mocha",
+    "commitSha": "1e5a3a1a9597ab54e5cc3d3fc58071009d0335d3",
+    "version": "v11.1.0"
+  },
+  "regexp": {
+    "repoUrl": "https://github.com/ota-meshi/eslint-plugin-regexp",
+    "commitSha": "788787a7e9e820c40321fe2f1095d00d4a486866",
+    "version": "v3.1.0"
+  }
+}

--- a/apps/oxlint/conformance/snapshots/cypress.md
+++ b/apps/oxlint/conformance/snapshots/cypress.md
@@ -1,5 +1,7 @@
 # Conformance test results - cypress
 
+Tested against: [cypress@c7d6a7d](https://github.com/cypress-io/eslint-plugin-cypress/tree/c7d6a7da5a7f0063f6b1abc15ae9711d34f529c5) (v6.3.1)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/e18e.md
+++ b/apps/oxlint/conformance/snapshots/e18e.md
@@ -1,5 +1,7 @@
 # Conformance test results - e18e
 
+Tested against: [e18e@1dc399b](https://github.com/e18e/eslint-plugin/tree/1dc399be6eb9dcee207e5cd63ef184bd6c902492) (0.1.4)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/eslint.md
+++ b/apps/oxlint/conformance/snapshots/eslint.md
@@ -1,5 +1,7 @@
 # Conformance test results - eslint
 
+Tested against: [eslint@4e6c4ac](https://github.com/eslint/eslint/tree/4e6c4ac042e321da8fc29ce53ed03c86dcaa44a7) (10.0.0)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/mocha.md
+++ b/apps/oxlint/conformance/snapshots/mocha.md
@@ -1,5 +1,7 @@
 # Conformance test results - mocha
 
+Tested against: [mocha@1e5a3a1](https://github.com/lo1tuma/eslint-plugin-mocha/tree/1e5a3a1a9597ab54e5cc3d3fc58071009d0335d3) (v11.1.0)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/playwright.md
+++ b/apps/oxlint/conformance/snapshots/playwright.md
@@ -1,5 +1,7 @@
 # Conformance test results - playwright
 
+Tested against: [playwright@7e16bd5](https://github.com/mskelton/eslint-plugin-playwright/tree/7e16bd565cfccd365a6a8f1f7f6fe29a1c868036) (v2.9.0)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/react-hooks.md
+++ b/apps/oxlint/conformance/snapshots/react-hooks.md
@@ -1,5 +1,7 @@
 # Conformance test results - react-hooks
 
+Tested against: [react-hooks@612e371](https://github.com/facebook/react/tree/612e371fb215498edde4c853bd1e0c8e9203808f) (19.2.3)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/regexp.md
+++ b/apps/oxlint/conformance/snapshots/regexp.md
@@ -1,5 +1,7 @@
 # Conformance test results - regexp
 
+Tested against: [regexp@788787a](https://github.com/ota-meshi/eslint-plugin-regexp/tree/788787a7e9e820c40321fe2f1095d00d4a486866) (v3.1.0)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/sonarjs.md
+++ b/apps/oxlint/conformance/snapshots/sonarjs.md
@@ -1,5 +1,7 @@
 # Conformance test results - sonarjs
 
+Tested against: [sonarjs@8852e25](https://github.com/SonarSource/SonarJS/tree/8852e2593390e00f9d9aea764b0b0b9a503d1f08) (3.0.6)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/storybook.md
+++ b/apps/oxlint/conformance/snapshots/storybook.md
@@ -1,5 +1,7 @@
 # Conformance test results - storybook
 
+Tested against: [storybook@99aa489](https://github.com/storybookjs/storybook/tree/99aa48989f6798ae24d9867bc2b5fe6991a2e341) (v10.3.0-alpha.12)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/stylistic.md
+++ b/apps/oxlint/conformance/snapshots/stylistic.md
@@ -1,5 +1,7 @@
 # Conformance test results - stylistic
 
+Tested against: [stylistic@5c4b512](https://github.com/eslint-stylistic/eslint-stylistic/tree/5c4b512a225a314fa5f41eead9fdc4d51fc243d7) (5.7.1)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/snapshots/testing_library.md
+++ b/apps/oxlint/conformance/snapshots/testing_library.md
@@ -1,5 +1,7 @@
 # Conformance test results - testing_library
 
+Tested against: [testing_library@b8ef377](https://github.com/testing-library/eslint-plugin-testing-library/tree/b8ef3772487a32c886cb5c338da2a144560a437b) (7.15.4)
+
 ## Summary
 
 ### Rules

--- a/apps/oxlint/conformance/src/groups/cypress.ts
+++ b/apps/oxlint/conformance/src/groups/cypress.ts
@@ -1,7 +1,10 @@
+import repos from "../../repos.json" with { type: "json" };
+
 import type { TestGroup } from "../index.ts";
 
 const group: TestGroup = {
   name: "cypress",
+  ...repos.cypress,
 
   submoduleName: "cypress",
   testFilesDirPath: "tests/lib/rules",

--- a/apps/oxlint/conformance/src/groups/e18e.ts
+++ b/apps/oxlint/conformance/src/groups/e18e.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type { LanguageOptions, TestCase } from "../rule_tester.ts";
@@ -7,6 +8,7 @@ type TSEslintParser = typeof import("@typescript-eslint/parser");
 
 const group: TestGroup = {
   name: "e18e",
+  ...repos.e18e,
 
   submoduleName: "e18e",
   testFilesDirPath: "src/rules",

--- a/apps/oxlint/conformance/src/groups/eslint.ts
+++ b/apps/oxlint/conformance/src/groups/eslint.ts
@@ -1,8 +1,11 @@
+import repos from "../../repos.json" with { type: "json" };
+
 import type { TestGroup } from "../index.ts";
 import type { TestCase } from "../rule_tester.ts";
 
 const group: TestGroup = {
   name: "eslint",
+  ...repos.eslint,
 
   submoduleName: "eslint",
   testFilesDirPath: "tests/lib/rules",

--- a/apps/oxlint/conformance/src/groups/mocha.ts
+++ b/apps/oxlint/conformance/src/groups/mocha.ts
@@ -1,7 +1,10 @@
+import repos from "../../repos.json" with { type: "json" };
+
 import type { TestGroup } from "../index.ts";
 
 const group: TestGroup = {
   name: "mocha",
+  ...repos.mocha,
 
   submoduleName: "mocha",
   testFilesDirPath: "source/rules",

--- a/apps/oxlint/conformance/src/groups/playwright.ts
+++ b/apps/oxlint/conformance/src/groups/playwright.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type { LanguageOptions, TestCases } from "../rule_tester.ts";
@@ -8,6 +9,7 @@ type TSEslintParser = typeof import("@typescript-eslint/parser");
 
 const group: TestGroup = {
   name: "playwright",
+  ...repos.playwright,
 
   submoduleName: "playwright",
   testFilesDirPath: "src/rules",

--- a/apps/oxlint/conformance/src/groups/react_hooks.ts
+++ b/apps/oxlint/conformance/src/groups/react_hooks.ts
@@ -1,8 +1,11 @@
+import repos from "../../repos.json" with { type: "json" };
+
 import type { MockFn, TestGroup } from "../index.ts";
 import type { TestCase } from "../rule_tester.ts";
 
 const group: TestGroup = {
   name: "react-hooks",
+  ...repos.react,
 
   submoduleName: "react",
   testFilesDirPath: "packages/eslint-plugin-react-hooks/__tests__",

--- a/apps/oxlint/conformance/src/groups/regexp.ts
+++ b/apps/oxlint/conformance/src/groups/regexp.ts
@@ -3,6 +3,7 @@ import { join as pathJoin } from "node:path";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type {
@@ -30,6 +31,7 @@ const SNAPSHOTS_DIR = pathJoin(
 
 const group: TestGroup = {
   name: "regexp",
+  ...repos.regexp,
 
   submoduleName: "regexp",
   testFilesDirPath: "tests/lib/rules",

--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { join as pathJoin } from "node:path";
 import { currentRule } from "../capture.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type { TestCase, TestCases, ValidTestCase, InvalidTestCase } from "../rule_tester.ts";
@@ -17,6 +18,7 @@ const TEST_FILES_DIR_PATH = pathJoin(
 
 const group: TestGroup = {
   name: "sonarjs",
+  ...repos.sonarjs,
 
   submoduleName: SUBMODULE_NAME,
   testFilesDirPath: TEST_FILES_RELATIVE_DIR_PATH,

--- a/apps/oxlint/conformance/src/groups/storybook.ts
+++ b/apps/oxlint/conformance/src/groups/storybook.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import assert from "node:assert";
 
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type { LanguageOptions, TestCase, TestCases } from "../rule_tester.ts";
@@ -49,6 +50,7 @@ fs.readFileSync = function (...args: unknown[]): unknown {
 // Test group definition
 const group: TestGroup = {
   name: "storybook",
+  ...repos.storybook,
 
   submoduleName: "storybook",
   testFilesDirPath: "code/lib/eslint-plugin/src/rules",

--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -1,5 +1,6 @@
 import { unindent } from "eslint-vitest-rule-tester";
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type {
@@ -17,6 +18,7 @@ type TSEslintParser = typeof import("@typescript-eslint/parser");
 
 const group: TestGroup = {
   name: "stylistic",
+  ...repos.stylistic,
 
   submoduleName: "stylistic",
   testFilesDirPath: "packages/eslint-plugin/rules",

--- a/apps/oxlint/conformance/src/groups/testing_library.ts
+++ b/apps/oxlint/conformance/src/groups/testing_library.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "../rule_tester.ts";
+import repos from "../../repos.json" with { type: "json" };
 
 import type { MockFn, TestGroup } from "../index.ts";
 import type { LanguageOptions, TestCase, TestCases } from "../rule_tester.ts";
@@ -8,6 +9,7 @@ type TSEslintParser = typeof import("@typescript-eslint/parser");
 
 const group: TestGroup = {
   name: "testing_library",
+  ...repos.testing_library,
 
   submoduleName: "testing_library",
   testFilesDirPath: "tests/rules",

--- a/apps/oxlint/conformance/src/index.ts
+++ b/apps/oxlint/conformance/src/index.ts
@@ -46,6 +46,24 @@ export interface TestGroup {
   name: string;
 
   /**
+   * URL of the upstream repository.
+   * e.g. `"https://github.com/eslint/eslint"`
+   */
+  repoUrl: string;
+
+  /**
+   * Git commit SHA that the tests are pinned to.
+   * Must match the SHA used in `init.sh`.
+   */
+  commitSha: string;
+
+  /**
+   * Version tag or label corresponding to the pinned commit.
+   * e.g. `"10.0.0"`, `"v2.9.0"`
+   */
+  version: string;
+
+  /**
    * Name of the submodule for this group.
    * i.e. name of the directory in `submodules` directory.
    */
@@ -304,7 +322,7 @@ function runGroup(group: TestGroup, mocks: Mocks) {
   // Write results to markdown file
   const snapshotPath = pathJoin(SNAPSHOTS_DIR_PATH, `${groupName}.md`);
 
-  const report = generateReport(group.name, results);
+  const report = generateReport(group.name, group.repoUrl, group.commitSha, group.version, results);
   fs.writeFileSync(snapshotPath, report);
   console.log(`\nResults written to: ${snapshotPath}`);
 

--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -21,10 +21,20 @@ const normalizeSlashes =
 
 /**
  * Generate report of test results as markdown.
- * @param results - Results of running tests
- * @returns Report as markdown
+ * @param groupName - Name of the test group or suite.
+ * @param repoUrl - URL of the repository containing the rules and tests.
+ * @param commitSha - Commit SHA associated with this test run.
+ * @param version - Version of the tool or ruleset used for the tests.
+ * @param results - Results of running tests.
+ * @returns Report as markdown.
  */
-export function generateReport(groupName: string, results: RuleResult[]): string {
+export function generateReport(
+  groupName: string,
+  repoUrl: string,
+  commitSha: string,
+  version: string,
+  results: RuleResult[],
+): string {
   // Categorize rules
   const loadErrorRules: RuleResult[] = [],
     noTestRules: RuleResult[] = [],
@@ -118,8 +128,12 @@ export function generateReport(groupName: string, results: RuleResult[]): string
     return `${String(count).padStart(5)} | ${formatPercent(count, total).padStart(6)}`;
   }
 
+  const shortSha = commitSha.slice(0, 7);
+
   block(`
     # Conformance test results - ${groupName}
+
+    Tested against: [${groupName}@${shortSha}](${repoUrl}/tree/${commitSha}) (${version})
 
     ## Summary
 


### PR DESCRIPTION
This also simplifies the way we track the conformance versions a bit, by centralizing the info into `repos.json`.

I know #20607 will conflict with this one, so feel free to merge whichever of these two you prefer, and then I'll resolve the conflicts afterward.

AI Disclosure: Generated with help from Claude Code.