### PR TITLE
feat(linter): enhance import plugin diagnostics with help messages

### DIFF
--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -10,6 +10,7 @@ use crate::{ModuleRecord, context::LintContext, rule::Rule};
 
 fn no_named_export(module_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("No named exports found in module '{module_name}'"))
+        .with_help("Remove the `export *` re-export, or add named exports to the target module.")
         .with_label(span)
 }
 
@@ -93,6 +94,7 @@ impl Rule for Export {
 
                 ctx.diagnostic(
                     OxcDiagnostic::warn(format!("Multiple exports of name '{name}'."))
+                        .with_help("Rename or remove the duplicate export so each name is exported only once.")
                         .with_labels(labels),
                 );
             }

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -21,6 +21,7 @@ fn no_export(span: Span, specifier_name: &str, namespace_name: &str) -> OxcDiagn
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in imported namespace {namespace_name:?}."
     ))
+    .with_help("Check for typos in the referenced name, or add the missing export to the source module.")
     .with_label(span)
 }
 
@@ -32,6 +33,7 @@ fn no_export_in_deeply_imported_namespace(
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in deeply imported namespace {namespace_name:?}."
     ))
+    .with_help("Check the nested namespace chain and ensure the name is exported at each level.")
     .with_label(span)
 }
 
@@ -39,11 +41,13 @@ fn computed_reference(span: Span, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Unable to validate computed reference to imported namespace {namespace_name:?}."
     ))
+    .with_help("Use a static property access (e.g. `namespace.name`) instead of a computed one.")
     .with_label(span)
 }
 
 fn assignment(span: Span, namespace_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Assignment to member of namespace {namespace_name:?}.'"))
+        .with_help("Imported namespace members are read-only. Assign to a local variable instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -21,7 +21,6 @@ fn no_export(span: Span, specifier_name: &str, namespace_name: &str) -> OxcDiagn
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in imported namespace {namespace_name:?}."
     ))
-    .with_help("Check for typos in the referenced name, or add the missing export to the source module.")
     .with_label(span)
 }
 
