### PR TITLE
perf(parser): move directive handling into cold fn

### DIFF
--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -75,22 +75,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.state.potential_await_reparse.push((stmt_index, checkpoint));
             }
 
-            // Section 11.2.1 Directive Prologue
-            // The only way to get a correct directive is to parse the statement first and check if it is a string literal.
-            // All other method are flawed, see test cases in [babel](https://github.com/babel/babel/blob/v7.26.2/packages/babel-parser/test/fixtures/core/categorized/not-directive/input.js)
             if expecting_directives {
-                if let Statement::ExpressionStatement(expr) = &stmt
-                    && let Expression::StringLiteral(string) = &expr.expression
-                {
-                    // span start will mismatch if they are parenthesized when `preserve_parens = false`
-                    if expr.span.start == string.span.start {
-                        let src = &self.source_text
-                            [string.span.start as usize + 1..string.span.end as usize - 1];
-                        let directive =
-                            self.ast.directive(expr.span, (*string).clone(), Atom::from(src));
-                        directives.push(directive);
-                        continue;
-                    }
+                if self.push_directive_if_present(&mut directives, &stmt) {
+                    continue;
                 }
                 expecting_directives = false;
             }
@@ -98,6 +85,31 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         (directives, statements)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn push_directive_if_present(
+        &self,
+        directives: &mut Vec<'a, Directive<'a>>,
+        stmt: &Statement<'a>,
+    ) -> bool {
+        // Section 11.2.1 Directive Prologue
+        // The only way to get a correct directive is to parse the statement first and check if it is a string literal.
+        // All other methods are flawed, see test cases in [babel](https://github.com/babel/babel/blob/v7.26.2/packages/babel-parser/test/fixtures/core/categorized/not-directive/input.js)
+        if let Statement::ExpressionStatement(expr) = stmt
+            && let Expression::StringLiteral(string) = &expr.expression
+            // span start will mismatch if they are parenthesized when `preserve_parens = false`
+            && expr.span.start == string.span.start
+        {
+            let src =
+                &self.source_text[string.span.start as usize + 1..string.span.end as usize - 1];
+            let directive = self.ast.directive(expr.span, (*string).clone(), Atom::from(src));
+            directives.push(directive);
+            true
+        } else {
+            false
+        }
     }
 
     /// `StatementListItem`[Yield, Await, Return] :


### PR DESCRIPTION
### TL;DR

Extracted directive parsing logic into a separate method to improve code organization and performance.

### What changed?

The inline directive parsing logic in the statement parsing loop has been moved to a new dedicated method `push_directive_if_present`. This method is marked with `#[cold]` and `#[inline(never)` attributes to optimize the hot path when directives are not present.

### How to test?

Run existing parser tests to ensure directive parsing still works correctly. Test with JavaScript files containing directive prologues like `"use strict"` at the beginning of functions or modules.

### Why make this change?

This refactoring improves code readability by separating concerns and provides a performance optimization by marking the directive parsing path as cold code, which helps the compiler optimize the more common case where directives are not being processed.