### PR TITLE
refactor(formatter,oxfmt): Fix up xxx-in-js logic

### DIFF
--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -104,10 +104,9 @@ export type FormatEmbeddedCodeParam = {
 };
 
 /**
- * Format xxx-in-js code snippets into formatted string.
- *
- * This will be gradually replaced by `formatEmbeddedDoc` which returns `Doc`.
- * For now, html|css|md-in-js are using this.
+ * Format non-js code snippets into formatted string.
+ * Mainly used for formatting code fences within JSDoc,
+ * and is also used as a temporary fallback for html-in-js.
  *
  * @returns Formatted code snippet
  */
@@ -135,15 +134,15 @@ export type FormatEmbeddedDocParam = {
 };
 
 /**
- * Format xxx-in-js code snippets into Prettier `Doc` JSON strings.
+ * Format non-js code snippets into Prettier `Doc` JSON strings.
  *
- * This makes `oxc_formatter` correctly handle `printWidth` even for embedded code.
+ * This makes our printer correctly handle `printWidth` even for embedded code.
  * - For gql-in-js, `texts` contains multiple parts split by `${}` in a template literal
  * - For others, `texts` always contains a single string with `${}` parts replaced by placeholders
  * However, this function does not need to be aware of that,
  * as it simply formats each text part independently and returns an array of formatted parts.
  *
- * @returns Doc JSON strings (one per input text)
+ * @returns Doc JSON strings
  */
 export async function formatEmbeddedDoc({
   texts,

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -373,16 +373,23 @@ impl ExternalFormatter {
 
 // ---
 
-/// Mapping from `oxc_formatter` language identifiers to Prettier `parser` names.
+/// Mapping from language identifiers to Prettier `parser` names.
 /// This is the single source of truth for supported embedded languages.
+///
+/// Language identifiers come from two sources:
+/// - xxx-in-js `(Tagged)TemplateLiteral` (`embed/*.rs`)
+/// - JSDoc fenced code blocks (`jsdoc/mdast_serialize/`)
+///
+/// NOTE: these identifiers happen to overlap with some Prettier parser names,
+/// but `oxc_formatter` treats them as generic language names.
+/// This function is the only place that maps them to Prettier-specific parsers.
 fn language_to_prettier_parser(language: &str) -> Option<&'static str> {
     match language {
-        // Template literal tags + JSDoc fenced code block language names
-        "tagged-css" | "styled-jsx" | "angular-styles" | "css" | "scss" | "less" => Some("scss"),
-        "tagged-graphql" | "graphql" | "gql" => Some("graphql"),
-        "tagged-html" | "html" => Some("html"),
-        "tagged-markdown" | "markdown" | "md" => Some("markdown"),
-        "angular-template" => Some("angular"),
+        "css" | "scss" | "less" => Some("scss"),
+        "graphql" | "gql" => Some("graphql"),
+        "html" => Some("html"),
+        "angular" => Some("angular"),
+        "markdown" | "md" => Some("markdown"),
         _ => None,
     }
 }

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -50,7 +50,7 @@ pub fn to_format_elements_for_template<'a>(
     }
 
     match language {
-        "tagged-graphql" => {
+        "graphql" => {
             let irs = doc_jsons
                 .into_iter()
                 .map(|envelope| {
@@ -67,7 +67,7 @@ pub fn to_format_elements_for_template<'a>(
                 .collect::<Result<Vec<_>, String>>()?;
             Ok(EmbeddedDocResult::MultipleDocs(irs))
         }
-        "tagged-css" => {
+        "css" => {
             let (mut ir, _) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for CSS"),
                 allocator,
@@ -86,7 +86,7 @@ pub fn to_format_elements_for_template<'a>(
                 html_has_multiple_root_elements: None,
             })
         }
-        "tagged-html" | "angular-template" => {
+        "html" | "angular" => {
             let (mut ir, metadata) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for HTML"),
                 allocator,
@@ -107,7 +107,7 @@ pub fn to_format_elements_for_template<'a>(
                 html_has_multiple_root_elements,
             })
         }
-        "tagged-markdown" => {
+        "markdown" => {
             let (mut ir, _) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for Markdown"),
                 allocator,

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -92,18 +92,20 @@ impl ExternalCallbacks {
         self
     }
 
-    /// Format embedded code with the given tag name.
+    /// Format embedded code with the given language name.
     ///
     /// # Arguments
-    /// * `tag_name` - The template tag (e.g., "css", "gql", "html")
+    /// * `language` - A generic language identifier (e.g., "css", "html", "graphql").
+    ///   These are NOT specific to any external formatter.
+    ///   The callback implementation is responsible for mapping them to its own parser/language names.
     /// * `code` - The code to format
     ///
     /// # Returns
     /// * `Some(Ok(String))` - The formatted code
     /// * `Some(Err(String))` - An error message if formatting failed
     /// * `None` - No embedded formatter callback is set
-    pub fn format_embedded(&self, tag_name: &str, code: &str) -> Option<Result<String, String>> {
-        self.embedded_formatter.as_ref().map(|cb| cb(tag_name, code))
+    pub fn format_embedded(&self, language: &str, code: &str) -> Option<Result<String, String>> {
+        self.embedded_formatter.as_ref().map(|cb| cb(language, code))
     }
 
     /// Format embedded code as Doc.
@@ -111,7 +113,9 @@ impl ExternalCallbacks {
     /// # Arguments
     /// * `allocator` - The arena allocator for allocating strings in `FormatElement::Text`
     /// * `group_id_builder` - Builder for creating unique `GroupId`s
-    /// * `language` - The embedded language (e.g. "tagged-css", "tagged-graphql")
+    /// * `language` - A generic language identifier (e.g., "css", "graphql", "html", "angular").
+    ///   These are NOT specific to any external formatter.
+    ///   The callback implementation is responsible for mapping them to its own parser/language names.
     /// * `texts` - The code texts to format (multiple quasis for GraphQL, single joined text for CSS/HTML)
     ///
     /// # Returns

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -42,7 +42,7 @@ pub(super) fn format_css_doc<'a>(
         let Some(Ok(EmbeddedDocResult::DocWithPlaceholders { ir, .. })) = f
             .context()
             .external_callbacks()
-            .format_embedded_doc(allocator, group_id_builder, "tagged-css", &[raw])
+            .format_embedded_doc(allocator, group_id_builder, "css", &[raw])
         else {
             return false;
         };
@@ -74,7 +74,7 @@ pub(super) fn format_css_doc<'a>(
     let Some(Ok(EmbeddedDocResult::DocWithPlaceholders { ir, placeholder_count, .. })) = f
         .context()
         .external_callbacks()
-        .format_embedded_doc(allocator, group_id_builder, "tagged-css", &[joined])
+        .format_embedded_doc(allocator, group_id_builder, "css", &[joined])
     else {
         return false;
     };

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -92,7 +92,7 @@ pub(super) fn format_graphql_doc<'a>(
         let Some(Ok(crate::external_formatter::EmbeddedDocResult::MultipleDocs(irs))) = f
             .context()
             .external_callbacks()
-            .format_embedded_doc(allocator, group_id_builder, "tagged-graphql", &texts_to_format)
+            .format_embedded_doc(allocator, group_id_builder, "graphql", &texts_to_format)
         else {
             return false;
         };

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -26,15 +26,16 @@ const COUNTER: &str = "0";
 /// Format an HTML(Angular)-in-JS template literal via the Doc->IR path with placeholder replacement.
 ///
 /// Uses `.cooked` values (unlike CSS which uses `.raw`), joins quasis with
-/// `PRETTIER_HTML_PLACEHOLDER_{N}_0_IN_JS` markers, formats via the given `language`,
+/// `PRETTIER_HTML_PLACEHOLDER_{N}_0_IN_JS` markers, formats via the given `embedded_language`,
 /// then replaces placeholder occurrences in the resulting IR with `${expr}` Docs.
 ///
-/// Supports both `"tagged-html"` (html-in-js) and `"angular-template"` (`@Component({ template })`).
+/// Supports both html-in-js and angular-in-js (`@Component({ template })`).
 pub(super) fn format_html_doc<'a>(
     quasi: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
-    language: &str,
+    is_angular: bool,
 ) -> bool {
+    let embedded_language = if is_angular { "angular" } else { "html" };
     let quasis = &quasi.quasis;
     let expressions: Vec<_> = quasi.expressions().iter().collect();
 
@@ -62,7 +63,7 @@ pub(super) fn format_html_doc<'a>(
         })) = f.context().external_callbacks().format_embedded_doc(
             allocator,
             group_id_builder,
-            language,
+            embedded_language,
             &[cooked],
         )
         else {
@@ -116,7 +117,7 @@ pub(super) fn format_html_doc<'a>(
     })) = f.context().external_callbacks().format_embedded_doc(
         allocator,
         group_id_builder,
-        language,
+        embedded_language,
         &[joined],
     )
     else {
@@ -328,8 +329,7 @@ fn format_js_in_html_as_fallback<'a>(
     expressions: &[&AstNode<'a, Expression<'a>>],
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
-    let Some(Ok(formatted)) =
-        f.context().external_callbacks().format_embedded("tagged-html", joined)
+    let Some(Ok(formatted)) = f.context().external_callbacks().format_embedded("html", joined)
     else {
         return false;
     };

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -40,7 +40,7 @@ pub(super) fn try_embed_markdown<'a>(
     let Some(Ok(crate::external_formatter::EmbeddedDocResult::SingleDoc(ir))) = f
         .context()
         .external_callbacks()
-        .format_embedded_doc(allocator, group_id_builder, "tagged-markdown", &[text])
+        .format_embedded_doc(allocator, group_id_builder, "markdown", &[text])
     else {
         return false;
     };

--- a/crates/oxc_formatter/src/print/template/embed/mod.rs
+++ b/crates/oxc_formatter/src/print/template/embed/mod.rs
@@ -21,7 +21,7 @@ pub(super) fn try_format_embedded_template<'a>(
     match get_tag_name(&tagged.tag) {
         Some("css" | "styled") => css::format_css_doc(tagged.quasi(), f),
         Some("gql" | "graphql") => graphql::format_graphql_doc(tagged.quasi(), f),
-        Some("html") => html::format_html_doc(tagged.quasi(), f, "tagged-html"),
+        Some("html") => html::format_html_doc(tagged.quasi(), f, false),
         // Markdown never supports `${}` (Prettier doesn't either)
         Some("md" | "markdown") if tagged.quasi.is_no_substitution_template() => {
             markdown::try_embed_markdown(tagged, f)
@@ -69,31 +69,13 @@ pub(super) fn try_format_comment_embedded<'a>(
     template: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
-    let Some(language) = get_language_comment(template, f) else {
-        return false;
-    };
-    match language {
-        "html" => html::format_html_doc(template, f, "tagged-html"),
-        "graphql" => graphql::format_graphql_doc(template, f),
-        _ => false,
-    }
-}
-
-/// Check if the template literal has a leading block comment that specifies an embedded language.
-///
-/// Returns the language name if found.
-/// The comment must be:
-/// - a block comment
-/// - with exactly one space on either side
-fn get_language_comment<'a>(
-    template: &AstNode<'a, TemplateLiteral<'a>>,
-    f: &Formatter<'_, 'a>,
-) -> Option<&'static str> {
     // By the time `TemplateLiteral::write()` runs, parent nodes have already printed
     // leading comments via the cursor-based system. So `/* HTML */` is the last printed comment.
-    let comment = f.context().comments().printed_comments().last()?;
+    let Some(comment) = f.context().comments().printed_comments().last() else {
+        return false;
+    };
     if !comment.is_block() || comment.span.end > template.span.start {
-        return None;
+        return false;
     }
 
     // Ensure there's nothing but whitespace between the comment and the template literal.
@@ -102,14 +84,14 @@ fn get_language_comment<'a>(
         .source_text()
         .all_bytes_match(comment.span.end, template.span.start, |b| b.is_ascii_whitespace())
     {
-        return None;
+        return false;
     }
 
     let text = f.source_text().text_for(&comment.content_span());
     match text {
-        " HTML " => Some("html"),
-        " GraphQL " => Some("graphql"),
-        _ => None,
+        " HTML " => html::format_html_doc(template, f, false),
+        " GraphQL " => graphql::format_graphql_doc(template, f),
+        _ => false,
     }
 }
 
@@ -160,15 +142,15 @@ pub(super) fn try_format_angular_component<'a>(
     template_literal: &AstNode<'a, TemplateLiteral<'a>>,
     f: &mut Formatter<'_, 'a>,
 ) -> bool {
-    match get_angular_component_language(template_literal) {
-        Some("angular-template") => html::format_html_doc(template_literal, f, "angular-template"),
-        Some("angular-styles") => css::format_css_doc(template_literal, f),
+    match get_angular_component_property(template_literal) {
+        Some("template") => html::format_html_doc(template_literal, f, true),
+        Some("styles") => css::format_css_doc(template_literal, f),
         _ => false,
     }
 }
 
 /// Detect Angular `@Component({ template: \`...\`, styles: \`...\` })`.
-fn get_angular_component_language(node: &AstNode<'_, TemplateLiteral<'_>>) -> Option<&'static str> {
+fn get_angular_component_property<'a>(node: &AstNode<'a, TemplateLiteral<'a>>) -> Option<&'a str> {
     let prop = match node.parent() {
         AstNodes::ObjectProperty(prop) => prop,
         AstNodes::ArrayExpression(arr) => {
@@ -204,8 +186,7 @@ fn get_angular_component_language(node: &AstNode<'_, TemplateLiteral<'_>>) -> Op
     }
 
     match key.name.as_str() {
-        "template" => Some("angular-template"),
-        "styles" => Some("angular-styles"),
+        "template" | "styles" => Some(key.name.as_str()),
         _ => None,
     }
 }


### PR DESCRIPTION
JSDoc formatting also uses the same logic as xxx-in-js.

So, adjustments have been made to accommodate this.
