### PR TITLE
feat(linter/vitest): implement require-awaited-expect-poll rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4307,6 +4307,11 @@ impl RuleRunner for crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy 
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -690,6 +690,7 @@ pub use crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBoolea
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
+pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll as VitestRequireAwaitedExpectPoll;
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
 pub use crate::rules::vitest::warn_todo::WarnTodo as VitestWarnTodo;
 pub use crate::rules::vue::define_emits_declaration::DefineEmitsDeclaration as VueDefineEmitsDeclaration;
@@ -1396,6 +1397,7 @@ pub enum RuleEnum {
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
+    VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll),
     VitestRequireLocalTestContextForConcurrentSnapshots(
         VitestRequireLocalTestContextForConcurrentSnapshots,
     ),
@@ -2181,8 +2183,9 @@ const VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID: usize = VITEST_PREFER_IMPORT_IN_
 const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
+const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
-    VITEST_PREFER_TO_BE_TRUTHY_ID + 1usize;
+    VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_WARN_TODO_ID: usize =
     VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = VITEST_WARN_TODO_ID + 1usize;
@@ -2993,6 +2996,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
+            Self::VitestRequireAwaitedExpectPoll(_) => VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID
             }
@@ -3794,6 +3798,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
+            Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::NAME,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::NAME
             }
@@ -4641,6 +4646,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
+            Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::CATEGORY,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::CATEGORY
             }
@@ -5445,6 +5451,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
+            Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::FIX,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::FIX
             }
@@ -6445,6 +6452,9 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
+            Self::VitestRequireAwaitedExpectPoll(_) => {
+                VitestRequireAwaitedExpectPoll::documentation()
+            }
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::documentation()
             }
