### PR TITLE
feat(linter): allow extending from `oxlint:recommended`

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1,11 +1,13 @@
 use std::{
     fmt::{self, Debug, Display},
     path::{Component as PathComponent, Path, PathBuf},
+    str::FromStr,
 };
 
 use itertools::Itertools;
 use oxc_resolver::{ResolveOptions, Resolver};
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use url::Url;
 
 use oxc_span::{CompactStr, format_compact_str};
@@ -14,7 +16,7 @@ use crate::{
     AllowWarnDeny, ExternalPluginStore, LintConfig, LintFilter, LintFilterKind, Oxlintrc,
     RuleCategory, RuleEnum,
     config::{
-        ESLintRule, OxlintOverrides, OxlintRules,
+        ESLintRule, OxlintOverrides, OxlintRules, RecommendedConfig,
         external_plugins::ExternalPluginEntry,
         overrides::OxlintOverride,
         plugins::{LintPlugins, is_normal_plugin_name, normalize_plugin_name},
@@ -78,6 +80,46 @@ impl ConfigStoreBuilder {
         let external_rules = FxHashMap::default();
         let extended_paths = Vec::new();
         Self { rules, external_rules, config, categories, overrides, extended_paths }
+    }
+
+    /// Returns the recommended configuration for the given plugin.
+    pub fn recommended(config: RecommendedConfig) -> Self {
+        let plugin = match config {
+            RecommendedConfig::Base => LintPlugins::ESLINT,
+            RecommendedConfig::React => LintPlugins::REACT,
+            RecommendedConfig::Unicorn => LintPlugins::UNICORN,
+            RecommendedConfig::TypeScript => LintPlugins::TYPESCRIPT,
+            RecommendedConfig::Oxc => LintPlugins::OXC,
+            RecommendedConfig::Import => LintPlugins::IMPORT,
+            RecommendedConfig::JsDoc => LintPlugins::JSDOC,
+            RecommendedConfig::Jest => LintPlugins::JEST,
+            RecommendedConfig::Vitest => LintPlugins::VITEST,
+            RecommendedConfig::JsxA11y => LintPlugins::JSX_A11Y,
+            RecommendedConfig::NextJs => LintPlugins::NEXTJS,
+            RecommendedConfig::ReactPerf => LintPlugins::REACT_PERF,
+            RecommendedConfig::Promise => LintPlugins::PROMISE,
+            RecommendedConfig::Node => LintPlugins::NODE,
+            RecommendedConfig::Vue => LintPlugins::VUE,
+        };
+        let Some(plugin_name) = plugin.name() else { return Self::empty() };
+        let config = LintConfig { plugins: plugin, ..LintConfig::default() };
+        let rules = RULES
+            .iter()
+            .filter(|rule| {
+                rule.plugin_name() == plugin_name
+                    && rule.tags().is_recommended()
+                    && rule.category() != RuleCategory::Nursery
+            })
+            .map(|rule| (rule.clone(), AllowWarnDeny::Deny))
+            .collect();
+        Self {
+            rules,
+            external_rules: FxHashMap::default(),
+            config,
+            categories: OxlintCategories::default(),
+            overrides: OxlintOverrides::default(),
+            extended_paths: Vec::new(),
+        }
     }
 
     /// Create a [`ConfigStoreBuilder`] from a loaded or manually built [`Oxlintrc`].
@@ -172,9 +214,17 @@ impl ConfigStoreBuilder {
                     // `eslint:` and `plugin:` named configs are not supported
                     continue;
                 }
+
+                let path_str = path.to_string_lossy();
+
+                if let Ok(recommended) = RecommendedConfig::from_str(&path_str) {
+                    oxlintrc = oxlintrc.merge(ConfigStoreBuilder::recommended(recommended).into());
+                    continue;
+                }
+
                 // if path does not include a ".", then we will heuristically skip it since it
                 // kind of looks like it might be a named config
-                if !path.to_string_lossy().contains('.') {
+                if !path_str.contains('.') {
                     continue;
                 }
 
@@ -700,6 +750,33 @@ fn get_name(plugin_name: &str, rule_name: &str) -> CompactStr {
         CompactStr::from(rule_name)
     } else {
         format_compact_str!("{plugin_name}/{rule_name}")
+    }
+}
+
+impl From<ConfigStoreBuilder> for Oxlintrc {
+    fn from(builder: ConfigStoreBuilder) -> Self {
+        Oxlintrc {
+            plugins: Some(builder.config.plugins),
+            categories: builder.categories,
+            rules: OxlintRules::new(
+                builder
+                    .rules
+                    .into_iter()
+                    .map(|(rule, severity)| ESLintRule {
+                        plugin_name: rule.plugin_name().to_string(),
+                        rule_name: rule.name().to_string(),
+                        severity,
+                        config: SmallVec::default(),
+                    })
+                    .collect(),
+            ),
+            settings: builder.config.settings,
+            env: builder.config.env,
+            globals: builder.config.globals,
+            overrides: builder.overrides,
+            options: builder.config.options,
+            ..Oxlintrc::default()
+        }
     }
 }
 
@@ -1480,6 +1557,25 @@ mod test {
             r#"{ "extends": ["fixtures/extends_config/options/max_warnings_0.json"] }"#,
         );
         assert_eq!(config.base.config.options.max_warnings, Some(0));
+    }
+
+    #[test]
+    fn test_extends_oxlint_recommended() {
+        let config = config_store_from_str(r#"{ "extends": ["oxlint:recommended/base"] }"#);
+        // This test may need to be updated over time, but assert that a rule that is
+        // not enabled by default (i.e., in correctness) is now enabled
+        // check preserve-caught-error
+        let rule = "preserve-caught-error";
+        assert_eq!(
+            RULES.iter().find(|r| r.name() == rule).unwrap().category(),
+            RuleCategory::Suspicious
+        );
+        assert!(
+            config
+                .rules()
+                .iter()
+                .any(|(r, severity)| r.name() == rule && *severity == AllowWarnDeny::Deny)
+        );
     }
 
     #[test]

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -10,6 +10,7 @@ mod ignore_matcher;
 mod overrides;
 mod oxlintrc;
 pub mod plugins;
+mod recommended;
 mod rules;
 mod settings;
 pub use config_builder::{ConfigBuilderError, ConfigStoreBuilder};
@@ -20,6 +21,7 @@ pub use ignore_matcher::LintIgnoreMatcher;
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
 pub use plugins::LintPlugins;
+pub use recommended::RecommendedConfig;
 pub use rules::{ESLintRule, OxlintRules};
 pub use settings::{OxlintSettings, ReactVersion, jsdoc::JSDocPluginSettings};
 

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -129,6 +129,29 @@ impl LintPlugins {
     pub fn has_import(self) -> bool {
         self.contains(LintPlugins::IMPORT)
     }
+
+    /// Returns the name of the plugin, if there is only one, otherwise returns `None`.
+    #[inline]
+    pub fn name(self) -> Option<&'static str> {
+        match self {
+            LintPlugins::ESLINT => Some("eslint"),
+            LintPlugins::REACT => Some("react"),
+            LintPlugins::UNICORN => Some("unicorn"),
+            LintPlugins::TYPESCRIPT => Some("typescript"),
+            LintPlugins::OXC => Some("oxc"),
+            LintPlugins::IMPORT => Some("import"),
+            LintPlugins::JSDOC => Some("jsdoc"),
+            LintPlugins::JEST => Some("jest"),
+            LintPlugins::VITEST => Some("vitest"),
+            LintPlugins::JSX_A11Y => Some("jsx_a11y"),
+            LintPlugins::NEXTJS => Some("nextjs"),
+            LintPlugins::REACT_PERF => Some("react_perf"),
+            LintPlugins::PROMISE => Some("promise"),
+            LintPlugins::NODE => Some("node"),
+            LintPlugins::VUE => Some("vue"),
+            _ => None,
+        }
+    }
 }
 
 impl TryFrom<&str> for LintPlugins {

--- a/crates/oxc_linter/src/config/recommended.rs
+++ b/crates/oxc_linter/src/config/recommended.rs
@@ -1,0 +1,50 @@
+use std::str::FromStr;
+
+/// Represents one of the built-in recommended configurations for the linter.
+#[derive(Debug, Clone, Copy)]
+pub enum RecommendedConfig {
+    Base,       // oxlint:recommended/base
+    React,      // oxlint:recommended/react
+    Unicorn,    // oxlint:recommended/unicorn
+    TypeScript, // oxlint:recommended/typescript
+    Oxc,        // oxlint:recommended/oxc
+    Import,     // oxlint:recommended/import
+    JsDoc,      // oxlint:recommended/jsdoc
+    Jest,       // oxlint:recommended/jest
+    Vitest,     // oxlint:recommended/vitest
+    JsxA11y,    // oxlint:recommended/jsx-a11y
+    NextJs,     // oxlint:recommended/nextjs
+    ReactPerf,  // oxlint:recommended/react-perf
+    Promise,    // oxlint:recommended/promise
+    Node,       // oxlint:recommended/node
+    Vue,        // oxlint:recommended/vue
+}
+
+impl FromStr for RecommendedConfig {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "oxlint:recommended/base" => Ok(RecommendedConfig::Base),
+            "oxlint:recommended/react" => Ok(RecommendedConfig::React),
+            "oxlint:recommended/unicorn" => Ok(RecommendedConfig::Unicorn),
+            "oxlint:recommended/typescript" => Ok(RecommendedConfig::TypeScript),
+            "oxlint:recommended/oxc" => Ok(RecommendedConfig::Oxc),
+            "oxlint:recommended/import" => Ok(RecommendedConfig::Import),
+            "oxlint:recommended/jsdoc" => Ok(RecommendedConfig::JsDoc),
+            "oxlint:recommended/jest" => Ok(RecommendedConfig::Jest),
+            "oxlint:recommended/vitest" => Ok(RecommendedConfig::Vitest),
+            "oxlint:recommended/jsx-a11y" | "oxlint:recommended/jsx_a11y" => {
+                Ok(RecommendedConfig::JsxA11y)
+            }
+            "oxlint:recommended/nextjs" => Ok(RecommendedConfig::NextJs),
+            "oxlint:recommended/react-perf" | "oxlint:recommended/react_perf" => {
+                Ok(RecommendedConfig::ReactPerf)
+            }
+            "oxlint:recommended/promise" => Ok(RecommendedConfig::Promise),
+            "oxlint:recommended/node" => Ok(RecommendedConfig::Node),
+            "oxlint:recommended/vue" => Ok(RecommendedConfig::Vue),
+            _ => Err(()),
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -287,6 +287,7 @@ declare_oxc_lint!(
     suspicious,
     conditional_fix,
     config = PreserveCaughtErrorOptions,
+    tags = [recommended],
 );
 impl PreserveCaughtError {
     fn check_try_statement<'a>(&self, try_stmt: &'a TryStatement<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
- `nursery` category rules are automatically excluded from the recommended config, as we don't want to automatically enable these unless explicitly specified
- all rules marked as `recommended` will be enabled as `deny` by default
- additional plugins should not be included