### PR TITLE
perf(parser): add `Modifiers::get` method

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -462,7 +462,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         modifiers: &Modifiers<'a>,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
-        if let Some(modifier) = modifiers.iter().find(|m| m.kind == ModifierKind::Declare) {
+        if let Some(modifier) = modifiers.get(ModifierKind::Declare) {
             self.error(diagnostics::declare_constructor(modifier.span));
         }
 

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -207,6 +207,17 @@ impl<'a> Modifiers<'a> {
         self.modifiers.as_ref().into_iter().flat_map(|modifiers| modifiers.iter())
     }
 
+    /// Look up a specific modifier by [`ModifierKind`].
+    pub fn get(&self, kind: ModifierKind) -> Option<&Modifier> {
+        if self.kinds.contains(kind) {
+            let modifier = self.iter().find(|m| m.kind == kind);
+            debug_assert!(modifier.is_some());
+            modifier
+        } else {
+            None
+        }
+    }
+
     pub fn accessibility(&self) -> Option<TSAccessibility> {
         self.kinds.accessibility()
     }


### PR DESCRIPTION
Add a `get` method to `Modifiers` that does a fast bitflags check whether the modifier is present before doing slower iteration through the `Vec<Modifier>`. The fast path is always taken except when there's a syntax error (rare).