### PR TITLE
feat(linter): add help text to promise plugin diagnostics

### DIFF
--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -26,7 +26,9 @@ use crate::{
 };
 
 fn always_return_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Each then() should return a value or throw").with_label(span)
+    OxcDiagnostic::warn("Each then() should return a value or throw")
+        .with_help("Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -6,7 +6,9 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn avoid_new_promise_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Avoid creating new promises").with_label(span)
+    OxcDiagnostic::warn("Avoid creating new promises")
+        .with_help("Use `async`/`await` instead of creating a new `Promise`.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
+++ b/crates/oxc_linter/src/rules/promise/no_multiple_resolved.rs
@@ -26,11 +26,14 @@ fn already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise should not be resolved multiple times. Promise is already resolved on line {line}."
     ))
+    .with_help("Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.")
     .with_label(span)
 }
 
 fn potentially_already_resolved_diagnostic(line: usize, span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}.")).with_label(span)
+    OxcDiagnostic::warn(format!("Promise should not be resolved multiple times. Promise is potentially resolved on line {line}."))
+    .with_help("Add a guard condition or return after resolving/rejecting to prevent multiple settlements.")
+    .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -14,6 +14,7 @@ fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Promise constructor parameters must be named to match `{pattern}`"
     ))
+    .with_help("Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
@@ -10,7 +10,9 @@ use oxc_span::{GetSpan, Span};
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_await_to_callbacks(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `async`/`await` to the callback pattern").with_label(span)
+    OxcDiagnostic::warn("Prefer `async`/`await` to the callback pattern")
+        .with_help("Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.")
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_then.rs
@@ -6,7 +6,9 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 fn prefer_wait_to_then_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer await to then()/catch()/finally()").with_label(span)
+    OxcDiagnostic::warn("Prefer await to then()/catch()/finally()")
+        .with_help("Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.")
+        .with_label(span)
 }
 
 use crate::{

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -14,6 +14,7 @@ use crate::{
 
 fn spec_only(prop_name: &str, member_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Avoid using non-standard `Promise.{prop_name}` method."))
+        .with_help("Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.")
         .with_label(member_span)
 }
 

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -13,6 +13,7 @@ fn zero_or_one_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 0 or 1 arguments, but received {args_len}."
     ))
+    .with_help("Remove the extra arguments to match the expected function signature.")
     .with_label(span)
 }
 
@@ -24,6 +25,7 @@ fn one_or_two_argument_required_diagnostic(
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 or 2 arguments, but received {args_len}."
     ))
+    .with_help("Adjust the number of arguments to match the expected function signature.")
     .with_label(span)
 }
 
@@ -31,6 +33,7 @@ fn one_argument_required_diagnostic(span: Span, prop_name: &str, args_len: usize
     OxcDiagnostic::warn(format!(
         "`Promise.{prop_name}()` requires 1 argument, but received {args_len}."
     ))
+    .with_help("Pass exactly 1 argument to match the expected function signature.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/promise_always_return.snap
+++ b/crates/oxc_linter/src/snapshots/promise_always_return.snap
@@ -7,84 +7,98 @@ source: crates/oxc_linter/src/tester.rs
  1 │ hey.then(x => {})
    ·          ───────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { })
    ·          ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { }).then(x)
    ·          ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { }).then(function() { })
    ·          ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:31]
  1 │ hey.then(function() { }).then(function() { })
    ·                               ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:39]
  1 │ hey.then(function() { return; }).then(function() { })
    ·                                       ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { doSomethingWicked(); })
    ·          ───────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return x; } })
    ·          ───────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return x; } else { }})
    ·          ───────────────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { } else { return x; }})
    ·          ───────────────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { process.chdir(); } else { return x; }})
    ·          ────────────────────────────────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function() { if (x) { return you.then(function() { return x; }); } })
    ·          ────────────────────────────────────────────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:11]
  1 │ hey.then( x => { x ? x.id : null })
    ·           ────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(function(x) { x ? x.id : null })
    ·          ───────────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
     ╭─[always_return.tsx:2:21]
@@ -99,6 +113,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ ╰─▶     })
  10 │     })()
     ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
