### PR TITLE
chore(fmt): enable JSDoc formatting in oxfmtrc

### DIFF
--- a/.github/scripts/check-changes.js
+++ b/.github/scripts/check-changes.js
@@ -6,13 +6,13 @@
  * Generic change detection script for CI jobs.
  *
  * Include mode: checks if changes affect specified crates or their transitive dependencies.
- *   node check-changes.js --packages oxc_minifier --paths tasks/minsize/
+ * node check-changes.js --packages oxc_minifier --paths tasks/minsize/
  *
  * Exclude mode: skips only if ALL changed files belong to excluded crate directories.
- *   node check-changes.js --exclude oxc_linter,oxc_language_server --paths napi/,npm/
+ * node check-changes.js --exclude oxc_linter,oxc_language_server --paths napi/,npm/
  *
  * Paths-only mode: run if any changed file matches the given paths (no cargo tree).
- *   node check-changes.js --paths apps/oxlint/,npm/oxlint/,napi/oxlint/
+ * node check-changes.js --paths apps/oxlint/,npm/oxlint/,napi/oxlint/
  */
 
 const { getChangedFiles } = require("./get-changed-files.js");
@@ -20,7 +20,8 @@ const { getCrateDependencies, checkFilesAffectCrates } = require("./utils.js");
 
 /**
  * Parse CLI arguments into structured options.
- * @returns {{ packages: string[], exclude: string[], paths: string[] }}
+ *
+ * @returns {{ packages: string[]; exclude: string[]; paths: string[] }}
  */
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -42,6 +43,7 @@ function parseArgs() {
 
 /**
  * Include mode: run if changes affect any of the specified crates (+ transitive deps) or paths.
+ *
  * @param {string[] | null} changedFiles
  * @param {string[]} packages - Root crate names
  * @param {string[]} paths - Additional trigger paths
@@ -94,8 +96,9 @@ function shouldRunInclude(changedFiles, packages, paths) {
 }
 
 /**
- * Exclude mode: skip only if ALL changed files belong to excluded crate directories.
- * Files matching `paths` always trigger the job. No cargo tree — exclusion is intentionally shallow.
+ * Exclude mode: skip only if ALL changed files belong to excluded crate directories. Files matching
+ * `paths` always trigger the job. No cargo tree — exclusion is intentionally shallow.
+ *
  * @param {string[] | null} changedFiles
  * @param {string[]} excludeCrates - Crate names to exclude
  * @param {string[]} paths - Additional paths that always trigger the job

--- a/.github/scripts/clone-parallel.mjs
+++ b/.github/scripts/clone-parallel.mjs
@@ -31,6 +31,7 @@ const NODE_COMPAT_TABLE = args[5] !== "false";
 
 /**
  * Run a git command and return a promise
+ *
  * @param {string[]} gitArgs - Arguments to pass to git
  * @param {string} cwd - Working directory
  * @returns {Promise<void>}
@@ -61,12 +62,13 @@ function runGit(gitArgs, cwd) {
 
 /**
  * Clone or update a repository
+ *
  * @param {boolean} shouldClone - Whether to clone this repo
  * @param {string} repo - GitHub repo path (e.g., "tc39/test262")
  * @param {string} path - Local path relative to repo root
  * @param {string} ref - Git ref (SHA) to checkout
  * @param {string} name - Display name for logging
- * @returns {Promise<{success: boolean, name: string, error?: string}>}
+ * @returns {Promise<{ success: boolean; name: string; error?: string }>}
  */
 async function cloneRepo(shouldClone, repo, path, ref, name) {
   if (!shouldClone) {

--- a/.github/scripts/generate-benchmark-matrix.js
+++ b/.github/scripts/generate-benchmark-matrix.js
@@ -34,6 +34,7 @@ const GLOBAL_FILES = [
 
 /**
  * Check if any global files have changed that affect all benchmarks
+ *
  * @param {string[]} changedFiles - Array of changed file paths
  * @returns {boolean} True if global changes detected
  */
@@ -54,6 +55,7 @@ function checkGlobalChanges(changedFiles) {
 
 /**
  * Map component to its feature
+ *
  * @param {string} component - Component name
  * @returns {string} Feature name
  */
@@ -69,6 +71,7 @@ const depsCache = new Map();
 
 /**
  * Get dependencies for a specific benchmark component
+ *
  * @param {string} component - Component name
  * @returns {string[]} Array of dependency names
  */
@@ -95,6 +98,7 @@ function getComponentDependencies(component) {
 
 /**
  * Check if a component is affected by the changed files
+ *
  * @param {string} component - Component name
  * @param {string[]} changedFiles - Array of changed file paths
  * @returns {boolean} True if component is affected
@@ -122,7 +126,8 @@ function isComponentAffected(component, changedFiles) {
 
 /**
  * Determine which components are affected by changes
- * @returns {Promise<Array<{component: string, feature: string}>>} Array of affected component objects
+ *
+ * @returns {Promise<{ component: string; feature: string }[]>} Array of affected component objects
  */
 async function determineAffectedComponents() {
   const changedFiles = await getChangedFiles();

--- a/.github/scripts/get-changed-files.js
+++ b/.github/scripts/get-changed-files.js
@@ -12,6 +12,7 @@ const process = require("process");
 
 /**
  * Make a GitHub API request
+ *
  * @param {string} path - API path
  * @returns {Promise<any>} API response
  */
@@ -50,6 +51,7 @@ function githubApi(path) {
 
 /**
  * Get all changed files for a PR, paginating through all pages
+ *
  * @param {string} repository - Repository name (owner/repo)
  * @param {string} prNumber - Pull request number
  * @returns {Promise<string[]>} Array of changed file paths
@@ -74,6 +76,7 @@ async function getPrChangedFiles(repository, prNumber) {
 
 /**
  * Get changed files based on the GitHub event type
+ *
  * @returns {Promise<string[] | null>} Array of changed file paths, or null to signal "run all"
  */
 async function getChangedFiles() {

--- a/.github/scripts/utils.js
+++ b/.github/scripts/utils.js
@@ -8,6 +8,7 @@ const { execSync } = require("child_process");
 
 /**
  * Execute a shell command and return the output
+ *
  * @param {string} command - Command to execute
  * @returns {string} Command output
  */
@@ -27,6 +28,7 @@ function exec(command) {
 
 /**
  * Get dependencies for one or more crates using cargo tree
+ *
  * @param {string | string[]} packages - Package name(s) to query
  * @param {object} options - Additional options
  * @param {string} [options.features] - Features to enable
@@ -64,6 +66,7 @@ function getCrateDependencies(packages, options = {}) {
 
 /**
  * Check if any changed files affect specified crates or paths
+ *
  * @param {string[] | null} changedFiles - Array of changed file paths, or null
  * @param {string[]} crates - Array of crate names to check
  * @param {string[]} [additionalPaths] - Additional paths to check (e.g., 'tasks/benchmark/')

--- a/apps/oxfmt/scripts/build.js
+++ b/apps/oxfmt/scripts/build.js
@@ -23,6 +23,7 @@ console.log("Build complete!");
 
 /**
  * Copy a file, creating parent directories if needed.
+ *
  * @param {string} srcPath - Source file path, absolute
  * @param {string} destPath - Destination file path, absolute
  * @returns {void}

--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -6,8 +6,8 @@ import { hasOxfmtrcFile, createBlankOxfmtrcFile, saveOxfmtrcFile, exitWithError 
 import { Options } from "prettier";
 
 /**
- * Run the `--migrate prettier` command to migrate various Prettier's config to `.oxfmtrc.json` file.
- * https://prettier.io/docs/configuration
+ * Run the `--migrate prettier` command to migrate various Prettier's config to `.oxfmtrc.json`
+ * file. https://prettier.io/docs/configuration
  */
 export async function runMigratePrettier() {
   const cwd = process.cwd();
@@ -187,6 +187,7 @@ const TAILWIND_OPTION_MAPPING: Record<string, string> = {
  * Migrate prettier-plugin-tailwindcss options to Oxfmt's sortTailwindcss format.
  *
  * Prettier format:
+ *
  * ```json
  * {
  *   "plugins": ["prettier-plugin-tailwindcss"],
@@ -196,6 +197,7 @@ const TAILWIND_OPTION_MAPPING: Record<string, string> = {
  * ```
  *
  * Oxfmt format:
+ *
  * ```json
  * {
  *   "sortTailwindcss": {

--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -42,7 +42,8 @@ export interface Oxfmtrc {
    */
   bracketSpacing?: boolean;
   /**
-   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the
+   * file.
    *
    * NOTE: XXX-in-JS support is incomplete.
    *
@@ -100,14 +101,15 @@ export interface Oxfmtrc {
    * How to wrap object literals when they could fit on one line or span multiple lines.
    *
    * By default, formats objects as multi-line if there is a newline prior to the first property.
-   * Authors can use this heuristic to contextually improve readability, though it has some downsides.
+   * Authors can use this heuristic to contextually improve readability, though it has some
+   * downsides.
    *
    * - Default: `"preserve"`
    */
   objectWrap?: ObjectWrapConfig;
   /**
-   * File-specific overrides.
-   * When a file matches multiple overrides, the later override takes precedence (array order matters).
+   * File-specific overrides. When a file matches multiple overrides, the later override takes
+   * precedence (array order matters).
    *
    * - Default: `[]`
    */
@@ -115,7 +117,8 @@ export interface Oxfmtrc {
   /**
    * Specify the line length that the printer will wrap on.
    *
-   * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
+   * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to
+   * disable it.
    *
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
@@ -124,9 +127,10 @@ export interface Oxfmtrc {
   /**
    * How to wrap prose.
    *
-   * By default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.
-   * To wrap prose to the print width, change this option to "always".
-   * If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
+   * By default, formatter will not change wrapping in markdown text since some services use a
+   * linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To wrap prose to the print
+   * width, change this option to "always". If you want to force all prose blocks to be on a single
+   * line and rely on editor/viewer soft wrapping instead, you can use "never".
    *
    * - Default: `"preserve"`
    */
@@ -160,8 +164,9 @@ export interface Oxfmtrc {
   /**
    * Sort import statements.
    *
-   * Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
-   * For details, see each field's documentation.
+   * Using the similar algorithm as
+   * [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports). For
+   * details, see each field's documentation.
    *
    * - Default: Disabled
    */
@@ -169,9 +174,9 @@ export interface Oxfmtrc {
   /**
    * Sort `package.json` keys.
    *
-   * The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
-   * But we believe it is clearer and easier to navigate.
-   * For details, see each field's documentation.
+   * The algorithm is NOT compatible with
+   * [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson). But
+   * we believe it is clearer and easier to navigate. For details, see each field's documentation.
    *
    * - Default: `true`
    */
@@ -179,9 +184,10 @@ export interface Oxfmtrc {
   /**
    * Sort Tailwind CSS classes.
    *
-   * Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
-   * Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
-   * For details, see each field's documentation.
+   * Using the same algorithm as
+   * [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
+   * Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of
+   * `tailwindConfig`). For details, see each field's documentation.
    *
    * - Default: Disabled
    */
@@ -241,7 +247,6 @@ export interface JsdocConfig {
    * - `"singleLine"` — Convert to single-line `/** content * /` when possible.
    * - `"multiline"` — Always use multi-line format.
    * - `"keep"` — Preserve original formatting.
-   *
    * - Default: `"singleLine"`
    */
   commentLineStrategy?: string;
@@ -268,12 +273,11 @@ export interface JsdocConfig {
    *
    * - `"greedy"` — Always re-wrap text to fit within print width.
    * - `"balance"` — Preserve original line breaks if all lines fit within print width.
-   *
    * - Default: `"greedy"`
    */
   lineWrappingStyle?: string;
   /**
-   * Use fenced code blocks (```` ``` ````) instead of 4-space indentation for code without a language tag.
+   * Use fenced code blocks (`````) instead of 4-space indentation for code without a language tag.
    *
    * - Default: `false`
    */
@@ -329,7 +333,8 @@ export interface FormatConfig {
    */
   bracketSpacing?: boolean;
   /**
-   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
+   * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the
+   * file.
    *
    * NOTE: XXX-in-JS support is incomplete.
    *
@@ -380,7 +385,8 @@ export interface FormatConfig {
    * How to wrap object literals when they could fit on one line or span multiple lines.
    *
    * By default, formats objects as multi-line if there is a newline prior to the first property.
-   * Authors can use this heuristic to contextually improve readability, though it has some downsides.
+   * Authors can use this heuristic to contextually improve readability, though it has some
+   * downsides.
    *
    * - Default: `"preserve"`
    */
@@ -388,7 +394,8 @@ export interface FormatConfig {
   /**
    * Specify the line length that the printer will wrap on.
    *
-   * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
+   * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to
+   * disable it.
    *
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
@@ -397,9 +404,10 @@ export interface FormatConfig {
   /**
    * How to wrap prose.
    *
-   * By default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.
-   * To wrap prose to the print width, change this option to "always".
-   * If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
+   * By default, formatter will not change wrapping in markdown text since some services use a
+   * linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To wrap prose to the print
+   * width, change this option to "always". If you want to force all prose blocks to be on a single
+   * line and rely on editor/viewer soft wrapping instead, you can use "never".
    *
    * - Default: `"preserve"`
    */
@@ -433,8 +441,9 @@ export interface FormatConfig {
   /**
    * Sort import statements.
    *
-   * Using the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
-   * For details, see each field's documentation.
+   * Using the similar algorithm as
+   * [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports). For
+   * details, see each field's documentation.
    *
    * - Default: Disabled
    */
@@ -442,9 +451,9 @@ export interface FormatConfig {
   /**
    * Sort `package.json` keys.
    *
-   * The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).
-   * But we believe it is clearer and easier to navigate.
-   * For details, see each field's documentation.
+   * The algorithm is NOT compatible with
+   * [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson). But
+   * we believe it is clearer and easier to navigate. For details, see each field's documentation.
    *
    * - Default: `true`
    */
@@ -452,9 +461,10 @@ export interface FormatConfig {
   /**
    * Sort Tailwind CSS classes.
    *
-   * Using the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
-   * Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).
-   * For details, see each field's documentation.
+   * Using the same algorithm as
+   * [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).
+   * Option names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of
+   * `tailwindConfig`). For details, see each field's documentation.
    *
    * - Default: Disabled
    */
@@ -496,8 +506,9 @@ export interface SortImportsConfig {
    * The `customGroups` list is ordered: The first definition that matches an element will be used.
    * Custom groups have a higher priority than any predefined group.
    *
-   * If you want a predefined group to take precedence over a custom group,
-   * you must write a custom group definition that does the same as what the predefined group does, and put it first in the list.
+   * If you want a predefined group to take precedence over a custom group, you must write a custom
+   * group definition that does the same as what the predefined group does, and put it first in the
+   * list.
    *
    * If you specify multiple conditions like `elementNamePattern`, `selector`, and `modifiers`,
    * all conditions must be met for an import to match the custom group (AND logic).
@@ -508,19 +519,22 @@ export interface SortImportsConfig {
   /**
    * Specifies a list of predefined import groups for sorting.
    *
-   * Each import will be assigned a single group specified in the groups option (or the `unknown` group if no match is found).
-   * The order of items in the `groups` option determines how groups are ordered.
+   * Each import will be assigned a single group specified in the groups option (or the `unknown`
+   * group if no match is found). The order of items in the `groups` option determines how groups
+   * are ordered.
    *
-   * Within a given group, members will be sorted according to the type, order, ignoreCase, etc. options.
+   * Within a given group, members will be sorted according to the type, order, ignoreCase, etc.
+   * options.
    *
-   * Individual groups can be combined together by placing them in an array.
-   * The order of groups in that array does not matter.
-   * All members of the groups in the array will be sorted together as if they were part of a single group.
+   * Individual groups can be combined together by placing them in an array. The order of groups in
+   * that array does not matter. All members of the groups in the array will be sorted together as
+   * if they were part of a single group.
    *
    * Predefined groups are characterized by a single selector and potentially multiple modifiers.
    * You may enter modifiers in any order, but the selector must always come at the end.
    *
    * The list of selectors is sorted from most to least important:
+   *
    * - `type` — TypeScript type imports.
    * - `side_effect_style` — Side effect style imports.
    * - `side_effect` — Side effect imports.
@@ -535,14 +549,15 @@ export interface SortImportsConfig {
    * - `import` — Any import.
    *
    * The list of modifiers is sorted from most to least important:
+   *
    * - `side_effect` — Side effect imports.
    * - `type` — TypeScript type imports.
    * - `value` — Value imports.
    * - `default` — Imports containing the default specifier.
    * - `wildcard` — Imports containing the wildcard (`* as`) specifier.
    * - `named` — Imports containing at least one named specifier.
-   *
    * - Default: See below
+   *
    * ```json
    * [
    * "builtin",
@@ -554,8 +569,9 @@ export interface SortImportsConfig {
    * ]
    * ```
    *
-   * Also, you can override the global `newlinesBetween` setting for specific group boundaries
-   * by including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired position.
+   * Also, you can override the global `newlinesBetween` setting for specific group boundaries by
+   * including a `{ "newlinesBetween": boolean }` marker object in the `groups` list at the desired
+   * position.
    */
   groups?: SortGroupItemConfig[];
   /**
@@ -592,10 +608,10 @@ export interface SortImportsConfig {
    * When `true`, all comments will be treated as delimiters, creating partitions.
    *
    * ```js
-   * import { b1, b2 } from 'b'
+   * import { b1, b2 } from "b";
    * // PARTITION
-   * import { a } from 'a'
-   * import { c } from 'c'
+   * import { a } from "a";
+   * import { c } from "c";
    * ```
    *
    * - Default: `false`
@@ -608,10 +624,10 @@ export interface SortImportsConfig {
    * This helps maintain the defined order of logically separated groups of members.
    *
    * ```js
-   * import { b1, b2 } from 'b'
+   * import { b1, b2 } from "b";
    *
-   * import { a } from 'a'
-   * import { c } from 'c'
+   * import { a } from "a";
+   * import { c } from "c";
    * ```
    *
    * - Default: `false`

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -35,6 +35,7 @@ export interface OxfmtConfig extends Oxfmtrc {}
  *
  * Based on `FormatConfig` generated from the JSON Schema,
  * with additional deprecated aliases for backward compatibility.
+ *
  * @deprecated Use `FormatConfig` instead.
  */
 export type FormatOptions = FormatConfig & {

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -2,10 +2,13 @@
  * API functions for Prettier integration.
  *
  * These must be plain functions because:
+ *
  * - They can be called as `tinypool` RPC functions via `cli-worker.ts`
+ *
  *   - Tinypool runs workers as `child_process`, so each worker is an isolated process
  *   - Module-level caches are shared only within each worker process
  * - They can also be imported directly via `index.ts` (Node.js API)
+ *
  *   - In this case, module-level caches are shared globally
  *
  * The caches (`xxxCache`) are for lazy loading
@@ -138,10 +141,11 @@ export type FormatEmbeddedDocParam = {
  * Format xxx-in-js code snippets into Prettier `Doc` JSON strings.
  *
  * This makes `oxc_formatter` correctly handle `printWidth` even for embedded code.
+ *
  * - For gql-in-js, `texts` contains multiple parts split by `${}` in a template literal
  * - For others, `texts` always contains a single string with `${}` parts replaced by placeholders
- * However, this function does not need to be aware of that,
- * as it simply formats each text part independently and returns an array of formatted parts.
+ *   However, this function does not need to be aware of that, as it simply formats each text part
+ *   independently and returns an array of formatted parts.
  *
  * @returns Doc JSON strings (one per input text)
  */
@@ -245,6 +249,7 @@ export interface SortTailwindClassesArgs {
 
 /**
  * Process Tailwind CSS classes found in JS/TS files in batch.
+ *
  * @param args - Object containing classes and options (filepath is in options.filepath)
  * @returns Array of sorted class strings (same order/length as input)
  */

--- a/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
+++ b/apps/oxfmt/src-js/libs/prettier-plugin-oxfmt/text-to-doc.ts
@@ -38,7 +38,9 @@ export const textToDoc: Parser<Doc>["parse"] = async (embeddedSourceText, textTo
  * Detects Vue fragment mode from Prettier's internal flags.
  *
  * When Prettier formats Vue SFC templates, it calls textToDoc with special flags:
- * - `__isVueForBindingLeft`: v-for left-hand side (e.g., `(item, index)` in `v-for="(item, index) in items"`)
+ *
+ * - `__isVueForBindingLeft`: v-for left-hand side (e.g., `(item, index)` in `v-for="(item, index) in
+ *   items"`)
  * - `__isVueBindings`: v-slot bindings (e.g., `{ item }` in `#default="{ item }"`)
  * - `__isEmbeddedTypescriptGenericParameters`: `<script generic="...">` type parameters
  */

--- a/apps/oxlint/conformance/src/capture.ts
+++ b/apps/oxlint/conformance/src/capture.ts
@@ -36,6 +36,7 @@ export let currentGroup: TestGroup | null = null;
 /**
  * Set the current group being tested.
  * Call before starting running tests for a test group.
+ *
  * @param group - `TestGroup` object
  */
 export function setCurrentGroup(group: TestGroup): void {
@@ -48,6 +49,7 @@ export let currentRule: RuleResult | null = null;
 /**
  * Set the current rule being tested.
  * Call before loading a file containing tests.
+ *
  * @param rule - `RuleResult` object
  */
 export function setCurrentRule(rule: RuleResult): void {
@@ -68,6 +70,7 @@ let currentTest: TestCase | null = null;
 /**
  * Set the current test being tested.
  * Call before running linter for a test case (in `modifyTestCase` hook).
+ *
  * @param test - `TestCase` object
  */
 export function setCurrentTest(test: TestCase): void {
@@ -76,6 +79,7 @@ export function setCurrentTest(test: TestCase): void {
 
 /**
  * `describe` function that tracks the test hierarchy.
+ *
  * @param name - Name of the test group
  * @param fn - Function to run tests in the group
  */
@@ -106,6 +110,7 @@ export function describe(name: string, fn: () => void): void {
 
 /**
  * `it` function that runs and records individual tests.
+ *
  * @param name - Name of the test
  * @param fn - Function to run test
  */
@@ -154,6 +159,7 @@ export function it(code: string, fn: () => void): void {
 
 /**
  * Determine if failing test case should be skipped.
+ *
  * @param ruleName - Rule name
  * @param test - Test case
  * @param code - Code for test case

--- a/apps/oxlint/conformance/src/filter.ts
+++ b/apps/oxlint/conformance/src/filter.ts
@@ -22,6 +22,7 @@ export const SHOULD_SKIP_CODE = createShouldSkipFn(FILTER_ONLY_CODE);
 
 /**
  * Create a function which determines if should skip based on a filter.
+ *
  * @param filter - Filter
  * @returns Filter function
  */

--- a/apps/oxlint/conformance/src/groups/sonarjs.ts
+++ b/apps/oxlint/conformance/src/groups/sonarjs.ts
@@ -147,7 +147,9 @@ const group: TestGroup = {
 export default group;
 
 /**
- * If test case contains JSX syntax with a `.js` filename, convert filename to `.jsx` to allow them to be parsed.
+ * If test case contains JSX syntax with a `.js` filename, convert filename to `.jsx` to allow them
+ * to be parsed.
+ *
  * @param test - Test case
  * @returns - Amended test case
  */

--- a/apps/oxlint/conformance/src/groups/storybook.ts
+++ b/apps/oxlint/conformance/src/groups/storybook.ts
@@ -81,9 +81,9 @@ const group: TestGroup = {
 export default group;
 
 /**
- * Create a module to replace `@typescript-eslint/rule-tester`,
- * which presents the same API, but uses conformance `RuleTester` with TS-ESLint parser.
- * It also adds `before` and `after` hooks to all test cases to track when we're in a test case for this plugin.
+ * Create a module to replace `@typescript-eslint/rule-tester`, which presents the same API, but
+ * uses conformance `RuleTester` with TS-ESLint parser. It also adds `before` and `after` hooks to
+ * all test cases to track when we're in a test case for this plugin.
  *
  * @param tsEslintParser - TSESLint parser module
  * @param codeDirPath - Path to `code` directory in submodule

--- a/apps/oxlint/conformance/src/groups/stylistic.ts
+++ b/apps/oxlint/conformance/src/groups/stylistic.ts
@@ -238,7 +238,9 @@ function createStylisticRuleRunnerMock(tsEslintParser: TSEslintParser) {
 }
 
 /**
- * Modify a valid test case from `eslint-vitest-rule-tester`'s object shape to what `RuleTester` expects.
+ * Modify a valid test case from `eslint-vitest-rule-tester`'s object shape to what `RuleTester`
+ * expects.
+ *
  * @param test - Test case
  */
 function modifyValidTestCase(test: ValidTestCase) {
@@ -246,7 +248,9 @@ function modifyValidTestCase(test: ValidTestCase) {
 }
 
 /**
- * Modify an invalid test case from `eslint-vitest-rule-tester`'s object shape to what `RuleTester` expects.
+ * Modify an invalid test case from `eslint-vitest-rule-tester`'s object shape to what `RuleTester`
+ * expects.
+ *
  * @param test - Test case
  */
 function modifyInvalidTestCase(test: InvalidTestCase) {
@@ -270,6 +274,7 @@ function modifyInvalidTestCase(test: InvalidTestCase) {
 /**
  * `eslint-vitest-rule-tester` takes `parserOptions` and `parser` as properties of test case.
  * Move them to be properties of `languageOptions`.
+ *
  * @param test - Test case
  */
 function modifyTestCase(test: StylisticTestCase) {
@@ -289,9 +294,12 @@ function modifyTestCase(test: StylisticTestCase) {
 
 /**
  * Get language options from `StylisticParserOptions` and `LanguageOptions`.
- * @param parserOptions - Parser options from options passed to `run` function, or included as properties of test case
+ *
+ * @param parserOptions - Parser options from options passed to `run` function, or included as
+ *   properties of test case
  * @param languageOptions - Language options from test case object
- * @returns `LanguageOptions` to add to config / test case, combining `parserOptions` and `languageOptions`
+ * @returns `LanguageOptions` to add to config / test case, combining `parserOptions` and
+ *   `languageOptions`
  */
 function getLanguageOptions(
   parserOptions: StylisticParserOptions,
@@ -317,6 +325,7 @@ function getLanguageOptions(
 
 /**
  * Compact whitespace in code.
+ *
  * @param code - Code
  * @returns Code with whitespace compacted
  */

--- a/apps/oxlint/conformance/src/groups/testing_library.ts
+++ b/apps/oxlint/conformance/src/groups/testing_library.ts
@@ -115,8 +115,10 @@ function createRuleTesterModule(tsEslintParser: TSEslintParser): { RuleTester: t
 }
 
 /**
- * Patch test case to make `filename`'s extension `.tsx` if `languageOptions.parserOptions.ecmaFeatures.jsx` is `true`.
- * Otherwise, `filename: "whatever.test.js"` takes precedence over `jsx: true`, and fails to parse.
+ * Patch test case to make `filename`'s extension `.tsx` if
+ * `languageOptions.parserOptions.ecmaFeatures.jsx` is `true`. Otherwise, `filename:
+ * "whatever.test.js"` takes precedence over `jsx: true`, and fails to parse.
+ *
  * @param test - Test case
  * @param languageOptions - Language options from config
  * @returns Patched test case

--- a/apps/oxlint/conformance/src/index.ts
+++ b/apps/oxlint/conformance/src/index.ts
@@ -52,19 +52,21 @@ export interface TestGroup {
   submoduleName: string;
 
   /**
-   * Path to the directory containing test files for this group, relative to the submodule directory.
+   * Path to the directory containing test files for this group, relative to the submodule
+   * directory.
    */
   testFilesDirPath: string;
 
   /**
    * Transform test file name to test name.
    *
-   * e.g.:
+   * E.g.:
+   *
    * ```ts
    * (path: string) => {
    *   if (!path.endsWith(".js")) return null;
    *   return path.slice(0, -3);
-   * }
+   * };
    * ```
    *
    * @param filename - Filename of test file
@@ -74,6 +76,7 @@ export interface TestGroup {
 
   /**
    * Function to run before loading any test files.
+   *
    * @param require - Require function, which requires modules relative to the test files directory
    * @param mock - Mock function, which mocks modules relative to the test files directory
    */
@@ -94,16 +97,18 @@ export interface TestGroup {
   /**
    * `RuleTester` instances to replace with the Oxc conformance `RuleTester`.
    *
-   * - `specifier` is a module specifier which is resolved relative to the tests directory, using `require.resolve`.
-   * - `propName` is name of the property to set on the module to the `RuleTester` class.
-   *   If `null`, the module is set as `module.exports`.
+   * - `specifier` is a module specifier which is resolved relative to the tests directory, using
+   *   `require.resolve`.
+   * - `propName` is name of the property to set on the module to the `RuleTester` class. If `null`,
+   *   the module is set as `module.exports`.
    *
-   * e.g.:
+   * E.g.:
+   *
    * ```js
    * [
    *   { specifier: "eslint", propName: "RuleTester" },
    *   { specifier: "../../lib/rule-tester.js", propName: null },
-   * ]
+   * ];
    * ```
    */
   ruleTesters: { specifier: string; propName: string | null }[];
@@ -111,14 +116,15 @@ export interface TestGroup {
   /**
    * Known parsers to accept.
    *
-   * If one of these parsers is passed as `languageOptions.parser` in test case config, Oxc parser will be used instead.
-   * Otherwise, custom parsers are not accepted, and the test case will throw an error.
+   * If one of these parsers is passed as `languageOptions.parser` in test case config, Oxc parser
+   * will be used instead. Otherwise, custom parsers are not accepted, and the test case will throw
+   * an error.
    *
-   * `specifier` is a module specifier which is resolved relative to the tests directory, using `require.resolve`.
-   * `lang` is the language to parse the test case code with when this parser is used.
-   * `propName` (optional) is the name of the property of the module which is the parser.
+   * `specifier` is a module specifier which is resolved relative to the tests directory, using
+   * `require.resolve`. `lang` is the language to parse the test case code with when this parser is
+   * used. `propName` (optional) is the name of the property of the module which is the parser.
    *
-   * e.g. `{ specifier: "@typescript-eslint/parser", lang: "ts" }`
+   * E.g. `{ specifier: "@typescript-eslint/parser", lang: "ts" }`
    * e.g. `{ specifier: "typescript-eslint", propName: "parser", lang: "ts" }`
    */
   parsers: ParserDetails[];
@@ -133,8 +139,8 @@ export interface TestGroup {
  * If need to mock a module which is imported by another package, pass the specifiers of
  * "breadcrumb" packages on way to the module as `via`.
  *
- * e.g. If test file imports `foo`, `foo` imports `bar`, and `bar` imports `qux`, and `qux` is the module to mock:
- * `mock("qux", value, ["foo", "bar"])`
+ * E.g. If test file imports `foo`, `foo` imports `bar`, and `bar` imports `qux`, and `qux` is the
+ * module to mock: `mock("qux", value, ["foo", "bar"])`
  */
 export type MockFn = (specifier: string, value: unknown, via?: string[]) => void;
 
@@ -211,6 +217,7 @@ function initMocks(): Mocks {
 
 /**
  * Run all test groups.
+ *
  * @param groups - Test groups
  */
 function runGroups(groups: TestGroup[], mocks: Mocks) {
@@ -222,6 +229,7 @@ function runGroups(groups: TestGroup[], mocks: Mocks) {
 
 /**
  * Run all tests in a test group.
+ *
  * @param group - Test group
  */
 function runGroup(group: TestGroup, mocks: Mocks) {
@@ -334,6 +342,7 @@ function runGroup(group: TestGroup, mocks: Mocks) {
 
 /**
  * Create a mock function which mocks a module relative to the test files directory.
+ *
  * @param testFilesDirPath - Path to the test files directory
  * @param mocks - Mocks
  * @returns Mock function
@@ -355,6 +364,7 @@ function createMockFn(testFilesDirPath: string, mocks: Mocks): MockFn {
 
 /**
  * Find all test files for a test group.
+ *
  * @param group - Test group
  * @returns Test file details
  */
@@ -383,6 +393,7 @@ function findTestFiles(group: TestGroup): TestFile[] {
 
 /**
  * Run all test files for a group.
+ *
  * @param testFiles - Test files
  * @returns Results of running tests
  */
@@ -421,6 +432,7 @@ function runAllTests(testFiles: TestFile[]): RuleResult[] {
 
 /**
  * Run tests for a single rule file.
+ *
  * @param testFile - Test file details
  * @returns Results of running tests for rule
  */

--- a/apps/oxlint/conformance/src/report.ts
+++ b/apps/oxlint/conformance/src/report.ts
@@ -21,6 +21,7 @@ const normalizeSlashes =
 
 /**
  * Generate report of test results as markdown.
+ *
  * @param results - Results of running tests
  * @returns Report as markdown
  */
@@ -244,6 +245,7 @@ const CONTROL_CHAR_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/gu;
  * Clean a string for output.
  * Remove ANSI escape sequences and control characters from a string.
  * Keeps tab, newline, and carriage return.
+ *
  * @param str - String to clean
  * @returns Cleaned string
  */
@@ -324,6 +326,7 @@ function formatError(err: Error | null): string {
 
 /**
  * Format a test case as JSON.
+ *
  * @param testCase - Test case to format
  * @returns Test case formatted as JSON string, or `null` if not present, or could not format
  */
@@ -354,6 +357,7 @@ function formatTestCase(testCase: TestCase | null, code: string): string | null 
 
 /**
  * Produce a string of the form `count / total (percent%)`.
+ *
  * @param count - Count
  * @param total - Total count
  * @returns Formatted proportion
@@ -364,6 +368,7 @@ function formatProportion(count: number, total: number): string {
 
 /**
  * Produce a string representing `count / total` as a percentage.
+ *
  * @param count - Count
  * @param total - Total count
  * @returns Formatted percent

--- a/apps/oxlint/conformance/src/rule_tester.ts
+++ b/apps/oxlint/conformance/src/rule_tester.ts
@@ -96,6 +96,7 @@ class RuleTesterShim extends RuleTester {
 
 /**
  * Add `before` hook to test case to store test case in `currentTest`.
+ *
  * @param test - Test case
  * @returns Test case
  */
@@ -126,6 +127,7 @@ function addBeforeHook<T extends TestCase>(test: T): T {
 
 /**
  * Check if test case should run.
+ *
  * @param test - Test case
  * @returns `true` if test case should run, `false` if is filtered out
  */
@@ -140,6 +142,7 @@ function shouldRunTestCase(test: TestCase): boolean {
 /**
  * Modify test case before running it.
  * Store test case in `currentTest` so it can be accessed in `it` function.
+ *
  * @param test - Test case
  */
 function modifyTestCase(test: TestCase): void {
@@ -242,6 +245,7 @@ function modifyTestCase(test: TestCase): void {
 /**
  * Combine globals from test case and ESLint's preset based on `languageOptions.ecmaVersion`
  * and `languageOptions.sourceType`.
+ *
  * @param languageOptions - Language options from test case
  * @returns Globals object
  */
@@ -300,6 +304,7 @@ function getGlobalsForEcmaVersion(
 
 /**
  * Add vars to `globals` from a globals preset.
+ *
  * @param preset - Globals preset object
  * @param globals - Globals object to add to
  */

--- a/apps/oxlint/scripts/generate-plugin-eslint.ts
+++ b/apps/oxlint/scripts/generate-plugin-eslint.ts
@@ -3,26 +3,27 @@
  *
  * This script produces:
  *
- * 1. `rules/<name>.cjs` - One file for each ESLint core rule, that re-exports the rule's `create` function.
- * 2. `index.ts` - Exports all rules as a `Record<string, CreateRule>`.
- *    This is the `rules` property of the `oxlint-plugin-eslint` plugin.
+ * 1. `rules/<name>.cjs` - One file for each ESLint core rule, that re-exports the rule's `create`
+ *    function.
+ * 2. `index.ts` - Exports all rules as a `Record<string, CreateRule>`. This is the `rules` property of
+ *    the `oxlint-plugin-eslint` plugin.
  * 3. `rule_names.ts` - Exports a list of all rule names, which is used in TSDown config.
  *
  * `index.ts` uses a split eager/lazy strategy so that `registerPlugin` can read each rule's `meta`
  * without loading the rule module itself:
  *
- * - `meta` is serialized and inlined at build time.
- *   `registerPlugin` needs it at plugin registration time (for `fixable`, `hasSuggestions`, `schema`,
- *   `defaultOptions`, `messages`), so it must be available immediately without requiring the rule module.
- *
- * - `create` is deferred via a cached `require` call.
- *   The rule module is only loaded the first time `create` is called (i.e. when the rule actually runs at lint time).
- *   A top-level variable per rule caches the loaded function so subsequent calls skip the `require` call.
+ * - `meta` is serialized and inlined at build time. `registerPlugin` needs it at plugin registration
+ *   time (for `fixable`, `hasSuggestions`, `schema`, `defaultOptions`, `messages`), so it must be
+ *   available immediately without requiring the rule module.
+ * - `create` is deferred via a cached `require` call. The rule module is only loaded the first time
+ *   `create` is called (i.e. when the rule actually runs at lint time). A top-level variable per
+ *   rule caches the loaded function so subsequent calls skip the `require` call.
  *
  * Build-time validations:
+ *
  * - Each rule object must only have `meta` and `create` properties.
- * - `meta` values are walked to ensure they contain no functions
- *   (which would be serialized as executable code by `serialize-javascript`).
+ * - `meta` values are walked to ensure they contain no functions (which would be serialized as
+ *   executable code by `serialize-javascript`).
  */
 
 import { readdirSync, mkdirSync, writeFileSync, rmSync } from "node:fs";

--- a/apps/oxlint/src-js/cli.ts
+++ b/apps/oxlint/src-js/cli.ts
@@ -15,11 +15,13 @@ let loadJsConfigs: typeof import("./js_config.ts").loadJsConfigs | null = null;
 /**
  * Load a plugin.
  *
- * Lazy-loads plugins code on first call, so that overhead is skipped if user doesn't use JS plugins.
+ * Lazy-loads plugins code on first call, so that overhead is skipped if user doesn't use JS
+ * plugins.
  *
  * @param path - Absolute path of plugin file
  * @param pluginName - Plugin name (either alias or package name)
- * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that plugin defines itself)
+ * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that
+ *   plugin defines itself)
  * @param workspaceUri - Workspace URI (`null` in CLI mode, `string` in LSP mode)
  * @returns Plugin details or error serialized to JSON string
  */
@@ -65,7 +67,8 @@ function setupRuleConfigsWrapper(optionsJSON: string): string | null {
  *
  * @param filePath - Absolute path of file being linted
  * @param bufferId - ID of buffer containing file data
- * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent to JS
+ * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent
+ *   to JS
  * @param ruleIds - IDs of rules to run on this file
  * @param optionsIds - IDs of options to use for rules on this file, in same order as `ruleIds`
  * @param settingsJSON - Settings for file, as JSON
@@ -106,7 +109,8 @@ function lintFileWrapper(
 /**
  * Create a new workspace.
  *
- * Lazy-loads workspace code on first call, so that overhead is skipped if user doesn't use JS plugins.
+ * Lazy-loads workspace code on first call, so that overhead is skipped if user doesn't use JS
+ * plugins.
  *
  * @param workspace - Workspace URI
  * @returns Promise which resolves when workspace is created

--- a/apps/oxlint/src-js/generated/constants.ts
+++ b/apps/oxlint/src-js/generated/constants.ts
@@ -17,7 +17,8 @@ export const BUFFER_ALIGN = 4294967296;
 export const ACTIVE_SIZE = 2147483552;
 
 /**
- * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const DATA_POINTER_POS_32 = 536870900;
 
@@ -37,12 +38,14 @@ export const IS_JSX_FLAG_POS = 2147483613;
 export const HAS_BOM_FLAG_POS = 2147483614;
 
 /**
- * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const TOKENS_OFFSET_POS_32 = 536870901;
 
 /**
- * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const TOKENS_LEN_POS_32 = 536870902;
 

--- a/apps/oxlint/src-js/generated/type_ids.ts
+++ b/apps/oxlint/src-js/generated/type_ids.ts
@@ -198,8 +198,8 @@ export const DECLARATION_NODE_TYPE_IDS = [
 ];
 
 /**
- * Type IDs which may match `:pattern` selector class.
- * Only *may* match because `Identifier` nodes only match this class if their parent is not a `MetaProperty`.
+ * Type IDs which may match `:pattern` selector class. Only _may_ match because `Identifier` nodes
+ * only match this class if their parent is not a `MetaProperty`.
  */
 export const PATTERN_NODE_TYPE_IDS = [
   2, 6, 8, 28, 29, 30, 31, 32, 33, 34, 37, 39, 42, 43, 56, 57, 62, 66, 67, 68, 70, 71, 72, 73, 79,
@@ -207,8 +207,8 @@ export const PATTERN_NODE_TYPE_IDS = [
 ];
 
 /**
- * Type IDs which may match `:expression` selector class.
- * Only *may* match because `Identifier` nodes only match this class if their parent is not a `MetaProperty`.
+ * Type IDs which may match `:expression` selector class. Only _may_ match because `Identifier`
+ * nodes only match this class if their parent is not a `MetaProperty`.
  */
 export const EXPRESSION_NODE_TYPE_IDS = [
   2, 6, 8, 28, 30, 31, 33, 34, 37, 39, 42, 43, 56, 57, 62, 66, 67, 68, 70, 71, 73, 79, 84, 85, 88,

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -11,24 +11,13 @@ export type ExternalPluginEntry =
       /**
        * Custom name/alias for the plugin.
        *
-       * Note: The following plugin names are reserved because they are implemented natively in Rust within oxlint and cannot be used for JS plugins:
-       * - react (includes react-hooks)
-       * - unicorn
-       * - typescript (includes @typescript-eslint)
-       * - oxc
-       * - import (includes import-x)
-       * - jsdoc
-       * - jest
-       * - vitest
-       * - jsx-a11y
-       * - nextjs
-       * - react-perf
-       * - promise
-       * - node
-       * - vue
-       * - eslint
+       * Note: The following plugin names are reserved because they are implemented natively in Rust
+       * within oxlint and cannot be used for JS plugins: - react (includes react-hooks) - unicorn -
+       * typescript (includes @typescript-eslint) - oxc - import (includes import-x) - jsdoc - jest
+       * - vitest - jsx-a11y - nextjs - react-perf - promise - node - vue - eslint
        *
-       * If you need to use the JavaScript version of any of these plugins, provide a custom alias to avoid conflicts.
+       * If you need to use the JavaScript version of any of these plugins, provide a custom alias
+       * to avoid conflicts.
        */
       name: string;
       /**
@@ -148,32 +137,32 @@ export type CustomComponent =
  * import { defineConfig } from "oxlint";
  *
  * export default defineConfig({
- * plugins: ["import", "typescript", "unicorn"],
- * env: {
- * "browser": true
- * },
- * globals: {
- * "foo": "readonly"
- * },
- * settings: {
- * react: {
- * version: "18.2.0"
- * },
- * custom: { option: true }
- * },
- * rules: {
- * "eqeqeq": "warn",
- * "import/no-cycle": "error",
- * "react/self-closing-comp": ["error", { "html": false }]
- * },
- * overrides: [
- * {
- * files: ["*.test.ts", "*.spec.ts"],
- * rules: {
- * "@typescript-eslint/no-explicit-any": "off"
- * }
- * }
- * ]
+ *   plugins: ["import", "typescript", "unicorn"],
+ *   env: {
+ *     browser: true,
+ *   },
+ *   globals: {
+ *     foo: "readonly",
+ *   },
+ *   settings: {
+ *     react: {
+ *       version: "18.2.0",
+ *     },
+ *     custom: { option: true },
+ *   },
+ *   rules: {
+ *     eqeqeq: "warn",
+ *     "import/no-cycle": "error",
+ *     "react/self-closing-comp": ["error", { html: false }],
+ *   },
+ *   overrides: [
+ *     {
+ *       files: ["*.test.ts", "*.spec.ts"],
+ *       rules: {
+ *         "@typescript-eslint/no-explicit-any": "off",
+ *       },
+ *     },
+ *   ],
  * });
  * ```
  */
@@ -302,6 +291,7 @@ export interface Oxlintrc {
  * Rules enabled or disabled this way will be overwritten by individual rules in the `rules` field.
  *
  * Example
+ *
  * ```json
  * {
  *   "$schema": "./node_modules/oxlint/configuration_schema.json",
@@ -326,8 +316,8 @@ export interface RuleCategories {
 /**
  * Predefine global variables.
  *
- * Environments specify what global variables are predefined.
- * See [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
+ * Environments specify what global variables are predefined. See [ESLint's list of
+ * environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
  * for what environments are available and what each one provides.
  */
 export interface OxlintEnv {
@@ -411,6 +401,7 @@ export interface OxlintOverride {
    * A list of glob patterns to override.
    *
    * ## Example
+   *
    * `[ "*.test.ts", "*.spec.ts" ]`
    */
   files: GlobSet;
@@ -573,7 +564,7 @@ export interface JSXA11YPluginSettings {
    * For example, if you set the `polymorphicPropName` to `as`, then this element:
    *
    * ```jsx
-   * <Box as="h3">Hello</Box>
+   * <Box as="h3">Hello</Box>;
    * ```
    *
    * Will be treated as an `h3`. If not set, this component will be treated
@@ -610,7 +601,8 @@ export interface NextPluginSettings {
 /**
  * Configure React plugin rules.
  *
- * Derived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)
+ * Derived from
+ * [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)
  */
 export interface ReactPluginSettings {
   /**

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -34,6 +34,7 @@ let rawTransferIsSupported: boolean | null = null;
 
 /**
  * Parser source text into buffer.
+ *
  * @param path - Path of file to parse
  * @param sourceText - Source text to parse
  * @param options - Parsing options
@@ -82,10 +83,11 @@ export function parse(path: string, sourceText: string, options?: ParseOptions) 
 /**
  * Create a `Uint8Array` which is 2 GiB in size, with its start aligned on 4 GiB.
  *
- * Store it in `buffer`, and also in `buffers` array, so it's accessible to `lintFileImpl` by passing `0`as `bufferId`.
+ * Store it in `buffer`, and also in `buffers` array, so it's accessible to `lintFileImpl` by
+ * passing `0`as `bufferId`.
  *
- * Achieve this by creating a 6 GiB `ArrayBuffer`, getting the offset within it that's aligned to 4 GiB,
- * chopping off that number of bytes from the start, and shortening to 2 GiB.
+ * Achieve this by creating a 6 GiB `ArrayBuffer`, getting the offset within it that's aligned to 4
+ * GiB, chopping off that number of bytes from the start, and shortening to 2 GiB.
  *
  * It's always possible to obtain a 2 GiB slice aligned on 4 GiB within a 6 GiB buffer,
  * no matter how the 6 GiB buffer is aligned.

--- a/apps/oxlint/src-js/package/rule_tester.ts
+++ b/apps/oxlint/src-js/package/rule_tester.ts
@@ -37,6 +37,7 @@ type ItFn = ((text: string, fn: () => void) => void) & { only?: ItFn };
 
 /**
  * Default `describe` function, if `describe` doesn't exist as a global.
+ *
  * @param text - Description of the test case
  * @param method - Test case logic
  * @returns Returned value of `method`
@@ -53,10 +54,11 @@ let describe: DescribeFn =
 
 /**
  * Default `it` function, if `it` doesn't exist as a global.
+ *
  * @param text - Description of the test case
  * @param method - Test case logic
- * @throws {Error} Any error upon execution of `method`
  * @returns Returned value of `method`
+ * @throws {Error} Any error upon execution of `method`
  */
 function defaultIt<T, R>(this: T, text: string, method: (this: T) => R): R {
   try {
@@ -78,9 +80,10 @@ let itOnly: ItFn | null =
 
 /**
  * Get `it` function.
+ *
  * @param only - `true` if `it.only` should be used
- * @throws {Error} If `it.only` is not available
  * @returns `it` or `it.only` function
+ * @throws {Error} If `it.only` is not available
  */
 function getIt(only?: boolean): ItFn {
   return only ? getItOnly() : it;
@@ -88,8 +91,9 @@ function getIt(only?: boolean): ItFn {
 
 /**
  * Get `it.only` function.
- * @throws {Error} If `it.only` is not available
+ *
  * @returns `it.only` function
+ * @throws {Error} If `it.only` is not available
  */
 function getItOnly(): ItFn {
   if (itOnly === null) {
@@ -116,15 +120,13 @@ interface Config {
    * It is recommended to only use this option as a temporary measure and alter the test cases
    * so `eslintCompat` is no longer required.
    *
-   * If `true`:
-   * - Column offsets in diagnostics are incremented by 1.
-   * - Fixes which are adjacent to each other are considered overlapping, and only the first fix is applied.
-   * - Defaults `sourceType` to "module" if not provided (otherwise default is "unambiguous").
-   * - Disallows `sourceType: "unambiguous"`.
-   * - Allows `null` as property value for `globals`.
-   *   `globals: { foo: null }` is treated as equivalent to `globals: { foo: "readonly" }`.
-   *   ESLint accepts `null`, though this is undocumented. Oxlint does not accept `null`.
-   * - Slightly different behavior when `report` is called with `loc` of form `{ line, column }`.
+   * If `true`: - Column offsets in diagnostics are incremented by 1. - Fixes which are adjacent to
+   * each other are considered overlapping, and only the first fix is applied. - Defaults
+   * `sourceType` to "module" if not provided (otherwise default is "unambiguous"). - Disallows
+   * `sourceType: "unambiguous"`. - Allows `null` as property value for `globals`. `globals: { foo:
+   * null }` is treated as equivalent to `globals: { foo: "readonly" }`. ESLint accepts `null`,
+   * though this is undocumented. Oxlint does not accept `null`. - Slightly different behavior when
+   * `report` is called with `loc` of form `{ line, column }`.
    *
    * All of these match ESLint `RuleTester`'s behavior.
    */
@@ -164,10 +166,9 @@ interface LanguageOptions {
 }
 
 /**
- * Language options config, with `parser` and `ecmaVersion` properties, and extended `parserOptions`.
- * These properties should not be present in `languageOptions` config,
- * but could be if test cases are ported from ESLint.
- * For internal use only.
+ * Language options config, with `parser` and `ecmaVersion` properties, and extended
+ * `parserOptions`. These properties should not be present in `languageOptions` config, but could be
+ * if test cases are ported from ESLint. For internal use only.
  */
 export interface LanguageOptionsInternal extends LanguageOptions {
   ecmaVersion?: number | "latest";
@@ -412,6 +413,7 @@ export class RuleTester {
 
   /**
    * Creates a new instance of RuleTester.
+   *
    * @param config? - Extra configuration for the tester (optional)
    */
   constructor(config?: Config | null) {
@@ -426,6 +428,7 @@ export class RuleTester {
 
   /**
    * Set the configuration to use for all future tests.
+   *
    * @param config - The configuration to use
    * @throws {TypeError} If `config` is not an object
    */
@@ -438,6 +441,7 @@ export class RuleTester {
 
   /**
    * Get the current configuration used for all tests.
+   *
    * @returns The current configuration
    */
   static getDefaultConfig(): Config {
@@ -447,6 +451,7 @@ export class RuleTester {
   /**
    * Reset the configuration to the initial configuration of the tester removing
    * any changes made until now.
+   *
    * @returns {void}
    */
   static resetDefaultConfig() {
@@ -486,6 +491,7 @@ export class RuleTester {
 
   /**
    * Add the `only` property to a test to run it in isolation.
+   *
    * @param item - A single test to run by itself
    * @returns The test with `only` set
    */
@@ -496,10 +502,11 @@ export class RuleTester {
 
   /**
    * Adds a new rule test to execute.
+   *
    * @param ruleName - Name of the rule to run
    * @param rule - Rule to test
    * @param tests - Collection of tests to run
-   * @throws {TypeError|Error} If `rule` is not an object with a `create` method,
+   * @throws {TypeError | Error} If `rule` is not an object with a `create` method,
    *   or if non-object `test`, or if a required scenario of the given type is missing
    */
   run(ruleName: string, rule: Rule, tests: TestCases): void {
@@ -554,6 +561,7 @@ if (CONFORMANCE) {
 
 /**
  * Run valid test case.
+ *
  * @param test - Valid test case
  * @param plugin - Plugin containing rule being tested
  * @param config - Config from `RuleTester` instance
@@ -577,6 +585,7 @@ function runValidTestCase(
 
 /**
  * Assert that valid test case passes.
+ *
  * @param test - Valid test case
  * @param plugin - Plugin containing rule being tested
  * @param config - Config from `RuleTester` instance
@@ -591,6 +600,7 @@ function assertValidTestCasePasses(test: ValidTestCase, plugin: Plugin, config: 
 
 /**
  * Run invalid test case.
+ *
  * @param test - Invalid test case
  * @param plugin - Plugin containing rule being tested
  * @param config - Config from `RuleTester` instance
@@ -615,6 +625,7 @@ function runInvalidTestCase(
 
 /**
  * Assert that invalid test case passes.
+ *
  * @param test - Invalid test case
  * @param plugin - Plugin containing rule being tested
  * @param config - Config from `RuleTester` instance
@@ -734,6 +745,7 @@ function runFixes(diagnostics: Diagnostic[], code: string, eslintCompat: boolean
 
 /**
  * Assert that message reported by rule under test matches the expected message.
+ *
  * @param diagnostic - Diagnostic emitted by rule under test
  * @param error - Error object from test case
  * @param messages - Messages from rule under test
@@ -772,7 +784,8 @@ function assertInvalidTestCaseMessageIsCorrect(
 }
 
 /**
- * Assert that a `messageId` used by the rule under test is correct, and validate `data` (if provided).
+ * Assert that a `messageId` used by the rule under test is correct, and validate `data` (if
+ * provided).
  *
  * @param reportedMessageId - `messageId` from the diagnostic or suggestion
  * @param reportedMessage - Message from the diagnostic or suggestion
@@ -781,7 +794,8 @@ function assertInvalidTestCaseMessageIsCorrect(
  * @param messages - Messages from the rule under test
  * @param prefix - Prefix for assertion error messages (e.g. "" or "Suggestion at index 0: ")
  * @throws {AssertionError} If messageId is not correct
- * @throws {AssertionError} If message tenplate with placeholder data inserted does not match reported message
+ * @throws {AssertionError} If message tenplate with placeholder data inserted does not match
+ *   reported message
  */
 function assertMessageIdIsCorrect(
   reportedMessageId: string | null,
@@ -841,6 +855,7 @@ function assertMessageIdIsCorrect(
 
 /**
  * Assert that location reported by rule under test matches the expected location.
+ *
  * @param diagnostic - Diagnostic emitted by rule under test
  * @param error - Error object from test case
  * @param config - Config for this test case
@@ -914,6 +929,7 @@ function assertInvalidTestCaseLocationIsCorrect(
 
 /**
  * Assert that suggestions reported by the rule under test match expected suggestions.
+ *
  * @param diagnostic - Diagnostic emitted by the rule under test
  * @param error - Error object from the test case
  * @param messages - Messages from the rule under test
@@ -968,6 +984,7 @@ function assertSuggestionsAreCorrect(
 
 /**
  * Assert that a suggestion's message matches expectations.
+ *
  * @param actual - Actual suggestion from the diagnostic
  * @param expected - Expected suggestion from the test case
  * @param messages - Messages from the rule under test
@@ -1018,6 +1035,7 @@ function assertSuggestionMessageIsCorrect(
 
 /**
  * Assert that the number of errors reported for test case is as expected.
+ *
  * @param diagnostics - Diagnostics reported by the rule under test
  * @param expectedErrorCount - Expected number of diagnistics
  * @throws {AssertionError} If the number of diagnostics is not as expected
@@ -1041,6 +1059,7 @@ function assertErrorCountIsCorrect(diagnostics: Diagnostic[], expectedErrorCount
 /**
  * Assert that message is matched by matcher.
  * Matcher can be a string or a regular expression.
+ *
  * @param message - Message
  * @param matcher - Matcher
  * @throws {AssertionError} If message does not match
@@ -1054,8 +1073,9 @@ function assertMessageMatches(message: string, matcher: string | RegExp) {
 }
 
 /**
- * Get placeholders in the reported messages but only includes the placeholders available in the raw message
- * and not in the provided data.
+ * Get placeholders in the reported messages but only includes the placeholders available in the raw
+ * message and not in the provided data.
+ *
  * @param message - Reported message
  * @param raw - Raw message specified in the rule's `meta.messages`
  * @param data - Data from the test case's error object
@@ -1078,6 +1098,7 @@ function getUnsubstitutedMessagePlaceholders(
 
 /**
  * Extract names of `{{ name }}` placeholders from a message.
+ *
  * @param message - Message
  * @returns Array of placeholder names
  */
@@ -1086,9 +1107,9 @@ function getMessagePlaceholders(message: string): string[] {
 }
 
 /**
- * Create config for a test run.
- * Merges config from `RuleTester` instance on top of shared config.
- * Removes properties which are not allowed in `Config`s, as they can only be properties of `TestCase`.
+ * Create config for a test run. Merges config from `RuleTester` instance on top of shared config.
+ * Removes properties which are not allowed in `Config`s, as they can only be properties of
+ * `TestCase`.
  *
  * @param config - Config from `RuleTester` instance
  * @returns Merged config
@@ -1142,6 +1163,7 @@ function mergeConfigIntoTestCase<T extends ValidTestCase | InvalidTestCase>(
 
 /**
  * Merge language options from test case / config onto language options from base config.
+ *
  * @param localLanguageOptions - Language options from test case / config
  * @param baseLanguageOptions - Language options from base config
  * @returns Merged language options, or `undefined` if neither has language options
@@ -1166,6 +1188,7 @@ function mergeLanguageOptions(
 
 /**
  * Merge parser options from test case / config onto language options from base config.
+ *
  * @param localParserOptions - Parser options from test case / config
  * @param baseParserOptions - Parser options from base config
  * @returns Merged parser options, or `undefined` if neither has parser options
@@ -1189,6 +1212,7 @@ function mergeParserOptions(
 
 /**
  * Merge ecma features from test case / config onto ecma features from base config.
+ *
  * @param localEcmaFeatures - Ecma features from test case / config
  * @param baseEcmaFeatures - Ecma features from base config
  * @returns Merged ecma features, or `undefined` if neither has ecma features
@@ -1204,6 +1228,7 @@ function mergeEcmaFeatures(
 
 /**
  * Merge globals from test case / config onto globals from base config.
+ *
  * @param localGlobals - Globals from test case / config
  * @param baseGlobals - Globals from base config
  * @returns Merged globals
@@ -1219,6 +1244,7 @@ function mergeGlobals(
 
 /**
  * Lint a test case.
+ *
  * @param test - Test case
  * @param plugin - Plugin containing rule being tested
  * @returns Array of diagnostics
@@ -1323,6 +1349,7 @@ function lint(test: TestCase, plugin: Plugin): Diagnostic[] {
 
 /**
  * Get parse options for a test case.
+ *
  * @param test - Test case
  * @returns Parse options
  */
@@ -1461,7 +1488,8 @@ function getGlobalsJson(test: TestCase): string {
  *
  * This function builds a JSON string in same format as Rust does, and calls `setOptions` with it.
  *
- * Returns the options ID to pass to `lintFileImpl` (either 0 for default options, or 1 for user-provided options).
+ * Returns the options ID to pass to `lintFileImpl` (either 0 for default options, or 1 for
+ * user-provided options).
  *
  * @param test - Test case
  * @param cwd - Current working directory for test case
@@ -1507,8 +1535,10 @@ function setupOptions(test: TestCase, cwd: string): number {
  * - `languageOptions.parserOptions.ecmaFeatures.globalReturn` into scope analyzer options.
  * - `languageOptions.parserOptions.ecmaFeatures.impliedStrict` into scope analyzer options.
  *
- * This is only supported in conformance tests, where it's necessary to pass some tests.
- * Oxlint doesn't support any ECMA version except latest, or the `globalReturn` or `impliedStrict` ECMA features.
+ * This is only supported in conformance tests, where it's necessary to pass some tests. Oxlint
+ * doesn't support any ECMA version except latest, or the `globalReturn` or `impliedStrict` ECMA
+ * features.
+ *
  * @param test - Test case
  */
 function setEcmaVersionAndFeatures(test: TestCase) {
@@ -1545,6 +1575,7 @@ const CONTROL_CHAR_REGEX = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/gu;
 /**
  * Get name of test case.
  * Control characters in name are replaced with `\u00xx` form.
+ *
  * @param test - Test case
  * @returns Name of test case
  */
@@ -1561,9 +1592,10 @@ function getTestName(test: TestCase): string {
 
 /**
  * Runs before hook on the given test case.
+ *
  * @param test - Test to run the hook on
  * @throws {Error} - If the hook is not a function
- * @throws {*} - Value thrown by the hook function
+ * @throws {any} - Value thrown by the hook function
  */
 function runBeforeHook(test: TestCase): void {
   // oxlint-disable-next-line typescript/unbound-method - bound in `runHook`
@@ -1572,9 +1604,10 @@ function runBeforeHook(test: TestCase): void {
 
 /**
  * Runs after hook on the given test case.
+ *
  * @param test - Test to run the hook on
  * @throws {Error} - If the hook is not a function
- * @throws {*} - Value thrown by the hook function
+ * @throws {any} - Value thrown by the hook function
  */
 function runAfterHook(test: TestCase): void {
   // oxlint-disable-next-line typescript/unbound-method - bound in `runHook`
@@ -1583,11 +1616,12 @@ function runAfterHook(test: TestCase): void {
 
 /**
  * Runs a hook on the given test case.
+ *
  * @param test - Test to run the hook on
  * @param hook - Hook function
  * @param name - Name of the hook
  * @throws {Error} - If the property is not a function
- * @throws {*} - Value thrown by the hook function
+ * @throws {any} - Value thrown by the hook function
  */
 function runHook<T extends TestCase>(
   test: T,
@@ -1679,6 +1713,7 @@ function assertInvalidTestCaseIsWellFormed(
 
 /**
  * Assert that the common properties of a valid/invalid test case have the correct types.
+ *
  * @param {Object} test - Test case object to check
  * @throws {AssertionError} If the test case is not valid
  */
@@ -1708,8 +1743,10 @@ const DUPLICATION_IGNORED_PROPS = new Set(["name", "errors", "output"]);
 
 /**
  * Assert that this test case is not a duplicate of one we have seen before.
+ *
  * @param test - Test case object
- * @param seenTestCases - Set of serialized test cases we have seen so far (managed by this function)
+ * @param seenTestCases - Set of serialized test cases we have seen so far (managed by this
+ *   function)
  * @throws {AssertionError} If the test case is a duplicate
  */
 function assertNotDuplicateTestCase(test: TestCase, seenTestCases: Set<string>): void {
@@ -1730,9 +1767,10 @@ function assertNotDuplicateTestCase(test: TestCase, seenTestCases: Set<string>):
 }
 
 /**
- * Check if a value is serializable.
- * Functions or objects like RegExp cannot be serialized by JSON.stringify().
- * Inspired by: https://stackoverflow.com/questions/30579940/reliable-way-to-check-if-objects-is-serializable-in-javascript
+ * Check if a value is serializable. Functions or objects like RegExp cannot be serialized by
+ * JSON.stringify(). Inspired by:
+ * https://stackoverflow.com/questions/30579940/reliable-way-to-check-if-objects-is-serializable-in-javascript
+ *
  * @param value - Value
  * @param seenObjects - Objects already seen in this path from the root object.
  * @returns {boolean} `true` if the value is serializable
@@ -1763,6 +1801,7 @@ function isSerializable(value: unknown, seenObjects: Set<object> = new Set()): b
 
 /**
  * Check if a value is a primitive or plain object created by the `Object` constructor.
+ *
  * @param value - Value to check
  * @returns `true` if `value` is a primitive or plain object
  */

--- a/apps/oxlint/src-js/plugins/cfg.ts
+++ b/apps/oxlint/src-js/plugins/cfg.ts
@@ -25,6 +25,7 @@ import type { Node, Program } from "../generated/types.d.ts";
  * Using 256 as it's a power of 2 and larger than the maximum type ID (171).
  *
  * Type ID encoding:
+ *
  * - Enter visit (nodes): 0 to NODE_TYPES_COUNT - 1 (0-164)
  * - Call method (CFG events): NODE_TYPES_COUNT to TYPE_IDS_COUNT - 1 (165-171)
  * - Exit visit (non-leaf nodes): Node type ID + EXIT_TYPE_ID_OFFSET (256+)
@@ -41,6 +42,7 @@ debugAssert(
 
 /**
  * Encoded type IDs for each step.
+ *
  * - For enter visits: Node type ID (0-164)
  * - For CFG events: Event type ID (165-171)
  * - For exit visits: Node type ID + `EXIT_TYPE_ID_OFFSET` (256+)
@@ -70,16 +72,16 @@ export function resetCfgWalk(): void {
  *
  * Use this function to walk AST instead of `walkProgram`, when visitor listens for CFG events.
  *
- * It's much slower than `walkProgram`, so prefer `walkProgram` unless visitor includes handlers for CFG events.
+ * It's much slower than `walkProgram`, so prefer `walkProgram` unless visitor includes handlers for
+ * CFG events.
  *
  * It walks the whole AST twice:
  *
- * 1. First time to build the CFG graph.
- *    In this first pass, it builds a list of steps to walk AST (including visiting nodes and CFG events).
- *    This list is stored in the SoA arrays (stepTypeIds, stepData).
- *
- * 2. Visit AST with provided visitor.
- *    Run through the steps, in order, calling visit functions for each step.
+ * 1. First time to build the CFG graph. In this first pass, it builds a list of steps to walk AST
+ *    (including visiting nodes and CFG events). This list is stored in the SoA arrays (stepTypeIds,
+ *    stepData).
+ * 2. Visit AST with provided visitor. Run through the steps, in order, calling visit functions for
+ *    each step.
  *
  * TODO: This is was originally copied from ESLint, and has been adapted for better performance.
  * We could further improve its performance by copying ESLint's `CodePathAnalyzer` into this repo,
@@ -156,6 +158,7 @@ export function walkProgramWithCfg(
 
 /**
  * Walk AST and put a list of all steps to walk AST into the SoA arrays.
+ *
  * @param ast - AST
  */
 function prepareSteps(ast: Program) {
@@ -278,6 +281,7 @@ function traverseNode(node: Node, enter: (node: Node) => void, leave: (node: Nod
 /**
  * Debug assert that `enterExit` is an `EnterExit` object.
  * In release build, this function does nothing and is removed entirely by minifier.
+ *
  * @param enterExit - Object
  * @throws {TypeError} If `enterExit` is not an `EnterExit` object in debug build
  */
@@ -289,6 +293,7 @@ export function debugAssertIsEnterExitObject(enterExit: unknown): asserts enterE
 
 /**
  * Check if an object is an `EnterExit` object.
+ *
  * @param obj - Object
  * @returns `true` if `obj` is an `EnterExit` object, `false` otherwise
  */

--- a/apps/oxlint/src-js/plugins/comments.ts
+++ b/apps/oxlint/src-js/plugins/comments.ts
@@ -92,10 +92,10 @@ let getCommentPrivateLoc: (comment: Comment) => Location | null;
 /**
  * Comment class.
  *
- * Creates `loc` lazily and caches it in a private field.
- * Using a class with a private `#loc` field avoids hidden class transitions that would occur
- * with `Object.defineProperty` / `delete` on plain objects.
- * All `Comment` instances always have the same V8 hidden class, keeping property access monomorphic.
+ * Creates `loc` lazily and caches it in a private field. Using a class with a private `#loc` field
+ * avoids hidden class transitions that would occur with `Object.defineProperty` / `delete` on plain
+ * objects. All `Comment` instances always have the same V8 hidden class, keeping property access
+ * monomorphic.
  */
 class Comment implements Span {
   type: CommentType["type"] = null!; // Overwritten later
@@ -197,10 +197,12 @@ export function deserializeComments(): void {
 /**
  * Initialize typed array views over the comments region of the buffer.
  *
- * Populates `commentsUint8`, `commentsUint32`, and `commentsLen`, and grows `cachedComments` if needed.
- * Does NOT deserialize comments - they are deserialized lazily via `deserializeCommentIfNeeded`.
+ * Populates `commentsUint8`, `commentsUint32`, and `commentsLen`, and grows `cachedComments` if
+ * needed. Does NOT deserialize comments - they are deserialized lazily via
+ * `deserializeCommentIfNeeded`.
  *
- * Exception: If the file has a hashbang, eagerly deserializes the first comment and sets its type to `Shebang`.
+ * Exception: If the file has a hashbang, eagerly deserializes the first comment and sets its type
+ * to `Shebang`.
  */
 export function initCommentsBuffer(): void {
   debugAssert(
@@ -340,7 +342,8 @@ function deserializeCommentIfNeeded(index: number): Comment | null {
 /**
  * Check comments buffer has valid ranges and ascending order.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugCheckValidRanges(): void {
   if (!DEBUG) return;
@@ -365,7 +368,8 @@ function debugCheckValidRanges(): void {
 /**
  * Check all deserialized comments are in ascending order.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugCheckDeserializedComments(): void {
   if (!DEBUG) return;
@@ -446,7 +450,8 @@ export function resetComments(): void {
 /**
  * Check that all comment objects have been cleared.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugAssertAllCommentsCleared(): void {
   if (!DEBUG) return;

--- a/apps/oxlint/src-js/plugins/comments_methods.ts
+++ b/apps/oxlint/src-js/plugins/comments_methods.ts
@@ -29,6 +29,7 @@ import type { Node, NodeOrToken } from "./types.ts";
 
 /**
  * Retrieve an array containing all comments in the source code.
+ *
  * @returns Array of `Comment`s in order they appear in source.
  */
 export function getAllComments(): Comment[] {
@@ -51,7 +52,8 @@ debugAssert(MERGED_TYPE_OFFSET32 > 0, "`getCommentsBefore` relies on this");
  * const y = 2;
  * ```
  *
- * `sourceCode.getCommentsBefore(varDeclY)` will only return "Define `y`" comment, not also "Define `x`".
+ * `sourceCode.getCommentsBefore(varDeclY)` will only return "Define `y`" comment, not also "Define
+ * `x`".
  *
  * @param nodeOrToken - The AST node or token to check for adjacent comment tokens.
  * @returns Array of `Comment`s in occurrence order.
@@ -115,7 +117,8 @@ export function getCommentsBefore(nodeOrToken: NodeOrToken): Comment[] {
  * const z = 3;
  * ```
  *
- * `sourceCode.getCommentsAfter(varDeclX)` will only return "Define `y`" comment, not also "Define `z`".
+ * `sourceCode.getCommentsAfter(varDeclX)` will only return "Define `y`" comment, not also "Define
+ * `z`".
  *
  * @param nodeOrToken - The AST node or token to check for adjacent comment tokens.
  * @returns Array of `Comment`s in occurrence order.
@@ -166,6 +169,7 @@ export function getCommentsAfter(nodeOrToken: NodeOrToken): Comment[] {
 
 /**
  * Get all comment tokens inside the given node.
+ *
  * @param node - The AST node to get the comments for.
  * @returns Array of `Comment`s in occurrence order.
  */
@@ -195,6 +199,7 @@ export function getCommentsInside(node: Node): Comment[] {
 
 /**
  * Check whether any comments exist or not between the given 2 nodes.
+ *
  * @param nodeOrToken1 - Start node/token.
  * @param nodeOrToken2 - End node/token.
  * @returns `true` if one or more comments exist between the two.
@@ -230,7 +235,6 @@ export function commentsExistBetween(
  * Retrieve the JSDoc comment for a given node.
  *
  * @deprecated
- *
  * @param node - The AST node to get the comment for.
  * @returns The JSDoc comment for the given node, or `null` if not found.
  */

--- a/apps/oxlint/src-js/plugins/context.ts
+++ b/apps/oxlint/src-js/plugins/context.ts
@@ -52,6 +52,7 @@ export let cwd: string | null = null;
 
 /**
  * Set CWD. Used when switching workspaces.
+ *
  * @param cwdInput - CWD
  */
 export function setCwd(cwdInput: string) {
@@ -60,6 +61,7 @@ export function setCwd(cwdInput: string) {
 
 /**
  * Set up context for linting a file.
+ *
  * @param filePathInput - Absolute path of file being linted
  */
 export function setupFileContext(filePathInput: string): void {
@@ -69,9 +71,10 @@ export function setupFileContext(filePathInput: string): void {
 /**
  * Reset file context.
  *
- * This disables all getters on `Context` objects, and `FILE_CONTEXT`.
- * Only way user could trigger a getter if this wasn't done is to store a `Context` object, and then access one of its
- * properties in next tick, in between linting files (highly unlikely). But it's cheap to do, so we cover this odd case.
+ * This disables all getters on `Context` objects, and `FILE_CONTEXT`. Only way user could trigger a
+ * getter if this wasn't done is to store a `Context` object, and then access one of its properties
+ * in next tick, in between linting files (highly unlikely). But it's cheap to do, so we cover this
+ * odd case.
  */
 export function resetFileContext(): void {
   filePath = null;
@@ -101,6 +104,7 @@ const PARSER = Object.freeze({
 
   /**
    * Parse code into an AST.
+   *
    * @param code - Code to parse
    * @param options? - Parser options
    * @returns AST
@@ -335,8 +339,9 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * Get absolute path of the file being linted.
-   * @returns Absolute path of the file being linted.
+   *
    * @deprecated Use `context.filename` property instead.
+   * @returns Absolute path of the file being linted.
    */
   getFilename(): string {
     if (filePath === null) throw new Error("Cannot call `context.getFilename` in `createOnce`");
@@ -357,8 +362,9 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * Get physical absolute path of the file being linted.
-   * @returns Physical absolute path of the file being linted.
+   *
    * @deprecated Use `context.physicalFilename` property instead.
+   * @returns Physical absolute path of the file being linted.
    */
   getPhysicalFilename(): string {
     if (filePath === null) {
@@ -379,8 +385,9 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * Get current working directory.
-   * @returns The current working directory.
+   *
    * @deprecated Use `context.cwd` property instead.
+   * @returns The current working directory.
    */
   getCwd(): string {
     if (filePath === null) throw new Error("Cannot call `context.getCwd` in `createOnce`");
@@ -399,8 +406,9 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * Get source code of the file being linted.
-   * @returns Source code of the file being linted.
+   *
    * @deprecated Use `context.sourceCode` property instead.
+   * @returns Source code of the file being linted.
    */
   getSourceCode(): SourceCode {
     if (filePath === null) throw new Error("Cannot call `context.getSourceCode` in `createOnce`");
@@ -432,6 +440,7 @@ const FILE_CONTEXT = Object.freeze({
   /**
    * Create a new object with the current object as the prototype and
    * the specified properties as its own properties.
+   *
    * @param extension - The properties to add to the new object.
    * @returns A new object with the current object as the prototype
    *   and the specified properties as its own properties.
@@ -443,6 +452,7 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * Parser options used to parse the file being linted.
+   *
    * @deprecated Use `languageOptions.parserOptions` instead.
    */
   get parserOptions(): Record<string, unknown> {
@@ -452,6 +462,7 @@ const FILE_CONTEXT = Object.freeze({
 
   /**
    * The path to the parser used to parse this file.
+   *
    * @deprecated No longer supported.
    */
   get parserPath(): string | undefined {
@@ -489,6 +500,7 @@ export interface Context extends FileContext {
 
 /**
  * Create `Context` object for a rule.
+ *
  * @param ruleDetails - `RuleDetails` object
  * @returns `Context` object
  */

--- a/apps/oxlint/src-js/plugins/fix.ts
+++ b/apps/oxlint/src-js/plugins/fix.ts
@@ -217,8 +217,8 @@ function getFixesFromFixFn(fixFn: FixFn, thisArg: Diagnostic | Suggestion): FixR
  *
  * Check that `range` has 2 numeric elements, and convert `text` to string if needed.
  *
- * Purpose of validation is to ensure any input which ESLint accepts does not cause an error in `JSON.stringify()`,
- * or in deserializing on Rust side.
+ * Purpose of validation is to ensure any input which ESLint accepts does not cause an error in
+ * `JSON.stringify()`, or in deserializing on Rust side.
  *
  * @param fix - Fix object to validate, possibly malformed
  * @returns `FixReport` object

--- a/apps/oxlint/src-js/plugins/json.ts
+++ b/apps/oxlint/src-js/plugins/json.ts
@@ -67,6 +67,7 @@ export function deepFreezeJsonArray(arr: JsonValue[]): undefined {
 
 /**
  * Deep clone a JSON value, recursively cloning all nested objects and arrays.
+ *
  * @param value - The value to deep clone
  * @returns Cloned value
  */
@@ -79,6 +80,7 @@ export function deepCloneJsonValue(value: JsonValue): JsonValue {
 
 /**
  * Deep clone a JSON object, recursively cloning all nested objects and arrays.
+ *
  * @param obj - The object to deep clone
  * @returns Cloned object
  */
@@ -98,6 +100,7 @@ export function deepCloneJsonObject(obj: JsonObject): JsonObject {
 
 /**
  * Deep clone a JSON array, recursively cloning all nested objects and arrays.
+ *
  * @param arr - The array to deep clone
  * @returns Cloned array
  */

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -41,11 +41,13 @@ const OPTIONS_DESCRIPTOR: PropertyDescriptor = { value: null };
 /**
  * Lint a file.
  *
- * Main logic is in separate function `lintFileImpl`, because V8 cannot optimize functions containing try/catch.
+ * Main logic is in separate function `lintFileImpl`, because V8 cannot optimize functions
+ * containing try/catch.
  *
  * @param filePath - Absolute path of file being linted
  * @param bufferId - ID of buffer containing file data
- * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent to JS
+ * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent
+ *   to JS
  * @param ruleIds - IDs of rules to run on this file
  * @param optionsIds - IDs of options to use for rules on this file, in same order as `ruleIds`
  * @param settingsJSON - Settings for this file, as JSON string
@@ -102,14 +104,15 @@ export function lintFile(
  *
  * @param filePath - Absolute path of file being linted
  * @param bufferId - ID of buffer containing file data
- * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent to JS
+ * @param buffer - Buffer containing file data, or `null` if buffer with this ID was previously sent
+ *   to JS
  * @param ruleIds - IDs of rules to run on this file
  * @param optionsIds - IDs of options to use for rules on this file, in same order as `ruleIds`
  * @param settingsJSON - Settings for this file, as JSON string
  * @param globalsJSON - Globals for this file, as JSON string
  * @param workspaceUri - Workspace URI (`null` in CLI, string in LSP)
  * @throws {Error} If any parameters are invalid
- * @throws {*} If any rule throws
+ * @throws {any} If any rule throws
  */
 export function lintFileImpl(
   filePath: string,
@@ -261,17 +264,20 @@ export function lintFileImpl(
 /**
  * Run any `after` hooks.
  *
- * Rules using `before` and `after` hooks likely maintain some internal state in their `createOnce` method.
- * To keep that state in sync, it's critical that `after` hooks always run, even if an error is thrown during any of:
+ * Rules using `before` and `after` hooks likely maintain some internal state in their `createOnce`
+ * method. To keep that state in sync, it's critical that `after` hooks always run, even if an error
+ * is thrown during any of:
  *
  * 1. A later rule's `before` hook.
  * 2. AST walk.
  * 3. An earlier rule's `after` hook.
  *
- * So if any `after` hook throws an error, this function continues running remaining hooks, and re-throws the error
- * only at the very end. This ensures an error in one rule does not affect any other rules.
+ * So if any `after` hook throws an error, this function continues running remaining hooks, and
+ * re-throws the error only at the very end. This ensures an error in one rule does not affect any
+ * other rules.
  *
- * This function is called by `resetStateAfterError` to ensure `after` hooks are run no matter where an error occurs.
+ * This function is called by `resetStateAfterError` to ensure `after` hooks are run no matter where
+ * an error occurs.
  *
  * @param shouldThrowIfError - `true` if any errors thrown in after hooks should be re-thrown
  */

--- a/apps/oxlint/src-js/plugins/load.ts
+++ b/apps/oxlint/src-js/plugins/load.ts
@@ -86,6 +86,7 @@ export let registeredRules: RuleDetails[] = [];
 
 /**
  * Set `registeredRules`. Used when switching workspaces.
+ *
  * @param rules - Array of `RuleDetails` objects
  */
 export function setRegisteredRules(rules: RuleDetails[]) {
@@ -108,11 +109,13 @@ interface PluginDetails {
 /**
  * Load a plugin.
  *
- * Main logic is in separate function `loadPluginImpl`, because V8 cannot optimize functions containing try/catch.
+ * Main logic is in separate function `loadPluginImpl`, because V8 cannot optimize functions
+ * containing try/catch.
  *
  * @param url - Absolute path of plugin file as a `file://...` URL
  * @param pluginName - Plugin name (either alias or package name)
- * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that plugin defines itself)
+ * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that
+ *   plugin defines itself)
  * @param workspaceUri - Workspace URI (`null` in CLI, string in LSP)
  * @returns Plugin details or error serialized to JSON string
  */
@@ -136,11 +139,13 @@ export async function loadPlugin(
  *
  * @param plugin - Plugin
  * @param pluginName - Plugin name (either alias or package name)
- * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that plugin defines itself)
+ * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that
+ *   plugin defines itself)
  * @param workspaceUri - Workspace URI (`null` in CLI, string in LSP)
  * @returns - Plugin details
  * @throws {Error} If `plugin.meta.name` is `null` / `undefined` and `packageName` not provided
- * @throws {TypeError} If one of plugin's rules is malformed, or its `createOnce` method returns invalid visitor
+ * @throws {TypeError} If one of plugin's rules is malformed, or its `createOnce` method returns
+ *   invalid visitor
  * @throws {TypeError} If `plugin.meta.name` is not a string
  */
 export function registerPlugin(
@@ -317,7 +322,8 @@ export function registerPlugin(
  *
  * @param plugin - Plugin object
  * @param pluginName - Plugin name (either alias or package name)
- * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that plugin defines itself)
+ * @param pluginNameIsAlias - `true` if plugin name is an alias (takes priority over name that
+ *   plugin defines itself)
  * @returns Plugin name
  * @throws {TypeError} If `plugin.meta.name` is not a string
  * @throws {Error} If neither `plugin.meta.name` nor `packageName` are defined
@@ -356,12 +362,13 @@ function getPluginName(
  * Normalize plugin name by stripping common ESLint plugin prefixes and suffixes.
  *
  * This handles the various naming conventions used in the ESLint ecosystem:
+ *
  * - `eslint-plugin-foo` -> `foo`
  * - `@scope/eslint-plugin` -> `@scope`
  * - `@scope/eslint-plugin-foo` -> `@scope/foo`
  *
- * This logic is replicated on Rust side in `normalize_plugin_name` in `crates/oxc_linter/src/config/plugins.rs`.
- * The 2 implementations must be kept in sync.
+ * This logic is replicated on Rust side in `normalize_plugin_name` in
+ * `crates/oxc_linter/src/config/plugins.rs`. The 2 implementations must be kept in sync.
  *
  * @param name - Plugin name defined by plugin
  * @returns Normalized plugin name
@@ -389,9 +396,10 @@ function normalizePluginName(name: string): string {
 /**
  * Serialize default options to JSON and deserialize again.
  *
- * This is the simplest way to make sure that `defaultOptions` does not contain any `undefined` values,
- * or circular references. It may also be the fastest, as `JSON.parse` and `JSON.stringify` are native code.
- * If we move to doing options merging on Rust side, we'll need to convert to JSON anyway.
+ * This is the simplest way to make sure that `defaultOptions` does not contain any `undefined`
+ * values, or circular references. It may also be the fastest, as `JSON.parse` and `JSON.stringify`
+ * are native code. If we move to doing options merging on Rust side, we'll need to convert to JSON
+ * anyway.
  *
  * Special handling for `Infinity` / `-Infinity` values, to ensure they survive the round trip.
  * Without this, they would be converted to `null`.
@@ -443,6 +451,7 @@ const NEG_INFINITY_PLACEHOLDER_STR = JSON.stringify(NEG_INFINITY_PLACEHOLDER);
 
 /**
  * Validate and conform `before` / `after` hook function.
+ *
  * @param hookFn - Hook function, or `null` / `undefined`
  * @param hookName - Name of the hook
  * @returns Hook function, or null

--- a/apps/oxlint/src-js/plugins/location.ts
+++ b/apps/oxlint/src-js/plugins/location.ts
@@ -135,9 +135,10 @@ export function resetLinesAndLocs(): void {
 
 /**
  * Convert a source text index into a (line, column) pair.
+ *
  * @param offset - The index of a character in a file.
  * @returns `{line, column}` location object with 1-indexed line and 0-indexed column.
- * @throws {TypeError|RangeError} If non-numeric `offset`, or `offset` out of range.
+ * @throws {TypeError | RangeError} If non-numeric `offset`, or `offset` out of range.
  */
 export function getLineColumnFromOffset(offset: number): LineColumn {
   if (typeof offset !== "number" || offset < 0 || (offset | 0) !== offset) {
@@ -183,10 +184,12 @@ export function getLineColumnFromOffset(offset: number): LineColumn {
 
 /**
  * Convert a `{ line, column }` pair into a range index.
+ *
  * @param loc - A line/column location.
  * @returns The character index of the location in the file.
- * @throws {TypeError|RangeError} If `loc` is not an object with a numeric `line` and `column`,
- *   or if the `line` is less than or equal to zero, or the line or column is out of the expected range.
+ * @throws {TypeError | RangeError} If `loc` is not an object with a numeric `line` and `column`, or
+ *   if the `line` is less than or equal to zero, or the line or column is out of the expected
+ *   range.
  */
 export function getOffsetFromLineColumn(loc: LineColumn): number {
   if (loc !== null && typeof loc === "object") {
@@ -246,6 +249,7 @@ export function getOffsetFromLineColumn(loc: LineColumn): number {
 
 /**
  * Get the range of the given node or token.
+ *
  * @param nodeOrToken - Node or token to get the range of
  * @returns Range of the node or token
  */
@@ -255,6 +259,7 @@ export function getRange(nodeOrToken: NodeOrToken): Range {
 
 /**
  * Get the location of the given node or token.
+ *
  * @param nodeOrToken - Node or token to get the location of
  * @returns Location of the node or token
  */
@@ -272,8 +277,8 @@ export function getLoc(nodeOrToken: NodeOrToken): Location {
  * Used in `loc` getter on AST nodes (not tokens or comments - they use their own caching
  * via `Token` / `Comment` class private fields).
  *
- * Defines a `loc` property on the node with the calculated `Location`, so accessing `loc` twice on same node
- * results in the same object each time.
+ * Defines a `loc` property on the node with the calculated `Location`, so accessing `loc` twice on
+ * same node results in the same object each time.
  *
  * For internal use only.
  *
@@ -404,6 +409,7 @@ export function computeLoc(start: number, end: number): Location {
 
 /**
  * Get the deepest node containing a range index.
+ *
  * @param offset - Range index of the desired node
  * @returns The node if found, or `null` if not found
  */

--- a/apps/oxlint/src-js/plugins/options.ts
+++ b/apps/oxlint/src-js/plugins/options.ts
@@ -38,9 +38,8 @@ export type Options = JsonValue[];
 export type RuleOptionsSchema = JSONSchema4 | JSONSchema4[] | false;
 
 /**
- * Schema validator function.
- * Does not return anything. Throws an error if validation fails.
- * Should be passed full name of the rule, in form `<plugin>/<rule>`. This is used in error messages.
+ * Schema validator function. Does not return anything. Throws an error if validation fails. Should
+ * be passed full name of the rule, in form `<plugin>/<rule>`. This is used in error messages.
  * `options` maybe be mutated if schema contains default values.
  */
 export type SchemaValidator = (options: Options, ruleName: string) => void;
@@ -56,6 +55,7 @@ export let allOptions: Readonly<Options>[] | null = null;
 
 /**
  * Set `allOptions`. Used when switching workspaces.
+ *
  * @param options - Array of options objects
  */
 export function setAllOptions(options: Readonly<Options>[]) {
@@ -100,16 +100,18 @@ AJV.addMetaSchema(metaSchema);
  *
  * Returned validator function will throw if validation fails.
  *
- * This function should be called once when loading a rule, and the returned validator stored in `RuleDetails`.
+ * This function should be called once when loading a rule, and the returned validator stored in
+ * `RuleDetails`.
  *
- * ESLint allows array shorthand: `schema: [item1, item2]` which means `options[0]` must match `item1`, etc.
- * This function converts that to a proper JSON Schema, before compiling it.
+ * ESLint allows array shorthand: `schema: [item1, item2]` which means `options[0]` must match
+ * `item1`, etc. This function converts that to a proper JSON Schema, before compiling it.
  *
  * Based on ESLint's `getRuleOptionsSchema`:
  * https://github.com/eslint/eslint/blob/v9.39.2/lib/config/config.js#L177-L210
  *
  * @param schema - Rule's schema from `meta.schema`
- * @returns Compiled AJV validator, or `null` if no options accepted, or `false` if validation is disabled
+ * @returns Compiled AJV validator, or `null` if no options accepted, or `false` if validation is
+ *   disabled
  */
 export function compileSchema(
   schema: RuleOptionsSchema | null | undefined,
@@ -142,6 +144,7 @@ export function compileSchema(
 
 /**
  * Wrap AJV validator function to throw if validation fails.
+ *
  * @param validate - AJV validator function
  * @returns Wrapped validator function, which throws if validation fails
  */
@@ -186,6 +189,7 @@ function wrapSchemaValidator(validate: Ajv.ValidateFunction): SchemaValidator {
 /**
  * Set all external rule options.
  * Called once from Rust after config building, before any linting occurs.
+ *
  * @param optionsJSON - Array of all rule options across all configurations, serialized as JSON
  * @throws `Error` if options fail validation
  */
@@ -258,7 +262,8 @@ export function setOptions(optionsJson: string): void {
  *
  * This order ensures precedence: config > defaultOptions > schema defaults.
  *
- * ESLint calls `#normalizeRulesConfig()` first (merges `defaultOptions`), then `validateRulesConfig()` (AJV):
+ * ESLint calls `#normalizeRulesConfig()` first (merges `defaultOptions`), then
+ * `validateRulesConfig()` (AJV):
  * https://github.com/eslint/eslint/blob/v9.39.2/lib/config/config.js#L483-L484
  * https://github.com/eslint/eslint/blob/v9.39.2/lib/config/config.js#L532-L637
  *
@@ -312,9 +317,9 @@ function processOptions(configOptions: Options, ruleDetails: RuleDetails): Reado
  *
  * Config options take precedence over default options.
  *
- * Options returned are entirely mutable. No parts are frozen, even parts which come from default options.
- * Any parts of `defaultOptions` which are included are deep cloned.
- * Any parts of `configOptions` which are included in return value are *not* cloned.
+ * Options returned are entirely mutable. No parts are frozen, even parts which come from default
+ * options. Any parts of `defaultOptions` which are included are deep cloned. Any parts of
+ * `configOptions` which are included in return value are _not_ cloned.
  *
  * @param configOptions - Options from config
  * @param defaultOptions - Default options from `rule.meta.defaultOptions`

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -97,6 +97,7 @@ export const PLACEHOLDER_REGEX = /\{\{([^{}]+)\}\}/gu;
 
 /**
  * Report error.
+ *
  * @param diagnostic - Diagnostic object
  * @param extraArgs - Extra arguments passed to `context.report()` (legacy positional forms)
  * @param ruleDetails - `RuleDetails` object, containing rule-specific details e.g. `isFixable`
@@ -240,13 +241,14 @@ function convertLegacyCallArgs(node: unknown, extraArgs: unknown[]): Diagnostic 
 /**
  * Get message from a diagnostic or suggestion.
  *
- * Resolve message from `messageId` if present, and interpolate placeholders {{key}} with data values.
+ * Resolve message from `messageId` if present, and interpolate placeholders {{key}} with data
+ * values.
  *
  * @param message - Provided message string
  * @param descriptor - `Diagnostic` or `Suggestion` object
  * @param ruleDetails - `RuleDetails` object, containing rule-specific `messages`
  * @returns Object containing message string and message ID (if present in `descriptor`)
- * @throws {Error|TypeError} If neither `message` nor `messageId` provided, or of wrong type
+ * @throws {Error | TypeError} If neither `message` nor `messageId` provided, or of wrong type
  */
 export function getMessage(
   message: string | null | undefined,
@@ -277,6 +279,7 @@ export function getMessage(
 
 /**
  * Resolve a message ID to its message string, with optional data interpolation.
+ *
  * @param messageId - The message ID to resolve
  * @param ruleDetails - `RuleDetails` object, containing rule-specific `messages`
  * @returns Resolved message string
@@ -303,6 +306,7 @@ function resolveMessageFromMessageId(messageId: string, ruleDetails: RuleDetails
 
 /**
  * Replace placeholders in message with values from `data`.
+ *
  * @param message - Message
  * @param data - Data to replace placeholders with
  * @returns Message with placeholders replaced with data values
@@ -324,13 +328,14 @@ export function replacePlaceholders(message: string, data: DiagnosticData): stri
  * 1. Does not check that `lineCol` is an object - caller must do that.
  * 2. Allows `column` to be less than 0 or greater than the length of the line.
  *
- * Relaxing the restriction on `column` is required because some rules (e.g. ESLint's `func-call-spacing`)
- * produce `column: -1` in some cases.
+ * Relaxing the restriction on `column` is required because some rules (e.g. ESLint's
+ * `func-call-spacing`) produce `column: -1` in some cases.
  *
  * @param lineCol - A line/column location.
  * @returns The character index of the location in the file.
  * @throws {TypeError} If `lineCol` is not an object with a integer `line` and `column`.
- * @throws {RangeError} If `line` is less than or equal to 0, or greater than the number of lines in the source text.
+ * @throws {RangeError} If `line` is less than or equal to 0, or greater than the number of lines in
+ *   the source text.
  * @throws {RangeError} If computed offset is out of range of the source text.
  */
 function getOffsetFromLineColumn(lineCol: LineColumn): number {

--- a/apps/oxlint/src-js/plugins/rule_meta.ts
+++ b/apps/oxlint/src-js/plugins/rule_meta.ts
@@ -8,13 +8,13 @@ export interface RuleMeta {
   /**
    * Type of rule.
    *
-   * - `problem`: The rule is identifying code that either will cause an error or may cause a confusing behavior.
-   *   Developers should consider this a high priority to resolve.
-   * - `suggestion`: The rule is identifying something that could be done in a better way but no errors will occur
-   *   if the code isn’t changed.
-   * - `layout`: The rule cares primarily about whitespace, semicolons, commas, and parentheses, all the parts
-   *   of the program that determine how the code looks rather than how it executes.
-   *   These rules work on parts of the code that aren’t specified in the AST.
+   * - `problem`: The rule is identifying code that either will cause an error or may cause a
+   *   confusing behavior. Developers should consider this a high priority to resolve.
+   * - `suggestion`: The rule is identifying something that could be done in a better way but no
+   *   errors will occur if the code isn’t changed.
+   * - `layout`: The rule cares primarily about whitespace, semicolons, commas, and parentheses, all
+   *   the parts of the program that determine how the code looks rather than how it executes. These
+   *   rules work on parts of the code that aren’t specified in the AST.
    */
   type?: "problem" | "suggestion" | "layout";
   /**
@@ -33,6 +33,7 @@ export interface RuleMeta {
   /**
    * Specifies whether rule can return suggestions.
    * Must be `true` if the rule provides suggestions.
+   *
    * @default false
    */
   hasSuggestions?: boolean;
@@ -42,17 +43,19 @@ export interface RuleMeta {
    */
   schema?: RuleOptionsSchema;
   /**
-   * Default options for the rule.
-   * If present, any user-provided options in their config will be merged on top of them recursively.
+   * Default options for the rule. If present, any user-provided options in their config will be
+   * merged on top of them recursively.
    */
   defaultOptions?: Options;
   /**
-   * Indicates whether the rule has been deprecated, and info about the deprecation and possible replacements.
+   * Indicates whether the rule has been deprecated, and info about the deprecation and possible
+   * replacements.
    */
   deprecated?: boolean | RuleDeprecatedInfo;
   /**
    * Information about available replacements for the rule.
    * This may be an empty array to explicitly state there is no replacement.
+   *
    * @deprecated Use `deprecated.replacedBy` instead.
    */
   replacedBy?: RuleReplacedByInfo[];
@@ -90,7 +93,8 @@ export interface RuleDocs {
 // Note: ESLint docs specifically say "Every property is optional."
 export interface RuleDeprecatedInfo {
   /**
-   * General message presentable to the user. May contain why this rule is deprecated or how to replace the rule.
+   * General message presentable to the user. May contain why this rule is deprecated or how to
+   * replace the rule.
    */
   message?: string;
   /**
@@ -110,7 +114,8 @@ export interface RuleDeprecatedInfo {
    * Version (as semver string) likely to remove the rule.
    * e.g. the next major version.
    *
-   * The special value `null` means the rule will no longer be changed, but will be kept available indefinitely.
+   * The special value `null` means the rule will no longer be changed, but will be kept available
+   * indefinitely.
    */
   availableUntil?: string | null;
 }

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -223,6 +223,7 @@ function addGlobals(): void {
 
 /**
  * Create a global variable with the given name and add it to the global scope.
+ *
  * @param name - Var name
  * @param globalScope - Global scope object
  * @param isWritable - `true` if the variable is writable, `false` otherwise
@@ -300,6 +301,7 @@ export const SCOPE_MANAGER = Object.freeze({
    * Get the variables that a given AST node defines.
    * The returned variables' `def[].node` / `def[].parent` property is the node.
    * If the node does not define any variable, this returns an empty array.
+   *
    * @param node AST node to get variables of.
    */
   getDeclaredVariables(node: ESTree.Node): Variable[] {
@@ -328,6 +330,7 @@ export type ScopeManager = typeof SCOPE_MANAGER;
 
 /**
  * Determine whether the given identifier node is a reference to a global variable.
+ *
  * @param node - `Identifier` node to check.
  * @returns `true` if the identifier is a reference to a global variable.
  */
@@ -362,6 +365,7 @@ export function isGlobalReference(node: ESTree.Node): boolean {
 /**
  * Get the variables that `node` defines.
  * This is a convenience method that passes through to the same method on the `ScopeManager`.
+ *
  * @param node - The node for which the variables are obtained.
  * @returns An array of variable nodes representing the variables that `node` defines.
  */
@@ -376,6 +380,7 @@ export function getDeclaredVariables(node: ESTree.Node): Variable[] {
 
 /**
  * Get the scope for the given node.
+ *
  * @param node - The node to get the scope of.
  * @returns The scope information for this node.
  */
@@ -408,9 +413,9 @@ export function getScope(node: ESTree.Node): Scope {
 /**
  * Marks as used a variable with the given name in a scope indicated by the given reference node.
  *
- * IMPORTANT: At present marking variables as used only affects other JS plugins.
- * It does *not* get communicated to Oxlint's rules which are implemented on Rust side e.g. `no-unused-vars`.
- * This is a known shortcoming, and will be addressed in a future release.
+ * IMPORTANT: At present marking variables as used only affects other JS plugins. It does _not_ get
+ * communicated to Oxlint's rules which are implemented on Rust side e.g. `no-unused-vars`. This is
+ * a known shortcoming, and will be addressed in a future release.
  * https://github.com/oxc-project/oxc/issues/20350
  *
  * @param name - Variable name

--- a/apps/oxlint/src-js/plugins/selector.ts
+++ b/apps/oxlint/src-js/plugins/selector.ts
@@ -60,6 +60,7 @@ const ESQUERY_OPTIONS: ESQueryOptions = {
 // ESQuery license: https://github.com/estools/esquery/blob/6c4f10370606c5a08adfcb5becc8248fb1edad43/license.txt
 /**
  * Check if an AST node matches a selector class.
+ *
  * @param className - Class name parsed from selector
  * @param node - AST node
  * @param _ancestors - AST node's ancestors
@@ -209,7 +210,8 @@ export function parseSelector(key: string): Selector {
  * Analyse an `EsquerySelector` to determine:
  *
  * 1. What node types it matches on.
- * 2. Whether it is "simple" or "complex" - "simple" matches a subset of node types without further conditions.
+ * 2. Whether it is "simple" or "complex" - "simple" matches a subset of node types without further
+ *    conditions.
  * 3. It's specificity (number of identifiers and attributes).
  *
  * This function traverses the `EsquerySelector` and calls itself recursively.

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -48,6 +48,7 @@ export let ast: Program | null = null;
 
 /**
  * Set up source for the file about to be linted.
+ *
  * @param bufferInput - Buffer containing AST
  * @param hasBOMInput - `true` if file's original source text has Unicode BOM
  */
@@ -87,11 +88,12 @@ export function initAst(): void {
 /**
  * Fix AST for conformance tests.
  *
- * Oxc parser always parses as latest ECMAScript version.
- * Some conformance tests request parsing with `ecmaVersion: 3`, and expect directives to be parsed as string literals.
- * When using ES3, traverse the AST and remove the `directive` property from `ExpressionStatement`s.
+ * Oxc parser always parses as latest ECMAScript version. Some conformance tests request parsing
+ * with `ecmaVersion: 3`, and expect directives to be parsed as string literals. When using ES3,
+ * traverse the AST and remove the `directive` property from `ExpressionStatement`s.
  *
- * This function is only called in conformance tests. In standard builds, minifier removes this function entirely.
+ * This function is only called in conformance tests. In standard builds, minifier removes this
+ * function entirely.
  */
 function fixES3Ast(): void {
   if (!CONFORMANCE) throw new Error("Should be unreachable outside of conformance tests");
@@ -124,12 +126,11 @@ function fixES3Node(node: any): void {
 /**
  * Reset source and AST after file has been linted, to free memory.
  *
- * Setting `buffer` to `null` also prevents AST being deserialized after linting,
- * at which point the buffer may be being reused for another file.
- * The buffer might contain a half-constructed AST (if parsing is currently in progress in Rust),
- * which would cause deserialization to malfunction.
- * With `buffer` set to `null`, accessing `SOURCE_CODE.ast` will still throw, but the error message will be clearer,
- * and no danger of an infinite loop due to a circular AST (unlikely but possible).
+ * Setting `buffer` to `null` also prevents AST being deserialized after linting, at which point the
+ * buffer may be being reused for another file. The buffer might contain a half-constructed AST (if
+ * parsing is currently in progress in Rust), which would cause deserialization to malfunction. With
+ * `buffer` set to `null`, accessing `SOURCE_CODE.ast` will still throw, but the error message will
+ * be clearer, and no danger of an infinite loop due to a circular AST (unlikely but possible).
  */
 export function resetSourceAndAst(): void {
   buffer = null;
@@ -145,6 +146,7 @@ export function resetSourceAndAst(): void {
 
 /**
  * Get whether file is JSX.
+ *
  * @returns `true` if file is JSX, `false` if not
  */
 export function fileIsJsx(): boolean {
@@ -155,6 +157,7 @@ export function fileIsJsx(): boolean {
 
 /**
  * Get whether file is TypeScript.
+ *
  * @returns `true` if file is TypeScript, `false` if not
  */
 export function fileIsTs(): boolean {
@@ -253,6 +256,7 @@ export const SOURCE_CODE = Object.freeze({
 
   /**
    * Get the source code for the given node.
+   *
    * @param node? - The AST node to get the text for.
    * @param beforeCount? - The number of characters before the node to retrieve.
    * @param afterCount? - The number of characters after the node to retrieve.
@@ -276,6 +280,7 @@ export const SOURCE_CODE = Object.freeze({
 
   /**
    * Get all the ancestors of a given node.
+   *
    * @param node - AST node
    * @returns All the ancestor nodes in the AST, not including the provided node,
    *   starting from the root node at index 0 and going inwards to the parent node.
@@ -294,7 +299,8 @@ export const SOURCE_CODE = Object.freeze({
   },
 
   /**
-   * Get source text as array of lines, split according to specification's definition of line breaks.
+   * Get source text as array of lines, split according to specification's definition of line
+   * breaks.
    */
   getLines(): string[] {
     if (lines.length === 0) initLines();

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -480,7 +480,8 @@ function unescapeIdentifier(name: string): string {
 /**
  * Check tokens buffer has valid ranges and ascending order.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugCheckValidRanges(): void {
   if (!DEBUG) return;
@@ -501,7 +502,8 @@ function debugCheckValidRanges(): void {
 /**
  * Check all deserialized tokens are in ascending order.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugCheckDeserializedTokens(): void {
   if (!DEBUG) return;
@@ -595,7 +597,8 @@ export function resetTokens() {
 /**
  * Check that all token and regex objects have been cleared.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugAssertAllTokensCleared(): void {
   if (!DEBUG) return;

--- a/apps/oxlint/src-js/plugins/tokens_and_comments.ts
+++ b/apps/oxlint/src-js/plugins/tokens_and_comments.ts
@@ -215,7 +215,8 @@ function mergeTokensAndComments(tokensUint32: Uint32Array, commentsUint32: Uint3
 /**
  * Check that merged entries are in ascending order of `start`.
  *
- * Only runs in debug build (tests). In release build, this function is entirely removed by minifier.
+ * Only runs in debug build (tests). In release build, this function is entirely removed by
+ * minifier.
  */
 function debugCheckMergedOrder(): void {
   if (!DEBUG) return;

--- a/apps/oxlint/src-js/plugins/tokens_methods.ts
+++ b/apps/oxlint/src-js/plugins/tokens_methods.ts
@@ -75,12 +75,14 @@ const INCLUDE_COMMENTS_SKIP_OPTIONS: SkipOptions = { includeComments: true, skip
 
 /**
  * Get all tokens that are related to the given node.
+ *
  * @param node - The AST node.
  * @param countOptions? - Options object. If is a function, equivalent to `{ filter: fn }`.
  * @returns Array of `Token`s, or array of `Token | Comment`s if `includeComments` is `true`.
  */
 /**
  * Get all tokens that are related to the given node.
+ *
  * @param node - The AST node.
  * @param beforeCount? - The number of tokens before the node to retrieve.
  * @param afterCount? - The number of tokens after the node to retrieve.
@@ -171,6 +173,7 @@ export function getTokens<Options extends CountOptions | number | FilterFn | nul
 
 /**
  * Get the first token of the given node.
+ *
  * @param node - The AST node.
  * @param skipOptions? - Options object.
  *   If is a number, equivalent to `{ skip: n }`.
@@ -252,6 +255,7 @@ export function getFirstToken<Options extends SkipOptions | number | FilterFn | 
 
 /**
  * Get the first tokens of the given node.
+ *
  * @param node - The AST node.
  * @param countOptions? - Options object.
  *   If is a number, equivalent to `{ count: n }`.
@@ -332,6 +336,7 @@ export function getFirstTokens<Options extends CountOptions | number | FilterFn 
 
 /**
  * Get the last token of the given node.
+ *
  * @param node - The AST node.
  * @param skipOptions? - Options object.
  *   If is a number, equivalent to `{ skip: n }`.
@@ -412,6 +417,7 @@ export function getLastToken<Options extends SkipOptions | number | FilterFn | n
 
 /**
  * Get the last tokens of the given node.
+ *
  * @param node - The AST node.
  * @param countOptions? - Options object.
  *   If is a number, equivalent to `{ count: n }`.
@@ -495,6 +501,7 @@ export function getLastTokens<Options extends CountOptions | number | FilterFn |
 
 /**
  * Get the token that precedes a given node or token.
+ *
  * @param nodeOrToken - The AST node or token.
  * @param skipOptions? - Options object.
  *   If is a number, equivalent to `{ skip: n }`.
@@ -574,7 +581,6 @@ export function getTokenBefore<Options extends SkipOptions | number | FilterFn |
  * Get the token that precedes a given node or token.
  *
  * @deprecated Use `sourceCode.getTokenBefore` with `includeComments: true` instead.
- *
  * @param nodeOrToken The AST node or token.
  * @param skip - Number of tokens to skip.
  * @returns `TokenOrComment | null`.
@@ -591,6 +597,7 @@ export function getTokenOrCommentBefore(
 
 /**
  * Get the tokens that precede a given node or token.
+ *
  * @param nodeOrToken - The AST node or token.
  * @param countOptions? - Options object.
  *   If is a number, equivalent to `{ count: n }`.
@@ -664,6 +671,7 @@ export function getTokensBefore<
 
 /**
  * Get the token that follows a given node or token.
+ *
  * @param nodeOrToken - The AST node or token.
  * @param skipOptions? - Options object.
  *   If is a number, equivalent to `{ skip: n }`.
@@ -742,7 +750,6 @@ export function getTokenAfter<Options extends SkipOptions | number | FilterFn | 
  * Get the token that follows a given node or token.
  *
  * @deprecated Use `sourceCode.getTokenAfter` with `includeComments: true` instead.
- *
  * @param nodeOrToken The AST node or token.
  * @param skip - Number of tokens to skip.
  * @returns `TokenOrComment | null`.
@@ -759,6 +766,7 @@ export function getTokenOrCommentAfter(
 
 /**
  * Get the tokens that follow a given node or token.
+ *
  * @param nodeOrToken - The AST node or token.
  * @param countOptions? - Options object.
  *   If is a number, equivalent to `{ count: n }`.
@@ -832,6 +840,7 @@ export function getTokensAfter<Options extends CountOptions | number | FilterFn 
 
 /**
  * Get all of the tokens between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param countOptions? - Options object. If is a function, equivalent to `{ filter: fn }`.
@@ -839,6 +848,7 @@ export function getTokensAfter<Options extends CountOptions | number | FilterFn 
  */
 /**
  * Get all of the tokens between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param padding - Number of extra tokens on either side of center.
@@ -921,6 +931,7 @@ export function getTokensBetween<
 
 /**
  * Get the first token between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param skipOptions? - Options object.
@@ -1003,6 +1014,7 @@ export function getFirstTokenBetween<
 
 /**
  * Get the first tokens between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param countOptions? - Options object.
@@ -1085,6 +1097,7 @@ export function getFirstTokensBetween<
 
 /**
  * Get the last token between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param skipOptions? - Options object.
@@ -1169,6 +1182,7 @@ export function getLastTokenBetween<
 
 /**
  * Get the last tokens between two non-overlapping nodes.
+ *
  * @param left - Node or token before the desired token range.
  * @param right - Node or token after the desired token range.
  * @param countOptions? - Options object.
@@ -1253,6 +1267,7 @@ export function getLastTokensBetween<
 
 /**
  * Get the token starting at the specified index.
+ *
  * @param offset - Start offset of the token.
  * @param rangeOptions - Options object.
  * @returns `Token` (or `Token | Comment` if `includeComments` is `true`), or `null` if none found.
@@ -1373,12 +1388,11 @@ export function isSpaceBetween(first: NodeOrToken, second: NodeOrToken): boolean
  * Checks for whitespace *between tokens*, not including whitespace *inside tokens*.
  * e.g. Returns `false` for `isSpaceBetween(x, y)` in `x+" "+y`.
  *
- * Unlike `SourceCode#isSpaceBetween`, this function does return `true` if there is a `JSText` token between the two
- * input tokens, and it contains whitespace.
- * e.g. Returns `true` for `isSpaceBetweenTokens(x, slash)` in `<X>a b</X>`.
+ * Unlike `SourceCode#isSpaceBetween`, this function does return `true` if there is a `JSText` token
+ * between the two input tokens, and it contains whitespace. e.g. Returns `true` for
+ * `isSpaceBetweenTokens(x, slash)` in `<X>a b</X>`.
  *
  * @deprecated Use `sourceCode.isSpaceBetween` instead.
- *
  * @param first - The first node or token to check between.
  * @param second - The second node or token to check between.
  * @returns `true` if there is a whitespace character between
@@ -1470,8 +1484,8 @@ function entryStart(index: number, uint32: Uint32Array): number {
 }
 
 /**
- * Get `end` offset of token/comment at `index`.
- * For tokens-only, reads from `tokensUint32`. For `includeComments`, looks up from the original buffer.
+ * Get `end` offset of token/comment at `index`. For tokens-only, reads from `tokensUint32`. For
+ * `includeComments`, looks up from the original buffer.
  *
  * @param index - Entry index in the tokens or merged buffer
  * @param includeComments - Whether to use the merged tokens-and-comments buffer
@@ -1521,7 +1535,8 @@ function collectEntries(
 }
 
 /**
- * Find the index of the first entry in a `Uint32Array` buffer whose `start` is >= `offset`, via binary search.
+ * Find the index of the first entry in a `Uint32Array` buffer whose `start` is >= `offset`, via
+ * binary search.
  *
  * Each entry occupies 4 x u32s (16 bytes), with `start` as the first u32.
  * Searched range starts at `startIndex` and ends at `length`.

--- a/apps/oxlint/src-js/plugins/visitor.ts
+++ b/apps/oxlint/src-js/plugins/visitor.ts
@@ -508,9 +508,11 @@ export function finalizeCompiledVisitor(): VisitorState {
 /**
  * Reset compiled visitor.
  *
- * This frees visit functions stored in `compiledVisitor`, and makes them eligible for garbage collection.
+ * This frees visit functions stored in `compiledVisitor`, and makes them eligible for garbage
+ * collection.
  *
- * After calling this function, `compiledVisitor` is in a clean state, ready for next file's visitor to be compiled.
+ * After calling this function, `compiledVisitor` is in a clean state, ready for next file's visitor
+ * to be compiled.
  */
 export function resetCompiledVisitor(): void {
   // Reset `compiledVisitor` array
@@ -536,7 +538,8 @@ type Merger = (visitProps: VisitProp[]) => VisitFn;
 type CfgMerger = (visitProps: CfgVisitProp[]) => CfgVisitFn;
 
 /**
- * Merge array of visit functions into a single function, which calls each of input functions in turn.
+ * Merge array of visit functions into a single function, which calls each of input functions in
+ * turn.
  *
  * The array passed is cleared (length set to 0), so the array can be reused.
  *
@@ -594,13 +597,15 @@ function mergeVisitFns(visitProps: VisitProp[]): VisitFn {
 }
 
 /**
- * Merge array of CFG visit functions into a single function, which calls each of input functions in turn.
+ * Merge array of CFG visit functions into a single function, which calls each of input functions in
+ * turn.
  *
- * The difference between this function and `mergeVisitFns` is that this function is for CFG event handlers.
- * Unlike all other visit functions, CFG event handlers are called with more than 1 argument.
- * We keep this separate from `mergeVisitFns` because the merger functions use `...args` to pass all arguments,
- * which is likely less performant than the simpler version which passes a single argument.
- * AST node visitation is a lot more common than CFG event visitation, and we want to keep the common case fast.
+ * The difference between this function and `mergeVisitFns` is that this function is for CFG event
+ * handlers. Unlike all other visit functions, CFG event handlers are called with more than 1
+ * argument. We keep this separate from `mergeVisitFns` because the merger functions use `...args`
+ * to pass all arguments, which is likely less performant than the simpler version which passes a
+ * single argument. AST node visitation is a lot more common than CFG event visitation, and we want
+ * to keep the common case fast.
  *
  * The array passed is cleared (length set to 0), so the array can be reused.
  *
@@ -648,6 +653,7 @@ function mergeCfgVisitFns(visitProps: CfgVisitProp[]): CfgVisitFn {
  * Create a merger function that merges `fnCount` functions.
  *
  * Generated code for `fnCount: 3`, `isCfg: false` (AST node visit function merger):
+ *
  * ```js
  * function(p) {
  *   var v0 = p[0].fn,
@@ -662,6 +668,7 @@ function mergeCfgVisitFns(visitProps: CfgVisitProp[]): CfgVisitFn {
  * ```
  *
  * Generated code for `fnCount: 2`, `isCfg: true` (CFG event handler merger):
+ *
  * ```js
  * function(p) {
  *   var v0 = p[0].fn,

--- a/apps/oxlint/src-js/utils/asserts.ts
+++ b/apps/oxlint/src-js/utils/asserts.ts
@@ -12,14 +12,14 @@ export function typeAssertIs<T>(value: unknown): asserts value is T {}
 /**
  * Assert a value is not `null` or `undefined`.
  *
- * In release builds, is a no-op. Only does runtime checks in debug builds.
- * Minification removes this function and all calls to it in release builds, so it has zero runtime cost.
+ * In release builds, is a no-op. Only does runtime checks in debug builds. Minification removes
+ * this function and all calls to it in release builds, so it has zero runtime cost.
  *
  * Use this for testing conditions which would indicate a bug in the code.
  * Do NOT use this for validating user input.
  *
- * If creating the error message is expensive, or potentially creating the message itself can result in an error
- * when the assertion passes, pass a function which returns the message.
+ * If creating the error message is expensive, or potentially creating the message itself can result
+ * in an error when the assertion passes, pass a function which returns the message.
  *
  * ```ts
  * debugAssertIsNonNull(thing, () => `Should not be null: ${getErrorMessage()}`);
@@ -50,14 +50,14 @@ export function debugAssertIsNonNull<T>(
 /**
  * Assert a value is not `undefined`.
  *
- * In release builds, is a no-op. Only does runtime checks in debug builds.
- * Minification removes this function and all calls to it in release builds, so it has zero runtime cost.
+ * In release builds, is a no-op. Only does runtime checks in debug builds. Minification removes
+ * this function and all calls to it in release builds, so it has zero runtime cost.
  *
  * Use this for testing conditions which would indicate a bug in the code.
  * Do NOT use this for validating user input.
  *
- * If creating the error message is expensive, or potentially creating the message itself can result in an error
- * when the assertion passes, pass a function which returns the message.
+ * If creating the error message is expensive, or potentially creating the message itself can result
+ * in an error when the assertion passes, pass a function which returns the message.
  *
  * ```ts
  * debugAssertIsNotUndefined(thing, () => `Should not be undefined: ${getErrorMessage()}`);
@@ -87,8 +87,8 @@ export function debugAssertIsNotUndefined<T>(
 /**
  * Debug assert that `fn` is a function.
  *
- * In release builds, is a no-op. Only does runtime checks in debug builds.
- * Minification removes this function and all calls to it in release builds, so it has zero runtime cost.
+ * In release builds, is a no-op. Only does runtime checks in debug builds. Minification removes
+ * this function and all calls to it in release builds, so it has zero runtime cost.
  *
  * @param fn - Function
  * @throws {TypeError} If `fn` is not a function in debug build
@@ -102,14 +102,14 @@ export function debugAssertIsFunction(fn: unknown): asserts fn is Function {
 /**
  * Assert a condition.
  *
- * In release builds, is a no-op. Only does runtime checks in debug builds.
- * Minification removes this function and all calls to it in release builds, so it has zero runtime cost.
+ * In release builds, is a no-op. Only does runtime checks in debug builds. Minification removes
+ * this function and all calls to it in release builds, so it has zero runtime cost.
  *
  * Use this for testing conditions which would indicate a bug in the code.
  * Do NOT use this for validating user input.
  *
- * If creating the error message is expensive, or potentially creating the message itself can result in an error
- * when the assertion passes, pass a function which returns the message.
+ * If creating the error message is expensive, or potentially creating the message itself can result
+ * in an error when the assertion passes, pass a function which returns the message.
  *
  * ```ts
  * debugAssert(condition, () => `Condition failed: ${getErrorMessage()}`);

--- a/apps/oxlint/src-js/utils/types.ts
+++ b/apps/oxlint/src-js/utils/types.ts
@@ -2,11 +2,11 @@
  * Utility type to make specified properties of a type nullable.
  *
  * @example
- * ```ts
- * type Foo = { str: string, num: number };
- * type FooWithNullableNum = SetNullable<Foo, 'num'>;
- * // { str: string, num: number | null }
- * ```
+ *   ```ts
+ *   type Foo = { str: string; num: number };
+ *   type FooWithNullableNum = SetNullable<Foo, "num">;
+ *   // { str: string, num: number | null }
+ *   ```;
  */
 export type SetNullable<BaseType, Keys extends keyof BaseType = keyof BaseType> = {
   [Key in keyof BaseType]: Key extends Keys ? BaseType[Key] | null : BaseType[Key];

--- a/apps/oxlint/src-js/utils/utils.ts
+++ b/apps/oxlint/src-js/utils/utils.ts
@@ -3,15 +3,16 @@
  *
  * `err` is expected to be an `Error` object, but can be anything.
  *
- * * If it's an `Error`, the error message and stack trace is returned.
- * * If it's another object with a string `message` property, `message` is returned.
- * * Otherwise, a generic "Unknown error" message is returned.
+ * - If it's an `Error`, the error message and stack trace is returned.
+ * - If it's another object with a string `message` property, `message` is returned.
+ * - Otherwise, a generic "Unknown error" message is returned.
  *
  * This function will never throw, and always returns a non-empty string, even if:
  *
- * * `err` is `null` or `undefined`.
- * * `err` is an object with a getter for `message` property which throws.
- * * `err` has a getter for `stack` or `message` property which returns a different value each time it's accessed.
+ * - `err` is `null` or `undefined`.
+ * - `err` is an object with a getter for `message` property which throws.
+ * - `err` has a getter for `stack` or `message` property which returns a different value each time
+ *   it's accessed.
  *
  * @param err - Error
  * @returns Error message

--- a/apps/oxlint/src-js/workspace/index.ts
+++ b/apps/oxlint/src-js/workspace/index.ts
@@ -91,6 +91,7 @@ export function destroyWorkspace(workspaceUri: string): undefined {
 
 /**
  * Set the current workspace.
+ *
  * @param workspace - Workspace object
  * @param workspaceUri - Workspace URI
  */

--- a/apps/oxlint/test/e2e.test.ts
+++ b/apps/oxlint/test/e2e.test.ts
@@ -19,9 +19,10 @@ const NODE_BIN_PATH = process.execPath;
  * - `files` as the first argument (so only lints the files in the fixture's `files` directory).
  * - Additional arguments from `options.json` file in fixture directory, if it exists.
  *
- * Fixtures with an `options.json` file containing `"fix": true` are also run with `--fix` CLI option.
- * Fixtures with an `options.json` file containing `"fixSuggestions": true` are also run with `--fix-suggestions` CLI option.
- * The files' contents after fixes are recorded in the snapshot.
+ * Fixtures with an `options.json` file containing `"fix": true` are also run with `--fix` CLI
+ * option. Fixtures with an `options.json` file containing `"fixSuggestions": true` are also run
+ * with `--fix-suggestions` CLI option. The files' contents after fixes are recorded in the
+ * snapshot.
  *
  * Fixtures with an `options.json` file containing `"oxlint": false` are skipped.
  */
@@ -47,6 +48,7 @@ describe("oxlint CLI", { concurrent: process.platform !== "win32" }, () => {
 
 /**
  * Run Oxlint on a test fixture.
+ *
  * @param fixture - Fixture object
  * @param expect - Vitest expect function from test context
  */

--- a/apps/oxlint/test/eslint_compat.test.ts
+++ b/apps/oxlint/test/eslint_compat.test.ts
@@ -26,6 +26,7 @@ describe("ESLint compatibility", { timeout: 20_000 }, () => {
 
 /**
  * Run ESLint on a test fixture.
+ *
  * @param fixture - Fixture object
  */
 async function runFixture(fixture: Fixture): Promise<void> {

--- a/apps/oxlint/test/fixtures/createOnce_hook_errors/plugin.ts
+++ b/apps/oxlint/test/fixtures/createOnce_hook_errors/plugin.ts
@@ -38,6 +38,7 @@ const events = new Map<string, Record<string, string[]>>();
 
 /**
  * Record an event.
+ *
  * @param context - Context object
  * @param event - Event name
  */
@@ -64,6 +65,7 @@ function addEvent(context: Context, event: string) {
 
 /**
  * Get recorded events for a directory, serialized as pretty-printed JSON.
+ *
  * @param path - File path
  * @returns Events for directory as JSON string
  */

--- a/apps/oxlint/test/fixtures/tokens_and_comments_order/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens_and_comments_order/plugin.ts
@@ -6,9 +6,9 @@
  * Files are named `001.js` through `120.js` (5! = 120 permutations).
  * The filename number determines the order in which 5 operations are performed.
  *
- * After performing all operations, we verify:
- * 1. Each operation returns correct results.
- * 2. Object identity is preserved - the same token/comment objects are returned by all methods that return them.
+ * After performing all operations, we verify: 1. Each operation returns correct results. 2. Object
+ * identity is preserved - the same token/comment objects are returned by all methods that return
+ * them.
  */
 import assert from "node:assert";
 

--- a/apps/oxlint/test/fixtures/unicode_comments/files/index.js
+++ b/apps/oxlint/test/fixtures/unicode_comments/files/index.js
@@ -3,6 +3,7 @@ const greeting = "Hello 🌍"; // Line comment with emoji
 
 /**
  * Function with emoji in JSDoc
+ *
  * @param {string} name - User's name 👤
  * @returns {string} Greeting message
  */
@@ -18,6 +19,7 @@ const 你好世界 = "Testing üöä"; // Line comment: ñáéíóú
 
 /**
  * JSDoc with emojis and unicode: 你好 👋
+ *
  * @param {number} count - Number of items 🔢
  */
 function processItems(count) {

--- a/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
+++ b/apps/oxlint/test/fixtures/unicode_comments/output.snap.md
@@ -25,107 +25,109 @@
    `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "4,0-8,3",
-  |     "value": "*\n * Function with emoji in JSDoc\n * @param {string} name - User's name 👤\n * @returns {string} Greeting message\n "
+  |     "lines": "4,0-9,3",
+  |     "value": "*\n * Function with emoji in JSDoc\n *\n * @param {string} name - User's name 👤\n * @returns {string} Greeting message\n "
   | }
-   ,-[files/index.js:4:1]
- 3 |     
- 4 | ,-> /**
- 5 | |    * Function with emoji in JSDoc
- 6 | |    * @param {string} name - User's name 👤
- 7 | |    * @returns {string} Greeting message
- 8 | `->  */
- 9 |     function greetUser(name) {
-   `----
+    ,-[files/index.js:4:1]
+  3 |     
+  4 | ,-> /**
+  5 | |    * Function with emoji in JSDoc
+  6 | |    *
+  7 | |    * @param {string} name - User's name 👤
+  8 | |    * @returns {string} Greeting message
+  9 | `->  */
+ 10 |     function greetUser(name) {
+    `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "10,2-10,39",
+  |     "lines": "11,2-11,39",
   |     "value": " Comment with multiple emojis 🚀⭐💫"
   | }
-    ,-[files/index.js:10:3]
-  9 | function greetUser(name) {
- 10 |   // Comment with multiple emojis 🚀⭐💫
+    ,-[files/index.js:11:3]
+ 10 | function greetUser(name) {
+ 11 |   // Comment with multiple emojis 🚀⭐💫
     :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 11 |   const message = `Hello ${name}! 🌟`;
+ 12 |   const message = `Hello ${name}! 🌟`;
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "12,2-12,42",
+  |     "lines": "13,2-13,42",
   |     "value": " Block comment with unicode: ñáéíóú "
   | }
-    ,-[files/index.js:12:3]
- 11 |   const message = `Hello ${name}! 🌟`;
- 12 |   /* Block comment with unicode: ñáéíóú */
+    ,-[files/index.js:13:3]
+ 12 |   const message = `Hello ${name}! 🌟`;
+ 13 |   /* Block comment with unicode: ñáéíóú */
     :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 13 |   return message;
+ 14 |   return message;
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "16,0-16,30",
+  |     "lines": "17,0-17,30",
   |     "value": " Multi-byte comment: 你好世界 "
   | }
-    ,-[files/index.js:16:1]
- 15 | 
- 16 | /* Multi-byte comment: 你好世界 */
+    ,-[files/index.js:17:1]
+ 16 | 
+ 17 | /* Multi-byte comment: 你好世界 */
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 17 | const 你好世界 = "Testing üöä"; // Line comment: ñáéíóú
+ 18 | const 你好世界 = "Testing üöä"; // Line comment: ñáéíóú
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "17,28-17,51",
+  |     "lines": "18,28-18,51",
   |     "value": " Line comment: ñáéíóú"
   | }
-    ,-[files/index.js:17:40]
- 16 | /* Multi-byte comment: 你好世界 */
- 17 | const 你好世界 = "Testing üöä"; // Line comment: ñáéíóú
+    ,-[files/index.js:18:40]
+ 17 | /* Multi-byte comment: 你好世界 */
+ 18 | const 你好世界 = "Testing üöä"; // Line comment: ñáéíóú
     :                                 ^^^^^^^^^^^^^^^^^^^^^^^
- 18 | 
+ 19 | 
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "19,0-22,3",
-  |     "value": "*\n * JSDoc with emojis and unicode: 你好 👋\n * @param {number} count - Number of items 🔢\n "
+  |     "lines": "20,0-24,3",
+  |     "value": "*\n * JSDoc with emojis and unicode: 你好 👋\n *\n * @param {number} count - Number of items 🔢\n "
   | }
-    ,-[files/index.js:19:1]
- 18 |     
- 19 | ,-> /**
- 20 | |    * JSDoc with emojis and unicode: 你好 👋
- 21 | |    * @param {number} count - Number of items 🔢
- 22 | `->  */
- 23 |     function processItems(count) {
+    ,-[files/index.js:20:1]
+ 19 |     
+ 20 | ,-> /**
+ 21 | |    * JSDoc with emojis and unicode: 你好 👋
+ 22 | |    *
+ 23 | |    * @param {number} count - Number of items 🔢
+ 24 | `->  */
+ 25 |     function processItems(count) {
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "24,2-24,52",
+  |     "lines": "26,2-26,52",
   |     "value": " Comment with mixed unicode: αβγδε русский עברית"
   | }
-    ,-[files/index.js:24:3]
- 23 | function processItems(count) {
- 24 |   // Comment with mixed unicode: αβγδε русский עברית
+    ,-[files/index.js:26:3]
+ 25 | function processItems(count) {
+ 26 |   // Comment with mixed unicode: αβγδε русский עברית
     :   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 25 |   const result = count * 2; /* Block: ñáéíóú 🚀 */
+ 27 |   const result = count * 2; /* Block: ñáéíóú 🚀 */
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "25,28-25,50",
+  |     "lines": "27,28-27,50",
   |     "value": " Block: ñáéíóú 🚀 "
   | }
-    ,-[files/index.js:25:29]
- 24 |   // Comment with mixed unicode: αβγδε русский עברית
- 25 |   const result = count * 2; /* Block: ñáéíóú 🚀 */
+    ,-[files/index.js:27:29]
+ 26 |   // Comment with mixed unicode: αβγδε русский עברית
+ 27 |   const result = count * 2; /* Block: ñáéíóú 🚀 */
     :                             ^^^^^^^^^^^^^^^^^^^^^^
- 26 |   return result;
+ 28 |   return result;
     `----
 
   x unicode-comments(unicode-comments): {
-  |     "lines": "29,0-29,34",
+  |     "lines": "31,0-31,34",
   |     "value": " Final comment with emoji: 🎉✨🎊"
   | }
-    ,-[files/index.js:29:1]
- 28 | 
- 29 | // Final comment with emoji: 🎉✨🎊
+    ,-[files/index.js:31:1]
+ 30 | 
+ 31 | // Final comment with emoji: 🎉✨🎊
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 30 | const finalVar = "Done ✅";
+ 32 | const finalVar = "Done ✅";
     `----
 
 Found 0 warnings and 11 errors.

--- a/apps/oxlint/test/isSpaceBetween.test.ts
+++ b/apps/oxlint/test/isSpaceBetween.test.ts
@@ -19,6 +19,7 @@ import type { Program } from "../src-js/generated/types.d.ts";
 /**
  * Parse source text into AST using Oxc parser.
  * Set up global state, as if was linting the provided file.
+ *
  * @param filename - Filename
  * @param sourceText - Source text
  * @param options - Parse options

--- a/apps/oxlint/test/rule_tester.test.ts
+++ b/apps/oxlint/test/rule_tester.test.ts
@@ -39,6 +39,7 @@ RuleTester.it = itHook;
 
 /**
  * Run all current test cases.
+ *
  * @returns Array containing errors for each test case
  */
 function runCases(): (Error | null)[] {

--- a/apps/oxlint/test/tokens.test-d.ts
+++ b/apps/oxlint/test/tokens.test-d.ts
@@ -1,19 +1,23 @@
 /**
  * Type tests for token method return types.
  *
- * These are compile-time only — they don't run any code, they just verify that the conditional return types
- * resolve correctly for various calling patterns.
+ * These are compile-time only — they don't run any code, they just verify that the conditional
+ * return types resolve correctly for various calling patterns.
  *
  * Enforced by the type-checker: If any `satisfies` check fails, type check will error.
  *
- * `getTokens` and `getFirstToken` are tested exhaustively because they represent the two return type patterns:
+ * `getTokens` and `getFirstToken` are tested exhaustively because they represent the two return
+ * type patterns:
+ *
  * 1. Array - `TokenResult<Options>[]`
  * 2. Single - `TokenResult<Options> | null`
  *
- * All other conditional-return methods use the same `TokenResult` type, so they only get minimal tests:
+ * All other conditional-return methods use the same `TokenResult` type, so they only get minimal
+ * tests:
+ *
  * 1. No options -> `Token`
- * 2. `{ includeComments: true }` -> `TokenOrComment`
- * This guards against a method accidentally missing the `TokenResult` return type.
+ * 2. `{ includeComments: true }` -> `TokenOrComment` This guards against a method accidentally missing
+ *    the `TokenResult` return type.
  */
 
 import {

--- a/apps/oxlint/test/tokens.test.ts
+++ b/apps/oxlint/test/tokens.test.ts
@@ -41,13 +41,16 @@ const SOURCE_TEXT = "/*A*/var answer/*B*/=/*C*/a/*D*/* b/*E*///F\n    call();\n/
  * Setup for a test case, using `sourceText` as source text.
  *
  * This function:
+ *
  * - Parses source text with Oxc parser - which writes AST and source text into buffer.
  * - Initializes global state, as if was linting the provided file.
  * - Initializes source text.
- * - Does *not* deserialize the AST - tokens methods should do that automatically where they require AST.
+ * - Does _not_ deserialize the AST - tokens methods should do that automatically where they require
+ *   AST.
  *
- * It's not necessary to call this function before each test case, because `beforeEach` hook calls it already.
- * Only use this function if test needs to set source text to a different value from default `SOURCE_TEXT`.
+ * It's not necessary to call this function before each test case, because `beforeEach` hook calls
+ * it already. Only use this function if test needs to set source text to a different value from
+ * default `SOURCE_TEXT`.
  *
  * @param sourceText - Source text to use for test
  */

--- a/apps/oxlint/test/utils.ts
+++ b/apps/oxlint/test/utils.ts
@@ -53,6 +53,7 @@ const DEFAULT_OPTIONS: Fixture["options"] = {
 
 /**
  * Get all fixtures in `test/fixtures`, and their options.
+ *
  * @returns Array of fixtures
  */
 export function getFixtures(): Fixture[] {
@@ -121,6 +122,7 @@ interface TestFixtureOptions {
 
 /**
  * Run a test fixture.
+ *
  * @param options - Options for running the test
  */
 export async function testFixtureWithCommand(options: TestFixtureOptions): Promise<void> {
@@ -317,6 +319,7 @@ export function normalizeStdout(stdout: string, fixtureName: string, isESLint: b
  * before being passed to this function.
  *
  * Examples:
+ *
  * - `/apps/oxlint/test/fixtures/foo/bar.js` => `<fixture>/bar.js`
  * - `/apps/oxlint/test/fixtures/foo` => `<fixtures>/foo`
  * - `/apps/oxlint/something/else` => `<root>/apps/oxlint/something/else`
@@ -339,6 +342,7 @@ export function convertSubPath(subPath: string, fixtureName: string): string {
  * before being passed to this function.
  *
  * Examples:
+ *
  * - `/foo/bar.js` => `<fixture>/bar.js`
  * - `/foo` => `<fixtures>/foo`
  */

--- a/apps/oxlint/tsdown_plugins/inline_search.ts
+++ b/apps/oxlint/tsdown_plugins/inline_search.ts
@@ -22,11 +22,12 @@ const { fnParams, returnParamIndex, fnBodySource } = extractInlinedFunction(
 );
 
 /**
- * Plugin to inline calls to binary search helper function `firstTokenAtOrAfter` into its call sites.
+ * Plugin to inline calls to binary search helper function `firstTokenAtOrAfter` into its call
+ * sites.
  *
  * This eliminates function call overhead for the binary search used by all token/comment methods.
- * The function definition is read from the source file, so edits to the helper function are automatically
- * reflected in the inlined output.
+ * The function definition is read from the source file, so edits to the helper function are
+ * automatically reflected in the inlined output.
  *
  * The function is inlined into all call sites in `FILES` list above.
  *
@@ -62,6 +63,7 @@ const plugin: Plugin = {
 
       /**
        * Convert offset to line number.
+       *
        * @param offset - Offset in source code
        * @returns Line number
        */
@@ -165,6 +167,7 @@ export default plugin;
 
 /**
  * Check if a node is a call to the function to be inlined.
+ *
  * @param node - AST node to check
  * @returns `true` if `node` is a call to the function to be inlined
  */

--- a/apps/oxlint/tsdown_plugins/replace_asserts.ts
+++ b/apps/oxlint/tsdown_plugins/replace_asserts.ts
@@ -8,12 +8,12 @@ import type { Plugin } from "rolldown";
 const ASSERTS_PATH = pathJoin(import.meta.dirname, "../src-js/utils/asserts.ts");
 
 /**
- * Plugin to remove imports of `debugAssert*` / `typeAssert*` functions from `src-js/utils/asserts.ts`,
- * and all their call sites.
+ * Plugin to remove imports of `debugAssert*` / `typeAssert*` functions from
+ * `src-js/utils/asserts.ts`, and all their call sites.
  *
  * ```ts
  * // Original code
- * import { debugAssertIsNonNull } from '../utils/asserts.ts';
+ * import { debugAssertIsNonNull } from "../utils/asserts.ts";
  * const foo = getFoo();
  * debugAssertIsNonNull(foo.bar);
  *
@@ -25,17 +25,17 @@ const ASSERTS_PATH = pathJoin(import.meta.dirname, "../src-js/utils/asserts.ts")
  *
  * # 1. Minifier works chunk-by-chunk
  *
- * Minifier can already remove all calls to these functions as dead code, but only if the functions are defined
- * in the same file as the call sites.
+ * Minifier can already remove all calls to these functions as dead code, but only if the functions
+ * are defined in the same file as the call sites.
  *
- * Problem is that `asserts.ts` is imported by files which end up in all output chunks.
- * So without this transform, TSDown creates a shared chunk for `asserts.ts`. Minifier works chunk-by-chunk,
- * so can't see that these functions are no-ops, and doesn't remove the function calls.
+ * Problem is that `asserts.ts` is imported by files which end up in all output chunks. So without
+ * this transform, TSDown creates a shared chunk for `asserts.ts`. Minifier works chunk-by-chunk, so
+ * can't see that these functions are no-ops, and doesn't remove the function calls.
  *
  * # 2. Not entirely removed
  *
- * Even if minifier does remove all calls to these functions, it can't prove that expressions *inside* the calls
- * don't have side effects.
+ * Even if minifier does remove all calls to these functions, it can't prove that expressions
+ * _inside_ the calls don't have side effects.
  *
  * In example above, it can't know if `foo` has a getter for `bar` property.
  * So it removes the call to `debugAssertIsNonNull`, but leaves behind the `foo.bar` expression.
@@ -45,8 +45,8 @@ const ASSERTS_PATH = pathJoin(import.meta.dirname, "../src-js/utils/asserts.ts")
  * foo.bar;
  * ```
  *
- * This plugin visits AST and removes all calls to `debugAssert*` / `typeAssert*` functions entirely,
- * *including* the expressions inside the calls.
+ * This plugin visits AST and removes all calls to `debugAssert*` / `typeAssert*` functions
+ * entirely, _including_ the expressions inside the calls.
  *
  * This makes these debug assertion functions act like `debug_assert!` in Rust.
  */

--- a/apps/oxlint/tsdown_plugins/replace_globals.ts
+++ b/apps/oxlint/tsdown_plugins/replace_globals.ts
@@ -157,6 +157,7 @@ export default plugin;
 
 /**
  * Parse `utils/globals.ts` and return a list of globals and global vars it exports.
+ *
  * @param path - Path to `utils/globals.ts`
  * @returns Mapping from global name (e.g. `Object`) to mapping of properties of that global to var names
  *   (e.g. `hasOwn` -> `ObjectHasOwn`).

--- a/apps/oxlint/tsdown_plugins/utils.ts
+++ b/apps/oxlint/tsdown_plugins/utils.ts
@@ -4,6 +4,7 @@ import type { Program } from "@oxc-project/types";
 
 /**
  * Parse code and return the AST.
+ *
  * @param path - Path to file
  * @param code - Source code
  * @returns AST

--- a/napi/parser/src-js/generated/constants.js
+++ b/napi/parser/src-js/generated/constants.js
@@ -17,7 +17,8 @@ export const BUFFER_ALIGN = 4294967296;
 export const ACTIVE_SIZE = 2147483552;
 
 /**
- * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the data pointer within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const DATA_POINTER_POS_32 = 536870900;
 
@@ -37,12 +38,14 @@ export const IS_JSX_FLAG_POS = 2147483613;
 export const HAS_BOM_FLAG_POS = 2147483614;
 
 /**
- * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens offset within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const TOKENS_OFFSET_POS_32 = 536870901;
 
 /**
- * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array` indexing).
+ * Byte offset of the tokens length within the buffer, divided by 4 (for `Uint32Array`
+ * indexing).
  */
 export const TOKENS_LEN_POS_32 = 536870902;
 

--- a/napi/parser/src-js/index.js
+++ b/napi/parser/src-js/index.js
@@ -26,6 +26,7 @@ let parseSyncRaw = null,
 
 /**
  * Lazy-load code related to raw transfer.
+ *
  * @returns {undefined}
  */
 function loadRawTransfer() {
@@ -36,6 +37,7 @@ function loadRawTransfer() {
 
 /**
  * Lazy-load code related to raw transfer lazy deserialization.
+ *
  * @returns {undefined}
  */
 function loadRawTransferLazy() {
@@ -49,8 +51,9 @@ function loadRawTransferLazy() {
  *
  * @param {string} filename - Filename
  * @param {string} sourceText - Source text of file
- * @param {Object|undefined} options - Parsing options
- * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
+ * @param {Object | undefined} options - Parsing options
+ * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and
+ *   `errors`
  * @throws {Error} - If `experimentalRawTransfer` or `experimentalLazy` option is enabled,
  *   and raw transfer is not supported on this platform
  */
@@ -69,20 +72,21 @@ export function parseSync(filename, sourceText, options) {
 /**
  * Parse JS/TS source asynchronously on a separate thread.
  *
- * Note that not all of the workload can happen on a separate thread.
- * Parsing on Rust side does happen in a separate thread, but deserialization of the AST to JS objects
- * has to happen on current thread. This synchronous deserialization work typically outweighs
- * the asynchronous parsing by a factor of between 3 and 20.
+ * Note that not all of the workload can happen on a separate thread. Parsing on Rust side does
+ * happen in a separate thread, but deserialization of the AST to JS objects has to happen on
+ * current thread. This synchronous deserialization work typically outweighs the asynchronous
+ * parsing by a factor of between 3 and 20.
  *
- * i.e. the majority of the workload cannot be parallelized by using this method.
+ * I.e. the majority of the workload cannot be parallelized by using this method.
  *
  * Generally `parseSync` is preferable to use as it does not have the overhead of spawning a thread.
  * If you need to parallelize parsing multiple files, it is recommended to use worker threads.
  *
  * @param {string} filename - Filename
  * @param {string} sourceText - Source text of file
- * @param {Object|undefined} options - Parsing options
- * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
+ * @param {Object | undefined} options - Parsing options
+ * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and
+ *   `errors`
  * @throws {Error} - If `experimentalRawTransfer` or `experimentalLazy` option is enabled,
  *   and raw transfer is not supported on this platform
  */
@@ -100,6 +104,7 @@ export async function parse(filename, sourceText, options) {
 
 /**
  * Get `Visitor` class to construct visitors with.
+ *
  * @returns {function} - `Visitor` class
  */
 export function experimentalGetLazyVisitor() {

--- a/napi/parser/src-js/raw-transfer/common.js
+++ b/napi/parser/src-js/raw-transfer/common.js
@@ -175,9 +175,10 @@ const textEncoder = new TextEncoder();
  *
  * @param {string} sourceText - Source text of file
  * @returns {Object} - Object of form `{ buffer, sourceByteLen }`.
+ *
  *   - `buffer`: `Uint8Array` containing the AST in raw form.
- *   - `sourceByteLen`: Length of source text in UTF-8 bytes
- *     (which may not be equal to `sourceText.length` if source contains non-ASCII characters).
+ *   - `sourceByteLen`: Length of source text in UTF-8 bytes (which may not be equal to
+ *     `sourceText.length` if source contains non-ASCII characters).
  */
 export function prepareRaw(sourceText) {
   // Cancel timeout for clearing buffers
@@ -254,8 +255,8 @@ function clearBuffersCache() {
 /**
  * Create a `Uint8Array` which is 2 GiB in size, with its start aligned on 4 GiB.
  *
- * Achieve this by creating a 6 GiB `ArrayBuffer`, getting the offset within it that's aligned to 4 GiB,
- * chopping off that number of bytes from the start, and shortening to 2 GiB.
+ * Achieve this by creating a 6 GiB `ArrayBuffer`, getting the offset within it that's aligned to 4
+ * GiB, chopping off that number of bytes from the start, and shortening to 2 GiB.
  *
  * It's always possible to obtain a 2 GiB slice aligned on 4 GiB within a 6 GiB buffer,
  * no matter how the 6 GiB buffer is aligned.

--- a/napi/parser/src-js/raw-transfer/eager.js
+++ b/napi/parser/src-js/raw-transfer/eager.js
@@ -5,12 +5,14 @@ import { isJsAst, parseAsyncRawImpl, parseSyncRawImpl, returnBufferToCache } fro
 const require = createRequire(import.meta.url);
 
 /**
- * Parse JS/TS source synchronously on current thread, using raw transfer to speed up deserialization.
+ * Parse JS/TS source synchronously on current thread, using raw transfer to speed up
+ * deserialization.
  *
  * @param {string} filename - Filename
  * @param {string} sourceText - Source text of file
  * @param {Object} options - Parsing options
- * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
+ * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and
+ *   `errors`
  */
 export function parseSyncRaw(filename, sourceText, options) {
   return parseSyncRawImpl(filename, sourceText, options, deserialize);
@@ -19,20 +21,22 @@ export function parseSyncRaw(filename, sourceText, options) {
 /**
  * Parse JS/TS source asynchronously, using raw transfer to speed up deserialization.
  *
- * Note that not all of the workload can happen on a separate thread.
- * Parsing on Rust side does happen in a separate thread, but deserialization of the AST to JS objects
- * has to happen on current thread. This synchronous deserialization work typically outweighs
- * the asynchronous parsing by a factor of around 3.
+ * Note that not all of the workload can happen on a separate thread. Parsing on Rust side does
+ * happen in a separate thread, but deserialization of the AST to JS objects has to happen on
+ * current thread. This synchronous deserialization work typically outweighs the asynchronous
+ * parsing by a factor of around 3.
  *
- * i.e. the majority of the workload cannot be parallelized by using this method.
+ * I.e. the majority of the workload cannot be parallelized by using this method.
  *
- * Generally `parseSyncRaw` is preferable to use as it does not have the overhead of spawning a thread.
- * If you need to parallelize parsing multiple files, it is recommended to use worker threads.
+ * Generally `parseSyncRaw` is preferable to use as it does not have the overhead of spawning a
+ * thread. If you need to parallelize parsing multiple files, it is recommended to use worker
+ * threads.
  *
  * @param {string} filename - Filename
  * @param {string} sourceText - Source text of file
  * @param {Object} options - Parsing options
- * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
+ * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and
+ *   `errors`
  */
 export function parse(filename, sourceText, options) {
   return parseAsyncRawImpl(filename, sourceText, options, deserialize);
@@ -60,7 +64,8 @@ const deserializerNames = [
  * @param {string} sourceText - Source for the file
  * @param {number} sourceByteLen - Length of source text in UTF-8 bytes
  * @param {Object} options - Parsing options
- * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and `errors`
+ * @returns {Object} - Object with property getters for `program`, `module`, `comments`, and
+ *   `errors`
  */
 function deserialize(buffer, sourceText, sourceByteLen, options) {
   const isJs = isJsAst(buffer),
@@ -169,6 +174,7 @@ const IS_ESCAPED_FIELD_OFFSET = 10;
 
 /**
  * Deserialize tokens from buffer.
+ *
  * @param {Uint8Array} buffer - Buffer containing AST in raw form
  * @param {string} sourceText - Source for the file
  * @param {boolean} isJs - `true` if parsing in JS mode
@@ -191,6 +197,7 @@ function deserializeTokens(buffer, sourceText, isJs) {
 
 /**
  * Deserialize a token from buffer at position `pos`.
+ *
  * @param {number} pos - Position in buffer containing Rust `Token` type
  * @param {Uint8Array} buffer - Buffer containing AST in raw form
  * @param {string} sourceText - Source for the file

--- a/napi/parser/src-js/raw-transfer/lazy-common.js
+++ b/napi/parser/src-js/raw-transfer/lazy-common.js
@@ -4,6 +4,7 @@ export const TOKEN = {};
 
 /**
  * Throw error when restricted class constructor is called by user code.
+ *
  * @throws {Error}
  */
 export function constructorError() {

--- a/napi/parser/src-js/raw-transfer/lazy.js
+++ b/napi/parser/src-js/raw-transfer/lazy.js
@@ -12,8 +12,8 @@ export { Visitor } from "./visitor.js";
  * The data in buffer is not deserialized. Is deserialized to JS objects lazily, when accessing the
  * properties of objects.
  *
- * e.g. `program` in returned object is an instance of `Program` class, with getters for `start`, `end`,
- * `body` etc.
+ * E.g. `program` in returned object is an instance of `Program` class, with getters for `start`,
+ * `end`, `body` etc.
  *
  * Returned object contains a `visit` function which can be used to visit the AST with a `Visitor`
  * (`Visitor` class can be obtained by calling `experimentalGetLazyVisitor()`).
@@ -39,11 +39,11 @@ export function parseSyncLazy(filename, sourceText, options) {
  * The data in buffer is not deserialized. Is deserialized to JS objects lazily, when accessing the
  * properties of objects.
  *
- * e.g. `program` in returned object is an instance of `Program` class, with getters for `start`, `end`,
- * `body` etc.
+ * E.g. `program` in returned object is an instance of `Program` class, with getters for `start`,
+ * `end`, `body` etc.
  *
- * Because this function does not deserialize the AST, unlike `parse`, very little work happens
- * on current thread in this function. Deserialization work only occurs when properties of the objects
+ * Because this function does not deserialize the AST, unlike `parse`, very little work happens on
+ * current thread in this function. Deserialization work only occurs when properties of the objects
  * are accessed.
  *
  * Returned object contains a `visit` function which can be used to visit the AST with a `Visitor`
@@ -128,10 +128,10 @@ function construct(buffer, sourceText, sourceByteLen, _options) {
  *
  * Buffer is returned to the cache to be reused.
  *
- * The buffer would be returned to the cache anyway, once all nodes of the AST are garbage collected,
- * but calling `dispose` is preferable, as it will happen immediately.
- * Otherwise, garbage collector may take time to collect the `ast` object, and new buffers may be created
- * in the meantime, when we could have reused this one.
+ * The buffer would be returned to the cache anyway, once all nodes of the AST are garbage
+ * collected, but calling `dispose` is preferable, as it will happen immediately. Otherwise, garbage
+ * collector may take time to collect the `ast` object, and new buffers may be created in the
+ * meantime, when we could have reused this one.
  *
  * @param {Object} ast - AST object containing buffer etc
  * @returns {undefined}

--- a/napi/parser/src-js/raw-transfer/node-array.js
+++ b/napi/parser/src-js/raw-transfer/node-array.js
@@ -76,8 +76,8 @@ export class NodeArray extends Array {
    * Override `slice` method to return a `NodeArray`.
    *
    * @this {NodeArray}
-   * @param {*} start - Start of slice
-   * @param {*} end - End of slice
+   * @param {any} start - Start of slice
+   * @param {any} end - End of slice
    * @returns {NodeArray} - `NodeArray` containing slice of this one
    */
   slice(start, end) {
@@ -128,6 +128,7 @@ export class NodeArray extends Array {
   static {
     /**
      * Get internal properties of `NodeArray`, given a proxy wrapping a `NodeArray`.
+     *
      * @param {Proxy} proxy - Proxy wrapping `NodeArray` object
      * @returns {Object} - Internal properties object
      */
@@ -135,6 +136,7 @@ export class NodeArray extends Array {
 
     /**
      * Get length of `NodeArray`.
+     *
      * @param {NodeArray} arr - `NodeArray` object
      * @returns {number} - Array length
      */
@@ -145,7 +147,7 @@ export class NodeArray extends Array {
      *
      * @param {NodeArray} arr - `NodeArray` object
      * @param {number} index - Index of element to get
-     * @returns {*} - Element at index `index`, or `undefined` if out of bounds
+     * @returns {any} - Element at index `index`, or `undefined` if out of bounds
      */
     getElement = (arr, index) => {
       const internal = arr.#internal;
@@ -334,8 +336,9 @@ const PROXY_HANDLERS = {
  * e.g. `"-1"`, `"01"`, `"0xFF"`, `"1e1"`, `"1 "` are not valid indexes.
  * Integers >= 4294967295 are not valid indexes.
  *
- * @param {string|Symbol} - Key used for property lookup.
- * @returns {number|null} - `key` converted to integer, if it's a valid array index, otherwise `null`.
+ * @param {string | Symbol} - Key used for property lookup.
+ * @returns {number | null} - `key` converted to integer, if it's a valid array index, otherwise
+ *   `null`.
  */
 function toIndex(key) {
   if (typeof key === "string") {
@@ -354,7 +357,7 @@ const INDEX_REGEX = /^[1-9]\d*$/;
  * Convert value to integer.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#integer_conversion
  *
- * @param {*} value - Value to convert to integer.
+ * @param {any} value - Value to convert to integer.
  * @returns {number} - Integer
  */
 function toInt(value) {

--- a/napi/parser/src-js/raw-transfer/visitor.js
+++ b/napi/parser/src-js/raw-transfer/visitor.js
@@ -23,12 +23,12 @@ export class Visitor {
    *
    * ```js
    * const visitor = new Visitor({
-   *     BinaryExpression(binExpr) {
-   *         // Do stuff when entering a `BinaryExpression`
-   *     },
-   *     'BinaryExpression:exit'(binExpr) {
-   *         // Do stuff when exiting a `BinaryExpression`
-   *     },
+   *   BinaryExpression(binExpr) {
+   *     // Do stuff when entering a `BinaryExpression`
+   *   },
+   *   "BinaryExpression:exit"(binExpr) {
+   *     // Do stuff when exiting a `BinaryExpression`
+   *   },
    * });
    * ```
    *
@@ -52,13 +52,13 @@ export const getVisitorsArr = getVisitorsArrTemp;
  *
  * Each element of array is one of:
  *
- * * No visitor for this type = `null`.
- * * Visitor for leaf node = visit function.
- * * Visitor for non-leaf node = object of form `{ enter, exit }`,
- *   where each property is either a visitor function or `null`.
+ * - No visitor for this type = `null`.
+ * - Visitor for leaf node = visit function.
+ * - Visitor for non-leaf node = object of form `{ enter, exit }`, where each property is either a
+ *   visitor function or `null`.
  *
  * @param {Object} visitor - Visitors object from user
- * @returns {Array<Object|Function|null>} - Array of visitors
+ * @returns {(Object | Function | null)[]} - Array of visitors
  */
 function createVisitorsArr(visitor) {
   if (visitor === null || typeof visitor !== "object") {

--- a/napi/parser/src-js/visit/index.js
+++ b/napi/parser/src-js/visit/index.js
@@ -31,6 +31,7 @@ export class Visitor {
 
   /**
    * Visit AST.
+   *
    * @param program - The AST to visit.
    * @returns {undefined}
    */

--- a/napi/parser/src-js/visit/visitor.js
+++ b/napi/parser/src-js/visit/visitor.js
@@ -319,7 +319,8 @@ export function finalizeCompiledVisitor() {
 }
 
 /**
- * Merge array of visit functions into a single function, which calls each of input functions in turn.
+ * Merge array of visit functions into a single function, which calls each of input functions in
+ * turn.
  *
  * The array passed is cleared (length set to 0), so the array can be reused.
  *

--- a/napi/parser/test/typescript-make-units-from-test.ts
+++ b/napi/parser/test/typescript-make-units-from-test.ts
@@ -13,7 +13,8 @@ const META_OPTIONS_REGEX = /^\/\/\s*@(\w+)\s*:\s*([^\r\n]*)/gm;
 
 /**
  * Convert settings value to boolean
- * @param {string|null} value - Setting value
+ *
+ * @param {string | null} value - Setting value
  * @param {boolean} defaultValue - Default value if setting is not present
  * @returns {boolean}
  */
@@ -25,7 +26,8 @@ function valueToBoolean(value, defaultValue) {
 
 /**
  * Split comma-separated values into array
- * @param {string|null} value - Setting value
+ *
+ * @param {string | null} value - Setting value
  * @returns {string[]}
  */
 function splitValueOptions(value) {
@@ -35,6 +37,7 @@ function splitValueOptions(value) {
 
 /**
  * Create compiler settings from options map
+ *
  * @param {Map<string, string>} options - Compiler options
  * @returns {Object} CompilerSettings
  */
@@ -67,6 +70,7 @@ const EXTENSIONS = {
 
 /**
  * Check if extension explicitly indicates module type
+ *
  * @param {string} ext - File extension (lowercase, with dot)
  * @returns {boolean}
  */
@@ -76,9 +80,10 @@ function isExplicitModuleExtension(ext) {
 
 /**
  * Get source type from file path
+ *
  * @param {string} filePath - Path to the file
  * @param {Object} options - Compiler options
- * @returns {Object|null} Source type
+ * @returns {Object | null} Source type
  */
 function getSourceType(filePath, options) {
   const ext = path.extname(filePath).toLowerCase();
@@ -99,6 +104,7 @@ function getSourceType(filePath, options) {
 
 /**
  * Get error files for the test
+ *
  * @param {string} filePath - Path to the test file
  * @param {Object} options - Compiler options
  * @returns {string[]} Error files content
@@ -133,6 +139,7 @@ function getErrorFiles(filePath, options) {
 
 /**
  * Extract individual test units from a TypeScript test file
+ *
  * @param {string} filePath - Path to the test file
  * @param {string} code - Content of the test file
  * @returns {Object} TestCaseContent object

--- a/oxfmtrc.jsonc
+++ b/oxfmtrc.jsonc
@@ -1,5 +1,9 @@
 {
   "$schema": "./npm/oxfmt/configuration_schema.json",
+  "jsdoc": {
+    "commentLineStrategy": "keep",
+    "lineWrappingStyle": "balance",
+  },
   "ignorePatterns": [
     "**/tests/**",
     // Ignore `fixtures` directories except for `apps/oxlint/test/fixtures`

--- a/tasks/lint_rules/src/markdown-renderer.mjs
+++ b/tasks/lint_rules/src/markdown-renderer.mjs
@@ -1,9 +1,15 @@
 /**
- * @typedef {({ name: string } & import("./oxlint-rules.mjs").RuleEntry)} RuleEntryView
- * @typedef {{ isImplemented: number; isNotSupported: number; isPendingFix: number; total: number }} CounterView
+ * @typedef {{ name: string } & import("./oxlint-rules.mjs").RuleEntry} RuleEntryView
+ *
+ * @typedef {{
+ *   isImplemented: number;
+ *   isNotSupported: number;
+ *   isPendingFix: number;
+ *   total: number;
+ * }} CounterView
  */
 
-/** @param {{ npm: string[]; }} props */
+/** @param {{ npm: string[] }} props */
 const renderIntroduction = ({ npm }) => `
 > [!WARNING]
 > This comment is maintained by CI. Do not edit this comment directly.
@@ -63,7 +69,8 @@ Then implement the rule and get all the tests passing.
  *   counters: CounterView;
  *   views: RuleEntryView[];
  *   defaultOpen?: boolean;
- * }} props */
+ * }} props
+ */
 const renderRulesList = ({ title, counters, views, defaultOpen = true }) => `
 ## ${title}
 

--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -57,6 +57,7 @@ const readAllPendingFixRuleNames = async () => {
 
   /**
    * Recursively read all .rs files in a directory
+   *
    * @param {string} dir
    * @returns {Promise<string[]>}
    */
@@ -119,24 +120,25 @@ const readAllPendingFixRuleNames = async () => {
 /**
  * These rules will not be supported/implemented in oxlint.
  *
- * oxlint does not intend to cover stylistic lint rules, as oxfmt will handle code formatting.
- * There are some other rules listed here which are difficult to support due to technical limitations,
- * or rules that are deprecated in their source plugins and no longer relevant.
+ * Oxlint does not intend to cover stylistic lint rules, as oxfmt will handle code formatting. There
+ * are some other rules listed here which are difficult to support due to technical limitations, or
+ * rules that are deprecated in their source plugins and no longer relevant.
  *
  * @type {Set<string>}
- **/
+ */
 const NOT_SUPPORTED_RULE_NAMES = new Set(Object.keys(unsupportedRules.unsupportedRules ?? {}));
 
 /**
  * @typedef {{
- *   docsUrl: string,
- *   isDeprecated: boolean,
- *   isRecommended: boolean,
- *   isImplemented: boolean,
- *   isNotSupported: boolean,
- *   isPendingFix: boolean,
- *   unsupportedRationale: string | null
+ *   docsUrl: string;
+ *   isDeprecated: boolean;
+ *   isRecommended: boolean;
+ *   isImplemented: boolean;
+ *   isNotSupported: boolean;
+ *   isPendingFix: boolean;
+ *   unsupportedRationale: string | null;
  * }} RuleEntry
+ *
  * @typedef {Map<string, RuleEntry>} RuleEntries
  */
 
@@ -282,6 +284,7 @@ export const overrideTypeScriptPluginStatusWithEslintPluginStatus = async (ruleE
 /**
  * Some Jest rules are written to be compatible with Vitest, so we should
  * override the status of the Vitest rules to match the Jest rules.
+ *
  * @param {RuleEntries} ruleEntries
  */
 export const syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) => {
@@ -315,6 +318,7 @@ export const syncVitestPluginStatusWithJestPluginStatus = async (ruleEntries) =>
 /**
  * Some Unicorn rules rules are re-implemented version of eslint rules.
  * We should override these to make implementation status up-to-date.
+ *
  * @param {RuleEntries} ruleEntries
  */
 export const syncUnicornPluginStatusWithEslintPluginStatus = (ruleEntries) => {

--- a/tasks/transform_conformance/update_fixtures.mjs
+++ b/tasks/transform_conformance/update_fixtures.mjs
@@ -55,9 +55,11 @@ for (const packageName of PACKAGES) {
 
 /**
  * Update fixtures in directory, and its sub-directories.
+ *
  * @param {string} dirPath - Path to directory containing fixtures
  * @param {object} options - Transform options from parent directory
- * @param {boolean} hasChangedOptions - `true` if transform options from parent directory have changed
+ * @param {boolean} hasChangedOptions - `true` if transform options from parent directory have
+ *   changed
  * @returns {Promise<undefined>}
  */
 async function updateDir(dirPath, options, hasChangedOptions) {
@@ -118,6 +120,7 @@ async function updateDir(dirPath, options, hasChangedOptions) {
 
 /**
  * Remove unsupported presets + plugins from `options`.
+ *
  * @param {Object} options - Options object
  * @returns {boolean} - `true` if `options` has been altered.
  */
@@ -182,6 +185,7 @@ function ensureAllClassPluginsEnabled(options) {
 
 /**
  * Transform input with Babel.
+ *
  * @param {string} inputPath - Path of input file
  * @param {object} options - Transform options
  * @returns {Promise<string>}
@@ -234,7 +238,8 @@ async function transform(inputPath, options) {
 
 /**
  * Get name of plugin/preset.
- * @param {string|Array} stringOrArray - Input
+ *
+ * @param {string | Array} stringOrArray - Input
  * @returns {string} - Name of plugin/preset
  */
 function getName(stringOrArray) {
@@ -244,6 +249,7 @@ function getName(stringOrArray) {
 
 /**
  * Backup file.
+ *
  * @param {string} path - Original path
  * @returns {Promise<undefined>}
  */


### PR DESCRIPTION
## Summary

Enable JSDoc comment formatting with conservative settings:

- `commentLineStrategy: "keep"` — preserve multi-line vs single-line style
- `lineWrappingStyle: "balance"` — preserve original line breaks when they fit within print width

This applies the formatter's JSDoc normalization across JS/TS files:

- Adds blank lines between descriptions and `@param`/`@returns` tags
- Normalizes type syntax in JSDoc (commas → semicolons, adds spacing in object types)
- Strips extra indentation in description lines

## Test plan

- [ ] Verify `just fmt` is idempotent after this change
- [ ] Review JSDoc diffs for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)