@@ -33,7 +32,6 @@ fn no_export_in_deeply_imported_namespace(
     OxcDiagnostic::warn(format!(
         "{specifier_name:?} not found in deeply imported namespace {namespace_name:?}."
     ))
-    .with_help("Check the nested namespace chain and ensure the name is exported at each level.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_anonymous_default_export.rs
@@ -16,8 +16,9 @@ use crate::{
 };
 
 fn no_anonymous_default_export_diagnostic(span: Span, msg: &'static str) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn(msg).with_label(span)
+    OxcDiagnostic::warn(msg)
+        .with_note("Named default exports improve grepability and enable consistent auto-imports across the codebase.")
+        .with_label(span)
 }
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]

--- a/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
+++ b/crates/oxc_linter/src/rules/import/no_nodejs_modules.rs
@@ -18,6 +18,7 @@ use crate::{
 
 fn no_nodejs_modules_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not import Node.js builtin module `{module_name}`"))
+        .with_help("Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/import_export.snap
+++ b/crates/oxc_linter/src/snapshots/import_export.snap
@@ -7,12 +7,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ let foo; export { foo }; export * from "./export-all"
    ·                   ───    ────────────────────────────
    ╰────
+  help: Rename or remove the duplicate export so each name is exported only once.
 
   ⚠ eslint-plugin-import(export): Multiple exports of name 'foo'.
    ╭─[index.ts:1:26]
  1 │ let foo; export { foo as "foo" }; export * from "./export-all"
    ·                          ─────    ────────────────────────────
    ╰────
+  help: Rename or remove the duplicate export so each name is exported only once.
 
   × Identifier `Foo` has already been declared
    ╭─[index.ts:2:29]

--- a/crates/oxc_linter/src/snapshots/import_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/import_namespace.snap
@@ -7,153 +7,179 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as names from './named-exports'; console.log(names.c)
    ·                                                             ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): Unable to validate computed reference to imported namespace "names".
    ╭─[index.js:1:55]
  1 │ import * as names from './named-exports'; console.log(names['a']);
    ·                                                       ──────────
    ╰────
+  help: Use a static property access (e.g. `namespace.name`) instead of a computed one.
 
   ⚠ eslint-plugin-import(namespace): Assignment to member of namespace "foo".'
    ╭─[index.js:1:31]
  1 │ import * as foo from './bar'; foo.foo = 'y';
    ·                               ───────
    ╰────
+  help: Imported namespace members are read-only. Assign to a local variable instead.
 
   ⚠ eslint-plugin-import(namespace): Assignment to member of namespace "foo".'
    ╭─[index.js:1:31]
  1 │ import * as foo from './bar'; foo.x = 'y';
    ·                               ─────
    ╰────
+  help: Imported namespace members are read-only. Assign to a local variable instead.
 
   ⚠ eslint-plugin-import(namespace): "x" not found in imported namespace "./bar".
    ╭─[index.js:1:35]
  1 │ import * as foo from './bar'; foo.x = 'y';
    ·                                   ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c } = names
    ·                                                   ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:66]
  1 │ import * as names from "./named-exports"; function b() { const { c } = names }
    ·                                                                  ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: d } = names
    ·                                                   ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: { d } } = names
    ·                                                   ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:19]
  1 │ console.log(names.c); import * as names from './named-exports';
    ·                   ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:34]
  1 │ function x() { console.log(names.c) } import * as names from './named-exports';
    ·                                  ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "default" not found in imported namespace "./re-export".
    ╭─[index.js:1:53]
  1 │ import * as ree from "./re-export"; console.log(ree.default)
    ·                                                     ───────
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./named-exports".
    ╭─[index.js:1:62]
  1 │ import * as Names from "./named-exports"; const Foo = <Names.e/>
    ·                                                              ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:52]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.e)
    ·                                                    ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:54]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.c.e)
    ·                                                      ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep/a"; console.log(a.b.e)
    ·                                                ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:45]
  1 │ import { b } from "./deep/a"; console.log(b.e)
    ·                                             ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:50]
  1 │ import * as a from "./deep/a"; console.log(a.b.c.e)
    ·                                                  ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:47]
  1 │ import { b } from "./deep/a"; console.log(b.c.e)
    ·                                               ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:52]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.e)
    ·                                                    ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:49]
  1 │ import { b } from "./deep-es7/a"; console.log(b.e)
    ·                                                 ─
    ╰────
+  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:54]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.c.e)
    ·                                                      ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:51]
  1 │ import { b } from "./deep-es7/a"; console.log(b.c.e)
    ·                                                   ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:45]
  1 │ import * as a from "./deep-es7/a"; var {b:{ e }} = a
    ·                                             ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:53]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                     ─
    ╰────
+  help: Check the nested namespace chain and ensure the name is exported at each level.

--- a/crates/oxc_linter/src/snapshots/import_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/import_namespace.snap
@@ -7,7 +7,6 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as names from './named-exports'; console.log(names.c)
    ·                                                             ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): Unable to validate computed reference to imported namespace "names".
    ╭─[index.js:1:55]
@@ -35,151 +34,129 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import * as foo from './bar'; foo.x = 'y';
    ·                                   ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c } = names
    ·                                                   ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:66]
  1 │ import * as names from "./named-exports"; function b() { const { c } = names }
    ·                                                                  ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: d } = names
    ·                                                   ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:51]
  1 │ import * as names from "./named-exports"; const { c: { d } } = names
    ·                                                   ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:19]
  1 │ console.log(names.c); import * as names from './named-exports';
    ·                   ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "c" not found in imported namespace "./named-exports".
    ╭─[index.js:1:34]
  1 │ function x() { console.log(names.c) } import * as names from './named-exports';
    ·                                  ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "default" not found in imported namespace "./re-export".
    ╭─[index.js:1:53]
  1 │ import * as ree from "./re-export"; console.log(ree.default)
    ·                                                     ───────
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./named-exports".
    ╭─[index.js:1:62]
  1 │ import * as Names from "./named-exports"; const Foo = <Names.e/>
    ·                                                              ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:52]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.e)
    ·                                                    ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:54]
  1 │ import { "b" as b } from "./deep/a"; console.log(b.c.e)
    ·                                                      ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep/a"; console.log(a.b.e)
    ·                                                ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:45]
  1 │ import { b } from "./deep/a"; console.log(b.e)
    ·                                             ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:50]
  1 │ import * as a from "./deep/a"; console.log(a.b.c.e)
    ·                                                  ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:47]
  1 │ import { b } from "./deep/a"; console.log(b.c.e)
    ·                                               ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:52]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.e)
    ·                                                    ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in imported namespace "./b".
    ╭─[index.js:1:49]
  1 │ import { b } from "./deep-es7/a"; console.log(b.e)
    ·                                                 ─
    ╰────
