### PR TITLE
fix(formatter): Align more trailing comment cases with prettier (#20636)

### DIFF
--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1494,6 +1494,14 @@ impl<'a> Format<'a> for FormatTSSignature<'a, '_> {
             return write!(f, [self.signature]);
         }
 
+        if f.comments().has_trailing_suppression_comment(self.signature.span().end) {
+            write!(f, [FormatSuppressedNode(self.signature.span())]);
+            let comments =
+                f.context().comments().end_of_line_comments_after(self.signature.span().end);
+            write!(f, FormatTrailingComments::Comments(comments));
+            return;
+        }
+
         write!(f, [&self.signature]);
 
         match f.options().semicolons {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -184,6 +184,11 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, ObjectProperty<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
+        if f.comments().has_trailing_suppression_comment(self.span().end) {
+            write!(f, [FormatSuppressedNode(self.span())]);
+            return;
+        }
+
         let is_accessor = match &self.kind() {
             PropertyKind::Init => false,
             PropertyKind::Get => {
@@ -635,7 +640,11 @@ impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
 struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
 impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        write!(f, FormatNodeWithoutTrailingComments(self.0));
+        if f.comments().has_trailing_suppression_comment(self.0.span().end) {
+            write!(f, FormatSuppressedNode(self.0.span()));
+        } else {
+            write!(f, FormatNodeWithoutTrailingComments(self.0));
+        }
         let comments = f.context().comments().comments_before_character(self.0.span().end, b')');
         if !comments.is_empty() {
             write!(f, [space(), FormatTrailingComments::Comments(comments)]);

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -640,11 +640,9 @@ impl<'a> Format<'a> for FormatCommentForEmptyStatement<'a, '_> {
 struct FormatTestOfIfAndWhileStatement<'a, 'b>(&'b AstNode<'a, Expression<'a>>);
 impl<'a> Format<'a> for FormatTestOfIfAndWhileStatement<'a, '_> {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
-        if f.comments().has_trailing_suppression_comment(self.0.span().end) {
-            write!(f, FormatSuppressedNode(self.0.span()));
-        } else {
-            write!(f, FormatNodeWithoutTrailingComments(self.0));
-        }
+        // FormatNodeWithoutTrailingComments already handles suppression comments internally,
+        // so no separate has_trailing_suppression_comment check is needed here.
+        write!(f, FormatNodeWithoutTrailingComments(self.0));
         let comments = f.context().comments().comments_before_character(self.0.span().end, b')');
         if !comments.is_empty() {
             write!(f, [space(), FormatTrailingComments::Comments(comments)]);

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -211,9 +211,11 @@ fn format_union_types<'a>(
     let mut node_iter = node.iter().peekable();
     while let Some(element) = node_iter.next() {
         let element_span = element.span();
+        let has_trailing_suppression_comment =
+            f.comments().has_trailing_suppression_comment(element_span.end);
 
-        if suppressed_node_span == element_span {
-            let comments = f.context().comments().comments_before(suppressed_node_span.start);
+        if suppressed_node_span == element_span || has_trailing_suppression_comment {
+            let comments = f.context().comments().comments_before(element_span.start);
             FormatLeadingComments::Comments(comments).fmt(f);
             let needs_parentheses = element.needs_parentheses(f);
             if needs_parentheses {

--- a/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
+++ b/crates/oxc_formatter/src/utils/format_node_without_trailing_comments.rs
@@ -1,6 +1,10 @@
 use oxc_span::GetSpan;
 
-use crate::{Format, formatter::Formatter};
+use crate::{
+    Format,
+    formatter::{Formatter, trivia::format_leading_comments},
+    utils::suppressed::FormatSuppressedNode,
+};
 
 /// Generic wrapper for formatting a node without its trailing comments.
 ///
@@ -15,6 +19,12 @@ where
 {
     fn fmt(&self, f: &mut Formatter<'_, 'a>) {
         let node_end = self.0.span().end;
+
+        if f.comments().has_trailing_suppression_comment(node_end) {
+            format_leading_comments(self.0.span()).fmt(f);
+            FormatSuppressedNode(self.0.span()).fmt(f);
+            return;
+        }
 
         // Save the current comment view limit and temporarily restrict it
         // to hide comments that start at or after the node's end position

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts
@@ -18,3 +18,21 @@ function sectionsDemo() {
     primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
   };
 }
+
+const conditionalTest =
+  fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+    ? leftValue
+    : rightValue;
+
+const conditionalConsequent = condition
+  ? fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+  : rightValue;
+
+type UnionCase =
+  {a:1,b:2,c:3,d:4,e:5} // prettier-ignore
+  | Other;
+
+interface signatureLineCase {
+  value: SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+  method(): SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts
@@ -7,3 +7,14 @@ function demo(): { a: number } {
 
 type Complex = {a:1,b:2,c:3}; // prettier-ignore
 interface Cfg {a:number;b:string;} // prettier-ignore
+
+if (
+  await fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+) {
+}
+
+function sectionsDemo() {
+  const data = {
+    primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
+  };
+}

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 229
 ---
 ==================== Input ====================
 const config: Record<string, number> = {  retries:10,timeout:5000}; // prettier-ignore
@@ -11,6 +12,17 @@ function demo(): { a: number } {
 
 type Complex = {a:1,b:2,c:3}; // prettier-ignore
 interface Cfg {a:number;b:string;} // prettier-ignore
+
+if (
+  await fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+) {
+}
+
+function sectionsDemo() {
+  const data = {
+    primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
+  };
+}
 
 ==================== Output ====================
 ------------------
@@ -26,6 +38,17 @@ function demo(): { a: number } {
 type Complex = {a:1,b:2,c:3}; // prettier-ignore
 interface Cfg {a:number;b:string;} // prettier-ignore
 
+if (
+  await fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+) {
+}
+
+function sectionsDemo() {
+  const data = {
+    primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
+  };
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -38,5 +61,16 @@ function demo(): { a: number } {
 
 type Complex = {a:1,b:2,c:3}; // prettier-ignore
 interface Cfg {a:number;b:string;} // prettier-ignore
+
+if (
+  await fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+) {
+}
+
+function sectionsDemo() {
+  const data = {
+    primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
+  };
+}
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/ignore/trailing-comment.ts.snap
@@ -24,6 +24,24 @@ function sectionsDemo() {
   };
 }
 
+const conditionalTest =
+  fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+    ? leftValue
+    : rightValue;
+
+const conditionalConsequent = condition
+  ? fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+  : rightValue;
+
+type UnionCase =
+  {a:1,b:2,c:3,d:4,e:5} // prettier-ignore
+  | Other;
+
+interface signatureLineCase {
+  value: SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+  method(): SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -49,6 +67,24 @@ function sectionsDemo() {
   };
 }
 
+const conditionalTest =
+  fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+    ? leftValue
+    : rightValue;
+
+const conditionalConsequent = condition
+  ? fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+  : rightValue;
+
+type UnionCase =
+  | {a:1,b:2,c:3,d:4,e:5} // prettier-ignore
+  | Other;
+
+interface signatureLineCase {
+  value: SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+  method(): SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -71,6 +107,24 @@ function sectionsDemo() {
   const data = {
     primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
   };
+}
+
+const conditionalTest =
+  fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+    ? leftValue
+    : rightValue;
+
+const conditionalConsequent = condition
+  ? fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
+  : rightValue;
+
+type UnionCase =
+  | {a:1,b:2,c:3,d:4,e:5} // prettier-ignore
+  | Other;
+
+interface signatureLineCase {
+  value: SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
+  method(): SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
 }
 
 ===================== End =====================


### PR DESCRIPTION
I've found 6 more cases where prettier and oxfmt disagree on the trailing comment - and with this PR/fix, our own code base is now also formatted 100% the same

```
if (
  await fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
) {
}

function sectionsDemo() {
  const data = {
    primarySection: { id: 'primarySection', name: 'Primary Section', href: '/primary-section', icon: PrimarySectionIcon }, // prettier-ignore
  };
}

const conditionalTest =
  fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
    ? leftValue
    : rightValue;

const conditionalConsequent = condition
  ? fetchEntryByCompositeKey(source, primaryToken, previewTextValue, groupToken, rangeStartValue, rangeEndValue) // prettier-ignore
  : rightValue;

type UnionCase =
  | {a:1,b:2,c:3,d:4,e:5} // prettier-ignore
  | Other;

interface signatureLineCase {
  value: SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
  method(): SomeVeryLongTypeName<FirstParam, SecondParam, ThirdParam, FourthParam> // prettier-ignore
}
```


Playground link:

https://playground.oxc.rs/?t=formatter&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Atrue%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22tsx%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=if+%28%0A++await+fetchEntryByCompositeKey%28source%2C+primaryToken%2C+previewTextValue%2C+groupToken%2C+rangeStartValue%2C+rangeEndValue%29+%2F%2F+prettier-ignore%0A%29+%7B%0A%7D%0A%0Afunction+sectionsDemo%28%29+%7B%0A++const+data+%3D+%7B%0A++++primarySection%3A+%7B+id%3A+%27primarySection%27%2C+name%3A+%27Primary+Section%27%2C+href%3A+%27%2Fprimary-section%27%2C+icon%3A+PrimarySectionIcon+%7D%2C+%2F%2F+prettier-ignore%0A++%7D%3B%0A%7D%0A%0Aconst+conditionalTest+%3D%0A++fetchEntryByCompositeKey%28source%2C+primaryToken%2C+previewTextValue%2C+groupToken%2C+rangeStartValue%2C+rangeEndValue%29+%2F%2F+prettier-ignore%0A++++%3F+leftValue%0A++++%3A+rightValue%3B%0A%0Aconst+conditionalConsequent+%3D+condition%0A++%3F+fetchEntryByCompositeKey%28source%2C+primaryToken%2C+previewTextValue%2C+groupToken%2C+rangeStartValue%2C+rangeEndValue%29+%2F%2F+prettier-ignore%0A++%3A+rightValue%3B%0A%0Atype+UnionCase+%3D%0A++%7C+%7Ba%3A1%2Cb%3A2%2Cc%3A3%2Cd%3A4%2Ce%3A5%7D+%2F%2F+prettier-ignore%0A++%7C+Other%3B%0A%0Ainterface+signatureLineCase+%7B%0A++value%3A+SomeVeryLongTypeName%3CFirstParam%2C+SecondParam%2C+ThirdParam%2C+FourthParam%3E+%2F%2F+prettier-ignore%0A++method%28%29%3A+SomeVeryLongTypeName%3CFirstParam%2C+SecondParam%2C+ThirdParam%2C+FourthParam%3E+%2F%2F+prettier-ignore%0A%7D&formatterPanels=output%2Cprettier