### PR TITLE
fix(linter): detect unused type parameters in type/value redeclarations

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -199,15 +199,16 @@ impl NoUnusedVars {
         module_record: &ModuleRecord,
         symbol: &Symbol<'_, 'a>,
         param: &FormalParameter<'a>,
+        param_node_id: NodeId,
     ) -> bool {
         // early short-circuit when no argument checking should be performed
         if self.args.is_none() {
             return true;
         }
 
-        // find FormalParameters. Should be the next parent of param, but this
-        // is safer.
-        let Some((params, params_id)) = symbol.iter_parents().find_map(|p| {
+        // find FormalParameters by walking ancestors from the param node, not
+        // the symbol's primary declaration (which may differ in redeclarations).
+        let Some((params, params_id)) = symbol.nodes().ancestors(param_node_id).find_map(|p| {
             let params = p.kind().as_formal_parameters()?;
             Some((params, p.id()))
         }) else {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
@@ -18,6 +18,8 @@ fn pronoun_for_symbol(
         ("Interface", "interfaces")
     } else if symbol_flags.is_type_alias() {
         ("Type alias", "type aliases")
+    } else if symbol_flags.contains(SymbolFlags::TypeParameter) {
+        ("Type parameter", "type parameters")
     } else if symbol_flags.is_enum() {
         ("Enum", "enums")
     } else if symbol_flags.is_enum_member() {
@@ -85,6 +87,24 @@ where
     .with_help(help)
 }
 
+/// Like [`declared`], but uses an explicit span and flags for redeclaration reporting.
+pub fn declared_at<R>(
+    name: &str,
+    flags: SymbolFlags,
+    span: Span,
+    pat: &IgnorePattern<R>,
+) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
+    let (pronoun, pronoun_plural) = pronoun_for_symbol(flags);
+    let suffix = pat.diagnostic_help(pronoun_plural);
+
+    OxcDiagnostic::warn(format!("{pronoun} '{name}' is declared but never used.{suffix}"))
+        .with_label(span.label(format!("'{name}' is declared here")))
+        .with_help("Consider removing this declaration.")
+}
+
 /// Variable 'x' is assigned a value but never used.
 pub fn assign<R>(
     symbol: &Symbol<'_, '_>,
@@ -111,11 +131,18 @@ pub fn param<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnosti
 where
     R: fmt::Display,
 {
-    let name = symbol.name();
+    param_at(symbol.name(), symbol.span(), pat)
+}
+
+/// Like [`param`], but uses an explicit span for redeclaration reporting.
+pub fn param_at<R>(name: &str, span: Span, pat: &IgnorePattern<R>) -> OxcDiagnostic
+where
+    R: fmt::Display,
+{
     let suffix = pat.diagnostic_help("parameters");
 
     OxcDiagnostic::warn(format!("Parameter '{name}' is declared but never used.{suffix}"))
-        .with_label(symbol.span().label(format!("'{name}' is declared here")))
+        .with_label(span.label(format!("'{name}' is declared here")))
         .with_help("Consider removing this parameter.")
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -249,10 +249,15 @@ impl NoUnusedVars {
                 if self.report_used_ignore_pattern {
                     ctx.diagnostic(diagnostic::used_ignored(symbol, &self.vars_ignore_pattern));
                 }
+
                 return;
             }
             // used, ignored because of other ignore reason (e.g. rest siblings)
-            (_, Some(_)) | (true, None) => return,
+            (_, Some(_)) => return,
+            (true, None) => {
+                self.check_unused_redeclarations(symbol, ctx);
+                return;
+            }
             // needs acceptance check and/or reporting
             (false, None) => {}
         }
@@ -303,7 +308,7 @@ impl NoUnusedVars {
                 });
             }
             AstKind::FormalParameter(param) => {
-                if self.is_allowed_argument(ctx.semantic(), ctx.module_record(), symbol, param) {
+                if self.is_allowed_argument(ctx.semantic(), ctx.module_record(), symbol, param, declaration.id()) {
                     return;
                 }
                 ctx.diagnostic(diagnostic::param(symbol, &self.args_ignore_pattern));
@@ -364,6 +369,95 @@ impl NoUnusedVars {
                 );
             }
             _ => ctx.diagnostic(diagnostic::declared(symbol, &IgnorePattern::<&str>::None, false)),
+        }
+    }
+
+    /// When a symbol is "used" but has redeclarations that mix type parameters
+    /// with value declarations, one of the redeclarations might actually be unused.
+    ///
+    /// For example, in `function f<T>(T: number) { return T; }`, both the type
+    /// parameter `T` and the function parameter `T` share the same symbol ID.
+    /// Only the function parameter is referenced (value reference), so the type
+    /// parameter should be reported as unused.
+    ///
+    /// Only type parameters are checked here — unlike interfaces or type aliases,
+    /// type parameters shadow (not merge with) value declarations in TypeScript.
+    fn check_unused_redeclarations<'a>(&self, symbol: &Symbol<'_, 'a>, ctx: &LintContext<'a>) {
+        let redeclarations = ctx.scoping().symbol_redeclarations(symbol.id());
+        if redeclarations.is_empty() {
+            return;
+        }
+
+        let (mut has_type_param, mut has_value_decl) = (false, false);
+        for r in redeclarations {
+            if r.flags.contains(SymbolFlags::TypeParameter) {
+                has_type_param = true;
+            } else {
+                has_value_decl = true;
+            }
+            if has_type_param && has_value_decl {
+                break;
+            }
+        }
+        if !has_type_param || !has_value_decl {
+            return;
+        }
+
+        let (mut has_type_ref, mut has_value_ref) = (false, false);
+        for r in symbol.references() {
+            if r.is_type() {
+                has_type_ref = true;
+            } else {
+                has_value_ref = true;
+            }
+            if has_type_ref && has_value_ref {
+                break;
+            }
+        }
+
+        if has_type_ref && has_value_ref {
+            return;
+        }
+
+        let name = symbol.name();
+        for redecl in redeclarations {
+            let is_type_param = redecl.flags.contains(SymbolFlags::TypeParameter);
+            if is_type_param && !has_type_ref {
+                if self.is_allowed_type_parameter(symbol, redecl.declaration) {
+                    continue;
+                }
+                ctx.diagnostic(diagnostic::declared_at(
+                    name,
+                    redecl.flags,
+                    redecl.span,
+                    &self.vars_ignore_pattern,
+                ));
+            } else if !is_type_param && !has_value_ref {
+                let declaration_node = ctx.nodes().get_node(redecl.declaration);
+                if let AstKind::FormalParameter(param) = declaration_node.kind() {
+                    if self.is_allowed_argument(
+                        ctx.semantic(),
+                        ctx.module_record(),
+                        symbol,
+                        param,
+                        redecl.declaration,
+                    ) {
+                        continue;
+                    }
+                    ctx.diagnostic(diagnostic::param_at(
+                        name,
+                        redecl.span,
+                        &self.args_ignore_pattern,
+                    ));
+                } else {
+                    ctx.diagnostic(diagnostic::declared_at(
+                        name,
+                        redecl.flags,
+                        redecl.span,
+                        &self.vars_ignore_pattern,
+                    ));
+                }
+            }
         }
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -308,7 +308,13 @@ impl NoUnusedVars {
                 });
             }
             AstKind::FormalParameter(param) => {
-                if self.is_allowed_argument(ctx.semantic(), ctx.module_record(), symbol, param, declaration.id()) {
+                if self.is_allowed_argument(
+                    ctx.semantic(),
+                    ctx.module_record(),
+                    symbol,
+                    param,
+                    declaration.id(),
+                ) {
                     return;
                 }
                 ctx.diagnostic(diagnostic::param(symbol, &self.args_ignore_pattern));

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1655,6 +1655,28 @@ fn test_ignore() {
         .test_and_snapshot();
 }
 
+/// https://github.com/oxc-project/oxc/issues/20670
+#[test]
+fn test_type_value_redeclaration() {
+    let pass = vec![
+        // Both type param and value param are used
+        ("export function f<T>(T: T): T { return T; }", None),
+        // Type param used in return type, value param used in body
+        ("export function f<T>(T: number): T { return T; }", None),
+    ];
+
+    let fail = vec![
+        // Type param T is unused, only value param T is used
+        ("export function useParam<T>(T: number) { return T; }", None),
+        ("export function useParam<T>(T: number): T { }", None),
+    ];
+
+    Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)
+        .intentionally_allow_no_fix_tests()
+        .with_snapshot_suffix("type-value-redeclaration")
+        .test_and_snapshot();
+}
+
 // #[test]
 // fn test_template() {
 //     let pass = vec![];

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-namespaces.snap
@@ -18,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+  ⚠ eslint(no-unused-vars): Type parameter 'T' is declared but never used. Unused type parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:3:39]
  2 │         export namespace NonAmbientModuleDeclaration {
  3 │             export interface Matchers<T> extends MatcherOverride {
@@ -28,7 +28,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+  ⚠ eslint(no-unused-vars): Type parameter 'T' is declared but never used. Unused type parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:44]
  1 │ declare module 'bun:test' { type Matchers2<T> = {} }
    ·                                            ┬
@@ -44,7 +44,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'T' is declared but never used. Unused variables should start with a '_'.
+  ⚠ eslint(no-unused-vars): Type parameter 'T' is declared but never used. Unused type parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:43]
  1 │ declare module 'bun:test' { class MyClass<T> {} }
    ·                                           ┬

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-aliases.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-aliases.snap
@@ -26,7 +26,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing this declaration.
 
