### PR TITLE
fix(linter): add help text to eslint diagnostics 🤖🤖🤖

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_undefined.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undefined.rs
@@ -9,7 +9,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 pub struct NoUndefined;
 
 fn no_undefined_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected use of `undefined`").with_label(span)
+    OxcDiagnostic::warn("Unexpected use of `undefined`").with_help("Use `void 0` to get the `undefined` value, or check for `undefined` using `typeof x === 'undefined'` instead.").with_label(span)
 }
 
 declare_oxc_lint!(

--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -16,7 +16,7 @@ use crate::{
 
 fn prefer_numeric_literals_diagnostic(span: Span, prefix_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Use {prefix_name} literals instead of parseInt()."))
-        .with_label(span)
+        .with_help("Use numeric literals (e.g. `0b101`, `0o17`, `0xFF`) instead of `parseInt()` for better readability and to avoid potential radix confusion.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_has_own.rs
@@ -11,7 +11,7 @@ use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule}
 fn prefer_object_has_own_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
         "Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer use of `Object.hasOwn()`."
-    ).with_label(span)
+    ).with_help("Use `Object.hasOwn(obj, prop)` instead. It is a shorter and more reliable alternative to `Object.prototype.hasOwnProperty.call()`.").with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
Adds `.with_help()` to three eslint rule diagnostics that were only emitting a warning message without help or notes:

- **no-undefined**: Suggests using `void 0` or `typeof` check as alternatives
- **prefer-numeric-literals**: Explains numeric literal alternatives to `parseInt()`
- **prefer-object-has-own**: Suggests `Object.hasOwn()` as a shorter, more reliable alternative

Part of #19121.

**Note:** Snapshot tests will need to be regenerated (I don't have a Rust toolchain on this machine). Happy to update them if needed, or a maintainer can run `cargo insta review`.