### PR TITLE
feat(oxfmt): Support angular-in-js substitution

### DIFF
--- a/apps/oxfmt/.gitignore
+++ b/apps/oxfmt/.gitignore
@@ -2,4 +2,5 @@
 /dist/
 /conformance/fixtures/**
 !/conformance/fixtures/edge-cases
+!/conformance/fixtures/edge-cases/**
 *.node

--- a/apps/oxfmt/conformance/fixtures/edge-cases/angular-in-js/issue-18891.ts
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/angular-in-js/issue-18891.ts
@@ -1,0 +1,6 @@
+import { Component } from "@angular/core";
+
+@Component({
+  template: `<ng-content></ng-content>`,
+})
+export class Component {}

--- a/apps/oxfmt/conformance/fixtures/edge-cases/angular-in-js/template-expression.ts
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/angular-in-js/template-expression.ts
@@ -1,0 +1,5 @@
+@Component({
+  template: `<ul><li>${item}</li></ul>`,
+  styles: `div { color: ${color} }`,
+})
+class MyComponent {}

--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -101,6 +101,18 @@ const categories: Category[] = [
     },
   },
   {
+    name: "angular-in-js",
+    sources: [
+      {
+        dir: join(FIXTURES_DIR, "prettier", "typescript/angular-component-examples"),
+        ext: ".ts",
+      },
+      { dir: join(FIXTURES_DIR, "edge-cases", "angular-in-js") },
+    ],
+    optionSets: [{ printWidth: 80 }, { printWidth: 100, htmlWhitespaceSensitivity: "ignore" }],
+    notes: {},
+  },
+  {
     name: "xxx-in-js-comment",
     sources: [
       {

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -82,6 +82,20 @@
 | :--- | :--- |
 | [prettier/js/multiparser-html/issue-10691.js](diffs/html-in-js/prettier__js__multiparser-html__issue-10691.js.md) | js-in-html(`<script>`)-in-js needs lot more work; Please see oxc_formatter/src/print/template/embed/html.rs |
 
+## angular-in-js
+
+### Option 1: 6/6 (100.00%)
+
+```json
+{"printWidth":80}
+```
+
+### Option 2: 6/6 (100.00%)
+
+```json
+{"printWidth":100,"htmlWhitespaceSensitivity":"ignore"}
+```
+
 ## xxx-in-js-comment
 
 ### Option 1: 5/5 (100.00%)

--- a/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/js-in-vue/vue-vben-admin__effects__common-ui__src__components__api-component__api-component.vue.md
@@ -14,7 +14,7 @@
 ===================================================================
 --- prettier
 +++ oxfmt
-@@ -274,9 +274,9 @@
+@@ -285,9 +285,9 @@
    getOptions: () => unref(getOptions),
    /** 获取当前值 */
    getValue: () => unref(modelValue),
