### PR TITLE
feat(linter): Improve the oxlint config generated by `--init`.

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -967,6 +967,10 @@ mod test {
         Tester::new().with_cwd(temp_dir.path().to_path_buf()).test(args);
 
         assert!(fs::exists(&config_path).unwrap());
+
+        let content = fs::read_to_string(config_path).unwrap();
+
+        insta::assert_snapshot!("init_config", content);
     }
 
     #[test]

--- a/apps/oxlint/src/mode/init.rs
+++ b/apps/oxlint/src/mode/init.rs
@@ -1,33 +1,26 @@
 use std::{fs, path::Path};
 
-use oxc_linter::Oxlintrc;
-use serde_json::Value;
+use serde_json::json;
 
 use crate::{DEFAULT_OXLINTRC_NAME, cli::CliRunResult, lint::print_and_flush_stdout};
 
 pub fn run_init(cwd: &Path, stdout: &mut dyn std::io::Write) -> CliRunResult {
-    let oxlintrc_for_print = serde_json::to_string_pretty(&Oxlintrc::default()).unwrap();
+    let mut config = serde_json::Map::new();
 
-    let schema_relative_path = "node_modules/oxlint/configuration_schema.json";
-    let configuration = if cwd.join(schema_relative_path).is_file() {
-        let mut config_json: Value = serde_json::from_str(&oxlintrc_for_print).unwrap();
-        if let Value::Object(ref mut obj) = config_json {
-            let mut json_object = serde_json::Map::new();
-            json_object.insert("$schema".to_string(), format!("./{schema_relative_path}").into());
-            json_object.extend(obj.clone());
-            *obj = json_object;
-        }
-        serde_json::to_string_pretty(&config_json).unwrap()
-    } else {
-        oxlintrc_for_print
-    };
+    config.insert("$schema".to_string(), json!("./node_modules/oxlint/configuration_schema.json"));
+
+    config.insert("plugins".to_string(), json!(["typescript", "unicorn", "oxc"]));
+    config.insert("categories".to_string(), json!({ "correctness": "error" }));
+    config.insert("rules".to_string(), json!({}));
+    config.insert("env".to_string(), json!({ "builtin": true }));
+
+    let configuration = serde_json::to_string_pretty(&serde_json::Value::Object(config)).unwrap();
 
     if fs::write(cwd.join(DEFAULT_OXLINTRC_NAME), configuration).is_ok() {
         print_and_flush_stdout(stdout, "Configuration file created\n");
         return CliRunResult::ConfigFileInitSucceeded;
     }
 
-    // failed case
     print_and_flush_stdout(stdout, "Failed to create configuration file\n");
     CliRunResult::ConfigFileInitFailed
 }

--- a/apps/oxlint/src/snapshots/oxlint__lint__test__init_config.snap
+++ b/apps/oxlint/src/snapshots/oxlint__lint__test__init_config.snap
@@ -1,0 +1,19 @@
+---
+source: apps/oxlint/src/lint.rs
+expression: content
+---
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "unicorn",
+    "oxc"
+  ],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {},
+  "env": {
+    "builtin": true
+  }
+}


### PR DESCRIPTION
Motivated by https://github.com/oxc-project/oxc/issues/20614, and my own opinion for the last while that the init flag produced a config that was far too verbose.

AI Disclosure: Generated the change with Claude Code, fully reviewed, guided, and tested by me.

Before:

```jsonc
{
  "plugins": null,
  "categories": {},
  "rules": {},
  "settings": {
    "jsx-a11y": {
      "polymorphicPropName": null,
      "components": {},
      "attributes": {}
    },
    "next": {
      "rootDir": []
    },
    "react": {
      "formComponents": [],
      "linkComponents": [],
      "version": null,
      "componentWrapperFunctions": []
    },
    "jsdoc": {
      "ignorePrivate": false,
      "ignoreInternal": false,
      "ignoreReplacesDocs": true,
      "overrideReplacesDocs": true,
      "augmentsExtendsReplacesDocs": false,
      "implementsReplacesDocs": false,
      "exemptDestructuredRootsFromChecks": false,
      "tagNamePreference": {}
    },
    "vitest": {
      "typecheck": false
    }
  },
  "env": {
    "builtin": true
  },
  "globals": {},
  "ignorePatterns": []
}
```

After this PR:

```jsonc
{
  "$schema": "./node_modules/oxlint/configuration_schema.json",
  "plugins": [
    "typescript",
    "unicorn",
    "oxc"
  ],
  "categories": {
    "correctness": "error"
  },
  "rules": {},
  "env": {
    "builtin": true
  }
}
```

Also adds a snapshot test for the output of the `--init` flag, to ensure that we'll know if we change it in the future.

I realize this _technically_ is also a change in that correctness defaults to `warn` in oxlint with no config file, but I think that's a bad default so I changed it :) We can change it back if we really want to.

When running the snapshot tests I also got a warning about the old insta format being used for one of the snaps, so I force-regen'd them all, which is the reason for a few misc changes in this PR.