### PR TITLE
ci(release): add bump step for oxc-project/mirrors-oxfmt

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -756,3 +756,11 @@ jobs:
           workflow: main.yml
           token: ${{ secrets.OXC_BOT_PAT }}
           ref: main
+
+      - name: Bump oxc-project/mirrors-oxfmt
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1.3.1
+        with:
+          repo: oxc-project/mirrors-oxfmt
+          workflow: main.yml
+          token: ${{ secrets.OXC_BOT_PAT }}
+          ref: main


### PR DESCRIPTION
## Summary

Add a workflow dispatch step to bump `oxc-project/mirrors-oxfmt` in `release_apps.yml`, following the same pattern as the existing `mirrors-oxlint` bump step.

When a new oxfmt release is published, this step triggers the `main.yml` workflow in `oxc-project/mirrors-oxfmt`, which runs `pre-commit-mirror-maker` to generate the corresponding mirror commit and version tag.

## Related

- https://github.com/oxc-project/mirrors-oxfmt/pull/3 — Fixes the mirror initialization so that `pre-commit-mirror-maker` can generate version tags. This PR adds the automated trigger from the release workflow so that future oxfmt releases are mirrored without manual intervention.