### PR TITLE
refactor(parser): rename `ModifierFlags` to `ModifierKinds`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -4,14 +4,14 @@ use oxc_ast::ast::REGEXP_FLAGS_LIST;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
-use crate::modifiers::{Modifier, ModifierFlags, ModifierKind};
+use crate::modifiers::{Modifier, ModifierKind, ModifierKinds};
 
 trait DiagnosticExt {
-    fn with_allowed_modifier_help(self, allowed: Option<ModifierFlags>) -> Self;
+    fn with_allowed_modifier_help(self, allowed: Option<ModifierKinds>) -> Self;
 }
 
 impl DiagnosticExt for OxcDiagnostic {
-    fn with_allowed_modifier_help(self, allowed: Option<ModifierFlags>) -> Self {
+    fn with_allowed_modifier_help(self, allowed: Option<ModifierKinds>) -> Self {
         if let Some(allowed) = allowed {
             match allowed.count() {
                 0 => self.with_help("No modifiers are allowed here."),
@@ -846,7 +846,7 @@ pub fn import_requires_a_specifier(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn modifier_cannot_be_used_here(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("'{}' modifier cannot be used here.", modifier.kind))
         .with_label(modifier.span)
@@ -856,7 +856,7 @@ pub fn modifier_cannot_be_used_here(
 #[cold]
 pub fn modifier_only_on_property_declaration_or_index_signature(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error(
         "1024",
@@ -897,7 +897,7 @@ pub fn modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
 
 pub fn cannot_appear_on_class_elements(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error(
         "1031",
@@ -909,7 +909,7 @@ pub fn cannot_appear_on_class_elements(
 
 pub fn cannot_appear_on_a_type_member(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1070", format!("'{}' modifier cannot appear on a type member.", modifier.kind))
         .with_label(modifier.span)
@@ -919,7 +919,7 @@ pub fn cannot_appear_on_a_type_member(
 #[cold]
 pub fn cannot_appear_on_a_type_parameter(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1273", format!("'{}' modifier cannot be used on a type parameter.", modifier.kind))
         .with_label(modifier.span)
@@ -942,7 +942,7 @@ pub fn can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
 
 pub fn cannot_appear_on_a_parameter(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1090", format!("'{}' modifier cannot appear on a parameter.", modifier.kind))
         .with_label(modifier.span)
@@ -957,14 +957,14 @@ pub fn parameter_property_cannot_be_binding_pattern(span: Span) -> OxcDiagnostic
 
 pub fn cannot_appear_on_an_index_signature(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1071", format!("'{}' modifier cannot appear on an index signature.", modifier.kind))
         .with_label(modifier.span)
         .with_allowed_modifier_help(allowed)
 }
 
-pub fn accessor_modifier(modifier: &Modifier, allowed: Option<ModifierFlags>) -> OxcDiagnostic {
+pub fn accessor_modifier(modifier: &Modifier, allowed: Option<ModifierKinds>) -> OxcDiagnostic {
     ts_error(
         "1243",
         format!("'accessor' modifier cannot be used with '{}' modifier.", modifier.kind),
@@ -982,7 +982,7 @@ pub fn readonly_in_array_or_tuple_type(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn accessibility_modifier_on_private_property(
     modifier: &Modifier,
-    _allowed: Option<ModifierFlags>,
+    _allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("18010", "An accessibility modifier cannot be used with a private identifier.")
         .with_label(modifier.span)
@@ -1128,7 +1128,7 @@ pub fn rest_after_tuple_member_name(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn parameter_modifiers_in_ts(
     modifier: &Modifier,
-    allowed: Option<ModifierFlags>,
+    allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("8012", "Parameter modifiers can only be used in TypeScript files.")
         .with_label(modifier.span)
@@ -1241,7 +1241,7 @@ pub fn invalid_rest_assignment_target(span: Span) -> OxcDiagnostic {
 #[cold]
 pub fn modifiers_cannot_appear_here(
     modifier: &Modifier,
-    _: Option<ModifierFlags>,
+    _: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1184", "Modifiers cannot appear here.").with_label(modifier.span)
 }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{
     Context, ParserConfig as Config, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
-    modifiers::{ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
 use super::FunctionKind;
@@ -97,7 +97,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare, ModifierKind::Abstract]),
+            ModifierKinds::new([ModifierKind::Declare, ModifierKind::Abstract]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -238,7 +238,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             self.verify_modifiers(
                 &modifiers,
-                ModifierFlags::empty(),
+                ModifierKinds::empty(),
                 false,
                 diagnostics::modifiers_cannot_appear_here,
             );
@@ -247,7 +247,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             &modifiers,
-            ModifierFlags::all_except([ModifierKind::Export]),
+            ModifierKinds::all_except([ModifierKind::Export]),
             false,
             diagnostics::cannot_appear_on_class_elements,
         );
@@ -295,7 +295,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // No modifiers except `static` and `readonly` are valid here
             self.verify_modifiers(
                 &modifiers,
-                ModifierFlags::new([ModifierKind::Readonly, ModifierKind::Static]),
+                ModifierKinds::new([ModifierKind::Readonly, ModifierKind::Static]),
                 true,
                 diagnostics::cannot_appear_on_an_index_signature,
             );
@@ -323,7 +323,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_class_element_name(&mut self, modifiers: &Modifiers<'a>) -> (PropertyKey<'a>, bool) {
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::all_except([ModifierKind::Const, ModifierKind::In, ModifierKind::Out]),
+            ModifierKinds::all_except([ModifierKind::Const, ModifierKind::In, ModifierKind::Out]),
             false,
             |modifier, _| {
                 match modifier.kind {
@@ -343,7 +343,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 if self.is_ts {
                     self.verify_modifiers(
                         modifiers,
-                        ModifierFlags::all_except([
+                        ModifierKinds::all_except([
                             ModifierKind::Public,
                             ModifierKind::Private,
                             ModifierKind::Protected,
@@ -390,7 +390,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([
+            ModifierKinds::new([
                 ModifierKind::Public,
                 ModifierKind::Private,
                 ModifierKind::Protected,
@@ -447,7 +447,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.check_method_definition_accessor(&method_definition);
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::all_except([ModifierKind::Async, ModifierKind::Declare]),
+            ModifierKinds::all_except([ModifierKind::Async, ModifierKind::Declare]),
             false,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -527,10 +527,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if generator || matches!(self.cur_kind(), Kind::LParen | Kind::LAngle) {
             self.verify_modifiers(
                 modifiers,
-                ModifierFlags::all_except([ModifierKind::Declare, ModifierKind::Readonly]),
+                ModifierKinds::all_except([ModifierKind::Declare, ModifierKind::Readonly]),
                 false,
                 |modifier, _| {
-                    const ALLOWED: ModifierFlags = ModifierFlags::new([
+                    const ALLOWED: ModifierKinds = ModifierKinds::new([
                         ModifierKind::Public,
                         ModifierKind::Private,
                         ModifierKind::Protected,

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -6,7 +6,7 @@ use super::FunctionKind;
 use crate::{
     Context, ParserConfig as Config, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
-    modifiers::{ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
 impl FunctionKind {
@@ -158,7 +158,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let modifiers = self.parse_modifiers(false, false);
         if self.is_ts {
             let allowed_modifiers = if func_kind == FunctionKind::Constructor {
-                ModifierFlags::new([
+                ModifierKinds::new([
                     ModifierKind::Public,
                     ModifierKind::Private,
                     ModifierKind::Protected,
@@ -166,7 +166,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     ModifierKind::Readonly,
                 ])
             } else {
-                ModifierFlags::empty()
+                ModifierKinds::empty()
             };
             self.verify_modifiers(
                 &modifiers,
@@ -177,7 +177,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             self.verify_modifiers(
                 &modifiers,
-                ModifierFlags::empty(),
+                ModifierKinds::empty(),
                 true,
                 diagnostics::parameter_modifiers_in_ts,
             );
@@ -293,7 +293,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare, ModifierKind::Async]),
+            ModifierKinds::new([ModifierKind::Declare, ModifierKind::Async]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -7,7 +7,7 @@ use super::FunctionKind;
 use crate::{
     ParserConfig as Config, ParserImpl, diagnostics,
     lexer::Kind,
-    modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{Modifier, ModifierKind, ModifierKinds, Modifiers},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -716,7 +716,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         .vec1(Modifier::new(self.end_span(modifier_span), ModifierKind::Abstract));
                     let modifiers = Modifiers::new(
                         Some(modifiers),
-                        ModifierFlags::new([ModifierKind::Abstract]),
+                        ModifierKinds::new([ModifierKind::Abstract]),
                     );
                     return ExportDefaultDeclarationKind::ClassDeclaration(
                         self.parse_class_declaration(decl_span, &modifiers, decorators),

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -5,7 +5,7 @@ use oxc_syntax::operator::AssignmentOperator;
 use crate::{
     Context, ParserConfig as Config, ParserImpl, diagnostics,
     lexer::Kind,
-    modifiers::{ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
 use super::FunctionKind;
@@ -67,7 +67,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if asterisk_token || matches!(self.cur_kind(), Kind::LParen | Kind::LAngle) {
             self.verify_modifiers(
                 &modifiers,
-                ModifierFlags::new([ModifierKind::Async]),
+                ModifierKinds::new([ModifierKind::Async]),
                 true,
                 diagnostics::modifier_cannot_be_used_here,
             );
@@ -89,7 +89,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             &modifiers,
-            ModifierFlags::empty(),
+            ModifierKinds::empty(),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -219,7 +219,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::empty(),
+            ModifierKinds::empty(),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -6,7 +6,7 @@ use super::{VariableDeclarationParent, grammar::CoverGrammar};
 use crate::{
     Context, ParserConfig as Config, ParserImpl, StatementContext, diagnostics,
     lexer::Kind,
-    modifiers::{Modifier, ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{Modifier, ModifierKind, ModifierKinds, Modifiers},
 };
 
 impl<'a, C: Config> ParserImpl<'a, C> {
@@ -796,7 +796,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.is_ts && self.at(Kind::Enum) {
             let modifiers = self.ast.vec1(Modifier::new(self.end_span(span), ModifierKind::Const));
             let modifiers =
-                Modifiers::new(Some(modifiers), ModifierFlags::new([ModifierKind::Const]));
+                Modifiers::new(Some(modifiers), ModifierKinds::new([ModifierKind::Const]));
             Statement::from(self.parse_ts_enum_declaration(span, &modifiers))
         } else {
             self.parse_variable_statement(span, VariableDeclarationKind::Const, stmt_ctx)

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -14,25 +14,25 @@ use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
 /// A set of modifier kinds, stored as a bitfield.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct ModifierFlags(u16);
+pub struct ModifierKinds(u16);
 
-impl ModifierFlags {
+impl ModifierKinds {
     /// Create a set from an array of modifier kinds.
     #[inline]
     pub const fn new<const N: usize>(kinds: [ModifierKind; N]) -> Self {
-        let mut flags = Self::empty();
+        let mut out = Self::empty();
         let mut i = 0;
         while i < N {
-            flags = flags.with(kinds[i]);
+            out = out.with(kinds[i]);
             i += 1;
         }
-        flags
+        out
     }
 
     /// Create a set containing all modifier kinds EXCEPT the ones listed.
     #[inline]
     pub const fn all_except<const N: usize>(kinds: [ModifierKind; N]) -> Self {
-        const ALL: ModifierFlags = ModifierFlags::new(ModifierKind::VARIANTS);
+        const ALL: ModifierKinds = ModifierKinds::new(ModifierKind::VARIANTS);
         Self(Self::new(kinds).0 ^ ALL.0)
     }
 
@@ -109,7 +109,7 @@ impl ModifierFlags {
     }
 }
 
-impl Display for ModifierFlags {
+impl Display for ModifierKinds {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, kind) in self.iter().enumerate() {
             if i != 0 {
@@ -121,7 +121,7 @@ impl Display for ModifierFlags {
     }
 }
 
-impl Debug for ModifierFlags {
+impl Debug for ModifierKinds {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -159,7 +159,7 @@ pub struct Modifiers<'a> {
     /// Bitflag representation of modifier kinds stored in [`Self::modifiers`].
     /// Pre-computed to save CPU cycles on [`Self::contains`] checks (`O(1)`
     /// bitflag intersection vs `O(n)` linear search).
-    flags: ModifierFlags,
+    kinds: ModifierKinds,
 }
 
 impl Default for Modifiers<'_> {
@@ -172,35 +172,35 @@ impl<'a> Modifiers<'a> {
     /// Create a new set of modifiers
     ///
     /// # Invariants
-    /// `flags` must correctly reflect the [`ModifierKind`]s within
-    ///  `modifiers`. E.g., if `modifiers` is empty, then so is `flags``.
+    /// `kinds` must correctly reflect the [`ModifierKind`]s within
+    ///  `modifiers`. e.g., if `modifiers` is empty, then so is `kinds`.
     #[must_use]
-    pub(crate) fn new(modifiers: Option<Vec<'a, Modifier>>, flags: ModifierFlags) -> Self {
-        // Debug check that `modifiers` and `flags` are consistent with each other
+    pub(crate) fn new(modifiers: Option<Vec<'a, Modifier>>, kinds: ModifierKinds) -> Self {
+        // Debug check that `modifiers` and `kinds` are consistent with each other
         #[cfg(debug_assertions)]
         {
             if let Some(modifiers) = &modifiers {
                 assert!(!modifiers.is_empty());
 
-                let mut found_flags = ModifierFlags::empty();
+                let mut found_kinds = ModifierKinds::empty();
                 for modifier in modifiers {
-                    found_flags = found_flags.with(modifier.kind);
+                    found_kinds = found_kinds.with(modifier.kind);
                 }
-                assert_eq!(found_flags, flags);
+                assert_eq!(found_kinds, kinds);
             } else {
-                assert_eq!(flags, ModifierFlags::empty());
+                assert_eq!(kinds, ModifierKinds::empty());
             }
         }
 
-        Self { modifiers, flags }
+        Self { modifiers, kinds }
     }
 
     pub fn empty() -> Self {
-        Self { modifiers: None, flags: ModifierFlags::empty() }
+        Self { modifiers: None, kinds: ModifierKinds::empty() }
     }
 
     pub fn contains(&self, target: ModifierKind) -> bool {
-        self.flags.contains(target)
+        self.kinds.contains(target)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Modifier> + '_ {
@@ -208,37 +208,37 @@ impl<'a> Modifiers<'a> {
     }
 
     pub fn accessibility(&self) -> Option<TSAccessibility> {
-        self.flags.accessibility()
+        self.kinds.accessibility()
     }
 
     #[inline]
     pub fn contains_async(&self) -> bool {
-        self.flags.contains(ModifierKind::Async)
+        self.kinds.contains(ModifierKind::Async)
     }
 
     #[inline]
     pub fn contains_const(&self) -> bool {
-        self.flags.contains(ModifierKind::Const)
+        self.kinds.contains(ModifierKind::Const)
     }
 
     #[inline]
     pub fn contains_declare(&self) -> bool {
-        self.flags.contains(ModifierKind::Declare)
+        self.kinds.contains(ModifierKind::Declare)
     }
 
     #[inline]
     pub fn contains_abstract(&self) -> bool {
-        self.flags.contains(ModifierKind::Abstract)
+        self.kinds.contains(ModifierKind::Abstract)
     }
 
     #[inline]
     pub fn contains_readonly(&self) -> bool {
-        self.flags.contains(ModifierKind::Readonly)
+        self.kinds.contains(ModifierKind::Readonly)
     }
 
     #[inline]
     pub fn contains_override(&self) -> bool {
-        self.flags.contains(ModifierKind::Override)
+        self.kinds.contains(ModifierKind::Override)
     }
 }
 
@@ -337,18 +337,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.at_modifier() {
             return Modifiers::empty();
         }
-        let mut flags = ModifierFlags::empty();
+        let mut kinds = ModifierKinds::empty();
         let mut modifiers = self.ast.vec();
         while self.at_modifier() {
             let span = self.start_span();
             let kind = self.cur_kind();
             self.bump_any();
             let modifier = self.modifier(kind, self.end_span(span));
-            self.check_modifier(flags, &modifier);
-            flags = flags.with(modifier.kind);
+            self.check_modifier(kinds, &modifier);
+            kinds = kinds.with(modifier.kind);
             modifiers.push(modifier);
         }
-        Modifiers::new(Some(modifiers), flags)
+        Modifiers::new(Some(modifiers), kinds)
     }
 
     fn at_modifier(&mut self) -> bool {
@@ -393,7 +393,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let mut has_seen_static_modifier = false;
 
         let mut modifiers = None;
-        let mut modifier_flags = ModifierFlags::empty();
+        let mut modifier_kinds = ModifierKinds::empty();
 
         while let Some(modifier) = self.try_parse_modifier(
             has_seen_static_modifier,
@@ -403,12 +403,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if modifier.kind == ModifierKind::Static {
                 has_seen_static_modifier = true;
             }
-            self.check_modifier(modifier_flags, &modifier);
-            modifier_flags = modifier_flags.with(modifier.kind);
+            self.check_modifier(modifier_kinds, &modifier);
+            modifier_kinds = modifier_kinds.with(modifier.kind);
             modifiers.get_or_insert_with(|| self.ast.vec()).push(modifier);
         }
 
-        Modifiers::new(modifiers, modifier_flags)
+        Modifiers::new(modifiers, modifier_kinds)
     }
 
     fn try_parse_modifier(
@@ -500,41 +500,41 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         kind == Kind::LBrack || kind == Kind::PrivateIdentifier || kind.is_literal_property_name()
     }
 
-    fn check_modifier(&mut self, flags: ModifierFlags, modifier: &Modifier) {
+    fn check_modifier(&mut self, kinds: ModifierKinds, modifier: &Modifier) {
         match modifier.kind {
             ModifierKind::Public | ModifierKind::Private | ModifierKind::Protected => {
-                if flags.intersects(ModifierFlags::new([
+                if kinds.intersects(ModifierKinds::new([
                     ModifierKind::Public,
                     ModifierKind::Private,
                     ModifierKind::Protected,
                 ])) {
                     self.error(diagnostics::accessibility_modifier_already_seen(modifier));
-                } else if flags.contains(ModifierKind::Override) {
+                } else if kinds.contains(ModifierKind::Override) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Override,
                     ));
-                } else if flags.contains(ModifierKind::Static) {
+                } else if kinds.contains(ModifierKind::Static) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Static,
                     ));
-                } else if flags.contains(ModifierKind::Accessor) {
+                } else if kinds.contains(ModifierKind::Accessor) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Accessor,
                     ));
-                } else if flags.contains(ModifierKind::Readonly) {
+                } else if kinds.contains(ModifierKind::Readonly) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Readonly,
                     ));
-                } else if flags.contains(ModifierKind::Async) {
+                } else if kinds.contains(ModifierKind::Async) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Async,
                     ));
-                } else if flags.contains(ModifierKind::Abstract) {
+                } else if kinds.contains(ModifierKind::Abstract) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Abstract,
@@ -542,24 +542,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             ModifierKind::Static => {
-                if flags.contains(ModifierKind::Static) {
+                if kinds.contains(ModifierKind::Static) {
                     self.error(diagnostics::modifier_already_seen(modifier));
-                } else if flags.contains(ModifierKind::Readonly) {
+                } else if kinds.contains(ModifierKind::Readonly) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Readonly,
                     ));
-                } else if flags.contains(ModifierKind::Async) {
+                } else if kinds.contains(ModifierKind::Async) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Async,
                     ));
-                } else if flags.contains(ModifierKind::Accessor) {
+                } else if kinds.contains(ModifierKind::Accessor) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Accessor,
                     ));
-                } else if flags.contains(ModifierKind::Override) {
+                } else if kinds.contains(ModifierKind::Override) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Override,
@@ -567,19 +567,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             ModifierKind::Override => {
-                if flags.contains(ModifierKind::Override) {
+                if kinds.contains(ModifierKind::Override) {
                     self.error(diagnostics::modifier_already_seen(modifier));
-                } else if flags.contains(ModifierKind::Readonly) {
+                } else if kinds.contains(ModifierKind::Readonly) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Readonly,
                     ));
-                } else if flags.contains(ModifierKind::Accessor) {
+                } else if kinds.contains(ModifierKind::Accessor) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Accessor,
                     ));
-                } else if flags.contains(ModifierKind::Async) {
+                } else if kinds.contains(ModifierKind::Async) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Async,
@@ -587,14 +587,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             ModifierKind::Abstract => {
-                if flags.contains(ModifierKind::Abstract) {
+                if kinds.contains(ModifierKind::Abstract) {
                     self.error(diagnostics::modifier_already_seen(modifier));
-                } else if flags.contains(ModifierKind::Override) {
+                } else if kinds.contains(ModifierKind::Override) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Override,
                     ));
-                } else if flags.contains(ModifierKind::Accessor) {
+                } else if kinds.contains(ModifierKind::Accessor) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Accessor,
@@ -602,19 +602,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             ModifierKind::Export => {
-                if flags.contains(ModifierKind::Export) {
+                if kinds.contains(ModifierKind::Export) {
                     self.error(diagnostics::modifier_already_seen(modifier));
-                } else if flags.contains(ModifierKind::Declare) {
+                } else if kinds.contains(ModifierKind::Declare) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Declare,
                     ));
-                } else if flags.contains(ModifierKind::Abstract) {
+                } else if kinds.contains(ModifierKind::Abstract) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Abstract,
                     ));
-                } else if flags.contains(ModifierKind::Async) {
+                } else if kinds.contains(ModifierKind::Async) {
                     self.error(diagnostics::modifier_must_precede_other_modifier(
                         modifier,
                         ModifierKind::Async,
@@ -622,7 +622,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
             }
             _ => {
-                if flags.contains(modifier.kind) {
+                if kinds.contains(modifier.kind) {
                     self.error(diagnostics::modifier_already_seen(modifier));
                 }
             }
@@ -633,15 +633,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn verify_modifiers<F>(
         &mut self,
         modifiers: &Modifiers<'a>,
-        allowed: ModifierFlags,
+        allowed: ModifierKinds,
         // If `true`, `allowed` is exact match; if `false`, `allowed` is a superset.
         // Used for whether to pass `allowed` to `create_diagnostic` function.
         strict: bool,
         create_diagnostic: F,
     ) where
-        F: Fn(&Modifier, Option<ModifierFlags>) -> OxcDiagnostic,
+        F: Fn(&Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
     {
-        if modifiers.flags.has_any_not_in(allowed) {
+        if modifiers.kinds.has_any_not_in(allowed) {
             // Invalid modifiers are rare, so handle this case in `#[cold]` function.
             // Also `#[inline(never)]` to help `verify_modifiers` to get inlined.
             #[cold]
@@ -649,11 +649,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             fn report<'a, C: Config, F>(
                 parser: &mut ParserImpl<'a, C>,
                 modifiers: &Modifiers<'a>,
-                allowed: ModifierFlags,
+                allowed: ModifierKinds,
                 strict: bool,
                 create_diagnostic: F,
             ) where
-                F: Fn(&Modifier, Option<ModifierFlags>) -> OxcDiagnostic,
+                F: Fn(&Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
             {
                 let mut found_invalid_modifier = false;
                 for modifier in modifiers.iter() {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -6,7 +6,7 @@ use crate::{
     Context, ParserConfig as Config, ParserImpl, diagnostics,
     js::{FunctionKind, VariableDeclarationParent},
     lexer::Kind,
-    modifiers::{ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -29,7 +29,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.end_span(span);
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare, ModifierKind::Const]),
+            ModifierKinds::new([ModifierKind::Declare, ModifierKind::Const]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -163,7 +163,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare]),
+            ModifierKinds::new([ModifierKind::Declare]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -185,7 +185,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let extends = extends.unwrap_or_else(|| self.ast.vec());
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare]),
+            ModifierKinds::new([ModifierKind::Declare]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -239,7 +239,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.is_index_signature() {
             self.verify_modifiers(
                 &modifiers,
-                ModifierFlags::new([ModifierKind::Readonly]),
+                ModifierKinds::new([ModifierKind::Readonly]),
                 true,
                 diagnostics::cannot_appear_on_an_index_signature,
             );
@@ -250,7 +250,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             &modifiers,
-            ModifierFlags::new([ModifierKind::Readonly]),
+            ModifierKinds::new([ModifierKind::Readonly]),
             true,
             diagnostics::cannot_appear_on_a_type_member,
         );
@@ -329,7 +329,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare]),
+            ModifierKinds::new([ModifierKind::Declare]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -369,7 +369,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare]),
+            ModifierKinds::new([ModifierKind::Declare]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -395,7 +395,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.verify_modifiers(
             modifiers,
-            ModifierFlags::new([ModifierKind::Declare]),
+            ModifierKinds::new([ModifierKind::Declare]),
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
@@ -440,7 +440,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.bump_any();
                 self.verify_modifiers(
                     modifiers,
-                    ModifierFlags::new([ModifierKind::Declare]),
+                    ModifierKinds::new([ModifierKind::Declare]),
                     true,
                     diagnostics::modifier_cannot_be_used_here,
                 );

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -6,7 +6,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::{
     Context, ParserConfig as Config, ParserImpl, diagnostics,
     lexer::Kind,
-    modifiers::{ModifierFlags, ModifierKind, Modifiers},
+    modifiers::{ModifierKind, ModifierKinds, Modifiers},
 };
 
 use super::{super::js::FunctionKind, statement::CallOrConstructorSignature};
@@ -204,7 +204,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let modifiers = self.parse_modifiers(true, false);
         self.verify_modifiers(
             &modifiers,
-            ModifierFlags::new([ModifierKind::In, ModifierKind::Out, ModifierKind::Const]),
+            ModifierKinds::new([ModifierKind::In, ModifierKind::Out, ModifierKind::Const]),
             false, // `in` and `out` are only allowed on a type parameter of a class, interface or type alias
             diagnostics::cannot_appear_on_a_type_parameter,
         );
@@ -1427,7 +1427,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if kind == Kind::LParen || kind == Kind::LAngle {
             self.verify_modifiers(
                 modifiers,
-                ModifierFlags::all_except([ModifierKind::Readonly]),
+                ModifierKinds::all_except([ModifierKind::Readonly]),
                 false,
                 diagnostics::modifier_only_on_property_declaration_or_index_signature,
             );


### PR DESCRIPTION
Pure refactor. Rename `ModifierFlags` to `ModifierKinds`. This type represents a collection of `ModifierKind`s, and after #20738 it's no longer implemented as `bitflags!`, so the name is no longer appropriate.

This PR is pure renaming - rename the type, and variables that hold the type.