### PR TITLE
fix(codegen): preserve coverage comments before `ConditionalExpression` alternate and between `SwitchCase`s

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -517,6 +517,7 @@ impl Gen for SwitchStatement<'_> {
 impl Gen for SwitchCase<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_semicolon_if_needed();
+        p.print_comments_at(self.span.start);
         p.print_indent();
         p.add_source_mapping(self.span);
         match &self.test {
@@ -1907,6 +1908,13 @@ impl GenExpr for ConditionalExpression<'_> {
             p.print_soft_space();
             p.print_colon();
             p.print_soft_space();
+            if let Some(comments) = p.get_comments(self.alternate.span().start) {
+                p.print_comments(&comments);
+                if p.print_next_indent_as_space {
+                    p.print_hard_space();
+                    p.print_next_indent_as_space = false;
+                }
+            }
             self.alternate.print_expr(p, Precedence::Yield, ctx & Context::FORBID_IN);
         });
     }

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -220,6 +220,16 @@ catch (err) /* c8 ignore next */ /* istanbul ignore next */ { handle(err); }",
             "try { something(); }
 catch (err) // v8 ignore next
 { handle(err); }",
+            // Coverage comment before ConditionalExpression alternate
+            // https://github.com/oxc-project/oxc/issues/20549
+            "const a = Math.random() ? 1 : /* istanbul ignore next */ 2;",
+            // Coverage comment between SwitchStatement cases
+            // https://github.com/oxc-project/oxc/issues/20549
+            "switch (Math.random()) {
+  case 0.5: break;
+  /* istanbul ignore next */
+  default: break;
+}",
         ];
 
         snapshot("coverage", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/coverage.snap
@@ -140,3 +140,21 @@ try {
 } catch (err) {
 	handle(err);
 }
+
+########## 23
+const a = Math.random() ? 1 : /* istanbul ignore next */ 2;
+----------
+const a = Math.random() ? 1 : /* istanbul ignore next */ 2;
+
+########## 24
+switch (Math.random()) {
+  case 0.5: break;
+  /* istanbul ignore next */
+  default: break;
+}
+----------
+switch (Math.random()) {
+	case .5: break;
+	/* istanbul ignore next */
+	default: break;
+}


### PR DESCRIPTION
## Summary

- Print leading coverage ignore comments (e.g. `/* istanbul ignore next */`) before `ConditionalExpression`'s alternate expression
- Print leading coverage ignore comments before `case`/`default` keywords in `SwitchStatement`

Closes #20549

🤖 Generated with [Claude Code](https://claude.com/claude-code)