### PR TITLE
test(lsp): skip `test_get_parent_dir_uri` in windows because of UNIX paths

### DIFF
--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -1329,6 +1329,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))] // UNIX paths not supported on Windows
     fn test_get_parent_dir_uri() {
         // Typical file URI
         let file: Uri = "file:///path/to/dir/file.js".parse().unwrap();


### PR DESCRIPTION
https://github.com/oxc-project/oxc/actions/runs/23403866474/job/68079394830