### PR TITLE
ci(benchmarks): remove `parser_tokens` and `estree_tokens_raw` benchmarks

### DIFF
--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_ast_visit::utf8_to_utf16::Utf8ToUtf16;
 use oxc_benchmark::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
-use oxc_estree_tokens::{ESTreeTokenOptionsJS, to_estree_tokens_json, update_tokens};
+use oxc_estree_tokens::{ESTreeTokenOptionsJS, to_estree_tokens_json};
 use oxc_parser::{ParseOptions, Parser, ParserReturn, config::RuntimeParserConfig};
 use oxc_tasks_common::TestFiles;
 
@@ -26,43 +26,6 @@ fn bench_parser(criterion: &mut Criterion) {
                         ..ParseOptions::default()
                     })
                     .parse();
-                allocator.reset();
-            });
-        });
-    }
-
-    group.finish();
-}
-
-fn bench_parser_tokens(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("parser_tokens");
-
-    for file in TestFiles::minimal().files() {
-        let id = BenchmarkId::from_parameter(&file.file_name);
-        let source_text = &file.source_text;
-        let source_type = file.source_type;
-
-        group.bench_function(id, |b| {
-            // Do not include initializing allocator in benchmark.
-            // User code would likely reuse the same allocator over and over to parse multiple files,
-            // so we do the same here.
-            let mut allocator = Allocator::default();
-
-            b.iter(|| {
-                // Use `RuntimeParserConfig` (runtime config), same as NAPI parser package will.
-                // `bench_parser` uses `NoTokensParserConfig` (implicitly as default).
-                // Usually it's inadvisable to use 2 different configs in the same application,
-                // but this is just a benchmark, and it's better if we don't entwine this benchmark with `bench_parser`.
-                let config = RuntimeParserConfig::new(true);
-
-                Parser::new(&allocator, source_text, source_type)
-                    .with_options(ParseOptions {
-                        parse_regular_expression: true,
-                        ..ParseOptions::default()
-                    })
-                    .with_config(config)
-                    .parse();
-
                 allocator.reset();
             });
         });
@@ -160,58 +123,5 @@ fn bench_estree_tokens(criterion: &mut Criterion) {
     group.finish();
 }
 
-fn bench_estree_tokens_raw(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("estree_tokens_raw");
-
-    for file in TestFiles::complicated().files().iter().take(1) {
-        let id = BenchmarkId::from_parameter(&file.file_name);
-        let source_text = &file.source_text;
-        let source_type = file.source_type;
-        let mut allocator = Allocator::default();
-
-        group.bench_function(id, |b| {
-            b.iter_with_setup_wrapper(|runner| {
-                allocator.reset();
-
-                // Use `RuntimeParserConfig` (runtime config), same as NAPI parser package will.
-                // `bench_estree` uses `NoTokensParserConfig` (implicitly as default).
-                // Usually it's inadvisable to use 2 different configs in the same application,
-                // but this is just a benchmark, and it's better if we don't entwine this benchmark with `bench_estree`.
-                let config = RuntimeParserConfig::new(true);
-
-                let ret = Parser::new(&allocator, source_text, source_type)
-                    .with_options(ParseOptions {
-                        parse_regular_expression: true,
-                        ..ParseOptions::default()
-                    })
-                    .with_config(config)
-                    .parse();
-                let ParserReturn { program, mut tokens, .. } = ret;
-
-                // Creating span converter is not performed in measured section, as we only want to measure tokens.
-                // Span converter needs to be created anyway for converting spans in AST.
-                let span_converter = Utf8ToUtf16::new(program.source_text);
-
-                runner.run(|| {
-                    update_tokens(&mut tokens, &program, &span_converter, ESTreeTokenOptionsJS);
-
-                    black_box(tokens);
-
-                    program
-                });
-            });
-        });
-    }
-
-    group.finish();
-}
-
-criterion_group!(
-    parser,
-    bench_parser,
-    bench_parser_tokens,
-    bench_estree,
-    bench_estree_tokens,
-    bench_estree_tokens_raw
-);
+criterion_group!(parser, bench_parser, bench_estree, bench_estree_tokens);
 criterion_main!(parser);


### PR DESCRIPTION
I added these benchmarks while working on improving perf of tokens APIs in linter. That work is now complete, so these benchmarks are no longer needed. We can always restore them later on if we start working on perf of tokens again.