### PR TITLE
perf(allocator): remove op from `StringBuilder::grow_one`

### DIFF
--- a/crates/oxc_allocator/src/string_builder.rs
+++ b/crates/oxc_allocator/src/string_builder.rs
@@ -524,9 +524,10 @@ impl<'a> StringBuilder<'a> {
             // `DEFAULT_MIN_CAPACITY` in `with_capacity_in` and `from_str_in`, then can remove this line.
             let additional = cmp::max(current_capacity, DEFAULT_MIN_CAPACITY);
 
-            let new_capacity = current_capacity
-                .checked_add(additional)
-                .expect("attempt to grow `StringBuilder` beyond `isize::MAX` bytes");
+            // `current_capacity` is max `isize::MAX` bytes.
+            // `additional` is also max `isize::MAX` bytes.
+            // Therefore this addition cannot overflow.
+            let new_capacity = current_capacity + additional;
 
             // SAFETY: We already allocated this, so must have a valid layout
             let old_layout = unsafe { Layout::from_size_align_unchecked(current_capacity, 1) };


### PR DESCRIPTION
Remove a bounds check from `StringBuilder::grow_one` (which is used by `StringBuilder::push_ascii_byte`). Rationale is explained in comment added in this PR.