@@ -108,6 +123,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       }
  5 │ ╰─▶ })
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
@@ -117,6 +133,7 @@ source: crates/oxc_linter/src/tester.rs
  4 │ │       }
  5 │ ╰─▶ })
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:11]
@@ -125,12 +142,14 @@ source: crates/oxc_linter/src/tester.rs
    ·           ────────────────────────────────────────────────────────
  3 │     .then(function(y) { console.log(y) /* no error here */ })
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:22]
  1 │ const foo = hey.then(function(x) {});
    ·                      ──────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:21]
@@ -139,6 +158,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                     ──────────────
  3 │ }
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:2:27]
@@ -147,45 +167,53 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ───────────────────────
  3 │ }
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:23]
  1 │ const foo = hey?.then(x => { console.log(x) })
    ·                       ───────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { invalid = x })
    ·          ────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { invalid['x'] = x })
    ·          ─────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { wind[x] = x })
    ·          ────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { wind['x'] = x })
    ·          ──────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { windows['x'] = x })
    ·          ─────────────────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.
 
   ⚠ eslint-plugin-promise(always-return): Each then() should return a value or throw
    ╭─[always_return.tsx:1:10]
  1 │ hey.then(x => { x() })
    ·          ────────────
    ╰────
+  help: Return a value from the `then()` callback, throw an error, or return `undefined` explicitly.

--- a/crates/oxc_linter/src/snapshots/promise_avoid_new.snap
+++ b/crates/oxc_linter/src/snapshots/promise_avoid_new.snap
@@ -7,15 +7,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ var x = new Promise(function (x, y) {})
    ·         ───────────────────────────────
    ╰────
+  help: Use `async`/`await` instead of creating a new `Promise`.
 
   ⚠ eslint-plugin-promise(avoid-new): Avoid creating new promises
    ╭─[avoid_new.tsx:1:1]
  1 │ new Promise()
    · ─────────────
    ╰────
+  help: Use `async`/`await` instead of creating a new `Promise`.
 
   ⚠ eslint-plugin-promise(avoid-new): Avoid creating new promises
    ╭─[avoid_new.tsx:1:7]
  1 │ Thing(new Promise(() => {}))
    ·       ─────────────────────
    ╰────
+  help: Use `async`/`await` instead of creating a new `Promise`.

--- a/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
+++ b/crates/oxc_linter/src/snapshots/promise_no_multiple_resolved.snap
@@ -9,6 +9,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     })
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:6:5]
@@ -17,6 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  7 │ })
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 2.
    ╭─[no_multiple_resolved.tsx:3:5]
@@ -25,6 +27,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  4 │ })
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
     ╭─[no_multiple_resolved.tsx:12:9]
@@ -33,6 +36,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  13 │     })
     ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 5.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -41,6 +45,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
     ╭─[no_multiple_resolved.tsx:9:9]
@@ -49,6 +54,7 @@ source: crates/oxc_linter/src/tester.rs
     ·         ──────────────
  10 │     })
     ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -57,6 +63,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 8.
     ╭─[no_multiple_resolved.tsx:11:5]
@@ -65,6 +72,7 @@ source: crates/oxc_linter/src/tester.rs
     ·     ──────────────
  12 │ })
     ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -73,6 +81,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  9 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:5]
@@ -81,6 +90,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  6 │ })
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -89,6 +99,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ──────────────
  8 │ })
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:5]
@@ -97,6 +108,7 @@ source: crates/oxc_linter/src/tester.rs
    ·     ────────
  8 │ })
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 3.
    ╭─[no_multiple_resolved.tsx:5:9]
@@ -105,6 +117,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  6 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is potentially resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -113,6 +126,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ──────────────
  8 │     }
    ╰────
+  help: Add a guard condition or return after resolving/rejecting to prevent multiple settlements.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 4.
    ╭─[no_multiple_resolved.tsx:7:9]
@@ -121,6 +135,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  8 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -129,6 +144,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -137,6 +153,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:9]
@@ -145,6 +162,7 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
  9 │     }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.
 
   ⚠ eslint-plugin-promise(no-multiple-resolved): Promise should not be resolved multiple times. Promise is already resolved on line 5.
    ╭─[no_multiple_resolved.tsx:8:13]
@@ -153,3 +171,4 @@ source: crates/oxc_linter/src/tester.rs
    ·             ─────────────
  9 │         }
    ╰────
+  help: Ensure each code path through the Promise executor calls `resolve` or `reject` at most once.

