### PR TITLE
fix: support .ts config files via jiti (vite 8 projects)

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -20,6 +20,7 @@
     "generate-config-types": "node scripts/generate-config-types.ts"
   },
   "dependencies": {
+    "jiti": "^2.6.1",
     "prettier": "3.8.1",
     "prettier-plugin-tailwindcss": "0.0.0-insiders.3997fbd",
     "tinypool": "2.1.0"

--- a/apps/oxfmt/src-js/cli/js_config.ts
+++ b/apps/oxfmt/src-js/cli/js_config.ts
@@ -1,5 +1,5 @@
 import { basename as pathBasename } from "node:path";
-import { pathToFileURL } from "node:url";
+import { createJiti } from "jiti";
 
 const isObject = (v: unknown) => typeof v === "object" && v !== null && !Array.isArray(v);
 
@@ -9,7 +9,7 @@ const VITE_OXFMT_CONFIG_FIELD = "fmt";
 /**
  * Load a JavaScript/TypeScript config file.
  *
- * Uses native Node.js `import()` to evaluate the config file.
+ * Uses `jiti` to evaluate the config file, which supports TypeScript out-of-the-box.
  * The config file should have a default export containing the oxfmt configuration object.
  *
  * For `vite.config.ts`, extracts the `.fmt` field from the default export.
@@ -19,11 +19,10 @@ const VITE_OXFMT_CONFIG_FIELD = "fmt";
  * @returns Config object, or `null` to signal "skip"
  */
 export async function loadJsConfig(path: string): Promise<object | null> {
-  // Bypass Node.js module cache to allow reloading changed config files (used for LSP)
-  const fileUrl = pathToFileURL(path);
-  fileUrl.searchParams.set("cache", Date.now().toString());
-
-  const { default: config } = await import(fileUrl.href);
+  // Bypass module cache by creating a fresh jiti instance
+  const jiti = createJiti(import.meta.url, { moduleCache: false, fsCache: false });
+  const module = (await jiti.import(path)) as { default: unknown };
+  const config = module.default;
 
   if (config === undefined) throw new Error("Configuration file has no default export.");
 

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -29,7 +29,7 @@
     "build-napi": "napi build --esm --platform --js ./bindings.js --dts ./bindings.d.ts --output-dir src-js --no-dts-cache",
     "build-napi-test": "pnpm run build-napi --features testing --profile coverage",
     "build-napi-release": "pnpm run build-napi --release --features allocator",
-    "build-js": "node scripts/build.ts",
+    "build-js": "tsx scripts/build.ts",
     "generate-config-types": "node scripts/generate-config-types.ts",
     "test": "vitest --dir ./test run",
     "init-conformance": "cd conformance; ./init.sh",
@@ -92,5 +92,8 @@
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
+  },
+  "dependencies": {
+    "jiti": "^2.6.1"
   }
 }

--- a/apps/oxlint/src-js/js_config.ts
+++ b/apps/oxlint/src-js/js_config.ts
@@ -1,7 +1,8 @@
 import { basename as pathBasename } from "node:path";
+import { createJiti } from "jiti";
 
 import { getErrorMessage } from "./utils/utils.ts";
-import { DateNow, JSONStringify } from "./utils/globals.ts";
+import { JSONStringify } from "./utils/globals.ts";
 
 interface JsConfigResult {
   path: string;
@@ -95,12 +96,11 @@ function validateConfigExtends(root: object): void {
  */
 export async function loadJsConfigs(paths: string[]): Promise<string> {
   try {
-    const cacheKey = DateNow();
+    // Bypass module cache by creating a fresh jiti instance
+    const jiti = createJiti(import.meta.url, { moduleCache: false, fsCache: false });
     const results = await Promise.allSettled(
       paths.map(async (path): Promise<JsConfigResult> => {
-        // Bypass Node.js module cache to allow reloading changed config files (used for LSP, where we reload configs after important changes)
-        const fileUrl = new URL(`file://${path}?cache=${cacheKey}`);
-        const module = await import(fileUrl.href);
+        const module = (await jiti.import(path)) as { default: unknown };
         const config = module.default;
 
         if (config === undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
 
   apps/oxfmt:
     dependencies:
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -104,6 +107,10 @@ importers:
         version: 1.0.12
 
   apps/oxlint:
+    dependencies:
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
     devDependencies:
       '@arethetypeswrong/core':
         specifier: 'catalog:'
@@ -7977,8 +7984,7 @@ snapshots:
 
   iterare@1.2.1: {}
 
-  jiti@2.6.1:
-    optional: true
+  jiti@2.6.1: {}
 
   jquery@3.7.1: {}
 


### PR DESCRIPTION
I get the  error `Failed to load configuration file.` when I am trying to use `.ts` config file. 

I mention Vite 8 because I face the problem with it. and this PR solve it via [jiti](https://www.npmjs.com/package/jiti) package