### PR TITLE
docs(linter): Update rule docs to use Vue components for some sections.

### DIFF
--- a/tasks/website_linter/src/rules/doc_page.rs
+++ b/tasks/website_linter/src/rules/doc_page.rs
@@ -93,7 +93,7 @@ const source = `{}`;{}
         )?;
 
         // Add a <RuleHeader> element, will be handled by the Vitepress site to render necessary data.
-        writeln!(self.page, "\n<RuleHeader />\n")?;
+        writeln!(self.page, "\n<RuleHeader />")?;
 
         // rule documentation
         if let Some(docs) = documentation {
@@ -118,21 +118,11 @@ const source = `{}`;{}
             }
         }
 
-        // how to use
-        writeln!(self.page, "\n## How to use\n{}", how_to_use(rule))?;
-        writeln!(self.page, "\n## References\n")?;
-
-        // rule source link(s)
+        // how-to-use and rule references components.
         writeln!(
             self.page,
-            r#"- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>"#
+            "\n## How to use\n<RuleHowToUse />\n\n## References\n<RuleReferences />"
         )?;
-        if *is_tsgolint_rule {
-            writeln!(
-                self.page,
-                r#"- <a v-bind:href="tsgolintSource" target="_blank" rel="noreferrer">Rule Source (tsgolint)</a>"#
-            )?;
-        }
 
         Ok(self.page.take())
     }
@@ -267,73 +257,12 @@ fn tsgolint_rule_source(rule: &RuleTableRow) -> String {
     format!("https://github.com/oxc-project/tsgolint/blob/main/internal/rules/{rule_path}")
 }
 