-  help: Check for typos in the referenced name, or add the missing export to the source module.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:54]
  1 │ import * as a from "./deep-es7/a"; console.log(a.b.c.e)
    ·                                                      ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "b.c".
    ╭─[index.js:1:51]
  1 │ import { b } from "./deep-es7/a"; console.log(b.c.e)
    ·                                                   ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:45]
  1 │ import * as a from "./deep-es7/a"; var {b:{ e }} = a
    ·                                             ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b.c".
    ╭─[index.js:1:48]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.
 
   ⚠ eslint-plugin-import(namespace): "e" not found in deeply imported namespace "a.b".
    ╭─[index.js:1:53]
  1 │ import * as a from "./deep-es7/a"; var {b:{c:{ e }, e: { c }}} = a
    ·                                                     ─
    ╰────
-  help: Check the nested namespace chain and ensure the name is exported at each level.

--- a/crates/oxc_linter/src/snapshots/import_no_anonymous_default_export.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_anonymous_default_export.snap
@@ -7,57 +7,67 @@ source: crates/oxc_linter/src/tester.rs
  1 │ export default []
    · ─────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign arrow function to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default () => {}
    · ───────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Unexpected default export of anonymous class
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default class {}
    · ───────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Unexpected default export of anonymous function
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default function () {}
    · ─────────────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign call result to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default foo(bar)
    · ───────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default 123
    · ──────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign object to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default {}
    · ─────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign instance to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default new Foo()
    · ────────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default `foo`
    · ────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.
 
   ⚠ eslint-plugin-import(no-anonymous-default-export): Assign literal to a variable before exporting as module default
    ╭─[no_anonymous_default_export.tsx:1:1]
  1 │ export default /^123/
    · ─────────────────────
    ╰────
+  note: Named default exports improve grepability and enable consistent auto-imports across the codebase.

--- a/crates/oxc_linter/src/snapshots/import_no_nodejs_modules.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_nodejs_modules.snap
@@ -7,141 +7,165 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import path from "path"
    · ───────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "fs"
    · ───────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:12]
  1 │ var path = require("path")
    ·            ───────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:10]
  1 │ var fs = require("fs")
    ·          ─────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import(`fs`)
    · ────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "fs"
    · ───────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import crypto from "crypto"
    · ───────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `util`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("util")
    · ──────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export * from "fs"
    · ──────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import path from "node:path"
    · ────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:12]
  1 │ var path = require("node:path")
    ·            ────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "node:fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:10]
  1 │ var fs = require("node:fs")
    ·          ──────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import crypto from "node:crypto"
    · ────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("node:fs")
    · ─────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { foo } from "node:path"
    · ───────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:util`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import util = require("node:util")
    · ──────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs from "node:fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `node:crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import("node:crypto")
    · ─────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import fs = require("fs")
    · ─────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ import path = require("path")
    · ─────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `fs`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { foo } from "fs"
    · ────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `crypto`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export { default as foo } from "crypto"
    · ───────────────────────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.
 
   ⚠ eslint-plugin-import(no-nodejs-modules): Do not import Node.js builtin module `path`
    ╭─[no_nodejs_modules.tsx:1:1]
  1 │ export * from "path"
    · ────────────────────
    ╰────
+  help: Use a browser-compatible alternative or add this module to the `allow` list if Node.js usage is intentional.


### PR DESCRIPTION
Enhanced several diagnostic messages in the linter by adding helpful suggestions. This includes guidance for:
- No named exports found in a module
- Multiple exports of the same name
- Missing exports in imported namespaces
- Computed references to namespaces
- Assignment to members of namespaces
- Anonymous default exports

These improvements aim to provide clearer instructions for resolving common issues encountered during linting, enhancing the overall developer experience.