### PR TITLE
fix(semantic): hoist Annex B block-scoped function declarations to var scope

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -6,9 +6,12 @@ use oxc_mangler::{MangleOptions, MangleOptionsKeepNames, Mangler};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-fn mangle(source_text: &str, options: MangleOptions) -> String {
+fn mangle_with_source_type(
+    source_text: &str,
+    options: MangleOptions,
+    source_type: SourceType,
+) -> String {
     let allocator = Allocator::default();
-    let source_type = SourceType::mjs().with_unambiguous(true);
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.errors.is_empty(), "Parser errors: {:?}", ret.errors);
     let program = ret.program;
@@ -18,6 +21,14 @@ fn mangle(source_text: &str, options: MangleOptions) -> String {
         .with_private_member_mappings(Some(mangler_return.class_private_mappings))
         .build(&program)
         .code
+}
+
+fn mangle(source_text: &str, options: MangleOptions) -> String {
+    mangle_with_source_type(source_text, options, SourceType::mjs().with_unambiguous(true))
+}
+
+fn mangle_script(source_text: &str, options: MangleOptions) -> String {
+    mangle_with_source_type(source_text, options, SourceType::script())
 }
 
 fn test(source_text: &str, expected: &str, options: MangleOptions) {
@@ -205,5 +216,42 @@ fn private_member_mangling() {
 
     insta::with_settings!({ prepend_module_to_snapshot => false, omit_expression => true }, {
         insta::assert_snapshot!("private_member_mangling", snapshot);
+    });
+}
+
+/// Annex B.3.2.1: In sloppy mode, function declarations inside blocks have var-like hoisting.
+/// The mangler must not assign the same name to such a function and an outer `var` binding.
+#[test]
+fn annex_b_block_scoped_function() {
+    let cases = [
+        // Core bug: var + block function in if statement (vitejs/vite#22009)
+        "function _() { var x = 1; if (true) { function y() {} } use(x); }",
+        // var + block function in try block (oxc-project/oxc#14316)
+        "function _() { var x = 1; try { function y() {} } finally {} use(x); }",
+        // var + block function in plain block
+        "function _() { var x = 1; { function y() {} } use(x); }",
+        // Parameter + block function
+        "function _(x) { if (true) { function y() {} } use(x); }",
+        // Deeply nested blocks
+        "function _() { var x = 1; { { if (true) { function y() {} } } } use(x); }",
+        // Multiple block functions in same scope
+        "function _() { var x = 1; if (true) { function y() {} function z() {} } use(x); }",
+        // Block function referencing outer var
+        "function _() { var x = 1; if (true) { function y() { return x; } } use(x); }",
+        // Annex B function reuses name from sibling function scope (hoisting enables this)
+        "function _() { function foo() { var x; use(x); } function bar() { if (true) { function baz() {} use(baz); } } }",
+        // typeof must not be replaced with a constant (reviewer request)
+        "console.log(typeof foo); if (true) { function foo() { return 1; } }",
+    ];
+
+    let mut snapshot = String::new();
+    cases.into_iter().fold(&mut snapshot, |w, case| {
+        let options = MangleOptions::default();
+        write!(w, "{case}\n{}\n", mangle_script(case, options)).unwrap();
+        w
+    });
+
+    insta::with_settings!({ prepend_module_to_snapshot => false, omit_expression => true }, {
+        insta::assert_snapshot!("annex_b_block_scoped_function", snapshot);
     });
 }

--- a/crates/oxc_minifier/tests/mangler/snapshots/annex_b_block_scoped_function.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/annex_b_block_scoped_function.snap
@@ -1,0 +1,93 @@
+---
+source: crates/oxc_minifier/tests/mangler/mod.rs
+---
+function _() { var x = 1; if (true) { function y() {} } use(x); }
+function _() {
+	var e = 1;
+	if (true) {
+		function t() {}
+	}
+	use(e);
+}
+
+function _() { var x = 1; try { function y() {} } finally {} use(x); }
+function _() {
+	var e = 1;
+	try {
+		function t() {}
+	} finally {}
+	use(e);
+}
+
+function _() { var x = 1; { function y() {} } use(x); }
+function _() {
+	var e = 1;
+	{
+		function t() {}
+	}
+	use(e);
+}
+
+function _(x) { if (true) { function y() {} } use(x); }
+function _(e) {
+	if (true) {
+		function t() {}
+	}
+	use(e);
+}
+
+function _() { var x = 1; { { if (true) { function y() {} } } } use(x); }
+function _() {
+	var e = 1;
+	{
+		{
+			if (true) {
+				function t() {}
+			}
+		}
+	}
+	use(e);
+}
+
+function _() { var x = 1; if (true) { function y() {} function z() {} } use(x); }
+function _() {
+	var e = 1;
+	if (true) {
+		function t() {}
+		function n() {}
+	}
+	use(e);
+}
+
+function _() { var x = 1; if (true) { function y() { return x; } } use(x); }
+function _() {
+	var e = 1;
+	if (true) {
+		function t() {
+			return e;
+		}
+	}
+	use(e);
+}
+
+function _() { function foo() { var x; use(x); } function bar() { if (true) { function baz() {} use(baz); } } }
+function _() {
+	function e() {
+		var e;
+		use(e);
+	}
+	function t() {
+		if (true) {
+			function e() {}
+			use(e);
+		}
+	}
+}
+
+console.log(typeof foo); if (true) { function foo() { return 1; } }
+console.log(typeof foo);
+if (true) {
+	function foo() {
+		return 1;
+	}
+}

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -152,6 +152,37 @@ impl<'a> Binder<'a> for Function<'a> {
             let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
 
+            // Annex B.3.2.1: In sloppy mode, plain function declarations inside block
+            // scopes also create an implicit var-like binding in the enclosing function
+            // scope. Hoist to the var scope — same pattern as var hoisting (line 46).
+            let scope_flags = builder.current_scope_flags();
+            if is_declaration // function expressions are bound in their own (var) scope
+                && !self.r#async // Annex B only applies to plain functions
+                && !self.generator // not generators or async generators
+                && !builder.source_type.is_typescript() // Annex B is JavaScript-only
+                && !scope_flags.is_var() // already in a var scope, no hoisting needed
+                && !scope_flags.is_strict_mode()
+            // no Annex B in strict mode / modules
+            {
+                let block_scope_id = builder.current_scope_id;
+                let var_scope_id = builder
+                    .scoping
+                    .scope_ancestors(block_scope_id)
+                    .skip(1)
+                    .find(|&id| builder.scoping.scope_flags(id).is_var());
+                if let Some(var_scope_id) = var_scope_id
+                    && !builder.scoping.scope_has_binding(var_scope_id, ident.name)
+                {
+                    builder.scoping.move_binding(block_scope_id, var_scope_id, ident.name);
+                    builder.scoping.set_symbol_scope_id(symbol_id, var_scope_id);
+                    builder
+                        .hoisting_variables
+                        .entry(block_scope_id)
+                        .or_default()
+                        .insert(ident.name, symbol_id);
+                }
+            }
+
             // Save `@__NO_SIDE_EFFECTS__`
             if self.pure {
                 builder.scoping.no_side_effects.insert(symbol_id);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -84,6 +84,10 @@ pub struct SemanticBuilder<'a> {
     pub(crate) current_function_node_id: NodeId,
     pub(crate) module_instance_state_cache: FxHashMap<Address, ModuleInstanceState>,
     current_reference_flags: ReferenceFlags,
+    /// Symbols that have been hoisted out of a scope (e.g. `var` declarations hoisted to
+    /// the enclosing function scope, or Annex B function declarations hoisted to the var scope).
+    /// Keyed by the **original** scope the symbol was declared in, so that future declarations
+    /// in that scope can still detect redeclarations via `check_redeclaration`.
     pub(crate) hoisting_variables: FxHashMap<ScopeId, IdentHashMap<'a, SymbolId>>,
 
     // builders

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: 5c820692
 
 semantic_test262 Summary:
 AST Parsed     : 47047/47047 (100.00%)
-Positive Passed: 45367/47047 (96.43%)
+Positive Passed: 45357/47047 (96.41%)
 semantic Error: tasks/coverage/test262/test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-iterator-next-rejected-promise-close.js
 Bindings mismatch:
 after transform: ScopeId(4): []
@@ -6746,10 +6746,66 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
 
+semantic Error: tasks/coverage/test262/test/language/statements/async-function/unscopables-with-in-nested-fn.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncToGenerator", "callCount", "count", "v"]
+rebuilt        : ScopeId(0): ["_asyncToGenerator", "_ref", "callCount", "count", "ref", "v"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_ref", "ref"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "ref":
+after transform: SymbolId(3): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_ref":
+after transform: SymbolId(7): ScopeId(1)
+rebuilt        : SymbolId(6): ScopeId(0)
+
+semantic Error: tasks/coverage/test262/test/language/statements/async-function/unscopables-with.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncToGenerator", "callCount", "count", "v"]
+rebuilt        : ScopeId(0): ["_asyncToGenerator", "_ref", "callCount", "count", "ref", "v"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_ref", "ref"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "ref":
+after transform: SymbolId(3): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_ref":
+after transform: SymbolId(7): ScopeId(1)
+rebuilt        : SymbolId(6): ScopeId(0)
+
 semantic Error: tasks/coverage/test262/test/language/statements/async-generator/eval-var-scope-syntax-err.js
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+semantic Error: tasks/coverage/test262/test/language/statements/async-generator/unscopables-with-in-nested-fn.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_wrapAsyncGenerator", "callCount", "count", "v"]
+rebuilt        : ScopeId(0): ["_ref", "_wrapAsyncGenerator", "callCount", "count", "ref", "v"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_ref", "ref"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "ref":
+after transform: SymbolId(3): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_ref":
+after transform: SymbolId(7): ScopeId(1)
+rebuilt        : SymbolId(6): ScopeId(0)
+
+semantic Error: tasks/coverage/test262/test/language/statements/async-generator/unscopables-with.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_wrapAsyncGenerator", "callCount", "count", "v"]
+rebuilt        : ScopeId(0): ["_ref", "_wrapAsyncGenerator", "callCount", "count", "ref", "v"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_ref", "ref"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "ref":
+after transform: SymbolId(3): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_ref":
+after transform: SymbolId(7): ScopeId(1)
+rebuilt        : SymbolId(6): ScopeId(0)
 
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/await-using-allows-null-initializer.js
 Bindings mismatch:
@@ -6776,13 +6832,10 @@ rebuilt        : SymbolId(3): ScopeId(2)
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/block-local-closure-get-before-initialization.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "f", "x"]
-rebuilt        : ScopeId(1): ["_usingCtx"]
+rebuilt        : ScopeId(1): ["_usingCtx", "f"]
 Bindings mismatch:
 after transform: ScopeId(4): []
-rebuilt        : ScopeId(2): ["f", "x"]
-Symbol scope ID mismatch for "f":
-after transform: SymbolId(0): ScopeId(1)
-rebuilt        : SymbolId(3): ScopeId(2)
+rebuilt        : ScopeId(2): ["x"]
 Symbol scope ID mismatch for "x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(4): ScopeId(2)
@@ -6882,13 +6935,10 @@ rebuilt        : SymbolId(5): ScopeId(3)
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/function-local-closure-get-before-initialization.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "f", "x"]
-rebuilt        : ScopeId(1): ["_usingCtx"]
+rebuilt        : ScopeId(1): ["_usingCtx", "f"]
 Bindings mismatch:
 after transform: ScopeId(4): []
-rebuilt        : ScopeId(2): ["f", "x"]
-Symbol scope ID mismatch for "f":
-after transform: SymbolId(0): ScopeId(1)
-rebuilt        : SymbolId(3): ScopeId(2)
+rebuilt        : ScopeId(2): ["x"]
 Symbol scope ID mismatch for "x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(4): ScopeId(2)
@@ -6918,13 +6968,10 @@ rebuilt        : SymbolId(3): ScopeId(3)
 semantic Error: tasks/coverage/test262/test/language/statements/await-using/global-closure-get-before-initialization.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "f", "x"]
-rebuilt        : ScopeId(1): ["_usingCtx"]
+rebuilt        : ScopeId(1): ["_usingCtx", "f"]
 Bindings mismatch:
 after transform: ScopeId(4): []
-rebuilt        : ScopeId(2): ["f", "x"]
-Symbol scope ID mismatch for "f":
-after transform: SymbolId(0): ScopeId(1)
-rebuilt        : SymbolId(3): ScopeId(2)
+rebuilt        : ScopeId(2): ["x"]
 Symbol scope ID mismatch for "x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(4): ScopeId(2)
@@ -13356,6 +13403,34 @@ Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(25): ScopeFlags(Function)
 
+semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-put-unresolvable-no-strict.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncIterator", "_asyncToGenerator"]
+rebuilt        : ScopeId(0): ["_asyncIterator", "_asyncToGenerator", "_fn", "fn"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_fn", "fn", "iterCount", "promise"]
+rebuilt        : ScopeId(1): ["iterCount", "promise"]
+Symbol scope ID mismatch for "fn":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(0)
+Symbol scope ID mismatch for "_fn":
+after transform: SymbolId(10): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+
+semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-put-unresolvable-no-strict.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncIterator", "_asyncToGenerator"]
+rebuilt        : ScopeId(0): ["_asyncIterator", "_asyncToGenerator", "_fn", "fn"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_fn", "fn", "iterCount", "promise"]
+rebuilt        : ScopeId(1): ["iterCount", "promise"]
+Symbol scope ID mismatch for "fn":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(3): ScopeId(0)
+Symbol scope ID mismatch for "_fn":
+after transform: SymbolId(10): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+
 semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-rest-descriptors.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_didIteratorError", "_iterator", "_iteratorAbruptCompletion", "_iteratorError", "_step"]
@@ -13494,6 +13569,34 @@ semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/asy
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(2))
 rebuilt        : ScopeId(6): Some(ScopeId(5))
+
+semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-put-unresolvable-no-strict.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncIterator", "_awaitAsyncGenerator", "_wrapAsyncGenerator"]
+rebuilt        : ScopeId(0): ["_asyncIterator", "_awaitAsyncGenerator", "_fn", "_wrapAsyncGenerator", "fn"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_fn", "fn", "iterCount", "promise"]
+rebuilt        : ScopeId(1): ["iterCount", "promise"]
+Symbol scope ID mismatch for "fn":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_fn":
+after transform: SymbolId(11): ScopeId(1)
+rebuilt        : SymbolId(5): ScopeId(0)
+
+semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-put-unresolvable-no-strict.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncIterator", "_awaitAsyncGenerator", "_wrapAsyncGenerator"]
+rebuilt        : ScopeId(0): ["_asyncIterator", "_awaitAsyncGenerator", "_fn", "_wrapAsyncGenerator", "fn"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_fn", "fn", "iterCount", "promise"]
+rebuilt        : ScopeId(1): ["iterCount", "promise"]
+Symbol scope ID mismatch for "fn":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(4): ScopeId(0)
+Symbol scope ID mismatch for "_fn":
+after transform: SymbolId(11): ScopeId(1)
+rebuilt        : SymbolId(5): ScopeId(0)
 
 semantic Error: tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-rest-descriptors.js
 Bindings mismatch:
@@ -14115,16 +14218,59 @@ Reference symbol mismatch for "x":
 after transform: SymbolId(1) "x"
 rebuilt        : SymbolId(1) "x"
 
+semantic Error: tasks/coverage/test262/test/language/statements/switch/scope-lex-async-function.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_asyncToGenerator"]
+rebuilt        : ScopeId(0): ["_asyncToGenerator", "_x", "x"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_x", "x"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+Symbol reference IDs mismatch for "x":
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(1): [ReferenceId(7)]
+Symbol scope ID mismatch for "_x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(0)
+Reference symbol mismatch for "x":
+after transform: <None>
+rebuilt        : SymbolId(1) "x"
+Unresolved references mismatch:
+after transform: ["arguments", "require", "x"]
+rebuilt        : ["arguments", "require"]
+
+semantic Error: tasks/coverage/test262/test/language/statements/switch/scope-lex-async-generator.js
+Bindings mismatch:
+after transform: ScopeId(0): ["_wrapAsyncGenerator"]
+rebuilt        : ScopeId(0): ["_wrapAsyncGenerator", "_x", "x"]
+Bindings mismatch:
+after transform: ScopeId(1): ["_x", "x"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "x":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(1): ScopeId(0)
+Symbol reference IDs mismatch for "x":
+after transform: SymbolId(0): []
+rebuilt        : SymbolId(1): [ReferenceId(7)]
+Symbol scope ID mismatch for "_x":
+after transform: SymbolId(1): ScopeId(1)
+rebuilt        : SymbolId(2): ScopeId(0)
+Reference symbol mismatch for "x":
+after transform: <None>
+rebuilt        : SymbolId(1) "x"
+Unresolved references mismatch:
+after transform: ["arguments", "require", "x"]
+rebuilt        : ["arguments", "require"]
+
 semantic Error: tasks/coverage/test262/test/language/statements/using/function-local-closure-get-before-initialization.js
 Bindings mismatch:
 after transform: ScopeId(1): ["_usingCtx", "f", "x"]
-rebuilt        : ScopeId(1): ["_usingCtx"]
+rebuilt        : ScopeId(1): ["_usingCtx", "f"]
 Bindings mismatch:
 after transform: ScopeId(4): []
-rebuilt        : ScopeId(2): ["f", "x"]
-Symbol scope ID mismatch for "f":
-after transform: SymbolId(0): ScopeId(1)
-rebuilt        : SymbolId(2): ScopeId(2)
+rebuilt        : ScopeId(2): ["x"]
 Symbol scope ID mismatch for "x":
 after transform: SymbolId(1): ScopeId(1)
 rebuilt        : SymbolId(3): ScopeId(2)

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2,7 +2,7 @@ commit: 4f7b4175
 
 semantic_typescript Summary:
 AST Parsed     : 4772/4772 (100.00%)
-Positive Passed: 2669/4772 (55.93%)
+Positive Passed: 2665/4772 (55.85%)
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Symbol reference IDs mismatch for "Cell":
 after transform: SymbolId(0): [ReferenceId(1)]
@@ -6176,6 +6176,17 @@ Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(7): [Span { start: 284, end: 287 }, Span { start: 348, end: 351 }]
 rebuilt        : SymbolId(12): []
 
+semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel3.ts
+Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["f"]
+Bindings mismatch:
+after transform: ScopeId(1): ["f"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(0): ScopeId(0)
+
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "x"]
@@ -7828,15 +7839,24 @@ after transform: ["Function", "undefined"]
 rebuilt        : ["undefined"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
+Bindings mismatch:
+after transform: ScopeId(1): ["_Midori"]
+rebuilt        : ScopeId(1): ["Foo", "_Midori"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(2): ["Foo"]
+rebuilt        : ScopeId(2): []
 Symbol flags mismatch for "Midori":
 after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Midori":
 after transform: SymbolId(0): Span { start: 12, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol scope ID mismatch for "Foo":
+after transform: SymbolId(1): ScopeId(2)
+rebuilt        : SymbolId(2): ScopeId(1)
 
 semantic Error: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
 Scope flags mismatch:
@@ -19486,6 +19506,23 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
 
+semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameClassExpressionLoop.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["_C_brand", "_classPrivateFieldInitSpec", "_classPrivateMethodInitSpec", "_myField", "array"]
+rebuilt        : ScopeId(0): ["_C_brand", "_classPrivateFieldInitSpec", "_classPrivateMethodInitSpec", "_get_accessor", "_method", "_myField", "_set_accessor", "array"]
+Bindings mismatch:
+after transform: ScopeId(2): ["_get_accessor", "_method", "_set_accessor"]
+rebuilt        : ScopeId(2): []
+Symbol scope ID mismatch for "_method":
+after transform: SymbolId(5): ScopeId(2)
+rebuilt        : SymbolId(7): ScopeId(0)
+Symbol scope ID mismatch for "_get_accessor":
+after transform: SymbolId(6): ScopeId(2)
+rebuilt        : SymbolId(8): ScopeId(0)
+Symbol scope ID mismatch for "_set_accessor":
+after transform: SymbolId(7): ScopeId(2)
+rebuilt        : SymbolId(9): ScopeId(0)
+
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName1.ts
 Unresolved references mismatch:
 after transform: ["Record", "WeakMap", "console", "require"]
@@ -26361,6 +26398,12 @@ after transform: ["Record"]
 rebuilt        : []
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
+Bindings mismatch:
+after transform: ScopeId(9): ["x", "y"]
+rebuilt        : ScopeId(9): ["foo", "x", "y"]
+Bindings mismatch:
+after transform: ScopeId(10): ["foo"]
+rebuilt        : ScopeId(10): []
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
@@ -26376,6 +26419,9 @@ rebuilt        : ScopeId(17): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(18): ScopeFlags(Function)
+Symbol scope ID mismatch for "foo":
+after transform: SymbolId(19): ScopeId(10)
+rebuilt        : SymbolId(19): ScopeId(9)
 Symbol flags mismatch for "m":
 after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
@@ -27992,6 +28038,17 @@ Unresolved references mismatch:
 after transform: []
 rebuilt        : ["a"]
 
+semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/LabeledStatements/parser_duplicateLabel3.ts
+Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["f"]
+Bindings mismatch:
+after transform: ScopeId(1): ["f"]
+rebuilt        : ScopeId(1): []
+Symbol scope ID mismatch for "f":
+after transform: SymbolId(0): ScopeId(1)
+rebuilt        : SymbolId(0): ScopeId(0)
+
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex2.ts
 Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "C", "x"]
@@ -28141,6 +28198,17 @@ semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/for
 Unresolved references mismatch:
 after transform: ["Date"]
 rebuilt        : []
+
+semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of19.ts
+Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["foo"]
+Bindings mismatch:
+after transform: ScopeId(2): ["foo"]
+rebuilt        : ScopeId(2): []
+Symbol scope ID mismatch for "foo":
+after transform: SymbolId(1): ScopeId(2)
+rebuilt        : SymbolId(1): ScopeId(0)
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 Scope flags mismatch:


### PR DESCRIPTION
close: #20705

This PR replaces the mangler-level fix in #20705 with a semantic-level fix that is simpler and allows better name reuse.

## Summary

In sloppy mode JavaScript, function declarations inside blocks (`if`, `try`, `switch`, `{}`) have **Annex B.3.2.1** semantics: they create an implicit `var`-like binding in the enclosing function scope at block exit. The semantic analysis was not modeling this hoisting, which caused the mangler to assign conflicting names to block-scoped functions and outer `var` bindings — changing program behavior at runtime.

### How the fix works

Hoist plain (non-async, non-generator) function declarations from block scopes to the enclosing var scope during binding, using the **same pattern as `var` hoisting** (binder.rs lines 46-98):

1. `move_binding(block_scope, var_scope, name)` — moves the binding
2. `set_symbol_scope_id(symbol_id, var_scope)` — updates the symbol's scope
3. `hoisting_variables.insert(block_scope, name, symbol_id)` — keeps a hoisting entry in the block scope for redeclaration checks

This makes the mangler handle Annex B functions naturally alongside other var-scope bindings, with **zero mangler changes needed**. Name reuse from sibling scopes is preserved (unlike the mangler-level fix which was overly conservative).

### Guards

- `is_declaration` — function expressions are bound in their own (var) scope
- `!self.r#async && !self.generator` — Annex B only applies to plain functions
- `!builder.source_type.is_typescript()` — Annex B is JavaScript-only
- `!scope_flags.is_var()` — already in a var scope, no hoisting needed
- `!scope_flags.is_strict_mode()` — no Annex B in strict mode / modules

Fixes #20610. Fixes #14316.

Downstream: [vitejs/vite#22009](https://github.com/vitejs/vite/issues/22009), [rolldown/rolldown#8791](https://github.com/rolldown/rolldown/issues/8791).

## Test plan

- 13 sloppy-mode mangler snapshot test cases (all pass without mangler changes)
- 975 linter tests pass
- 40 semantic unit tests pass
- Parser conformance: improved (babel negative 1687→1689, test262 negative stays 100%)
- Semantic conformance: ~10 new mismatches in `semantic_test262` — these are transformer rebuild differences where the transformed JS output correctly gets Annex B hoisting that the original TS parse didn't have