### PR TITLE
fix(ci): remove negative glob for "A-cli" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,8 +12,7 @@ A-cfg:
 
 A-cli:
   - changed-files:
-      - any-glob-to-any-file:
-          ["apps/oxlint/**", "apps/oxfmt/**", "!apps/oxlint/src/lsp/**", "!apps/oxfmt/src/lsp/**"]
+      - any-glob-to-any-file: ["apps/oxlint/**", "apps/oxfmt/**"]
 
 A-editor:
   - changed-files:


### PR DESCRIPTION
half reverting https://github.com/oxc-project/oxc/pull/20627
Now the label "A-cli" is applied for files outside oxfmt and oxlint apps.

Example PR: https://github.com/oxc-project/oxc/pull/20576
<img width="607" height="82" alt="grafik" src="https://github.com/user-attachments/assets/ac49328d-36fa-4d15-b32e-3427818fb241" />