@@ -8398,6 +8408,10 @@ impl RuleEnum {
                 .or_else(|| VitestPreferToBeObject::schema(generator)),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::config_schema(generator)
                 .or_else(|| VitestPreferToBeTruthy::schema(generator)),
+            Self::VitestRequireAwaitedExpectPoll(_) => {
+                VitestRequireAwaitedExpectPoll::config_schema(generator)
+                    .or_else(|| VitestRequireAwaitedExpectPoll::schema(generator))
+            }
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::config_schema(generator)
                     .or_else(|| {
@@ -9149,6 +9163,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
+            Self::VitestRequireAwaitedExpectPoll(_) => "vitest",
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
             Self::VitestWarnTodo(_) => "vitest",
             Self::NodeGlobalRequire(_) => "node",
@@ -11353,6 +11368,9 @@ impl RuleEnum {
             Self::VitestPreferToBeTruthy(_) => {
                 Ok(Self::VitestPreferToBeTruthy(VitestPreferToBeTruthy::from_configuration(value)?))
             }
+            Self::VitestRequireAwaitedExpectPoll(_) => Ok(Self::VitestRequireAwaitedExpectPoll(
+                VitestRequireAwaitedExpectPoll::from_configuration(value)?,
+            )),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 Ok(Self::VitestRequireLocalTestContextForConcurrentSnapshots(
                     VitestRequireLocalTestContextForConcurrentSnapshots::from_configuration(value)?,
@@ -12112,6 +12130,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.to_configuration(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                 rule.to_configuration()
             }
@@ -12819,6 +12838,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run(node, ctx),
             Self::VitestWarnTodo(rule) => rule.run(node, ctx),
             Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
@@ -13524,6 +13544,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_once(ctx),
             Self::VitestWarnTodo(rule) => rule.run_once(ctx),
             Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
@@ -14327,6 +14348,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
             }
@@ -15034,6 +15056,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.should_run(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
             Self::VitestWarnTodo(rule) => rule.should_run(ctx),
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
@@ -16031,6 +16054,9 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
+            Self::VitestRequireAwaitedExpectPoll(_) => {
+                VitestRequireAwaitedExpectPoll::IS_TSGOLINT_RULE
+            }
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::IS_TSGOLINT_RULE
             }
@@ -16907,6 +16933,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
+            Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::HAS_CONFIG,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
                 VitestRequireLocalTestContextForConcurrentSnapshots::HAS_CONFIG
             }
@@ -17616,6 +17643,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.types_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
             Self::VitestWarnTodo(rule) => rule.types_info(),
             Self::NodeGlobalRequire(rule) => rule.types_info(),
@@ -18321,6 +18349,7 @@ impl RuleEnum {
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
+            Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
             Self::VitestWarnTodo(rule) => rule.run_info(),
             Self::NodeGlobalRequire(rule) => rule.run_info(),
@@ -19142,6 +19171,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),
+        RuleEnum::VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll::default()),
         RuleEnum::VitestRequireLocalTestContextForConcurrentSnapshots(
             VitestRequireLocalTestContextForConcurrentSnapshots::default(),
         ),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -718,6 +718,7 @@ pub(crate) mod vitest {
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;
+    pub mod require_awaited_expect_poll;
     pub mod require_local_test_context_for_concurrent_snapshots;
     pub mod warn_todo;
 }

--- a/crates/oxc_linter/src/rules/vitest/require_awaited_expect_poll.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_awaited_expect_poll.rs
@@ -30,7 +30,7 @@ pub struct RequireAwaitedExpectPoll;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule ensures that promises returned by expect.poll & expect.element calls are handled properly.
+    /// This rule ensures that promises returned by `expect.poll` and `expect.element` calls are handled properly.
     ///
     /// ### Why is this bad?
     ///

--- a/crates/oxc_linter/src/rules/vitest/require_awaited_expect_poll.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_awaited_expect_poll.rs
@@ -1,0 +1,289 @@
+use oxc_allocator::GetAddress;
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::Rule,
+    rules::PossibleJestNode,
+    utils::{KnownMemberExpressionProperty, parse_expect_and_typeof_vitest_fn_call},
+};
+
+fn require_awaited_expect_poll_diagnostic(span: Span, member_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`expect.{member_name}` must be awaited or returned"))
+        .with_help(format!("Add `await` to the `expect.{member_name}` call."))
+        .with_label(span)
+}
+
+fn require_awaited_expect_poll_return_diagnostic(span: Span, member_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("`expect.{member_name}` must be awaited or returned as the last expression"))
+          .with_help(format!("Add `await` to the `expect.{member_name}` call or move it to the last position in the sequence."))
+          .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireAwaitedExpectPoll;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule ensures that promises returned by expect.poll & expect.element calls are handled properly.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `expect.poll` and `expect.element` return promises. If not awaited or returned,
+    /// the test completes before the assertion resolves, meaning the test will pass
+    /// regardless of whether the assertion succeeds or fails.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// test('element exists', () => {
+    ///   asyncInjectElement()
+    ///
+    ///   expect.poll(() => document.querySelector('.element')).toBeInTheDocument()
+    /// })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// test('element exists', () => {
+    ///   asyncInjectElement()
+    ///
+    ///   return expect
+    ///     .poll(() => document.querySelector('.element'))
+    ///     .toBeInTheDocument()
+    /// })
+    /// test('element exists', async () => {
+    /// asyncInjectElement()
+    ///
+    /// await expect
+    ///     .poll(() => document.querySelector('.element'))
+    ///     .toBeInTheDocument()
+    /// })
+    /// ```
+    RequireAwaitedExpectPoll,
+    vitest,
+    correctness,
+);
+
+impl Rule for RequireAwaitedExpectPoll {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &crate::rules::PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        RequireAwaitedExpectPoll::run(jest_node, ctx);
+    }
+}
+
+impl RequireAwaitedExpectPoll {
+    fn run<'a, 'c>(possible_jest_node: &PossibleJestNode<'a, 'c>, ctx: &'c LintContext<'a>) {
+        let node = possible_jest_node.node;
+
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Some(expect) =
+            parse_expect_and_typeof_vitest_fn_call(call_expr, possible_jest_node, ctx)
+        else {
+            return;
+        };
+
+        if !expect.members.first().is_some_and(is_awaited_member) {
+            return;
+        }
+
+        let top_most_node = skip_sequence_expressions(skip_matchers_and_modifiers(node, ctx), ctx);
+
+        if is_returned_or_awaited(top_most_node, ctx) {
+            return;
+        }
+
+        if is_in_return_context(top_most_node, ctx) {
+            ctx.diagnostic(require_awaited_expect_poll_return_diagnostic(
+                call_expr.span,
+                expect.members.first().unwrap().name().unwrap().as_ref(),
+            ));
+        } else {
+            ctx.diagnostic(require_awaited_expect_poll_diagnostic(
+                call_expr.span,
+                expect.members.first().unwrap().name().unwrap().as_ref(),
+            ));
+        }
+    }
+}
+
+fn is_awaited_member(member: &KnownMemberExpressionProperty<'_>) -> bool {
+    member.is_name_equal("poll") || member.is_name_equal("element")
+}
+
+fn skip_sequence_expressions<'a, 'c>(
+    node: &AstNode<'a>,
+    ctx: &'c LintContext<'a>,
+) -> &'c AstNode<'a> {
+    let mut current_node = ctx.semantic().nodes().get_node(node.id());
+
+    loop {
+        let parent = ctx.semantic().nodes().parent_node(current_node.id());
+        let parent_kind = parent.kind();
+
+        match parent_kind {
+            AstKind::ParenthesizedExpression(_) => current_node = parent,
+            AstKind::SequenceExpression(sequence) => {
+                if sequence.expressions.last().is_some_and(|last_expression| {
+                    last_expression.address() != current_node.address()
+                }) {
+                    break;
+                }
+
+                current_node = parent;
+            }
+            _ => break,
+        }
+    }
+
+    current_node
+}
+
+fn skip_matchers_and_modifiers<'a, 'c>(
+    node: &AstNode<'_>,
+    ctx: &'c LintContext<'a>,
+) -> &'c AstNode<'a> {
+    let mut current_node = ctx.semantic().nodes().get_node(node.id());
+
+    loop {
+        let parent = ctx.semantic().nodes().parent_node(current_node.id());
+        let parent_kind = parent.kind();
+        if !matches!(
+            parent_kind,
+            AstKind::StaticMemberExpression(_)
+                | AstKind::ComputedMemberExpression(_)
+                | AstKind::PrivateFieldExpression(_)
+                | AstKind::CallExpression(_)
+        ) {
+            break;
+        }
+
+        current_node = parent;
+    }
+
+    current_node
+}
+
+fn is_in_return_context<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let parent = ctx.semantic().nodes().parent_node(node.id());
+
+    matches!(parent.kind(), AstKind::ReturnStatement(_))
+}
+
+fn is_returned_or_awaited<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
+    let parent = ctx.semantic().nodes().parent_node(node.id());
+
+    matches!(parent.kind(), AstKind::ReturnStatement(_) | AstKind::AwaitExpression(_))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "
+                    test('should pass', async () => {
+                      await expect.poll(() => element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should pass', async () => {
+                      await expect.element(element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should pass', () => {
+                      expect.syncElement(element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should pass', () => {
+                      return expect.poll(() => element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should pass', () => {
+                      return expect.element(element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should pass', () => {
+                      return expect(true).toBe(true);
+                    });
+                  ",
+"
+                    test('should pass', async () => {
+                      (sideEffect(), await expect.poll(() => element).toBeInTheDocument());
+                    });
+                  ",
+"
+                    test('should pass', async () => {
+                      await (sideEffect(), expect.poll(() => element).toBeInTheDocument());
+                    });
+                  ",
+"
+                    test('should pass', async () => {
+                      await (sideEffect(), (sideEffect(), (sideEffect(), expect.poll(() => element).toBeInTheDocument())));
+                    });
+                  ",
+"
+                    test('should pass', () => {
+                      return (sideEffect(), expect.poll(() => element).toBeInTheDocument());
+                    });
+                  "
+    ];
+
+    let fail = vec![
+        "
+                    test('should fail', () => {
+                      expect.poll(() => element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      expect.element(element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      expect['poll'](() => element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      expect['element'](element).toBeInTheDocument();
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      (expect.element(() => element).toBeInTheDocument(), expect(true).toBe(true));
+                    });
+                  ",
+"
+                    test('should fail', () => {
+                      return (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+                    });
+                  "
+    ];
+
+    Tester::new(RequireAwaitedExpectPoll::NAME, RequireAwaitedExpectPoll::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_require_awaited_expect_poll.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_require_awaited_expect_poll.snap
@@ -1,0 +1,129 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect.poll(() => element).toBeInTheDocument();
+   ·                       ──────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect.poll(() => element).toBeInTheDocument();
+   ·                       ──────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect.element(element).toBeInTheDocument();
+   ·                       ───────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect.element(element).toBeInTheDocument();
+   ·                       ───────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect['poll'](() => element).toBeInTheDocument();
+   ·                       ─────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect['poll'](() => element).toBeInTheDocument();
+   ·                       ─────────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect['element'](element).toBeInTheDocument();
+   ·                       ──────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:23]
+ 2 │                     test('should fail', () => {
+ 3 │                       expect['element'](element).toBeInTheDocument();
+   ·                       ──────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:24]
+ 2 │                     test('should fail', () => {
+ 3 │                       (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                        ──────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:24]
+ 2 │                     test('should fail', () => {
+ 3 │                       (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                        ──────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:24]
+ 2 │                     test('should fail', () => {
+ 3 │                       (expect.element(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                        ─────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.element` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:24]
+ 2 │                     test('should fail', () => {
+ 3 │                       (expect.element(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                        ─────────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.element` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:31]
+ 2 │                     test('should fail', () => {
+ 3 │                       return (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                               ──────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.
+
+  ⚠ eslint-plugin-vitest(require-awaited-expect-poll): `expect.poll` must be awaited or returned
+   ╭─[require_awaited_expect_poll.tsx:3:31]
+ 2 │                     test('should fail', () => {
+ 3 │                       return (expect.poll(() => element).toBeInTheDocument(), expect(true).toBe(true));
+   ·                               ──────────────────────────────────────────────
+ 4 │                     });
+   ╰────
+  help: Add `await` to the `expect.poll` call.


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

- [Docs](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-awaited-expect-poll.md)
- [Source Code](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/src/rules/require-awaited-expect-poll.ts)
- [Test](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/tests/require-awaited-expect-poll.test.ts)