-  ⚠ eslint(no-unused-vars): Variable 'R' is declared but never used. Unused variables should start with a '_'.
+  ⚠ eslint(no-unused-vars): Type parameter 'R' is declared but never used. Unused type parameters should start with a '_'.
    ╭─[no_unused_vars.tsx:1:36]
  1 │ export type F<T> = T extends infer R ? /* R not used */ string : never
    ·                                    ┬

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@type-value-redeclaration.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@type-value-redeclaration.snap
@@ -1,0 +1,20 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
+---
+
+  ⚠ eslint(no-unused-vars): Type parameter 'T' is declared but never used. Unused type parameters should start with a '_'.
+   ╭─[no_unused_vars.tsx:1:26]
+ 1 │ export function useParam<T>(T: number) { return T; }
+   ·                          ┬
+   ·                          ╰── 'T' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Parameter 'T' is declared but never used. Unused parameters should start with a '_'.
+   ╭─[no_unused_vars.tsx:1:29]
+ 1 │ export function useParam<T>(T: number): T { }
+   ·                             ┬
+   ·                             ╰── 'T' is declared here
+   ╰────
+  help: Consider removing this parameter.


### PR DESCRIPTION
## Summary

When a type parameter and a value parameter share the same name (e.g. `function f<T>(T: number) { return T; }`), they get the same `SymbolId` via redeclaration. Previously, `no-unused-vars` saw the symbol as "used" (because the value `T` is referenced) and skipped it entirely, missing the fact that the type parameter `T` was never referenced.

- Add `check_unused_redeclarations` to detect when a "used" symbol has redeclarations mixing type parameters with value declarations where one namespace has no references
- Add "Type parameter" to diagnostic pronoun list for better error messages (previously reported as "Variable")
- Add `declared_at` and `param_at` diagnostic helpers for reporting on specific redeclarations

Fixes #20670

## Test plan

- Added `test_type_value_redeclaration` with pass/fail cases
- All 47 existing `no-unused-vars` tests pass
- Snapshot updates for improved "Type parameter" pronoun in existing diagnostics