--- a/crates/oxc_linter/src/snapshots/promise_param_names.snap
+++ b/crates/oxc_linter/src/snapshots/promise_param_names.snap
@@ -7,45 +7,53 @@ source: crates/oxc_linter/src/tester.rs
  1 │ new Promise(function(reject, resolve) {})
    ·                      ──────
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:30]
  1 │ new Promise(function(reject, resolve) {})
    ·                              ───────
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:31]
  1 │ new Promise(function(resolve, rej) {})
    ·                               ───
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?resolve$`
    ╭─[param_names.tsx:1:13]
  1 │ new Promise(yes => {})
    ·             ───
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?resolve$`
    ╭─[param_names.tsx:1:14]
  1 │ new Promise((yes, no) => {})
    ·              ───
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^_?reject$`
    ╭─[param_names.tsx:1:19]
  1 │ new Promise((yes, no) => {})
    ·                   ──
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^yes$`
    ╭─[param_names.tsx:1:22]
  1 │ new Promise(function(resolve, reject) { config(); })
    ·                      ───────
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).
 
   ⚠ eslint-plugin-promise(param-names): Promise constructor parameters must be named to match `^no$`
    ╭─[param_names.tsx:1:31]
  1 │ new Promise(function(resolve, reject) { config(); })
    ·                               ──────
    ╰────
+  help: Rename the Promise constructor parameters to match the required naming convention (e.g. `resolve`, `reject`).

--- a/crates/oxc_linter/src/snapshots/promise_prefer_await_to_callbacks.snap
+++ b/crates/oxc_linter/src/snapshots/promise_prefer_await_to_callbacks.snap
@@ -7,81 +7,95 @@ source: crates/oxc_linter/src/tester.rs
  1 │ heart(function(err) {})
    ·       ────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:7]
  1 │ heart(err => {})
    ·       ─────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:15]
  1 │ heart("ball", function(err) {})
    ·               ────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:22]
  1 │ function getData(id, callback) {}
    ·                      ────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:18]
  1 │ const getData = (cb) => {}
    ·                  ──
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:22]
  1 │ var x = function (x, cb) {}
    ·                      ──
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:1]
  1 │ cb()
    · ────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:1]
  1 │ callback()
    · ──────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:7]
  1 │ heart(error => {})
    ·       ───────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:27]
  1 │ async.map(files, fs.stat, function(err, results) { if (err) throw err; });
    ·                           ──────────────────────────────────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:23]
  1 │ _.map(files, fs.stat, function(err, results) { if (err) throw err; });
    ·                       ──────────────────────────────────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:21]
  1 │ map(files, fs.stat, function(err, results) { if (err) throw err; });
    ·                     ──────────────────────────────────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:5]
  1 │ map(function(err, results) { if (err) throw err; });
    ·     ──────────────────────────────────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.
 
   ⚠ eslint-plugin-promise(prefer-await-to-callbacks): Prefer `async`/`await` to the callback pattern
    ╭─[prefer_await_to_callbacks.tsx:1:19]
  1 │ customMap(errors, (err) => err.message)
    ·                   ────────────────────
    ╰────
+  help: Refactor this function to use `async`/`await` instead of callbacks for better readability and error handling.

--- a/crates/oxc_linter/src/snapshots/promise_prefer_await_to_then.snap
+++ b/crates/oxc_linter/src/snapshots/promise_prefer_await_to_then.snap
@@ -7,81 +7,95 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function foo() { hey.then(x => {}) }
    ·                      ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:43]
  1 │ function foo() { hey.then(function() { }).then() }
    ·                                           ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:22]
  1 │ function foo() { hey.then(function() { }).then() }
    ·                      ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:51]
  1 │ function foo() { hey.then(function() { }).then(x).catch() }
    ·                                                   ─────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:43]
  1 │ function foo() { hey.then(function() { }).then(x).catch() }
    ·                                           ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:22]
  1 │ function foo() { hey.then(function() { }).then(x).catch() }
    ·                      ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:47]
  1 │ async function a() { hey.then(function() { }).then(function() { }) }
    ·                                               ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:26]
  1 │ async function a() { hey.then(function() { }).then(function() { }) }
    ·                          ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:22]
  1 │ function foo() { hey.catch(x => {}) }
    ·                      ─────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:22]
  1 │ function foo() { hey.finally(x => {}) }
    ·                      ───────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:13]
  1 │ something().then(async () => await somethingElse())
    ·             ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:38]
  1 │ async function foo() { await thing().then() }
    ·                                      ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:32]
  1 │ async function foo() { thing().then() }
    ·                                ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.
 
   ⚠ eslint-plugin-promise(prefer-await-to-then): Prefer await to then()/catch()/finally()
    ╭─[prefer_await_to_then.tsx:1:37]
  1 │ async function hi() { await thing().then(x => {}) }
    ·                                     ────
    ╰────
