### PR TITLE
perf(parser): pre-allocate `extends` vec with `1` cap

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -167,7 +167,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_extends_clause(&mut self) -> Vec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
-        let mut extends = self.ast.vec();
+        let mut extends = self.ast.vec_with_capacity(1);
         loop {
             let span = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();


### PR DESCRIPTION
if we hit here, it means that we've seen the `extends` keyword - having code like `class foo extends {}` is invalid as there must be at least one extends expression, so min size of the `extends`vec will be 1.

This just avoids the re-alloc