### PR TITLE
fix(transformer): remove false positive duplicate `__source`/`__self` prop error

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -604,20 +604,6 @@ impl<'a> JsxImpl<'a> {
                     JSXAttributeItem::Attribute(attr) => {
                         let JSXAttribute { span, name, value, .. } = attr.unbox();
                         match &name {
-                            JSXAttributeName::Identifier(ident)
-                                if self.options.development
-                                    && self.options.jsx_self_plugin
-                                    && ident.name == "__self" =>
-                            {
-                                JsxSelf::report_error(ident.span, ctx);
-                            }
-                            JSXAttributeName::Identifier(ident)
-                                if self.options.development
-                                    && self.options.jsx_source_plugin
-                                    && ident.name == "__source" =>
-                            {
-                                JsxSource::report_error(ident.span, ctx);
-                            }
                             JSXAttributeName::Identifier(ident) if ident.name == "key" => {
                                 if value.is_none() {
                                     ctx.state.error(diagnostics::valueless_key(ident.span));

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -29,8 +29,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-self/src/index.ts>
 
 use oxc_ast::ast::*;
-use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{SPAN, Span};
+use oxc_span::SPAN;
 use oxc_traverse::{Ancestor, Traverse};
 
 use crate::{context::TraverseCtx, state::TransformState};
@@ -56,11 +55,6 @@ impl<'a> Traverse<'a, TransformState<'a>> for JsxSelf {
 }
 
 impl<'a> JsxSelf {
-    pub fn report_error(span: Span, ctx: &mut TraverseCtx<'a>) {
-        let error = OxcDiagnostic::warn("Duplicate __self prop found.").with_label(span);
-        ctx.state.error(error);
-    }
-
     fn is_inside_constructor(ctx: &TraverseCtx<'a>) -> bool {
         for scope_id in ctx.ancestor_scopes() {
             let flags = ctx.scoping().scope_flags(scope_id);
@@ -96,17 +90,14 @@ impl<'a> JsxSelf {
 
     /// `<div __self={this} />`
     ///       ^^^^^^^^^^^^^
-    #[expect(clippy::unused_self)]
+    #[expect(clippy::unused_self, clippy::needless_pass_by_ref_mut)]
     fn add_self_this_attribute(&self, elem: &mut JSXOpeningElement<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Check if `__self` attribute already exists
-        for item in &elem.attributes {
-            if let JSXAttributeItem::Attribute(attribute) = item
-                && let JSXAttributeName::Identifier(ident) = &attribute.name
-                && ident.name == SELF
-            {
-                Self::report_error(ident.span, ctx);
-                return;
-            }
+        // Don't add `__self` if it already exists
+        if elem.attributes.iter().any(|item| {
+            matches!(item, JSXAttributeItem::Attribute(attribute)
+                if matches!(&attribute.name, JSXAttributeName::Identifier(ident) if ident.name == SELF))
+        }) {
+            return;
         }
 
         let name = ctx.ast.jsx_attribute_name_identifier(SPAN, SELF);

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -35,8 +35,7 @@
 
 use oxc_ast::{NONE, ast::*};
 use oxc_data_structures::rope::{Rope, get_line_column};
-use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{SPAN, Span};
+use oxc_span::SPAN;
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};
 use oxc_traverse::{BoundIdentifier, Traverse};
 
@@ -99,11 +98,6 @@ impl<'a> JsxSource<'a> {
         ctx.ast.object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
     }
 
-    pub fn report_error(span: Span, ctx: &mut TraverseCtx<'a>) {
-        let error = OxcDiagnostic::warn("Duplicate __source prop found.").with_label(span);
-        ctx.state.error(error);
-    }
-
     /// `<sometag __source={ { fileName: 'this/file.js', lineNumber: 10, columnNumber: 1 } } />`
     ///           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     fn add_source_attribute(
@@ -116,15 +110,12 @@ impl<'a> JsxSource<'a> {
             return;
         }
 
-        // Check if `__source` attribute already exists
-        for item in &elem.attributes {
-            if let JSXAttributeItem::Attribute(attribute) = item
-                && let JSXAttributeName::Identifier(ident) = &attribute.name
-                && ident.name == SOURCE
-            {
-                Self::report_error(ident.span, ctx);
-                return;
-            }
+        // Don't add `__source` if it already exists
+        if elem.attributes.iter().any(|item| {
+            matches!(item, JSXAttributeItem::Attribute(attribute)
+                if matches!(&attribute.name, JSXAttributeName::Identifier(ident) if ident.name == SOURCE))
+        }) {
+            return;
         }
 
         let key = ctx.ast.jsx_attribute_name_identifier(SPAN, SOURCE);

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -480,8 +480,6 @@ test("exec", () => {{
 fn get_babel_error(error: &str) -> String {
     match error {
         "transform-react-jsx: unknown variant `invalidOption`, expected `classic` or `automatic`" => "Runtime must be either \"classic\" or \"automatic\".",
-        "Duplicate __self prop found." => "Duplicate __self prop found. You are most likely using the deprecated transform-react-jsx-self Babel plugin. Both __source and __self are automatically set when using the automatic runtime. Please remove transform-react-jsx-source and transform-react-jsx-self from your Babel config.",
-        "Duplicate __source prop found." => "Duplicate __source prop found. You are most likely using the deprecated transform-react-jsx-source Babel plugin. Both __source and __self are automatically set when using the automatic runtime. Please remove transform-react-jsx-source and transform-react-jsx-self from your Babel config.",
         "Expected `>` but found `/`" => "Unexpected token, expected \",\"",
         _ => error
     }.to_string()


### PR DESCRIPTION
Fixes #20654

The JSX source and self plugins were erroneously reporting "Duplicate `__source` prop found" / "Duplicate `__self` prop found" warnings when a user wrote `<div __source={{}} />` or `<div __self={this} />`. This prevented valid code from being transformed.

In Babel, the duplicate error only exists to warn users who have both the automatic runtime AND the deprecated standalone plugins enabled simultaneously ([source](https://github.com/babel/babel/blob/9137617716e200cb440948562789ae3744559fcb/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts#L847-L853)). It's not relevant for oxc as a standalone transformer.

Now the plugins silently skip adding `__source`/`__self` when the user has already provided one, matching the behavior of Babel's standalone plugins.