### PR TITLE
feat(oxfmt): support boolean shorthand for `sortImports`

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -10,6 +10,7 @@ export type HtmlWhitespaceSensitivityConfig = "css" | "strict" | "ignore";
 export type ObjectWrapConfig = "preserve" | "collapse";
 export type ProseWrapConfig = "always" | "never" | "preserve";
 export type QuotePropsConfig = "as-needed" | "consistent" | "preserve";
+export type SortImportsUserConfig = boolean | SortImportsConfig;
 export type SortGroupItemConfig = NewlinesBetweenMarker | string | string[];
 export type SortOrderConfig = "asc" | "desc";
 export type SortPackageJsonUserConfig = boolean | SortPackageJsonConfig;
@@ -165,7 +166,7 @@ export interface Oxfmtrc {
    *
    * - Default: Disabled
    */
-  sortImports?: SortImportsConfig;
+  sortImports?: SortImportsUserConfig;
   /**
    * Sort `package.json` keys.
    *
@@ -438,7 +439,7 @@ export interface FormatConfig {
    *
    * - Default: Disabled
    */
-  sortImports?: SortImportsConfig;
+  sortImports?: SortImportsUserConfig;
   /**
    * Sort `package.json` keys.
    *

--- a/apps/oxfmt/src/core/oxfmtrc/format_config.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/format_config.rs
@@ -200,7 +200,7 @@ pub struct FormatConfig {
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalSortImports")]
-    pub sort_imports: Option<SortImportsConfig>,
+    pub sort_imports: Option<SortImportsUserConfig>,
 
     /// Sort `package.json` keys.
     ///
@@ -339,6 +339,19 @@ pub enum HtmlWhitespaceSensitivityConfig {
 }
 
 // ---
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SortImportsUserConfig {
+    Bool(bool),
+    Object(SortImportsConfig),
+}
+
+impl Default for SortImportsUserConfig {
+    fn default() -> Self {
+        Self::Bool(false)
+    }
+}
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]

--- a/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
+++ b/apps/oxfmt/src/core/oxfmtrc/to_oxfmt_options.rs
@@ -11,7 +11,8 @@ use oxc_toml::Options as TomlFormatterOptions;
 use super::format_config::{
     ArrowParensConfig, CustomGroupItemConfig, EmbeddedLanguageFormattingConfig, EndOfLineConfig,
     FormatConfig, HtmlWhitespaceSensitivityConfig, ObjectWrapConfig, QuotePropsConfig,
-    SortGroupItemConfig, SortOrderConfig, SortPackageJsonConfig, TrailingCommaConfig,
+    SortGroupItemConfig, SortImportsUserConfig, SortOrderConfig, SortPackageJsonConfig,
+    TrailingCommaConfig,
 };
 
 /// Resolved format options from `FormatConfig`.
@@ -157,120 +158,133 @@ pub fn to_oxfmt_options(config: FormatConfig) -> Result<OxfmtOptions, String> {
 
     // Below are our own extensions
 
-    if let Some(sort_imports_config) = config.sort_imports {
-        let mut sort_imports = SortImportsOptions::default();
-
-        if let Some(v) = sort_imports_config.partition_by_newline {
-            sort_imports.partition_by_newline = v;
-        }
-        if let Some(v) = sort_imports_config.partition_by_comment {
-            sort_imports.partition_by_comment = v;
-        }
-        if let Some(v) = sort_imports_config.sort_side_effects {
-            sort_imports.sort_side_effects = v;
-        }
-        if let Some(v) = sort_imports_config.order {
-            sort_imports.order = match v {
-                SortOrderConfig::Asc => SortOrder::Asc,
-                SortOrderConfig::Desc => SortOrder::Desc,
-            };
-        }
-        if let Some(v) = sort_imports_config.ignore_case {
-            sort_imports.ignore_case = v;
-        }
-        if let Some(v) = sort_imports_config.newlines_between {
-            sort_imports.newlines_between = v;
-        }
-        if let Some(v) = sort_imports_config.internal_pattern {
-            sort_imports.internal_pattern = v;
-        }
-        // Validate and parse `customGroups` first, since `groups` may refer to custom group names.
-        if let Some(v) = sort_imports_config.custom_groups {
-            let mut custom_groups = Vec::with_capacity(v.len());
-            for cg in v {
-                let CustomGroupItemConfig { group_name, element_name_pattern, .. } = cg;
-                let selector = match cg.selector.as_deref() {
-                    Some(s) => match ImportSelector::parse(s) {
-                        Some(parsed) => Some(parsed),
-                        None => {
-                            return Err(format!(
-                                "Invalid `sortImports` configuration: unknown selector: `{s}` in customGroups: `{group_name}`"
-                            ));
-                        }
-                    },
-                    None => None,
-                };
-                let raw_modifiers = cg.modifiers.unwrap_or_default();
-                let mut modifiers = Vec::with_capacity(raw_modifiers.len());
-                for m in &raw_modifiers {
-                    match ImportModifier::parse(m) {
-                        Some(parsed) => modifiers.push(parsed),
-                        None => {
-                            return Err(format!(
-                                "Invalid `sortImports` configuration: unknown modifier: `{m}` in customGroups: `{group_name}`"
-                            ));
-                        }
-                    }
-                }
-                custom_groups.push(CustomGroupDefinition {
-                    group_name,
-                    element_name_pattern,
-                    selector,
-                    modifiers,
-                });
+    if let Some(sort_imports_user_config) = config.sort_imports {
+        let sort_imports_config = match sort_imports_user_config {
+            SortImportsUserConfig::Bool(false) => None,
+            SortImportsUserConfig::Bool(true) => {
+                format_options.sort_imports = Some(SortImportsOptions::default());
+                None
             }
-            sort_imports.custom_groups = custom_groups;
-        }
-        if let Some(v) = sort_imports_config.groups {
-            let custom_group_names: FxHashSet<&str> =
-                sort_imports.custom_groups.iter().map(|g| g.group_name.as_str()).collect();
-            let mut groups = Vec::new();
-            let mut newline_boundary_overrides: Vec<Option<bool>> = Vec::new();
-            let mut pending_override: Option<bool> = None;
+            SortImportsUserConfig::Object(config) => Some(config),
+        };
 
-            for item in v {
-                match item {
-                    SortGroupItemConfig::NewlinesBetween(marker) => {
-                        if groups.is_empty() {
-                            return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the start of `groups`".to_string());
-                        }
-                        if pending_override.is_some() {
-                            return Err("Invalid `sortImports` configuration: consecutive `{ \"newlinesBetween\" }` markers are not allowed in `groups`".to_string());
-                        }
-                        pending_override = Some(marker.newlines_between);
-                    }
-                    other => {
-                        if !groups.is_empty() {
-                            newline_boundary_overrides.push(pending_override.take());
-                        }
-                        let mut entries = Vec::new();
-                        for name in other.into_vec() {
-                            let entry = GroupEntry::parse(&name);
-                            if let GroupEntry::Custom(ref n) = entry
-                                && !custom_group_names.contains(n.as_str())
-                            {
+        if let Some(sort_imports_config) = sort_imports_config {
+            let mut sort_imports = SortImportsOptions::default();
+
+            if let Some(v) = sort_imports_config.partition_by_newline {
+                sort_imports.partition_by_newline = v;
+            }
+            if let Some(v) = sort_imports_config.partition_by_comment {
+                sort_imports.partition_by_comment = v;
+            }
+            if let Some(v) = sort_imports_config.sort_side_effects {
+                sort_imports.sort_side_effects = v;
+            }
+            if let Some(v) = sort_imports_config.order {
+                sort_imports.order = match v {
+                    SortOrderConfig::Asc => SortOrder::Asc,
+                    SortOrderConfig::Desc => SortOrder::Desc,
+                };
+            }
+            if let Some(v) = sort_imports_config.ignore_case {
+                sort_imports.ignore_case = v;
+            }
+            if let Some(v) = sort_imports_config.newlines_between {
+                sort_imports.newlines_between = v;
+            }
+            if let Some(v) = sort_imports_config.internal_pattern {
+                sort_imports.internal_pattern = v;
+            }
+            // Validate and parse `customGroups` first, since `groups` may refer to custom group names.
+            if let Some(v) = sort_imports_config.custom_groups {
+                let mut custom_groups = Vec::with_capacity(v.len());
+                for cg in v {
+                    let CustomGroupItemConfig { group_name, element_name_pattern, .. } = cg;
+                    let selector = match cg.selector.as_deref() {
+                        Some(s) => match ImportSelector::parse(s) {
+                            Some(parsed) => Some(parsed),
+                            None => {
                                 return Err(format!(
-                                    "Invalid `sortImports` configuration: unknown group name `{name}` in `groups`"
+                                    "Invalid `sortImports` configuration: unknown selector: `{s}` in customGroups: `{group_name}`"
                                 ));
                             }
-                            entries.push(entry);
+                        },
+                        None => None,
+                    };
+                    let raw_modifiers = cg.modifiers.unwrap_or_default();
+                    let mut modifiers = Vec::with_capacity(raw_modifiers.len());
+                    for m in &raw_modifiers {
+                        match ImportModifier::parse(m) {
+                            Some(parsed) => modifiers.push(parsed),
+                            None => {
+                                return Err(format!(
+                                    "Invalid `sortImports` configuration: unknown modifier: `{m}` in customGroups: `{group_name}`"
+                                ));
+                            }
                         }
-                        groups.push(entries);
+                    }
+                    custom_groups.push(CustomGroupDefinition {
+                        group_name,
+                        element_name_pattern,
+                        selector,
+                        modifiers,
+                    });
+                }
+                sort_imports.custom_groups = custom_groups;
+            }
+            if let Some(v) = sort_imports_config.groups {
+                let custom_group_names: FxHashSet<&str> =
+                    sort_imports.custom_groups.iter().map(|g| g.group_name.as_str()).collect();
+                let mut groups = Vec::new();
+                let mut newline_boundary_overrides: Vec<Option<bool>> = Vec::new();
+                let mut pending_override: Option<bool> = None;
+
+                for item in v {
+                    match item {
+                        SortGroupItemConfig::NewlinesBetween(marker) => {
+                            if groups.is_empty() {
+                                return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the start of `groups`".to_string());
+                            }
+                            if pending_override.is_some() {
+                                return Err("Invalid `sortImports` configuration: consecutive `{ \"newlinesBetween\" }` markers are not allowed in `groups`".to_string());
+                            }
+                            pending_override = Some(marker.newlines_between);
+                        }
+                        other => {
+                            if !groups.is_empty() {
+                                newline_boundary_overrides.push(pending_override.take());
+                            }
+                            let mut entries = Vec::new();
+                            for name in other.into_vec() {
+                                let entry = GroupEntry::parse(&name);
+                                if let GroupEntry::Custom(ref n) = entry
+                                    && !custom_group_names.contains(n.as_str())
+                                {
+                                    return Err(format!(
+                                        "Invalid `sortImports` configuration: unknown group name `{name}` in `groups`"
+                                    ));
+                                }
+                                entries.push(entry);
+                            }
+                            groups.push(entries);
+                        }
                     }
                 }
+
+                if pending_override.is_some() {
+                    return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the end of `groups`".to_string());
+                }
+
+                sort_imports.groups = groups;
+                sort_imports.newline_boundary_overrides = newline_boundary_overrides;
             }
 
-            if pending_override.is_some() {
-                return Err("Invalid `sortImports` configuration: `{ \"newlinesBetween\" }` marker cannot appear at the end of `groups`".to_string());
-            }
+            sort_imports
+                .validate()
+                .map_err(|e| format!("Invalid `sortImports` configuration: {e}"))?;
 
-            sort_imports.groups = groups;
-            sort_imports.newline_boundary_overrides = newline_boundary_overrides;
+            format_options.sort_imports = Some(sort_imports);
         }
-
-        sort_imports.validate().map_err(|e| format!("Invalid `sortImports` configuration: {e}"))?;
-
-        format_options.sort_imports = Some(sort_imports);
     }
 
     if let Some(tw_config) = config.sort_tailwindcss {

--- a/apps/oxfmt/test/api/sort_imports.test.ts
+++ b/apps/oxfmt/test/api/sort_imports.test.ts
@@ -2,6 +2,23 @@ import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
 
 describe("Sort imports", () => {
+  it("should sort with `true` (boolean)", async () => {
+    const input = `import { b } from "b";
+import { a } from "a";
+`;
+    const result = await format("a.ts", input, {
+      experimentalSortImports: true,
+    });
+
+    expect(result.code).toBe(
+      `
+import { a } from "a";
+import { b } from "b";
+`.trimStart(),
+    );
+    expect(result.errors).toStrictEqual([]);
+  });
+
   it("should sort with customGroups", async () => {
     const input = `import { foo } from "./foo";
 import { util } from "~/utils/util";

--- a/apps/oxfmt/test/cli/sort_imports/__snapshots__/sort_imports.test.ts.snap
+++ b/apps/oxfmt/test/cli/sort_imports/__snapshots__/sort_imports.test.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`sort_imports > should sort imports when enabled with \`true\` (boolean) 1`] = `
+"--- FILE -----------
+input.ts
+--- BEFORE ---------
+import { b } from "b";
+import { a } from "a";
+
+--- AFTER ----------
+import { a } from "a";
+import { b } from "b";
+
+--------------------"
+`;

--- a/apps/oxfmt/test/cli/sort_imports/fixtures/boolean_true/.oxfmtrc.json
+++ b/apps/oxfmt/test/cli/sort_imports/fixtures/boolean_true/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+    "experimentalSortImports": true
+}

--- a/apps/oxfmt/test/cli/sort_imports/fixtures/boolean_true/input.ts
+++ b/apps/oxfmt/test/cli/sort_imports/fixtures/boolean_true/input.ts
@@ -1,0 +1,2 @@
+import { b } from "b";
+import { a } from "a";

--- a/apps/oxfmt/test/cli/sort_imports/sort_imports.test.ts
+++ b/apps/oxfmt/test/cli/sort_imports/sort_imports.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { join } from "node:path";
-import { runCli } from "../utils";
+import { runCli, runWriteModeAndSnapshot } from "../utils";
 
 const fixturesDir = join(import.meta.dirname, "fixtures");
 
 describe("sort_imports", () => {
+  it("should sort imports when enabled with `true` (boolean)", async () => {
+    const cwd = join(fixturesDir, "boolean_true");
+    const snapshot = await runWriteModeAndSnapshot(cwd, ["input.ts"]);
+    expect(snapshot).toMatchSnapshot();
+  });
+
   it("should sort imports with customGroups", async () => {
     const cwd = join(fixturesDir, "custom_groups");
     const result = await runCli(cwd, ["--check", "input.ts"]);

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -138,7 +138,7 @@
       "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
       "allOf": [
         {
-          "$ref": "#/definitions/SortImportsConfig"
+          "$ref": "#/definitions/SortImportsUserConfig"
         }
       ],
       "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
@@ -367,7 +367,7 @@
           "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
           "allOf": [
             {
-              "$ref": "#/definitions/SortImportsConfig"
+              "$ref": "#/definitions/SortImportsUserConfig"
             }
           ],
           "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
@@ -644,6 +644,16 @@
           "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
       }
+    },
+    "SortImportsUserConfig": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        }
+      ]
     },
     "SortOrderConfig": {
       "type": "string",

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -142,7 +142,7 @@ expression: json
       "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
       "allOf": [
         {
-          "$ref": "#/definitions/SortImportsConfig"
+          "$ref": "#/definitions/SortImportsUserConfig"
         }
       ],
       "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
@@ -371,7 +371,7 @@ expression: json
           "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled",
           "allOf": [
             {
-              "$ref": "#/definitions/SortImportsConfig"
+              "$ref": "#/definitions/SortImportsUserConfig"
             }
           ],
           "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\n- Default: Disabled"
@@ -648,6 +648,16 @@ expression: json
           "markdownDescription": "Specifies whether side effect imports should be sorted.\n\nBy default, sorting side-effect imports is disabled for security reasons.\n\n- Default: `false`"
         }
       }
+    },
+    "SortImportsUserConfig": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SortImportsConfig"
+        }
+      ]
     },
     "SortOrderConfig": {
       "type": "string",

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -604,7 +604,7 @@ For JSX, you can set the `jsxSingleQuote` option.
 
 ##### overrides[n].options.sortImports
 
-type: `object`
+type: `object | boolean`
 
 
 Sort import statements.
@@ -1073,7 +1073,7 @@ For JSX, you can set the `jsxSingleQuote` option.
 
 ## sortImports
 
-type: `object`
+type: `object | boolean`
 
 
 Sort import statements.


### PR DESCRIPTION
This PR supports a boolean option for `sortImports` similarly like `sortPackageJson`, allowing people to enable the feature with boolean flags:


```diff
import { defineConfig } from "oxfmt";

export const config = defineConfig({
  sortPackageJson: true,
- sortImports: {},
+ sortImports: true,
});
```

Note: currently all tests are still using `experimental` prefix, so I followed them. I am expecting some warnings from the copilot review.

I think the changes could be done in a seperate PR, I would like to create one if any maintainer requests this.