### PR TITLE
refactor(lexer): revert `Kind` methods to normal matches

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -217,10 +217,14 @@ impl Kind {
         matches!(self, Eof)
     }
 
-    /// All numeric literals are contiguous from Decimal..=HexBigInt in the enum.
+    #[rustfmt::skip]
     #[inline]
     pub const fn is_number(self) -> bool {
-        matches!(self as u8, x if x >= Decimal as u8 && x <= HexBigInt as u8)
+        matches!(
+            self,
+            Decimal | Float | Binary | Octal | Hex | PositiveExponential | NegativeExponential
+            | DecimalBigInt | BinaryBigInt | OctalBigInt | HexBigInt
+        )
     }
 
     #[inline] // Inline into `read_non_decimal` - see comment there as to why
@@ -363,10 +367,20 @@ impl Kind {
     }
 
     /// [Keywords and Reserved Words](https://tc39.es/ecma262/#sec-keywords-and-reserved-words)
-    /// All keywords are contiguous from Await..=Null in the enum for optimal range check.
     #[inline]
     pub const fn is_any_keyword(self) -> bool {
-        matches!(self as u8, x if x >= Await as u8 && x <= Null as u8)
+        // Note: `is_future_reserved_keyword` is a subset of `is_strict_mode_contextual_keyword`,
+        // so the last arm is redundant. We include it anyway so each spec category is represented:
+        // - Reserved words: https://tc39.es/ecma262/#prod-ReservedWord
+        // - Contextual keywords: https://tc39.es/ecma262/#sec-keywords-and-reserved-words
+        // - Strict mode reserved words: https://tc39.es/ecma262/#sec-strict-mode-of-ecmascript
+        // - Future reserved words: https://tc39.es/ecma262/#sec-future-reserved-words
+        // The compiler optimizes all four calls into a single range check (2 instructions total),
+        // so keeping `is_future_reserved_keyword` has no performance impact.
+        self.is_reserved_keyword()
+            || self.is_contextual_keyword()
+            || self.is_strict_mode_contextual_keyword()
+            || self.is_future_reserved_keyword()
     }
 
     #[rustfmt::skip]


### PR DESCRIPTION
Partially revert #14410. That PR altered `Kind::is_number` and `Kind::is_any_keyword`, replacing `matches!` on `Kind` variants and method calls with explicit matching on the enum discriminant range e.g. `matches!(self as u8, x if x >= Decimal as u8 && x <= HexBigInt as u8)`.

The rationale for the change was improved performance. I was suspicious of the AI's claims that this was a perf improvement, as I assumed that compiler would boil down the code to the same anyway.

I asked Claude to generate the ASM before / after and he concluded it makes no difference either way.

> The compiler generates identical code - a simple sub + cmp + setb range check in both cases.
>
> ```asm
> // is_number
> add dil, 107
> cmp dil, 11
> setb al
> ```
> 
> LLVM recognises that:
> 
> 1. Contiguous matches! variants can be reduced to a range check.
> 2. The union of the 4 keyword sub-methods covers a contiguous range, so it merges them into a single range check.
>
> The commit's claim about "20% fewer instructions" and "better pipeline utilization" is nonsense. The manual `as u8` casts just make the code harder to read for zero benefit.

New Claude pretty damning about old Claude!

So go back to explicit matches, as it's easier to understand.