### PR TITLE
feat(oxfmt): add `resolveConfig` API for resolving effective config per file

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -52,6 +52,14 @@ export interface FormatResult {
 export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, initExternalFormatterCb: (numThreads: number) => Promise<string[]>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
 
 /**
+ * NAPI based config resolution API entry point.
+ *
+ * Returns the effective configuration for the given file path after applying
+ * config discovery, `.oxfmtrc` overrides, and `.editorconfig` fallback values.
+ */
+export declare function resolveConfig(fileName: string, loadJsConfigCb: (path: string) => Promise<any>): Promise<any | null>
+
+/**
  * NAPI based JS CLI entry point.
  * For pure Rust CLI entry point, see `main.rs`.
  *

--- a/apps/oxfmt/src-js/bindings.js
+++ b/apps/oxfmt/src-js/bindings.js
@@ -579,8 +579,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Severity, format, jsTextToDoc, runCli } = nativeBinding
+const { Severity, format, jsTextToDoc, resolveConfig, runCli } = nativeBinding
 export { Severity }
 export { format }
 export { jsTextToDoc }
+export { resolveConfig }
 export { runCli }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -71,15 +71,9 @@ export function defineConfig<T extends OxfmtConfig>(config: T): T {
 /**
  * Format the given source text according to the specified options.
  */
-export async function format(
-  fileName: string,
-  sourceText: string,
-  options?: FormatConfig,
-) {
-  if (typeof fileName !== "string")
-    throw new TypeError("`fileName` must be a string");
-  if (typeof sourceText !== "string")
-    throw new TypeError("`sourceText` must be a string");
+export async function format(fileName: string, sourceText: string, options?: FormatConfig) {
+  if (typeof fileName !== "string") throw new TypeError("`fileName` must be a string");
+  if (typeof sourceText !== "string") throw new TypeError("`sourceText` must be a string");
 
   return napiFormat(
     fileName,
@@ -98,11 +92,8 @@ export async function format(
  *
  * Returns `null` when neither an Oxfmt config file nor `.editorconfig` is found.
  */
-export async function resolveConfig(
-  fileName: string,
-): Promise<FormatConfig | null> {
-  if (typeof fileName !== "string")
-    throw new TypeError("`fileName` must be a string");
+export async function resolveConfig(fileName: string): Promise<FormatConfig | null> {
+  if (typeof fileName !== "string") throw new TypeError("`fileName` must be a string");
   return napiResolveConfig(fileName, loadJsConfig);
 }
 

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -1,6 +1,10 @@
 // napi-JS `oxfmt` API entry point
 
-import { format as napiFormat, jsTextToDoc as napiJsTextToDoc } from "./bindings";
+import {
+  format as napiFormat,
+  jsTextToDoc as napiJsTextToDoc,
+  resolveConfig as napiResolveConfig,
+} from "./bindings";
 import {
   resolvePlugins,
   formatFile,
@@ -8,6 +12,7 @@ import {
   formatEmbeddedDoc,
   sortTailwindClasses,
 } from "./libs/apis";
+import { loadJsConfig } from "./cli/js_config";
 // Types are auto-generated from the JSON Schema.
 import type {
   Oxfmtrc,
@@ -66,9 +71,15 @@ export function defineConfig<T extends OxfmtConfig>(config: T): T {
 /**
  * Format the given source text according to the specified options.
  */
-export async function format(fileName: string, sourceText: string, options?: FormatConfig) {
-  if (typeof fileName !== "string") throw new TypeError("`fileName` must be a string");
-  if (typeof sourceText !== "string") throw new TypeError("`sourceText` must be a string");
+export async function format(
+  fileName: string,
+  sourceText: string,
+  options?: FormatConfig,
+) {
+  if (typeof fileName !== "string")
+    throw new TypeError("`fileName` must be a string");
+  if (typeof sourceText !== "string")
+    throw new TypeError("`sourceText` must be a string");
 
   return napiFormat(
     fileName,
@@ -80,6 +91,19 @@ export async function format(fileName: string, sourceText: string, options?: For
     (options, texts) => formatEmbeddedDoc({ options, texts }),
     (options, classes) => sortTailwindClasses({ options, classes }),
   );
+}
+
+/**
+ * Resolve the effective configuration for the given file path.
+ *
+ * Returns `null` when neither an Oxfmt config file nor `.editorconfig` is found.
+ */
+export async function resolveConfig(
+  fileName: string,
+): Promise<FormatConfig | null> {
+  if (typeof fileName !== "string")
+    throw new TypeError("`fileName` must be a string");
+  return napiResolveConfig(fileName, loadJsConfig);
 }
 
 /**

--- a/apps/oxfmt/src/api/mod.rs
+++ b/apps/oxfmt/src/api/mod.rs
@@ -1,2 +1,3 @@
 pub mod format_api;
+pub mod resolve_config_api;
 pub mod text_to_doc_api;

--- a/apps/oxfmt/src/api/resolve_config_api.rs
+++ b/apps/oxfmt/src/api/resolve_config_api.rs
@@ -1,0 +1,46 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use serde_json::Value;
+
+use crate::core::{
+    ConfigResolver, JsLoadJsConfigCb, create_js_config_loader, resolve_editorconfig_path,
+};
+
+/// `resolveConfig()` implementation for the NAPI API.
+///
+/// Returns `None` when no `.oxfmtrc*`, JS config, `vite.config.ts` with `fmt`,
+/// or `.editorconfig` can be found for the target file.
+///
+/// # Panics
+/// Panics if the current working directory cannot be determined.
+pub fn run(file_name: &str, load_js_config_cb: JsLoadJsConfigCb) -> Result<Option<Value>, String> {
+    let cwd = env::current_dir().expect("Failed to get current working directory");
+    let target_path = normalize_target_path(&cwd, file_name);
+    let discovery_cwd = target_path.parent().unwrap_or(&cwd);
+    let js_config_loader = create_js_config_loader(load_js_config_cb);
+    let editorconfig_path = resolve_editorconfig_path(discovery_cwd);
+
+    let mut resolver = ConfigResolver::from_config(
+        discovery_cwd,
+        None,
+        editorconfig_path.as_deref(),
+        Some(&js_config_loader),
+    )?;
+    resolver.build_and_validate()?;
+
+    if resolver.config_dir().is_none() && !resolver.has_editorconfig() {
+        return Ok(None);
+    }
+
+    serde_json::to_value(resolver.resolve_format_config(&target_path))
+        .map(Some)
+        .map_err(|err| err.to_string())
+}
+
+fn normalize_target_path(cwd: &Path, file_name: &str) -> PathBuf {
+    let path = PathBuf::from(file_name);
+    if path.is_absolute() { path } else { cwd.join(path) }
+}

--- a/apps/oxfmt/src/core/config.rs
+++ b/apps/oxfmt/src/core/config.rs
@@ -190,6 +190,9 @@ pub struct ConfigResolver {
     /// Cached parsed options after validation.
     /// Used to avoid re-parsing during per-file resolution, if no per-file overrides exist.
     cached_options: Option<(OxfmtOptions, Value)>,
+    /// Cached resolved `FormatConfig` after validation.
+    /// Used by API consumers that need effective config values without formatter defaults.
+    cached_format_config: Option<FormatConfig>,
     /// Resolved overrides from `.oxfmtrc` for file-specific matching.
     oxfmtrc_overrides: Option<OxfmtrcOverrides>,
     /// Parsed `.editorconfig`, if any.
@@ -204,12 +207,25 @@ impl ConfigResolver {
         config_dir: Option<PathBuf>,
         editorconfig: Option<EditorConfig>,
     ) -> Self {
-        Self { raw_config, config_dir, cached_options: None, oxfmtrc_overrides: None, editorconfig }
+        Self {
+            raw_config,
+            config_dir,
+            cached_options: None,
+            cached_format_config: None,
+            oxfmtrc_overrides: None,
+            editorconfig,
+        }
     }
 
     /// Returns the directory containing the config file, if any was loaded.
     pub fn config_dir(&self) -> Option<&Path> {
         self.config_dir.as_deref()
+    }
+
+    /// Returns `true` if an `.editorconfig` was resolved.
+    #[cfg(feature = "napi")]
+    pub fn has_editorconfig(&self) -> bool {
+        self.editorconfig.is_some()
     }
 
     /// Create a resolver, handling both JSON/JSONC and JS/TS config files.
@@ -412,6 +428,9 @@ impl ConfigResolver {
         let mut external_options = serde_json::to_value(&format_config)
             .expect("FormatConfig serialization should not fail");
 
+        // Save cache for the `resolve_format_config` fast path (before `format_config` is moved)
+        self.cached_format_config = Some(format_config.clone());
+
         // Convert `FormatConfig` to `OxfmtOptions`, applying defaults where needed
         let oxfmt_options = to_oxfmt_options(format_config)?;
 
@@ -434,6 +453,27 @@ impl ConfigResolver {
         ResolvedOptions::from_oxfmt_options(oxfmt_options, external_options, strategy)
     }
 
+    /// Resolve the effective `FormatConfig` for a specific file path.
+    ///
+    /// This applies `.oxfmtrc` overrides and `.editorconfig` fallback values,
+    /// but does not fill in formatter defaults.
+    #[cfg(feature = "napi")]
+    pub fn resolve_format_config(&self, path: &Path) -> FormatConfig {
+        let has_editorconfig_overrides =
+            self.editorconfig.as_ref().is_some_and(|ec| has_editorconfig_overrides(ec, path));
+        let has_oxfmtrc_overrides =
+            self.oxfmtrc_overrides.as_ref().is_some_and(|o| o.has_match(path));
+
+        if !has_editorconfig_overrides && !has_oxfmtrc_overrides {
+            return self
+                .cached_format_config
+                .clone()
+                .expect("`build_and_validate()` must be called first");
+        }
+
+        self.resolve_format_config_slow(path)
+    }
+
     /// Resolve options for a specific file path.
     /// Priority: oxfmtrc base → oxfmtrc overrides → editorconfig (fallback for unset fields) -> defaults
     ///
@@ -453,7 +493,20 @@ impl ConfigResolver {
                 .expect("`build_and_validate()` must be called first");
         }
 
-        // Slow path: reconstruct `FormatConfig` to apply overrides
+        let format_config = self.resolve_format_config_slow(path);
+
+        // NOTE: See `build_and_validate()` for details about `external_options` handling
+        let mut external_options = serde_json::to_value(&format_config)
+            .expect("FormatConfig serialization should not fail");
+        let oxfmt_options = to_oxfmt_options(format_config)
+            .expect("If this fails, there is an issue with override values");
+
+        sync_external_options(&oxfmt_options.format_options, &mut external_options);
+
+        (oxfmt_options, external_options)
+    }
+
+    fn resolve_format_config_slow(&self, path: &Path) -> FormatConfig {
         // Overrides are merged at `FormatConfig` level, not `OxfmtOptions` level
         let mut format_config: FormatConfig = serde_json::from_value(self.raw_config.clone())
             .expect("`build_and_validate()` should catch this before");
@@ -475,15 +528,7 @@ impl ConfigResolver {
             format_config.resolve_tailwind_paths(config_dir);
         }
 
-        // NOTE: See `build_and_validate()` for details about `external_options` handling
-        let mut external_options = serde_json::to_value(&format_config)
-            .expect("FormatConfig serialization should not fail");
-        let oxfmt_options = to_oxfmt_options(format_config)
-            .expect("If this fails, there is an issue with override values");
-
-        sync_external_options(&oxfmt_options.format_options, &mut external_options);
-
-        (oxfmt_options, external_options)
+        format_config
     }
 }
 

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -198,8 +198,7 @@ pub async fn resolve_config(
     file_name: String,
     #[napi(ts_arg_type = "(path: string) => Promise<any>")] load_js_config_cb: JsLoadJsConfigCb,
 ) -> napi::Result<Option<Value>> {
-    resolve_config_api::run(&file_name, load_js_config_cb)
-        .map_err(napi::Error::from_reason)
+    resolve_config_api::run(&file_name, load_js_config_cb).map_err(napi::Error::from_reason)
 }
 
 // ---

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -7,7 +7,7 @@ use oxc_napi::OxcError;
 use serde_json::Value;
 
 use crate::{
-    api::{format_api, text_to_doc_api},
+    api::{format_api, resolve_config_api, text_to_doc_api},
     cli::{FormatRunner, MigrateSource, Mode, format_command, init_miette, init_rayon},
     core::{
         ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
@@ -183,6 +183,23 @@ pub async fn format(
     );
 
     FormatResult { code, errors }
+}
+
+// ---
+
+/// NAPI based config resolution API entry point.
+///
+/// Returns the effective configuration for the given file path after applying
+/// config discovery, `.oxfmtrc` overrides, and `.editorconfig` fallback values.
+#[expect(clippy::allow_attributes)]
+#[allow(clippy::trailing_empty_array, clippy::unused_async, clippy::missing_errors_doc)] // https://github.com/napi-rs/napi-rs/issues/2758
+#[napi]
+pub async fn resolve_config(
+    file_name: String,
+    #[napi(ts_arg_type = "(path: string) => Promise<any>")] load_js_config_cb: JsLoadJsConfigCb,
+) -> napi::Result<Option<Value>> {
+    resolve_config_api::run(&file_name, load_js_config_cb)
+        .map_err(napi::Error::from_reason)
 }
 
 // ---

--- a/apps/oxfmt/test/api/resolve_config.test.ts
+++ b/apps/oxfmt/test/api/resolve_config.test.ts
@@ -23,9 +23,7 @@ describe("resolveConfig() API", () => {
       await fs.mkdir(join(dir, "src"), { recursive: true });
       await fs.writeFile(join(dir, "src", "test.ts"), "export const x=1\n");
 
-      await expect(
-        resolveConfig(join(dir, "src", "test.ts")),
-      ).resolves.toBeNull();
+      await expect(resolveConfig(join(dir, "src", "test.ts"))).resolves.toBeNull();
     });
   });
 
@@ -53,14 +51,9 @@ describe("resolveConfig() API", () => {
           "",
         ].join("\n"),
       );
-      await fs.writeFile(
-        join(dir, "nested", "example.test.ts"),
-        "export const x=1\n",
-      );
+      await fs.writeFile(join(dir, "nested", "example.test.ts"), "export const x=1\n");
 
-      await expect(
-        resolveConfig(join(dir, "nested", "example.test.ts")),
-      ).resolves.toEqual({
+      await expect(resolveConfig(join(dir, "nested", "example.test.ts"))).resolves.toEqual({
         semi: false,
         useTabs: true,
         tabWidth: 4,
@@ -80,12 +73,10 @@ describe("resolveConfig() API", () => {
       );
       await fs.writeFile(join(dir, "src", "test.ts"), "export const x=1\n");
 
-      await expect(resolveConfig(join(dir, "src", "test.ts"))).resolves.toEqual(
-        {
-          semi: false,
-          singleQuote: true,
-        },
-      );
+      await expect(resolveConfig(join(dir, "src", "test.ts"))).resolves.toEqual({
+        semi: false,
+        singleQuote: true,
+      });
     });
   });
 });

--- a/apps/oxfmt/test/api/resolve_config.test.ts
+++ b/apps/oxfmt/test/api/resolve_config.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveConfig } from "../../dist/index.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(join(tmpdir(), "oxfmt-resolve-config-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("resolveConfig() API", () => {
+  it("`resolveConfig()` function exists", () => {
+    expect(typeof resolveConfig).toBe("function");
+  });
+
+  it("returns null when no config is found", async () => {
+    await withTempDir(async (dir) => {
+      await fs.mkdir(join(dir, "src"), { recursive: true });
+      await fs.writeFile(join(dir, "src", "test.ts"), "export const x=1\n");
+
+      await expect(
+        resolveConfig(join(dir, "src", "test.ts")),
+      ).resolves.toBeNull();
+    });
+  });
+
+  it("resolves .oxfmtrc overrides and .editorconfig fallback", async () => {
+    await withTempDir(async (dir) => {
+      await fs.mkdir(join(dir, "nested"), { recursive: true });
+      await fs.writeFile(
+        join(dir, ".oxfmtrc.json"),
+        JSON.stringify({
+          semi: false,
+          sortTailwindcss: { config: "./tailwind.config.js" },
+          overrides: [{ files: ["**/*.test.ts"], options: { tabWidth: 4 } }],
+        }),
+      );
+      await fs.writeFile(
+        join(dir, ".editorconfig"),
+        [
+          "root = true",
+          "",
+          "[*]",
+          "indent_style = tab",
+          "",
+          "[nested/*.test.ts]",
+          "indent_size = 6",
+          "",
+        ].join("\n"),
+      );
+      await fs.writeFile(
+        join(dir, "nested", "example.test.ts"),
+        "export const x=1\n",
+      );
+
+      await expect(
+        resolveConfig(join(dir, "nested", "example.test.ts")),
+      ).resolves.toEqual({
+        semi: false,
+        useTabs: true,
+        tabWidth: 4,
+        sortTailwindcss: {
+          config: join(dir, "tailwind.config.js"),
+        },
+      });
+    });
+  });
+
+  it("resolves JavaScript config files during auto-discovery", async () => {
+    await withTempDir(async (dir) => {
+      await fs.mkdir(join(dir, "src"), { recursive: true });
+      await fs.writeFile(
+        join(dir, "oxfmt.config.ts"),
+        "export default { semi: false, singleQuote: true };\n",
+      );
+      await fs.writeFile(join(dir, "src", "test.ts"), "export const x=1\n");
+
+      await expect(resolveConfig(join(dir, "src", "test.ts"))).resolves.toEqual(
+        {
+          semi: false,
+          singleQuote: true,
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the equivalent of Prettier's [`resolveConfig()`](https://prettier.io/docs/api.html#prettierresolveconfigfileurlorpath--options) for oxfmt's Node.js API.

- Add `resolveConfig(fileName)` that discovers `.oxfmtrc*` / JS config, applies per-file overrides and `.editorconfig` fallback values
- Returns the effective `FormatConfig` or `null` when no config source exists
- Follows the same merge priority as Prettier: `editorconfig < oxfmtrc base < oxfmtrc overrides`

### Changes

- **`apps/oxfmt/src/api/resolve_config_api.rs`** (new): Core implementation — config discovery from file's parent dir, editorconfig resolution, null handling
- **`apps/oxfmt/src/core/config.rs`**: Add `resolve_format_config()` with fast-path caching + `resolve_format_config_slow()` extracted from `resolve_options_slow()`, add `has_editorconfig()` accessor
- **`apps/oxfmt/src/main_napi.rs`**: NAPI entry point for `resolveConfig`
- **`apps/oxfmt/src-js/index.ts`**: TypeScript wrapper with input validation
- **`apps/oxfmt/src-js/bindings.{d.ts,js}`**: Auto-generated NAPI bindings
- **`apps/oxfmt/test/api/resolve_config.test.ts`** (new): Tests for null case, oxfmtrc + editorconfig merge, and JS config discovery

Closes #19922