+  help: Use `await` with a `try`/`catch` block instead of `.then()`/`.catch()`/`.finally()` chains.

--- a/crates/oxc_linter/src/snapshots/promise_spec_only.snap
+++ b/crates/oxc_linter/src/snapshots/promise_spec_only.snap
@@ -7,24 +7,28 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.done()
    · ────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.something` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.something()
    · ─────────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:1:5]
  1 │ new Promise.done()
    ·     ────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:4:22]
@@ -33,6 +37,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ────────────
  5 │             }
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.done` method.
    ╭─[spec_only.tsx:3:20]
@@ -41,15 +46,18 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ────────────
  4 │             }
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.notPermittedMethod` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.notPermittedMethod()
    · ──────────────────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.
 
   ⚠ eslint-plugin-promise(spec-only): Avoid using non-standard `Promise.differingCase` method.
    ╭─[spec_only.tsx:1:1]
  1 │ Promise.differingCase()
    · ─────────────────────
    ╰────
+  help: Use only standard `Promise` methods (`all`, `allSettled`, `any`, `race`, `reject`, `resolve`, `withResolvers`) to ensure compatibility.

--- a/crates/oxc_linter/src/snapshots/promise_valid_params.snap
+++ b/crates/oxc_linter/src/snapshots/promise_valid_params.snap
@@ -7,141 +7,165 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.resolve(1, 2)
    · ─────────────────────
    ╰────
+  help: Remove the extra arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.resolve()` requires 0 or 1 arguments, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.resolve({}, function() {}, 1, 2, 3)
    · ───────────────────────────────────────────
    ╰────
+  help: Remove the extra arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject(1, 2, 3)
    · ───────────────────────
    ╰────
+  help: Remove the extra arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.reject()` requires 0 or 1 arguments, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.reject({}, function() {}, 1, 2)
    · ───────────────────────────────────────
    ╰────
+  help: Remove the extra arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race(1, 2)
    · ──────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.race()` requires 1 argument, but received 5.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.race({}, function() {}, 1, 2, 3)
    · ────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.all()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.all({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled(1, 2, 3)
    · ───────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.allSettled()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.allSettled({}, function() {}, 1, 2)
    · ───────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any(1, 2, 3)
    · ────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.any()` requires 1 argument, but received 4.
    ╭─[valid_params.tsx:1:1]
  1 │ Promise.any({}, function() {}, 1, 2)
    · ────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then()
    · ────────────────────
    ╰────
+  help: Adjust the number of arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().then(() => {}, () => {}, () => {})
    · ────────────────────────────────────────────────
    ╰────
+  help: Adjust the number of arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then()
    · ───────────────────────
    ╰────
+  help: Adjust the number of arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.then()` requires 1 or 2 arguments, but received 3.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.then(() => {}, () => {}, () => {})
    · ───────────────────────────────────────────────────
    ╰────
+  help: Adjust the number of arguments to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch()
    · ─────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().catch(() => {}, () => {})
    · ───────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch()
    · ────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.catch()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.catch(() => {}, () => {})
    · ──────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally()
    · ───────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ somePromise().finally(() => {}, () => {})
    · ─────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 0.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally()
    · ──────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.
 
   ⚠ eslint-plugin-promise(valid-params): `Promise.finally()` requires 1 argument, but received 2.
    ╭─[valid_params.tsx:1:1]
  1 │ promiseReference.finally(() => {}, () => {})
    · ────────────────────────────────────────────
    ╰────
+  help: Pass exactly 1 argument to match the expected function signature.


### PR DESCRIPTION
Adds \with_help\ to all 8 promise plugin rules that were missing help/note text in their diagnostics, making them more actionable for users.

**Rules updated:**
- \lways-return\
- \void-new\
- \
o-multiple-resolved\
- \param-names\
- \prefer-await-to-callbacks\
- \prefer-await-to-then\
- \spec-only\
- \alid-params\

Each diagnostic now includes a \with_help\ call that explains how to fix the issue.

Partially addresses #19121.