### PR TITLE
feat(linter): create recommended ruleset

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/constructor_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/constructor_super.rs
@@ -113,6 +113,7 @@ declare_oxc_lint!(
     ConstructorSuper,
     eslint,
     correctness,
+    tags = [recommended],
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/eslint/for_direction.rs
+++ b/crates/oxc_linter/src/rules/eslint/for_direction.rs
@@ -84,7 +84,8 @@ declare_oxc_lint!(
     ForDirection,
     eslint,
     correctness,
-    fix_dangerous
+    tags = [recommended],
+    fix_dangerous,
 );
 
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -85,6 +85,7 @@ declare_oxc_lint!(
     GetterReturn,
     eslint,
     nursery,
+    tags = [recommended],
     config = GetterReturn
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_async_promise_executor.rs
@@ -80,7 +80,8 @@ declare_oxc_lint!(
     /// ```
     NoAsyncPromiseExecutor,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoAsyncPromiseExecutor {

--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     NoCaseDeclarations,
     eslint,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -84,7 +84,8 @@ declare_oxc_lint!(
     /// ```
     NoClassAssign,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoClassAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     NoCompareNegZero,
     eslint,
     correctness,
+    tags = [recommended],
     conditional_fix_suggestion
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     NoCondAssign,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoCondAssignConfig,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// ```
     NoConstAssign,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoConstAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -56,7 +56,8 @@ declare_oxc_lint!(
     /// ```
     NoConstantBinaryExpression,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 fn constant_short_circuit(lhs_name: &str, expr_name: &str, span: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -103,6 +103,7 @@ declare_oxc_lint!(
     NoConstantCondition,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoConstantCondition,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_control_regex.rs
@@ -84,7 +84,8 @@ declare_oxc_lint!(
     /// ```
     NoControlRegex,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoControlRegex {

--- a/crates/oxc_linter/src/rules/eslint/no_debugger.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_debugger.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     NoDebugger,
     eslint,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_delete_var.rs
@@ -43,7 +43,8 @@ declare_oxc_lint!(
     /// ```
     NoDeleteVar,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDeleteVar {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -56,7 +56,8 @@ declare_oxc_lint!(
     /// ```
     NoDupeClassMembers,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDupeClassMembers {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -105,7 +105,8 @@ declare_oxc_lint!(
     /// ```
     NoDupeElseIf,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDupeElseIf {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_keys.rs
@@ -63,7 +63,8 @@ declare_oxc_lint!(
     /// ```
     NoDupeKeys,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDupeKeys {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -76,7 +76,8 @@ declare_oxc_lint!(
     /// ```
     NoDuplicateCase,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDuplicateCase {

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     NoEmpty,
     eslint,
     restriction,
+    tags = [recommended],
     suggestion,
     config = NoEmpty,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_character_class.rs
@@ -43,7 +43,8 @@ declare_oxc_lint!(
     /// ```
     NoEmptyCharacterClass,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoEmptyCharacterClass {

--- a/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_pattern.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     NoEmptyPattern,
     eslint,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoEmptyPattern {

--- a/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_static_block.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     NoEmptyStaticBlock,
     eslint,
     correctness,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -50,7 +50,8 @@ declare_oxc_lint!(
     /// ```
     NoExAssign,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoExAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extra_boolean_cast.rs
@@ -81,6 +81,7 @@ declare_oxc_lint!(
     NoExtraBooleanCast,
     eslint,
     correctness,
+    tags = [recommended],
     conditional_fix_or_conditional_suggestion,
     config = NoExtraBooleanCast,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -247,6 +247,7 @@ declare_oxc_lint!(
     NoFallthrough,
     eslint,
     pedantic, // Fall through code are still incorrect.
+    tags = [recommended],
     pending, // TODO: add a dangerous suggestion for this rule.
     config = NoFallthroughConfig,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -67,7 +67,8 @@ declare_oxc_lint!(
     /// ```
     NoFuncAssign,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoFuncAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     NoGlobalAssign,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoGlobalAssignConfig
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -49,7 +49,8 @@ declare_oxc_lint!(
     /// ```
     NoImportAssign,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 const OBJECT_MUTATION_METHODS: [&str; 5] =

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     NoInvalidRegexp,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoInvalidRegexpConfig,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -42,7 +42,8 @@ declare_oxc_lint!(
     /// ```
     NoIrregularWhitespace,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoIrregularWhitespace {

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -83,7 +83,8 @@ declare_oxc_lint!(
     /// ```
     NoLossOfPrecision,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoLossOfPrecision {

--- a/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_misleading_character_class.rs
@@ -116,6 +116,7 @@ declare_oxc_lint!(
     NoMisleadingCharacterClass,
     eslint,
     correctness,
+    tags = [recommended],
     pending,
     config = NoMisleadingCharacterClass,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoNewNativeNonconstructor,
     eslint,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoNewNativeNonconstructor {

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     NoNonoctalDecimalEscape,
     eslint,
     correctness,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     NoObjCalls,
     eslint,
     correctness,
+    tags = [recommended],
 );
 
 fn is_global_obj(s: &str) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_prototype_builtins.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     NoPrototypeBuiltins,
     eslint,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     NoRedeclare,
     eslint,
     pedantic,
+    tags = [recommended],
     config = NoRedeclare,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     NoRegexSpaces,
     eslint,
     restriction,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_assign.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     NoSelfAssign,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoSelfAssign
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -40,7 +40,8 @@ declare_oxc_lint!(
     /// ```
     NoSetterReturn,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoSetterReturn {

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -94,6 +94,7 @@ declare_oxc_lint!(
     NoShadowRestrictedNames,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoShadowRestrictedNamesConfig
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// ```
     NoSparseArrays,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoSparseArrays {

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -50,7 +50,8 @@ declare_oxc_lint!(
     /// ```
     NoThisBeforeSuper,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 #[derive(Default, Copy, Clone, Debug)]

--- a/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unassigned_vars.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoUnassignedVars,
     eslint,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnassignedVars {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     NoUndef,
     eslint,
     nursery,
+    tags = [recommended],
     config = NoUndef,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
@@ -103,6 +103,7 @@ declare_oxc_lint!(
     NoUnexpectedMultiline,
     eslint,
     suspicious,
+    tags = [recommended],
     fix_dangerous
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -54,7 +54,8 @@ declare_oxc_lint!(
     /// ```
     NoUnreachable,
     eslint,
-    nursery
+    nursery,
+    tags = [recommended],
 );
 
 impl Rule for NoUnreachable {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_finally.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// ```
     NoUnsafeFinally,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeFinally {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     NoUnsafeNegation,
     eslint,
     correctness,
+    tags = [recommended],
     fix,
     config = NoUnsafeNegation,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     NoUnsafeOptionalChaining,
     eslint,
     correctness,
+    tags = [recommended],
     config = NoUnsafeOptionalChaining,
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     NoUnusedLabels,
     eslint,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -87,7 +87,8 @@ declare_oxc_lint!(
     /// ```
     NoUnusedPrivateClassMembers,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnusedPrivateClassMembers {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -191,6 +191,7 @@ declare_oxc_lint!(
     NoUnusedVars,
     eslint,
     correctness,
+    tags = [recommended],
     fix = conditional_dangerous_fix_or_suggestion,
     config = NoUnusedVarsOptions
 );

--- a/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_backreference.rs
@@ -75,7 +75,8 @@ declare_oxc_lint!(
     /// ```
     NoUselessBackreference,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUselessBackreference {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_catch.rs
@@ -52,7 +52,8 @@ declare_oxc_lint!(
     /// ```
     NoUselessCatch,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUselessCatch {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -91,6 +91,7 @@ declare_oxc_lint!(
     NoUselessEscape,
     eslint,
     correctness,
+    tags = [recommended],
     fix,
     config = NoUselessEscapeConfig,
 );

--- a/crates/oxc_linter/src/rules/eslint/no_with.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_with.rs
@@ -39,7 +39,8 @@ declare_oxc_lint!(
     /// ```
     NoWith,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoWith {

--- a/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
+++ b/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs
@@ -285,6 +285,7 @@ declare_oxc_lint!(
     PreserveCaughtError,
     eslint,
     suspicious,
+    tags = [recommended],
     conditional_fix,
     config = PreserveCaughtErrorOptions,
 );

--- a/crates/oxc_linter/src/rules/eslint/require_yield.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_yield.rs
@@ -33,7 +33,8 @@ declare_oxc_lint!(
     /// ```
     RequireYield,
     eslint,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for RequireYield {

--- a/crates/oxc_linter/src/rules/eslint/use_isnan.rs
+++ b/crates/oxc_linter/src/rules/eslint/use_isnan.rs
@@ -96,6 +96,7 @@ declare_oxc_lint!(
     UseIsnan,
     eslint,
     correctness,
+    tags = [recommended],
     conditional_fix,
     config = UseIsnan,
 );

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     ValidTypeof,
     eslint,
     correctness,
+    tags = [recommended],
     conditional_fix,
     config = ValidTypeof,
 );

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -48,7 +48,8 @@ declare_oxc_lint!(
     /// ```
     Default,
     import,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for Default {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -46,7 +46,8 @@ declare_oxc_lint!(
     /// ```
     Export,
     import,
-    nursery
+    nursery,
+    tags = [recommended],
 );
 
 impl Rule for Export {

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -109,8 +109,9 @@ declare_oxc_lint!(
     /// ```
     Named,
     import,
-    nursery // There are race conditions in the runtime which may cause the module to
-            // not find any exports from `exported_bindings_from_star_export`.
+    nursery, // There are race conditions in the runtime which may cause the module to
+             // not find any exports from `exported_bindings_from_star_export`.
+    tags = [recommended],
 );
 
 impl Rule for Named {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -110,6 +110,7 @@ declare_oxc_lint!(
     Namespace,
     import,
     correctness,
+    tags = [recommended],
     config = Namespace,
 );
 

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -99,6 +99,7 @@ declare_oxc_lint!(
     NoDuplicates,
     import,
     style,
+    tags = [recommended],
     // This rule intentionally does not have a fixer, as `eslint/no-duplicate-imports` does the
     // same thing as this rule and is also pending a fixer.
     none,

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -68,7 +68,8 @@ declare_oxc_lint!(
     /// `tsconfig.json` files.
     NoNamedAsDefault,
     import,
-    suspicious
+    suspicious,
+    tags = [recommended],
 );
 
 impl Rule for NoNamedAsDefault {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -62,7 +62,8 @@ declare_oxc_lint!(
     /// ```
     NoNamedAsDefaultMember,
     import,
-    suspicious
+    suspicious,
+    tags = [recommended],
 );
 
 fn get_symbol_id_from_ident(

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     ExpectExpect,
     jest,
     correctness,
+    tags = [recommended],
     config = ExpectExpectConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -97,6 +97,7 @@ declare_oxc_lint!(
     NoAliasMethods,
     jest,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -51,7 +51,8 @@ declare_oxc_lint!(
     /// ```
     NoCommentedOutTests,
     jest,
-    suspicious
+    suspicious,
+    tags = [recommended],
 );
 
 //  /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -106,7 +106,8 @@ declare_oxc_lint!(
     /// ```
     NoConditionalExpect,
     jest,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 // To flag we encountered a conditional block/catch block when traversing the parents.

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -95,6 +95,7 @@ declare_oxc_lint!(
     NoDeprecatedFunctions,
     jest,
     style,
+    tags = [recommended],
     fix,
     config = NoDeprecatedFunctionsConfig,
 );

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -62,7 +62,8 @@ declare_oxc_lint!(
     /// ```
     NoDisabledTests,
     jest,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 fn no_disabled_tests_diagnostic(x1: &'static str, x2: &'static str, span3: Span) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     jest,
     // TODO: add suggestion (see jest-community/eslint-plugin-jest#586)
     style,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -41,7 +41,8 @@ declare_oxc_lint!(
     /// ```
     NoExport,
     jest,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 // Emits a diagnostic if the file matches all of these criteria:

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -65,6 +65,7 @@ declare_oxc_lint!(
     NoFocusedTests,
     jest,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -70,7 +70,8 @@ declare_oxc_lint!(
     /// ```
     NoIdenticalTitle,
     jest,
-    style
+    style,
+    tags = [recommended],
 );
 
 impl Rule for NoIdenticalTitle {

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -64,7 +64,8 @@ declare_oxc_lint!(
     /// ```
     NoInterpolationInSnapshots,
     jest,
-    style
+    style,
+    tags = [recommended],
 );
 
 impl Rule for NoInterpolationInSnapshots {

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -65,6 +65,7 @@ declare_oxc_lint!(
     NoJasmineGlobals,
     jest,
     style,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -56,7 +56,8 @@ declare_oxc_lint!(
     /// ```
     NoMocksImport,
     jest,
-    style
+    style,
+    tags = [recommended],
 );
 
 impl Rule for NoMocksImport {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect/mod.rs
@@ -85,6 +85,7 @@ declare_oxc_lint!(
     NoStandaloneExpect,
     jest,
     correctness,
+    tags = [recommended],
     config = NoStandaloneExpectConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     NoTestPrefixes,
     jest,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -71,7 +71,8 @@ declare_oxc_lint!(
     /// ```
     ValidDescribeCallback,
     jest,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for ValidDescribeCallback {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -97,6 +97,7 @@ declare_oxc_lint!(
     ValidExpect,
     jest,
     correctness,
+    tags = [recommended],
     pending,
     config = ValidExpectConfig,
 );

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -140,6 +140,7 @@ declare_oxc_lint!(
     ValidTitle,
     jest,
     correctness,
+    tags = [recommended],
     conditional_fix,
     // TODO: Replace this with an actual config struct. This is a dummy value to
     // indicate that this rule has configuration and avoid errors.

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -57,7 +57,8 @@ declare_oxc_lint!(
     /// ```
     CheckAccess,
     jsdoc,
-    restriction
+    restriction,
+    tags = [recommended],
 );
 
 const ACCESS_LEVELS: [&str; 4] = ["package", "private", "protected", "public"];

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     CheckPropertyNames,
     jsdoc,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -81,6 +81,7 @@ declare_oxc_lint!(
     CheckTagNames,
     jsdoc,
     correctness,
+    tags = [recommended],
     pending,
     config = CheckTagNamesConfig,
 );

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     EmptyTags,
     jsdoc,
     restriction,
+    tags = [recommended],
     pending,
     config = EmptyTagsConfig,
 );

--- a/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/implements_on_classes.rs
@@ -55,7 +55,8 @@ declare_oxc_lint!(
     /// ```
     ImplementsOnClasses,
     jsdoc,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 fn is_function_inside_of_class<'a, 'b>(node: &'b AstNode<'a>, ctx: &'b LintContext<'a>) -> bool {

--- a/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/no_defaults.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     NoDefaults,
     jsdoc,
     correctness,
+    tags = [recommended],
     pending,
     config = NoDefaultsConfig,
 );

--- a/crates/oxc_linter/src/rules/jsdoc/require_param.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param.rs
@@ -100,6 +100,7 @@ declare_oxc_lint!(
     RequireParam,
     jsdoc,
     pedantic,
+    tags = [recommended],
     pending,
     config = RequireParamConfig,
 );

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     RequireParamDescription,
     jsdoc,
     pedantic,
+    tags = [recommended],
     pending,
 );
 
@@ -115,7 +116,7 @@ fn test() {
 			           *
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -127,7 +128,7 @@ fn test() {
 			           * @param foo Foo.
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -176,7 +177,7 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             None,
@@ -192,7 +193,7 @@ fn test() {
 			           * @param {object} root.bar
 			           */
 			          function quux (foo, {bar: {baz}}) {
-			
+
 			          }
 			      ",
             None,
@@ -209,7 +210,7 @@ fn test() {
 			           * @param foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -221,7 +222,7 @@ fn test() {
 			           * @arg foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -237,7 +238,7 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             Some(
@@ -253,7 +254,7 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             Some(
@@ -269,7 +270,7 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             Some(

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_name.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     RequireParamName,
     jsdoc,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for RequireParamName {

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     RequireParamType,
     jsdoc,
     pedantic,
+    tags = [recommended],
     pending,
 );
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     RequireProperty,
     jsdoc,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -45,7 +45,8 @@ declare_oxc_lint!(
     /// ```
     RequirePropertyDescription,
     jsdoc,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for RequirePropertyDescription {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -45,7 +45,8 @@ declare_oxc_lint!(
     /// ```
     RequirePropertyName,
     jsdoc,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for RequirePropertyName {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -45,7 +45,8 @@ declare_oxc_lint!(
     /// ```
     RequirePropertyType,
     jsdoc,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for RequirePropertyType {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -94,6 +94,7 @@ declare_oxc_lint!(
     RequireReturns,
     jsdoc,
     pedantic,
+    tags = [recommended],
     pending,
     config = RequireReturnsConfig,
 );

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     RequireReturnsDescription,
     jsdoc,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for RequireReturnsDescription {
@@ -108,7 +109,7 @@ fn test() {
 			           *
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -120,7 +121,7 @@ fn test() {
 			           * @returns Foo.
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -132,7 +133,7 @@ fn test() {
 			           * @returns Foo.
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             Some(serde_json::json!([
@@ -150,7 +151,7 @@ fn test() {
 			           * @returns {undefined}
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -162,7 +163,7 @@ fn test() {
 			           * @returns {void}
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -174,7 +175,7 @@ fn test() {
 			           * @returns {Promise<void>}
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -186,7 +187,7 @@ fn test() {
 			           * @returns {Promise<undefined>}
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -221,7 +222,7 @@ fn test() {
 			           * @returns
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -233,7 +234,7 @@ fn test() {
 			           * @returns {string}
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -245,7 +246,7 @@ fn test() {
 			           * @return
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_type.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     RequireReturnsType,
     jsdoc,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for RequireReturnsType {
@@ -95,7 +96,7 @@ fn test() {
 			           * @returns {number}
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -130,7 +131,7 @@ fn test() {
 			           * @returns
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -142,7 +143,7 @@ fn test() {
 			           * @returns Foo.
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,
@@ -154,7 +155,7 @@ fn test() {
 			           * @return Foo.
 			           */
 			          function quux () {
-			
+
 			          }
 			      ",
             None,

--- a/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_yields.rs
@@ -100,6 +100,7 @@ declare_oxc_lint!(
     RequireYields,
     jsdoc,
     correctness,
+    tags = [recommended],
     config = RequireYieldsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/alt_text.rs
@@ -136,6 +136,7 @@ declare_oxc_lint!(
     AltText,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = AltTextConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_has_content.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     AnchorHasContent,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     conditional_suggestion
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_is_valid.rs
@@ -122,6 +122,7 @@ declare_oxc_lint!(
     AnchorIsValid,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = AnchorIsValidConfig
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -64,7 +64,8 @@ declare_oxc_lint!(
     /// ```
     AriaActivedescendantHasTabindex,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for AriaActivedescendantHasTabindex {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_props.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     AriaProps,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_proptypes.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_proptypes.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     AriaProptypes,
     jsx_a11y,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for AriaProptypes {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -98,6 +98,7 @@ declare_oxc_lint!(
     AriaRole,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = AriaRoleConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     AriaUnsupportedElements,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/autocomplete_valid.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     AutocompleteValid,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = AutocompleteValidConfig
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -46,7 +46,8 @@ declare_oxc_lint!(
     /// ```
     ClickEventsHaveKeyEvents,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for ClickEventsHaveKeyEvents {

--- a/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/heading_has_content.rs
@@ -67,6 +67,7 @@ declare_oxc_lint!(
     HeadingHasContent,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = HeadingHasContentConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/html_has_lang.rs
@@ -53,7 +53,8 @@ declare_oxc_lint!(
     /// ```
     HtmlHasLang,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for HtmlHasLang {

--- a/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/iframe_has_title.rs
@@ -56,7 +56,8 @@ declare_oxc_lint!(
     /// ```
     IframeHasTitle,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for IframeHasTitle {

--- a/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/img_redundant_alt.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     ImgRedundantAlt,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = ImgRedundantAltConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/label_has_associated_control.rs
@@ -120,6 +120,7 @@ declare_oxc_lint!(
     LabelHasAssociatedControl,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = LabelHasAssociatedControlConfig
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/media_has_caption.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     MediaHasCaption,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = MediaHasCaptionConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/mouse_events_have_key_events.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     MouseEventsHaveKeyEvents,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = MouseEventsHaveKeyEventsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_access_key.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     NoAccessKey,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     NoAutofocus,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     suggestion,
     config = NoAutofocus,
 );

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_distracting_elements.rs
@@ -87,6 +87,7 @@ declare_oxc_lint!(
     NoDistractingElements,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = NoDistractingElementsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -86,6 +86,7 @@ declare_oxc_lint!(
     NoNoninteractiveTabindex,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = NoNoninteractiveTabindexConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     NoRedundantRoles,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -80,6 +80,7 @@ declare_oxc_lint!(
     NoStaticElementInteractions,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     config = NoStaticElementInteractionsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_has_required_aria_props.rs
@@ -41,7 +41,8 @@ declare_oxc_lint!(
     /// ```
     RoleHasRequiredAriaProps,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 static ROLE_TO_REQUIRED_ARIA_PROPS: &[(&str, &[&str])] = &[

--- a/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/role_supports_aria_props.rs
@@ -54,7 +54,8 @@ declare_oxc_lint!(
     /// ```
     RoleSupportsAriaProps,
     jsx_a11y,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 fn default(span: Span, attr_name: &str, role: &str) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     Scope,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/tabindex_no_positive.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     TabindexNoPositive,
     jsx_a11y,
     correctness,
+    tags = [recommended],
     dangerous_suggestion
 );
 

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -73,7 +73,8 @@ declare_oxc_lint!(
     /// ```
     GoogleFontDisplay,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for GoogleFontDisplay {

--- a/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_preconnect.rs
@@ -44,7 +44,8 @@ declare_oxc_lint!(
     /// ```
     GoogleFontPreconnect,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for GoogleFontPreconnect {

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -91,7 +91,8 @@ declare_oxc_lint!(
     /// ```
     InlineScriptId,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for InlineScriptId {

--- a/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
+++ b/crates/oxc_linter/src/rules/nextjs/next_script_for_ga.rs
@@ -80,7 +80,8 @@ declare_oxc_lint!(
     /// ```
     NextScriptForGa,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NextScriptForGa {

--- a/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_assign_module_variable.rs
@@ -57,7 +57,8 @@ declare_oxc_lint!(
     /// ```
     NoAssignModuleVariable,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoAssignModuleVariable {

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -85,7 +85,8 @@ declare_oxc_lint!(
     /// ```
     NoAsyncClientComponent,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoAsyncClientComponent {

--- a/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_before_interactive_script_outside_document.rs
@@ -85,7 +85,8 @@ declare_oxc_lint!(
     /// ```
     NoBeforeInteractiveScriptOutsideDocument,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoBeforeInteractiveScriptOutsideDocument {

--- a/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_css_tags.rs
@@ -65,7 +65,8 @@ declare_oxc_lint!(
     /// ```
     NoCssTags,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoCssTags {

--- a/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_document_import_in_page.rs
@@ -54,7 +54,8 @@ declare_oxc_lint!(
     /// ```
     NoDocumentImportInPage,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDocumentImportInPage {

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -69,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     NoDuplicateHead,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDuplicateHead {

--- a/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_element.rs
@@ -66,7 +66,8 @@ declare_oxc_lint!(
     /// ```
     NoHeadElement,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoHeadElement {

--- a/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_head_import_in_document.rs
@@ -74,7 +74,8 @@ declare_oxc_lint!(
     /// ```
     NoHeadImportInDocument,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoHeadImportInDocument {

--- a/crates/oxc_linter/src/rules/nextjs/no_html_link_for_pages.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_html_link_for_pages.rs
@@ -75,7 +75,8 @@ declare_oxc_lint!(
     /// ```
     NoHtmlLinkForPages,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoHtmlLinkForPages {

--- a/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_img_element.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     NoImgElement,
     nextjs,
     correctness,
+    tags = [recommended],
     pending // TODO: add `import Image from "next/image"` (if missing), then change `<img />` to `<Image />`
 );
 

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     NoPageCustomFont,
     nextjs,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoPageCustomFont {

--- a/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_script_component_in_head.rs
@@ -62,7 +62,8 @@ declare_oxc_lint!(
     /// ```
     NoScriptComponentInHead,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoScriptComponentInHead {

--- a/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_styled_jsx_in_document.rs
@@ -75,6 +75,7 @@ declare_oxc_lint!(
     NoStyledJsxInDocument,
     nextjs,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoStyledJsxInDocument {

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -55,7 +55,8 @@ declare_oxc_lint!(
     /// ```
     NoSyncScripts,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoSyncScripts {
@@ -99,7 +100,7 @@ fn test() {
 
     let pass = vec![
         r"import {Head} from 'next/document';
-			
+
 			      export class Blah extends Head {
 			        render() {
 			          return (
@@ -111,7 +112,7 @@ fn test() {
 			        }
 			    }",
         r"import {Head} from 'next/document';
-			
+
 			      export class Blah extends Head {
 			        render(props) {
 			          return (
@@ -127,7 +128,7 @@ fn test() {
     let fail = vec![
         r"
 			      import {Head} from 'next/document';
-			
+
 			        export class Blah extends Head {
 			          render() {
 			            return (
@@ -140,7 +141,7 @@ fn test() {
 			      }",
         r"
 			      import {Head} from 'next/document';
-			
+
 			        export class Blah extends Head {
 			          render(props) {
 			            return (

--- a/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_title_in_document_head.rs
@@ -60,7 +60,8 @@ declare_oxc_lint!(
     /// ```
     NoTitleInDocumentHead,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoTitleInDocumentHead {

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoTypos,
     nextjs,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_unwanted_polyfillio.rs
@@ -63,7 +63,8 @@ declare_oxc_lint!(
     /// ```
     NoUnwantedPolyfillio,
     nextjs,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnwantedPolyfillio {

--- a/crates/oxc_linter/src/rules/node/no_exports_assign.rs
+++ b/crates/oxc_linter/src/rules/node/no_exports_assign.rs
@@ -77,6 +77,7 @@ declare_oxc_lint!(
     NoExportsAssign,
     node,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -183,6 +183,7 @@ declare_oxc_lint!(
     AlwaysReturn,
     promise,
     suspicious,
+    tags = [recommended],
     config = AlwaysReturnConfig,
 );
 

--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -81,6 +81,7 @@ declare_oxc_lint!(
     CatchOrReturn,
     promise,
     restriction,
+    tags = [recommended],
     config = CatchOrReturnConfig,
 );
 

--- a/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
+++ b/crates/oxc_linter/src/rules/promise/no_callback_in_promise.rs
@@ -84,6 +84,7 @@ declare_oxc_lint!(
     NoCallbackInPromise,
     promise,
     correctness,
+    tags = [recommended],
     config = NoCallbackInPromiseConfig,
 );
 

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     NoNesting,
     promise,
     style,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     NoNewStatics,
     promise,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
+++ b/crates/oxc_linter/src/rules/promise/no_promise_in_callback.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     NoPromiseInCallback,
     promise,
     suspicious,
+    tags = [recommended],
 );
 
 impl Rule for NoPromiseInCallback {

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     NoReturnInFinally,
     promise,
     nursery,
+    tags = [recommended],
 );
 
 impl Rule for NoReturnInFinally {

--- a/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_wrap.rs
@@ -131,6 +131,7 @@ declare_oxc_lint!(
     NoReturnWrap,
     promise,
     style,
+    tags = [recommended],
     pending,
     config = NoReturnWrap,
 );

--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     ParamNames,
     promise,
     style,
+    tags = [recommended],
     config = ParamNamesConfig,
 );
 

--- a/crates/oxc_linter/src/rules/promise/valid_params.rs
+++ b/crates/oxc_linter/src/rules/promise/valid_params.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     ValidParams,
     promise,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for ValidParams {

--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     DisplayName,
     react,
     pedantic,
+    tags = [recommended],
     config = DisplayNameConfig,
 );
 

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -108,6 +108,7 @@ declare_oxc_lint!(
     JsxKey,
     react,
     correctness,
+    tags = [recommended],
     config = JsxKey,
 );
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -50,7 +50,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoCommentTextnodes,
     react,
-    suspicious
+    suspicious,
+    tags = [recommended],
 );
 
 impl Rule for JsxNoCommentTextnodes {

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -55,7 +55,8 @@ declare_oxc_lint!(
     /// is allowed). This is intentional, as props are case-sensitive in JSX.
     JsxNoDuplicateProps,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for JsxNoDuplicateProps {

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -140,6 +140,7 @@ declare_oxc_lint!(
     JsxNoTargetBlank,
     react,
     pedantic,
+    tags = [recommended],
     pending,
     config = JsxNoTargetBlank,
 );

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -40,7 +40,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoUndef,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a IdentifierReference<'a>> {

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -54,7 +54,8 @@ declare_oxc_lint!(
     /// ```
     NoChildrenProp,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoChildrenProp {

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -45,7 +45,8 @@ declare_oxc_lint!(
     /// ```
     NoDangerWithChildren,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDangerWithChildren {

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -90,7 +90,8 @@ declare_oxc_lint!(
     /// ```
     NoDirectMutationState,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDirectMutationState {

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -47,7 +47,8 @@ declare_oxc_lint!(
     /// ```
     NoFindDomNode,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoFindDomNode {

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -46,7 +46,8 @@ declare_oxc_lint!(
     /// ```
     NoIsMounted,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoIsMounted {

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -48,7 +48,8 @@ declare_oxc_lint!(
     /// ```
     NoRenderReturnValue,
     react,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoRenderReturnValue {

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -85,6 +85,7 @@ declare_oxc_lint!(
     NoStringRefs,
     react,
     correctness,
+    tags = [recommended],
     config = NoStringRefs,
 );
 

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoUnescapedEntities,
     react,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -93,6 +93,7 @@ declare_oxc_lint!(
     NoUnknownProperty,
     react,
     restriction,
+    tags = [recommended],
     pending,
     config = NoUnknownPropertyConfig,
 );

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -55,7 +55,8 @@ declare_oxc_lint!(
     /// ```
     ReactInJsxScope,
     react,
-    suspicious
+    suspicious,
+    tags = [recommended],
 );
 
 impl Rule for ReactInJsxScope {

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -69,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     RequireRenderReturn,
     react,
-    nursery
+    nursery,
+    tags = [recommended],
 );
 
 impl Rule for RequireRenderReturn {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -37,7 +37,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoJsxAsProp,
     react_perf,
-    perf
+    perf,
+    tags = [recommended],
 );
 
 impl ReactPerfRule for JsxNoJsxAsProp {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -42,7 +42,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoNewArrayAsProp,
     react_perf,
-    perf
+    perf,
+    tags = [recommended],
 );
 
 impl ReactPerfRule for JsxNoNewArrayAsProp {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -39,7 +39,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoNewFunctionAsProp,
     react_perf,
-    perf
+    perf,
+    tags = [recommended],
 );
 
 impl ReactPerfRule for JsxNoNewFunctionAsProp {

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -43,7 +43,8 @@ declare_oxc_lint!(
     /// ```
     JsxNoNewObjectAsProp,
     react_perf,
-    perf
+    perf,
+    tags = [recommended],
 );
 
 impl ReactPerfRule for JsxNoNewObjectAsProp {

--- a/crates/oxc_linter/src/rules/typescript/await_thenable.rs
+++ b/crates/oxc_linter/src/rules/typescript/await_thenable.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     AwaitThenable(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -157,6 +157,7 @@ declare_oxc_lint!(
     BanTsComment,
     typescript,
     pedantic,
+    tags = [recommended],
     conditional_fix,
     config = BanTsCommentConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_array_delete.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_array_delete.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     NoArrayDelete(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_base_to_string.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     NoBaseToString(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     config = NoBaseToStringConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -85,7 +85,8 @@ declare_oxc_lint!(
     /// ```
     NoDuplicateEnumValues,
     typescript,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoDuplicateEnumValues {

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_type_constituents.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     NoDuplicateTypeConstituents(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     fix,
     config = NoDuplicateTypeConstituentsConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -159,6 +159,7 @@ declare_oxc_lint!(
     NoEmptyObjectType,
     typescript,
     restriction,
+    tags = [recommended],
     pending,
     config = NoEmptyObjectTypeConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     NoExplicitAny,
     typescript,
     restriction,
+    tags = [recommended],
     conditional_fix,
     config = NoExplicitAny,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     NoExtraNonNullAssertion,
     typescript,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -106,6 +106,7 @@ declare_oxc_lint!(
     NoFloatingPromises(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     suggestion,
     config = NoFloatingPromisesConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_for_in_array.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_for_in_array.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     NoForInArray(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoForInArray {}

--- a/crates/oxc_linter/src/rules/typescript/no_implied_eval.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_implied_eval.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoImpliedEval(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoImpliedEval {}

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -69,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     NoMisusedNew,
     typescript,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoMisusedNew {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -125,6 +125,7 @@ declare_oxc_lint!(
     NoMisusedPromises(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     config = NoMisusedPromisesConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -112,6 +112,7 @@ declare_oxc_lint!(
     NoNamespace,
     typescript,
     restriction,
+    tags = [recommended],
     config = NoNamespace,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     NoNonNullAssertedOptionalChain,
     typescript,
     correctness,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_redundant_type_constituents.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_redundant_type_constituents.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     NoRedundantTypeConstituents(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoRedundantTypeConstituents {}

--- a/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_require_imports.rs
@@ -112,6 +112,7 @@ declare_oxc_lint!(
     NoRequireImports,
     typescript,
     restriction,
+    tags = [recommended],
     pending,  // TODO: fixer (change require to import)
     config = NoRequireImportsConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -95,6 +95,7 @@ declare_oxc_lint!(
     NoThisAlias,
     typescript,
     correctness,
+    tags = [recommended],
     config = NoThisAliasConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_assertion.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeAssertion(tsgolint),
     typescript,
     suspicious,
+    tags = [recommended],
     fix,
     config = NoUnnecessaryTypeAssertionConfig,
 );

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     NoUnnecessaryTypeConstraint,
     typescript,
     suspicious,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_argument.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_argument.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     NoUnsafeArgument(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeArgument {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_assignment.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     NoUnsafeAssignment(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeAssignment {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_call.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_call.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     NoUnsafeCall(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeCall {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -44,7 +44,8 @@ declare_oxc_lint!(
     /// ```
     NoUnsafeDeclarationMerging,
     typescript,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeDeclarationMerging {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_enum_comparison.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_enum_comparison.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     typescript,
     suspicious,
     pending,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeEnumComparison {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     NoUnsafeFunctionType,
     typescript,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeFunctionType {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_member_access.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     NoUnsafeMemberAccess(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     config = NoUnsafeMemberAccessConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_return.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_return.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     NoUnsafeReturn(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeReturn {}

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_unary_minus.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_unary_minus.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     NoUnsafeUnaryMinus(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoUnsafeUnaryMinus {}

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     NoWrapperObjectTypes,
     typescript,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/only_throw_error.rs
@@ -88,6 +88,7 @@ declare_oxc_lint!(
     OnlyThrowError(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     config = OnlyThrowErrorConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     PreferAsConst,
     typescript,
     correctness,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     PreferNamespaceKeyword,
     typescript,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_promise_reject_errors.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     PreferPromiseRejectErrors(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     config = PreferPromiseRejectErrorsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/require_await.rs
+++ b/crates/oxc_linter/src/rules/typescript/require_await.rs
@@ -74,6 +74,7 @@ declare_oxc_lint!(
     RequireAwait(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     pending,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_plus_operands.rs
@@ -92,6 +92,7 @@ declare_oxc_lint!(
     RestrictPlusOperands(tsgolint),
     typescript,
     pedantic,
+    tags = [recommended],
     config = RestrictPlusOperandsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
+++ b/crates/oxc_linter/src/rules/typescript/restrict_template_expressions.rs
@@ -122,6 +122,7 @@ declare_oxc_lint!(
     RestrictTemplateExpressions(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     config = RestrictTemplateExpressionsConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -97,6 +97,7 @@ declare_oxc_lint!(
     TripleSlashReference,
     typescript,
     correctness,
+    tags = [recommended],
     config = TripleSlashReferenceConfig,
 );
 

--- a/crates/oxc_linter/src/rules/typescript/unbound_method.rs
+++ b/crates/oxc_linter/src/rules/typescript/unbound_method.rs
@@ -96,6 +96,7 @@ declare_oxc_lint!(
     UnboundMethod(tsgolint),
     typescript,
     correctness,
+    tags = [recommended],
     config = UnboundMethodConfig,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     ConsistentDateClone,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
@@ -67,6 +67,7 @@ declare_oxc_lint!(
     ConsistentExistenceIndexCheck,
     unicorn,
     style,
+    tags = [recommended],
     fix,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/error_message.rs
+++ b/crates/oxc_linter/src/rules/unicorn/error_message.rs
@@ -51,7 +51,8 @@ declare_oxc_lint!(
     /// ```
     ErrorMessage,
     unicorn,
-    style
+    style,
+    tags = [recommended],
 );
 
 impl Rule for ErrorMessage {

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     EscapeCase,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     NewForBuiltins,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -72,7 +72,8 @@ declare_oxc_lint!(
     /// ```
     NoAbusiveEslintDisable,
     unicorn,
-    restriction
+    restriction,
+    tags = [recommended],
 );
 
 impl Rule for NoAbusiveEslintDisable {

--- a/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_accessor_recursion.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     NoAccessorRecursion,
     unicorn,
     suspicious,
+    tags = [recommended],
 );
 
 impl Rule for NoAccessorRecursion {

--- a/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_anonymous_default_export.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     NoAnonymousDefaultExport,
     unicorn,
     restriction,
+    tags = [recommended],
     pending,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_for_each.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     NoArrayForEach,
     unicorn,
     restriction,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_method_this_argument.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoArrayMethodThisArgument,
     unicorn,
     style,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_reverse.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     NoArrayReverse,
     unicorn,
     suspicious,
+    tags = [recommended],
     fix,
     config = NoArrayReverse,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_array_sort.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     NoArraySort,
     unicorn,
     suspicious,
+    tags = [recommended],
     fix,
     config = NoArraySort,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     NoAwaitInPromiseMethods,
     unicorn,
     correctness,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_console_spaces.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoConsoleSpaces,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_document_cookie.rs
@@ -61,7 +61,8 @@ declare_oxc_lint!(
     /// ```
     NoDocumentCookie,
     unicorn,
-    restriction
+    restriction,
+    tags = [recommended],
 );
 
 impl Rule for NoDocumentCookie {

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -94,6 +94,7 @@ declare_oxc_lint!(
     NoEmptyFile,
     unicorn,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoEmptyFile {

--- a/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_hex_escape.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     NoHexEscape,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
@@ -124,6 +124,7 @@ declare_oxc_lint!(
     NoInstanceofBuiltins,
     unicorn,
     suspicious,
+    tags = [recommended],
     conditional_suggestion,
     config = NoInstanceofBuiltinsConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     NoInvalidFetchOptions,
     unicorn,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoInvalidFetchOptions {

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_remove_event_listener.rs
@@ -44,7 +44,8 @@ declare_oxc_lint!(
     /// ```
     NoInvalidRemoveEventListener,
     unicorn,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoInvalidRemoveEventListener {

--- a/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_lonely_if.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     NoLonelyIf,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoMagicArrayFlatDepth,
     unicorn,
     restriction,
+    tags = [recommended],
 );
 
 impl Rule for NoMagicArrayFlatDepth {

--- a/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negation_in_equality_check.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     NoNegationInEqualityCheck,
     unicorn,
     pedantic,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_array.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     NoNewArray,
     unicorn,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_new_buffer.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     NoNewBuffer,
     unicorn,
     pedantic,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_object_as_default_parameter.rs
@@ -42,7 +42,8 @@ declare_oxc_lint!(
     /// ```
     NoObjectAsDefaultParameter,
     unicorn,
-    pedantic
+    pedantic,
+    tags = [recommended],
 );
 impl Rule for NoObjectAsDefaultParameter {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_process_exit.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     NoProcessExit,
     unicorn,
     restriction,
+    tags = [recommended],
     pending // TODO: suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     NoSinglePromiseInPromiseMethods,
     unicorn,
     correctness,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     NoStaticOnlyClass,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix_dangerous
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -73,7 +73,8 @@ declare_oxc_lint!(
     /// ```
     NoThenable,
     unicorn,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoThenable {

--- a/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_this_assignment.rs
@@ -55,7 +55,8 @@ declare_oxc_lint!(
     /// ```
     NoThisAssignment,
     unicorn,
-    pedantic
+    pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoThisAssignment {

--- a/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_typeof_undefined.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoTypeofUndefined,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix_or_suggestion,
     config = NoTypeofUndefined,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_flat_depth.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     NoUnnecessaryArrayFlatDepth,
     unicorn,
     pedantic,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_splice_count.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_array_splice_count.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     NoUnnecessaryArraySpliceCount,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     NoUnnecessaryAwait,
     unicorn,
     correctness,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_slice_end.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     NoUnnecessarySliceEnd,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     NoUnreadableArrayDestructuring,
     unicorn,
     style,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_iife.rs
@@ -49,7 +49,8 @@ declare_oxc_lint!(
     /// ```
     NoUnreadableIife,
     unicorn,
-    pedantic
+    pedantic,
+    tags = [recommended],
 );
 
 impl Rule for NoUnreadableIife {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_collection_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_collection_argument.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     NoUselessCollectionArgument,
     unicorn,
     style,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_error_capture_stack_trace.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     NoUselessErrorCaptureStackTrace,
     unicorn,
     restriction,
+    tags = [recommended],
     suggestion
 );
 
@@ -376,7 +377,7 @@ fn test() {
             "class MyError extends Error {
                 constructor() {
                     const foo = () => {
-                        
+
                     }
                 }
             }",
@@ -389,7 +390,7 @@ fn test() {
             }",
             "export default class extends Error {
                 constructor() {
-                    
+
                 }
             }",
         ),
@@ -404,7 +405,7 @@ fn test() {
             "export default (
                 class extends Error {
                     constructor() {
-                        
+
                     }
                 }
             )",

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     NoUselessFallbackInSpread,
     unicorn,
     correctness,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     NoUselessLengthCheck,
     unicorn,
     correctness,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_promise_resolve_reject.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     NoUselessPromiseResolveReject,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix,
     config = NoUselessPromiseResolveRejectOptions,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -142,6 +142,7 @@ declare_oxc_lint!(
     NoUselessSpread,
     unicorn,
     correctness,
+    tags = [recommended],
     fix_dangerous
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_switch_case.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     NoUselessSwitchCase,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     NoUselessUndefined,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix,
     config = NoUselessUndefined,
 );

--- a/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_zero_fractions.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoZeroFractions,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -79,6 +79,7 @@ declare_oxc_lint!(
     NumberLiteralCase,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -134,6 +134,7 @@ declare_oxc_lint!(
     NumericSeparatorsStyle,
     unicorn,
     style,
+    tags = [recommended],
     fix,
     config = NumericSeparatorsStyleConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -38,6 +38,7 @@ declare_oxc_lint!(
     PreferAddEventListener,
     unicorn,
     suspicious,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_find.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     PreferArrayFind,
     unicorn,
     perf, // Encourages more efficient use of built-in methods
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     PreferArrayFlat,
     unicorn,
     pedantic,
+    tags = [recommended],
     conditional_dangerous_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat_map.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     PreferArrayFlatMap,
     unicorn,
     perf,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_index_of.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_index_of.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     PreferArrayIndexOf,
     unicorn,
     style,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_some.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     PreferArraySome,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
@@ -84,6 +84,7 @@ declare_oxc_lint!(
     PreferAt,
     unicorn,
     pedantic,
+    tags = [recommended],
     dangerous_fix,
     config = PreferAtConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_bigint_literals.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     PreferBigintLiterals,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_blob_reading_methods.rs
@@ -55,6 +55,7 @@ declare_oxc_lint!(
     PreferBlobReadingMethods,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_class_fields.rs
@@ -83,6 +83,7 @@ declare_oxc_lint!(
     PreferClassFields,
     unicorn,
     style,
+    tags = [recommended],
     conditional_fix_suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_classlist_toggle.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     PreferClasslistToggle,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_code_point.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     PreferCodePoint,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_date_now.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     PreferDateNow,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_default_parameters.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     PreferDefaultParameters,
     unicorn,
     style,
+    tags = [recommended],
     pending,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_append.rs
@@ -37,6 +37,7 @@ declare_oxc_lint!(
     PreferDomNodeAppend,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     PreferDomNodeDataset,
     unicorn,
     pedantic,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_remove.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     PreferDomNodeRemove,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     PreferDomNodeTextContent,
     unicorn,
     style,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -50,7 +50,8 @@ declare_oxc_lint!(
     /// ```
     PreferEventTarget,
     unicorn,
-    pedantic
+    pedantic,
+    tags = [recommended],
 );
 
 impl Rule for PreferEventTarget {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_global_this.rs
@@ -59,6 +59,7 @@ declare_oxc_lint!(
     PreferGlobalThis,
     unicorn,
     style,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_includes.rs
@@ -58,6 +58,7 @@ declare_oxc_lint!(
     PreferIncludes,
     unicorn,
     style,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     PreferKeyboardEventKey,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_logical_operator_over_ternary.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     PreferLogicalOperatorOverTernary,
     unicorn,
     style,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_min_max.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_min_max.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     PreferMathMinMax,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -46,6 +46,7 @@ declare_oxc_lint!(
     PreferMathTrunc,
     unicorn,
     pedantic,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     PreferModernDomApis,
     unicorn,
     style,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_math_apis.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     PreferModernMathApis,
     unicorn,
     restriction,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_module.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_module.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     PreferModule,
     unicorn,
     restriction,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_native_coercion_functions.rs
@@ -53,6 +53,7 @@ declare_oxc_lint!(
     PreferNativeCoercionFunctions,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_negative_index.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     PreferNegativeIndex,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 
@@ -479,7 +480,7 @@ fn test() {
                                     foo.slice(
                                         // comment 1
 
-                                        
+
 
                                         // comment 2
                                         - 1,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     PreferNodeProtocol,
     unicorn,
     restriction,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -82,6 +82,7 @@ declare_oxc_lint!(
     PreferNumberProperties,
     unicorn,
     restriction,
+    tags = [recommended],
     dangerous_fix,
     config = PreferNumberPropertiesConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -80,6 +80,7 @@ declare_oxc_lint!(
     PreferObjectFromEntries,
     unicorn,
     style,
+    tags = [recommended],
     pending,
     config = PreferObjectFromEntriesConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_optional_catch_binding.rs
@@ -40,6 +40,7 @@ declare_oxc_lint!(
     PreferOptionalCatchBinding,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_prototype_methods.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     PreferPrototypeMethods,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_reflect_apply.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     PreferReflectApply,
     unicorn,
     style,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_regexp_test.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     PreferRegexpTest,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_response_static_json.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     PreferResponseStaticJson,
     unicorn,
     style,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_has.rs
@@ -66,6 +66,7 @@ declare_oxc_lint!(
     PreferSetHas,
     unicorn,
     perf,
+    tags = [recommended],
     dangerous_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_set_size.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     PreferSetSize,
     unicorn,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     PreferStringRaw,
     unicorn,
     style,
+    tags = [recommended],
     fix,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     PreferStringReplaceAll,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_slice.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     PreferStringSlice,
     unicorn,
     pedantic,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     PreferStringStartsEndsWith,
     unicorn,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     PreferStringTrimStartEnd,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_structured_clone.rs
@@ -73,6 +73,7 @@ declare_oxc_lint!(
     PreferStructuredClone,
     unicorn,
     style,
+    tags = [recommended],
     suggestion,
     config = PreferStructuredCloneConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_ternary.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_ternary.rs
@@ -61,6 +61,7 @@ declare_oxc_lint!(
     PreferTernary,
     unicorn,
     style,
+    tags = [recommended],
     pending,
     config = PreferTernaryOption
 );

--- a/crates/oxc_linter/src/rules/unicorn/prefer_top_level_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_top_level_await.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     PreferTopLevelAwait,
     unicorn,
     pedantic,
+    tags = [recommended],
     pending
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_type_error.rs
@@ -47,6 +47,7 @@ declare_oxc_lint!(
     PreferTypeError,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/relative_url_style.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     RelativeUrlStyle,
     unicorn,
     style,
+    tags = [recommended],
     fix_suggestion,
     config = RelativeUrlStyleConfig,
 );

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     RequireArrayJoinSeparator,
     unicorn,
     style,
+    tags = [recommended],
     conditional_fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
@@ -60,6 +60,7 @@ declare_oxc_lint!(
     RequireModuleAttributes,
     unicorn,
     style,
+    tags = [recommended],
     suggestion,
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_specifiers.rs
@@ -50,6 +50,7 @@ declare_oxc_lint!(
     RequireModuleSpecifiers,
     unicorn,
     suspicious,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_number_to_fixed_digits_argument.rs
@@ -39,6 +39,7 @@ declare_oxc_lint!(
     RequireNumberToFixedDigitsArgument,
     unicorn,
     pedantic,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     TextEncodingIdentifierCase,
     unicorn,
     style,
+    tags = [recommended],
     fix,
     config = TextEncodingIdentifierCase
 );

--- a/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
+++ b/crates/oxc_linter/src/rules/unicorn/throw_new_error.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     ThrowNewError,
     unicorn,
     style,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     NoImportNodeTest,
     vitest,
     style,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -84,7 +84,8 @@ declare_oxc_lint!(
     /// ```
     RequireLocalTestContextForConcurrentSnapshots,
     vitest,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {

--- a/crates/oxc_linter/src/rules/vue/no_arrow_functions_in_watch.rs
+++ b/crates/oxc_linter/src/rules/vue/no_arrow_functions_in_watch.rs
@@ -69,7 +69,8 @@ declare_oxc_lint!(
     /// ```
     NoArrowFunctionsInWatch,
     vue,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoArrowFunctionsInWatch {

--- a/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
+++ b/crates/oxc_linter/src/rules/vue/no_deprecated_destroyed_lifecycle.rs
@@ -62,6 +62,7 @@ declare_oxc_lint!(
     NoDeprecatedDestroyedLifecycle,
     vue,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/vue/no_export_in_script_setup.rs
+++ b/crates/oxc_linter/src/rules/vue/no_export_in_script_setup.rs
@@ -44,6 +44,7 @@ declare_oxc_lint!(
     NoExportInScriptSetup,
     vue,
     correctness,
+    tags = [recommended],
 );
 
 impl Rule for NoExportInScriptSetup {

--- a/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
+++ b/crates/oxc_linter/src/rules/vue/no_lifecycle_after_await.rs
@@ -66,7 +66,8 @@ declare_oxc_lint!(
     /// ```
     NoLifecycleAfterAwait,
     vue,
-    correctness
+    correctness,
+    tags = [recommended],
 );
 
 const LIFECYCLE_HOOKS: &[&str] = &[

--- a/crates/oxc_linter/src/rules/vue/no_multiple_slot_args.rs
+++ b/crates/oxc_linter/src/rules/vue/no_multiple_slot_args.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     NoMultipleSlotArgs,
     vue,
     restriction,
+    tags = [recommended],
     pending  // TODO: Remove second argument, Spread argument is possible not supported
 );
 

--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -76,6 +76,7 @@ declare_oxc_lint!(
     NoRequiredPropWithDefault,
     vue,
     suspicious,
+    tags = [recommended],
     suggestion
 );
 

--- a/crates/oxc_linter/src/rules/vue/prefer_import_from_vue.rs
+++ b/crates/oxc_linter/src/rules/vue/prefer_import_from_vue.rs
@@ -41,6 +41,7 @@ declare_oxc_lint!(
     PreferImportFromVue,
     vue,
     correctness,
+    tags = [recommended],
     fix
 );
 

--- a/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_define_emits.rs
@@ -132,6 +132,7 @@ declare_oxc_lint!(
     ValidDefineEmits,
     vue,
     correctness,
+    tags = [recommended],
     pending  // TODO: removing empty `defineEmits` and merging multiple `defineEmits` calls
 );
 

--- a/crates/oxc_linter/src/rules/vue/valid_define_props.rs
+++ b/crates/oxc_linter/src/rules/vue/valid_define_props.rs
@@ -132,6 +132,7 @@ declare_oxc_lint!(
     ValidDefineProps,
     vue,
     correctness,
+    tags = [recommended],
     pending  // TODO: removing empty `defineProps` and merging multiple `defineProps` calls
 );
 


### PR DESCRIPTION
- Based on the recommended rulesets from each individual plugin, excluding any deprecated rules.
- I am also excluding the `oxc` plugin for now, as we'll have to make our own determination on what would be good to add there. 
- `unicorn` recommended rules are based on the `unopinionated` recommended rules