-/// Returns `true` if the given plugin is a default plugin.
-/// - Example: `eslint` => true
-/// - Example: `jest` => false
-fn is_default_plugin(plugin: &str) -> bool {
-    LintPlugins::try_from(plugin).is_ok_and(|plugin| LintPlugins::default().contains(plugin))
-}
-
 /// Returns the normalized plugin name.
 /// - Example: `react_perf` -> `react-perf`
 /// - Example: `eslint` -> `eslint`
 /// - Example: `jsx_a11y` -> `jsx-a11y`
 fn get_normalized_plugin_name(plugin: &str) -> &str {
     LintPlugins::try_from(plugin).unwrap_or(LintPlugins::empty()).into()
-}
-
-fn how_to_use(rule: &RuleTableRow) -> String {
-    let plugin = &rule.plugin;
-    let normalized_plugin_name = get_normalized_plugin_name(plugin);
-    // We don't want to display the `eslint/` prefix in the how-to-use for now.
-    let rule_full_name = full_rule_name(rule, normalized_plugin_name, false);
-    let is_default_plugin = is_default_plugin(plugin);
-    let is_tsgolint_rule = rule.is_tsgolint_rule;
-
-    let type_aware_flag = if is_tsgolint_rule { "--type-aware " } else { "" };
-
-    let enable_bash_example = if is_default_plugin {
-        format!(r"oxlint {type_aware_flag}--deny {rule_full_name}")
-    } else {
-        format!(
-            r"oxlint {type_aware_flag}--deny {rule_full_name} --{normalized_plugin_name}-plugin"
-        )
-    };
-    let enable_config_example = if is_default_plugin {
-        format!(
-            r#"{{
-    "rules": {{
-        "{rule_full_name}": "error"
-    }}
-}}"#
-        )
-    } else {
-        format!(
-            r#"{{
-    "plugins": ["{normalized_plugin_name}"],
-    "rules": {{
-        "{rule_full_name}": "error"
-    }}
-}}"#
-        )
-    };
-    format!(
-        r"
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{enable_config_example}
-```
-
-```bash [CLI]
-{enable_bash_example}
-```
-
-:::
-"
-    )
 }
 
 // Return the full rule name, including plugin prefix if necessary. For example:

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -20,7 +20,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 
 <RuleHeader />
 
-
 ### What it does
 
 Disallows variable declarations, imports, or type declarations that are
@@ -595,29 +594,10 @@ console.log(b);
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "no-unused-vars": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny no-unused-vars
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- import/namespace.md ---
@@ -637,7 +617,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -707,30 +686,10 @@ Whether to allow computed references to an imported namespace.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["import"],
-    "rules": {
-        "import/namespace": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny import/namespace --import-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- jest/expect-expect.md ---
@@ -750,7 +709,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -811,30 +769,10 @@ NOTE: The default value is `["expect"]` for Jest and
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["jest"],
-    "rules": {
-        "jest/expect-expect": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny jest/expect-expect --jest-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- nextjs/no-duplicate-head.md ---
@@ -854,7 +792,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -911,30 +848,10 @@ export default MyDocument
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["nextjs"],
-    "rules": {
-        "nextjs/no-duplicate-head": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny nextjs/no-duplicate-head --nextjs-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- promise/no-callback-in-promise.md ---
@@ -954,7 +871,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1025,30 +941,10 @@ Boolean as to whether callbacks in timeout functions like `setTimeout` will err.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["promise"],
-    "rules": {
-        "promise/no-callback-in-promise": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny promise/no-callback-in-promise --promise-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- react/no-will-update-set-state.md ---
@@ -1068,7 +964,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1117,30 +1012,10 @@ type: `"allowed" | "disallow-in-func"`
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["react"],
-    "rules": {
-        "react/no-will-update-set-state": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny react/no-will-update-set-state --react-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- typescript/no-floating-promises.md ---
@@ -1161,7 +1036,6 @@ const tsgolintSource = `https://github.com/oxc-project/tsgolint/blob/main/intern
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1416,30 +1290,10 @@ Ignore Promises that are void expressions.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "typescript/no-floating-promises": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --type-aware --deny typescript/no-floating-promises
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
-- <a v-bind:href="tsgolintSource" target="_blank" rel="noreferrer">Rule Source (tsgolint)</a>
+<RuleReferences />
 
 
 --- vue/no-lifecycle-after-await.md ---
@@ -1459,7 +1313,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1501,30 +1354,10 @@ export default {
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["vue"],
-    "rules": {
-        "vue/no-lifecycle-after-await": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny vue/no-lifecycle-after-await --vue-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- unicorn/prefer-array-find.md ---
@@ -1544,7 +1377,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1573,29 +1405,10 @@ const match = users.find(fn);
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "unicorn/prefer-array-find": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny unicorn/prefer-array-find
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- oxc/no-barrel-file.md ---
@@ -1615,7 +1428,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1671,29 +1483,10 @@ before the rule is triggered.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "oxc/no-barrel-file": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny oxc/no-barrel-file
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- react/forbid-dom-props.md ---
@@ -1713,7 +1506,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1806,30 +1598,10 @@ The name of the prop to forbid.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["react"],
-    "rules": {
-        "react/forbid-dom-props": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny react/forbid-dom-props --react-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- typescript/no-explicit-any.md ---
@@ -1849,7 +1621,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -1920,29 +1691,10 @@ Whether to ignore rest parameter arrays.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "typescript/no-explicit-any": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny typescript/no-explicit-any
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- jsdoc/require-returns.md ---
@@ -1962,7 +1714,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -2047,30 +1798,10 @@ Whether to require a `@returns` tag for async functions.
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["jsdoc"],
-    "rules": {
-        "jsdoc/require-returns": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny jsdoc/require-returns --jsdoc-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- react/rules-of-hooks.md ---
@@ -2090,7 +1821,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -2152,30 +1882,10 @@ function useCustomHook() {
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "plugins": ["react"],
-    "rules": {
-        "react/rules-of-hooks": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny react/rules-of-hooks --react-plugin
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />
 
 
 --- typescript/class-literal-property-style.md ---
@@ -2195,7 +1905,6 @@ const source = `https://github.com/oxc-project/oxc/blob/${ data }/crates/oxc_lin
 </script>
 
 <RuleHeader />
-
 
 ### What it does
 
@@ -2234,26 +1943,7 @@ type: `"fields" | "getters"`
 
 
 ## How to use
-
-To **enable** this rule using the config file or in the CLI, you can use:
-
-::: code-group
-
-```json [Config (.oxlintrc.json)]
-{
-    "rules": {
-        "typescript/class-literal-property-style": "error"
-    }
-}
-```
-
-```bash [CLI]
-oxlint --deny typescript/class-literal-property-style
-```
-
-:::
-
+<RuleHowToUse />
 
 ## References
-
-- <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>
+<RuleReferences />


### PR DESCRIPTION
I've created components in the website repo to handle the "How to use" and "References" sections of the rule documentation pages.

This will enable us to handle updates to these sections of the page centrally in those components, rather than needing to add more complex logic in the Rust code that generates the markdown for the rule docs.

See https://github.com/oxc-project/website/pull/1010 for the website change.

Results in the same output as the current live site, for example [consistent-type-exports](https://oxc.rs/docs/guide/usage/linter/rules/typescript/consistent-type-exports.html):

<img width="769" height="603" alt="Screenshot 2026-03-22 at 11 11 48 PM" src="https://github.com/user-attachments/assets/69f78acb-8912-4249-8b77-99ccb0875687" />

Though now it'll have the `typeAware` option set in the json config because I added that to the new component :) In the future we can also add a dynamic playground link, an example tab for `oxlint.config.ts`, and an example for `vite.config.ts`.