### PR TITLE
perf(parser): remove a lookahead from `eat_modifiers_before_declaration`

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -387,9 +387,6 @@ pub use modifier_kinds::ModifierKinds;
 
 impl<C: Config> ParserImpl<'_, C> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers {
-        if !self.at_modifier() {
-            return Modifiers::empty();
-        }
         let mut modifiers = Modifiers::empty();
         while self.at_modifier() {
             let span = self.start_span();


### PR DESCRIPTION
Remove an unnecessary lookahead from `eat_modifiers_before_declaration`. The loop below already does this check. There's no point doing it twice, especially as lookaheads aren't so cheap.