### PR TITLE
fix(semantic): report error on await-using inside nested static block

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -561,8 +561,7 @@ pub fn check_variable_declaration(decl: &VariableDeclaration, ctx: &SemanticBuil
     {
         ctx.error(diagnostics::using_declaration_not_allowed_in_script(decl.span));
     }
-    if decl.kind.is_await() && ctx.scoping.scope_flags(ctx.current_scope_id).is_class_static_block()
-    {
+    if decl.kind.is_await() && is_in_class_static_block(ctx) {
         ctx.error(diagnostics::class_static_block_await_using(decl.span));
     }
 }
@@ -1366,6 +1365,22 @@ fn is_in_formal_parameters(ctx: &SemanticBuilder<'_>) -> bool {
         }
     }
     false
+}
+
+fn is_in_class_static_block(ctx: &SemanticBuilder<'_>) -> bool {
+    ctx.scoping
+        .scope_ancestors(ctx.current_scope_id)
+        .map(|scope_id| ctx.scoping.scope_flags(scope_id))
+        .find_map(|flags| {
+            if flags.is_class_static_block() {
+                return Some(true);
+            }
+            if flags.is_function() {
+                return Some(false);
+            }
+            None
+        })
+        .unwrap_or(false)
 }
 
 pub fn check_await_expression(expr: &AwaitExpression, ctx: &SemanticBuilder<'_>) {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25882,6 +25882,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
  4 │         {
    ╰────
 
+  × Cannot use 'await using' in class static initialization block
+   ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.14.ts:5:13]
+ 4 │         {
+ 5 │             await using y = null;
+   ·             ─────────────────────
+ 6 │         }
+   ╰────
+
   × TS(1546): 'await using' declarations are not allowed in ambient contexts.
    ╭─[typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.16.ts:2:17]
  1 │ declare namespace N {


### PR DESCRIPTION
Fixes missing errors on the following case:
```ts
class C {
    static {
        {
            await using y = null;
        }
    }
}
```