### PR TITLE
fix(linter): isolate `--init` config writes from parallel tests

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -959,14 +959,14 @@ mod test {
 
     #[test]
     fn test_init_config() {
-        assert!(!fs::exists(DEFAULT_OXLINTRC_NAME).unwrap());
+        let temp_dir = tempfile::tempdir().expect("Could not create a temp dir");
+        let config_path = temp_dir.path().join(DEFAULT_OXLINTRC_NAME);
+        assert!(!fs::exists(&config_path).unwrap());
 
         let args = &["--init"];
-        Tester::new().with_cwd("fixtures".into()).test(args);
+        Tester::new().with_cwd(temp_dir.path().to_path_buf()).test(args);
 
-        assert!(fs::exists(DEFAULT_OXLINTRC_NAME).unwrap());
-
-        fs::remove_file(DEFAULT_OXLINTRC_NAME).unwrap();
+        assert!(fs::exists(&config_path).unwrap());
     }
 
     #[test]

--- a/apps/oxlint/src/mode/init.rs
+++ b/apps/oxlint/src/mode/init.rs
@@ -22,7 +22,7 @@ pub fn run_init(cwd: &Path, stdout: &mut dyn std::io::Write) -> CliRunResult {
         oxlintrc_for_print
     };
 
-    if fs::write(DEFAULT_OXLINTRC_NAME, configuration).is_ok() {
+    if fs::write(cwd.join(DEFAULT_OXLINTRC_NAME), configuration).is_ok() {
         print_and_flush_stdout(stdout, "Configuration file created\n");
         return CliRunResult::ConfigFileInitSucceeded;
     }


### PR DESCRIPTION
`run_init` wrote `.oxlintrc.json` to the process current directory instead of
the `CliRunner` cwd. In the oxlint test suite, `test_init_config` relied on
that behavior and created/deleted a real config file under `apps/oxlint`.

That leaked shared filesystem state across tests. In parallel runs, ancestor
config discovery for `test_import_plugin_detects_cycles_with_auto_discovered_tsconfig_paths`
could briefly observe the temporary crate-level `.oxlintrc.json`, then fail when
it had already been removed by another test. This showed up as a flaky
`InvalidOptionConfig`/snapshot failure instead of the expected `import/no-cycle`
diagnostic.

Fix this by writing `--init` output relative to the runner cwd, and update
`test_init_config` to use an isolated temporary directory rather than mutating
repo state.


fixes https://github.com/oxc-project/oxc/issues/20684