@@ -79,6 +79,8 @@ interface Props {
   alwaysLoad?: boolean;
   /** 在api请求之前的回调函数 */
   beforeFetch?: AnyPromiseFunction<any, any>;
+  /** 在api请求之前的判断是否允许请求的回调函数 */
+  shouldFetch?: AnyPromiseFunction<any, boolean>;
   /** 在api请求之后的回调函数 */
   afterFetch?: AnyPromiseFunction<any, any>;
   /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
@@ -121,6 +123,7 @@ const props = withDefaults(defineProps<Props>(), {
   alwaysLoad: false,
   loadingSlot: "",
   beforeFetch: undefined,
+  shouldFetch: undefined,
   afterFetch: undefined,
   modelPropName: "modelValue",
   api: undefined,
@@ -192,7 +195,7 @@ const bindProps = computed(() => {
 });
 
 async function fetchApi() {
-  const { api, beforeFetch, afterFetch, resultField } = props;
+  const { api, beforeFetch, shouldFetch, afterFetch, resultField } = props;
 
   if (!api || !isFunction(api)) {
     return;
@@ -210,6 +213,14 @@ async function fetchApi() {
     let finalParams = unref(mergedParams);
     if (beforeFetch && isFunction(beforeFetch)) {
       finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+    }
+    // 判断是否需要控制执行中断
+    if (
+      shouldFetch &&
+      isFunction(shouldFetch) &&
+      !(await shouldFetch(finalParams))
+    ) {
+      return;
     }
     let res = await api(finalParams);
     if (afterFetch && isFunction(afterFetch)) {
@@ -384,6 +395,8 @@ interface Props {
   alwaysLoad?: boolean;
   /** 在api请求之前的回调函数 */
   beforeFetch?: AnyPromiseFunction<any, any>;
+  /** 在api请求之前的判断是否允许请求的回调函数 */
+  shouldFetch?: AnyPromiseFunction<any, boolean>;
   /** 在api请求之后的回调函数 */
   afterFetch?: AnyPromiseFunction<any, any>;
   /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
@@ -426,6 +439,7 @@ const props = withDefaults(defineProps<Props>(), {
   alwaysLoad: false,
   loadingSlot: "",
   beforeFetch: undefined,
+  shouldFetch: undefined,
   afterFetch: undefined,
   modelPropName: "modelValue",
   api: undefined,
@@ -497,7 +511,7 @@ const bindProps = computed(() => {
 });
 
 async function fetchApi() {
-  const { api, beforeFetch, afterFetch, resultField } = props;
+  const { api, beforeFetch, shouldFetch, afterFetch, resultField } = props;
 
   if (!api || !isFunction(api)) {
     return;
@@ -515,6 +529,14 @@ async function fetchApi() {
     let finalParams = unref(mergedParams);
     if (beforeFetch && isFunction(beforeFetch)) {
       finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+    }
+    // 判断是否需要控制执行中断
+    if (
+      shouldFetch &&
+      isFunction(shouldFetch) &&
+      !(await shouldFetch(finalParams))
+    ) {
+      return;
     }
     let res = await api(finalParams);
     if (afterFetch && isFunction(afterFetch)) {
@@ -650,7 +672,7 @@ defineExpose({
 ===================================================================
 --- prettier
 +++ oxfmt
-@@ -259,9 +259,9 @@
+@@ -266,9 +266,9 @@
      getOptions: () => unref(getOptions),
      /** 获取当前值 */
      getValue: () => unref(modelValue),
@@ -715,6 +737,8 @@ defineExpose({
     alwaysLoad?: boolean;
     /** 在api请求之前的回调函数 */
     beforeFetch?: AnyPromiseFunction<any, any>;
+    /** 在api请求之前的判断是否允许请求的回调函数 */
+    shouldFetch?: AnyPromiseFunction<any, boolean>;
     /** 在api请求之后的回调函数 */
     afterFetch?: AnyPromiseFunction<any, any>;
     /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
@@ -752,6 +776,7 @@ defineExpose({
     alwaysLoad: false,
     loadingSlot: '',
     beforeFetch: undefined,
+    shouldFetch: undefined,
     afterFetch: undefined,
     modelPropName: 'modelValue',
     api: undefined,
@@ -817,7 +842,7 @@ defineExpose({
   });
 
   async function fetchApi() {
-    const { api, beforeFetch, afterFetch, resultField } = props;
+    const { api, beforeFetch, shouldFetch, afterFetch, resultField } = props;
 
     if (!api || !isFunction(api)) {
       return;
@@ -835,6 +860,10 @@ defineExpose({
       let finalParams = unref(mergedParams);
       if (beforeFetch && isFunction(beforeFetch)) {
         finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+      }
+      // 判断是否需要控制执行中断
+      if (shouldFetch && isFunction(shouldFetch) && !(await shouldFetch(finalParams))) {
+        return;
       }
       let res = await api(finalParams);
       if (afterFetch && isFunction(afterFetch)) {
@@ -1005,6 +1034,8 @@ defineExpose({
     alwaysLoad?: boolean;
     /** 在api请求之前的回调函数 */
     beforeFetch?: AnyPromiseFunction<any, any>;
+    /** 在api请求之前的判断是否允许请求的回调函数 */
+    shouldFetch?: AnyPromiseFunction<any, boolean>;
     /** 在api请求之后的回调函数 */
     afterFetch?: AnyPromiseFunction<any, any>;
     /** 直接传入选项数据，也作为api返回空数据时的后备数据 */
@@ -1042,6 +1073,7 @@ defineExpose({
     alwaysLoad: false,
     loadingSlot: '',
     beforeFetch: undefined,
+    shouldFetch: undefined,
     afterFetch: undefined,
     modelPropName: 'modelValue',
     api: undefined,
@@ -1107,7 +1139,7 @@ defineExpose({
   });
 
   async function fetchApi() {
-    const { api, beforeFetch, afterFetch, resultField } = props;
+    const { api, beforeFetch, shouldFetch, afterFetch, resultField } = props;
 
     if (!api || !isFunction(api)) {
       return;
@@ -1125,6 +1157,10 @@ defineExpose({
       let finalParams = unref(mergedParams);
       if (beforeFetch && isFunction(beforeFetch)) {
         finalParams = (await beforeFetch(cloneDeep(finalParams))) || finalParams;
+      }
+      // 判断是否需要控制执行中断
+      if (shouldFetch && isFunction(shouldFetch) && !(await shouldFetch(finalParams))) {
+        return;
       }
       let res = await api(finalParams);
       if (afterFetch && isFunction(afterFetch)) {

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -26,7 +26,7 @@ async function loadPrettier(): Promise<typeof import("prettier")> {
 
   prettierCache = await import("prettier");
 
-  // NOTE: This is needed for html-in-js formatting to work correctly.
+  // NOTE: This is needed for xxx-in-js formatting to work correctly.
   //
   // Prettier internally extends `options` with hidden fields for embedded-formatters during printing.
   // However, `__debug.printToDoc()` runs `normalizeFormatOptions()` which strips unknown keys.
@@ -39,13 +39,13 @@ async function loadPrettier(): Promise<typeof import("prettier")> {
   // there should be no side effects on other calls that don't set these fields.
   // @ts-expect-error: Use internal API
   const { formatOptionsHiddenDefaults } = prettierCache.__internal;
-  // For html-in-js: Prevent attribute level formatting from running.
+  // For html(angular)-in-js: Prevent attribute level formatting from running.
   // (e.g., CSS in `style="..."` attributes, JS in `onclick="..."` event handlers)
   // This does NOT affect `<style>`/`<script>` tags, they are always formatted.
   // Ideally we'd only block JS attributes while allowing CSS attributes (because no nesting is possible in CSS),
   // but Prettier's `!options.parentParser` check is all-or-nothing.
   formatOptionsHiddenDefaults.parentParser = null;
-  // For html-in-js: Capture `htmlHasMultipleRootElements` from the HTML AST root during `__debug.printToDoc()`.
+  // For html(angular)-in-js: Capture `htmlHasMultipleRootElements` from the HTML AST root during `__debug.printToDoc()`.
   // This is used to decide whether to wrap content with `indent`.
   // Without this, we'd need either:
   // - double parse AST
@@ -160,8 +160,8 @@ export async function formatEmbeddedDoc({
     texts.map(async (text) => {
       const metadata: Record<string, unknown> = {};
 
-      // html-in-js specific options: see the comment in `loadPrettier()` for rationale
-      if (options.parser === "html") {
+      // html(angular)-in-js specific options: see the comment in `loadPrettier()` for rationale
+      if (options.parser === "html" || options.parser === "angular") {
         // Any truthy value works
         options.parentParser = "OXFMT";
         // https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/html.js#L42-L44

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -84,7 +84,7 @@ pub fn to_format_elements_for_template<'a>(
                 html_has_multiple_root_elements: None,
             })
         }
-        "tagged-html" => {
+        "tagged-html" | "angular-template" => {
             let (mut ir, metadata) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for HTML"),
                 allocator,
@@ -95,7 +95,7 @@ pub fn to_format_elements_for_template<'a>(
             let placeholder_count = postprocess(
                 &mut ir,
                 allocator,
-                // HTML uses `.cooked` values, so template chars need escaping
+                // HTML/Angular use `.cooked` values, so template chars need escaping
                 true,
                 Some(("PRETTIER_HTML_PLACEHOLDER_", "_IN_JS")),
             );

--- a/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
+++ b/apps/oxfmt/test/cli/embedded_languages/__snapshots__/embedded_languages.test.ts.snap
@@ -279,11 +279,9 @@ export class AppComponent1 {}
 // Array form styles
 @Component({
   selector: "app-test",
-  template: \`
-    <ul>
-      <li>test</li>
-    </ul>
-  \`,
+  template: \`<ul>
+    <li>test</li>
+  </ul> \`,
   styles: [
     \`
       :host {
@@ -935,11 +933,9 @@ export class AppComponent1 {}
 // Array form styles
 @Component({
   selector: "app-test",
-  template: \`
-    <ul>
-      <li>test</li>
-    </ul>
-  \`,
+  template: \`<ul>
+    <li>test</li>
+  </ul> \`,
   styles: [
     \`
       :host {

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -23,14 +23,17 @@ const PLACEHOLDER_PREFIX: &str = "PRETTIER_HTML_PLACEHOLDER_";
 const PLACEHOLDER_SUFFIX: &str = "_IN_JS";
 const COUNTER: &str = "0";
 
-/// Format an HTML-in-JS template literal via the Doc->IR path with placeholder replacement.
+/// Format an HTML(Angular)-in-JS template literal via the Doc->IR path with placeholder replacement.
 ///
 /// Uses `.cooked` values (unlike CSS which uses `.raw`), joins quasis with
-/// `PRETTIER_HTML_PLACEHOLDER_{N}_0_IN_JS` markers, formats as HTML,
+/// `PRETTIER_HTML_PLACEHOLDER_{N}_0_IN_JS` markers, formats via the given `language`,
 /// then replaces placeholder occurrences in the resulting IR with `${expr}` Docs.
+///
+/// Supports both `"tagged-html"` (html-in-js) and `"angular-template"` (`@Component({ template })`).
 pub(super) fn format_html_doc<'a>(
     quasi: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
+    language: &str,
 ) -> bool {
     let quasis = &quasi.quasis;
     let expressions: Vec<_> = quasi.expressions().iter().collect();
@@ -59,7 +62,7 @@ pub(super) fn format_html_doc<'a>(
         })) = f.context().external_callbacks().format_embedded_doc(
             allocator,
             group_id_builder,
-            "tagged-html",
+            language,
             &[cooked],
         )
         else {
@@ -113,7 +116,7 @@ pub(super) fn format_html_doc<'a>(
     })) = f.context().external_callbacks().format_embedded_doc(
         allocator,
         group_id_builder,
-        "tagged-html",
+        language,
         &[joined],
     )
     else {

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -22,7 +22,7 @@ pub(super) fn try_format_embedded_template<'a>(
     match get_tag_name(&tagged.tag) {
         Some("css" | "styled") => css::format_css_doc(tagged.quasi(), f),
         Some("gql" | "graphql") => graphql::format_graphql_doc(tagged.quasi(), f),
-        Some("html") => html::format_html_doc(tagged.quasi(), f),
+        Some("html") => html::format_html_doc(tagged.quasi(), f, "tagged-html"),
         Some("md" | "markdown") => try_embed_markdown(tagged, f),
         _ => false,
     }
@@ -71,7 +71,7 @@ pub(super) fn try_format_comment_embedded<'a>(
         return false;
     };
     match language {
-        "html" => html::format_html_doc(template, f),
+        "html" => html::format_html_doc(template, f, "tagged-html"),
         "graphql" => graphql::format_graphql_doc(template, f),
         _ => false,
     }
@@ -159,13 +159,7 @@ pub(super) fn try_format_angular_component<'a>(
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
     match get_angular_component_language(template_literal) {
-        Some("angular-template") => {
-            if !template_literal.is_no_substitution_template() {
-                return false;
-            }
-            let template_content = template_literal.quasis()[0].value.raw.as_str();
-            format_embedded_template(f, "angular-template", template_content)
-        }
+        Some("angular-template") => html::format_html_doc(template_literal, f, "angular-template"),
         Some("angular-styles") => css::format_css_doc(template_literal, f),
         _ => false,
     }


### PR DESCRIPTION
Part of #15180, closes #18891

Angular-in-JS consists of 2 cases: `template` and `styles`.

- template: Similar to html-in-js, use the `parser: angular`
- styles: Same as css-in-js (already supported)