### PR TITLE
refactor(formatter/sort_imports): Reuse metadata from AST instead of re-parsing IRs

### DIFF
--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -295,6 +295,7 @@ fn convert_elements(
                 }
                 printer.last_was_hardline = false;
             }
+            FormatElement::ImportMetadata(_) => {}
         }
     }
 

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -536,6 +536,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                         );
                     }
                 }
+                FormatElement::ImportMetadata(_) => {}
             }
         }
 

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -100,6 +100,28 @@ pub enum FormatElement<'a> {
     /// The usize is an index into the collected tailwind classes array.
     /// During printing, this will be replaced with the sorted class name.
     TailwindClass(usize),
+
+    /// AST-derived import metadata for the sort-imports IR transform. Skipped during printing.
+    ImportMetadata(&'a ImportDeclMetadata<'a>),
+}
+
+/// Metadata for an import declaration, created during formatting from AST information.
+/// Used by the sort-imports IR transform.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ImportDeclMetadata<'a> {
+    /// The import source path value (without quotes).
+    /// e.g. `react` for `import React from "react"`.
+    pub source: &'a str,
+    /// Whether this is a side-effect-only import (e.g., `import "foo"`).
+    pub is_side_effect: bool,
+    /// Whether this is a type-only import (e.g., `import type { Foo } from "foo"`).
+    pub is_type_import: bool,
+    /// Whether this import has a default specifier (e.g., `import Foo from "foo"`).
+    pub has_default_specifier: bool,
+    /// Whether this import has a namespace specifier (e.g., `import * as Foo from "foo"`).
+    pub has_namespace_specifier: bool,
+    /// Whether this import has named specifiers (e.g., `import { foo } from "foo"`).
+    pub has_named_specifier: bool,
 }
 
 impl std::fmt::Debug for FormatElement<'_> {
@@ -118,6 +140,9 @@ impl std::fmt::Debug for FormatElement<'_> {
             FormatElement::Tag(tag) => fmt.debug_tuple("Tag").field(tag).finish(),
             FormatElement::TailwindClass(index) => {
                 fmt.debug_tuple("TailwindClass").field(index).finish()
+            }
+            FormatElement::ImportMetadata(metadata) => {
+                fmt.debug_tuple("ImportMetadata").field(metadata).finish()
             }
         }
     }
@@ -287,7 +312,8 @@ impl FormatElements for FormatElement<'_> {
             | FormatElement::Space
             | FormatElement::Tag(_)
             | FormatElement::HardSpace
-            | FormatElement::TailwindClass(_) => false,
+            | FormatElement::TailwindClass(_)
+            | FormatElement::ImportMetadata(_) => false,
         }
     }
 

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -278,6 +278,7 @@ impl<'a> Printer<'a> {
                     self.print_text(Text::Text { text, width });
                 }
             }
+            FormatElement::ImportMetadata(_) => {}
         }
 
         Ok(())
@@ -1179,6 +1180,8 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                     return Ok(self.fits_text(Text::Text { text, width }));
                 }
             }
+            // Import metadata is only used by IR transforms, not by the printer.
+            FormatElement::ImportMetadata(_) => {}
         }
 
         Ok(Fits::Maybe)

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -278,6 +278,7 @@ impl<'a> Printer<'a> {
                     self.print_text(Text::Text { text, width });
                 }
             }
+            #[expect(clippy::match_same_arms)]
             FormatElement::ImportMetadata(_) => {}
         }
 

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/compute_metadata.rs
@@ -3,22 +3,24 @@ use std::{borrow::Cow, path::Path};
 use cow_utils::CowUtils;
 use phf::phf_set;
 
-use crate::ir_transform::sort_imports::{
-    group_config::{ImportModifier, ImportSelector},
-    group_matcher::{GroupMatcher, ImportMetadata},
-    options::SortImportsOptions,
-    source_line::ImportLineMetadata,
+use crate::{
+    formatter::format_element::ImportDeclMetadata,
+    ir_transform::sort_imports::{
+        group_config::{ImportModifier, ImportSelector},
+        group_matcher::{GroupMatcher, ImportMetadata},
+        options::SortImportsOptions,
+    },
 };
 
 /// Compute all metadata derived from import line metadata.
 ///
 /// Returns `(group_idx, normalized_source, is_ignored)`.
 pub fn compute_import_metadata<'a>(
-    metadata: &ImportLineMetadata<'a>,
+    metadata: &ImportDeclMetadata<'a>,
     group_matcher: &GroupMatcher,
     options: &SortImportsOptions,
 ) -> (usize, Cow<'a, str>, bool) {
-    let source = extract_source_path(metadata.source);
+    let source = metadata.source.split('?').next().unwrap_or(metadata.source);
     let is_style_import = is_style(source);
     let path_kind = to_path_kind(source, options);
 
@@ -60,7 +62,7 @@ pub fn compute_import_metadata<'a>(
 /// 4. Path-based selectors (builtin, external, internal, parent, sibling, index)
 /// 5. Catch-all import selector
 fn compute_selectors(
-    metadata: &ImportLineMetadata,
+    metadata: &ImportDeclMetadata,
     is_style_import: bool,
     is_subpath: bool,
     path_kind: &ImportPathKind,
@@ -114,7 +116,7 @@ fn compute_selectors(
 }
 
 /// Compute all modifiers for this import.
-fn compute_modifiers(metadata: &ImportLineMetadata) -> Vec<ImportModifier> {
+fn compute_modifiers(metadata: &ImportDeclMetadata) -> Vec<ImportModifier> {
     let mut modifiers = vec![];
 
     if metadata.is_side_effect {
@@ -139,15 +141,6 @@ fn compute_modifiers(metadata: &ImportLineMetadata) -> Vec<ImportModifier> {
 }
 
 // ---
-
-/// Extract the import source path.
-///
-/// This removes quotes and query parameters from the source string.
-/// For example, `"./foo.js?bar"` becomes `./foo.js`.
-fn extract_source_path(source: &str) -> &str {
-    let source = source.trim_matches('"').trim_matches('\'');
-    source.split('?').next().unwrap_or(source)
-}
 
 // spellchecker:off
 static STYLE_EXTENSIONS: phf::Set<&'static str> = phf_set! {

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/partitioned_chunk.rs
@@ -88,7 +88,7 @@ impl<'a> PartitionedChunk<'a> {
 
         for line in lines {
             match line {
-                SourceLine::Import(_, ref metadata) => {
+                SourceLine::Import(_, metadata) => {
                     // Handle orphan content (separated by empty line from this import)
                     // These stay at their original slot position, not attached to any import.
                     if !orphan_pending.is_empty() {

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -2,13 +2,7 @@ use std::ops::Range;
 
 use oxc_allocator::Vec as ArenaVec;
 
-use crate::{
-    JsLabels,
-    formatter::format_element::{
-        FormatElement, LineMode,
-        tag::{LabelId, Tag},
-    },
-};
+use crate::formatter::format_element::{FormatElement, ImportDeclMetadata, LineMode};
 
 #[derive(Debug)]
 pub enum SourceLine<'a> {
@@ -16,7 +10,7 @@ pub enum SourceLine<'a> {
     /// May have leading comments like `/* ... */ import ...`.
     /// And also may have trailing comments like `import ...; // ...`.
     /// Never be a boundary.
-    Import(Range<usize>, ImportLineMetadata<'a>),
+    Import(Range<usize>, &'a ImportDeclMetadata<'a>),
     /// Empty line.
     /// May be used as a boundary if `options.partition_by_newline` is true.
     Empty,
@@ -38,6 +32,16 @@ impl<'a> SourceLine<'a> {
             "`range` must not be empty, otherwise use `SourceLine::Empty` directly."
         );
 
+        // Check if the line contains an import by looking for ImportMetadata element.
+        // This metadata was attached during formatting from AST information,
+        // so no token re-parsing is needed.
+        for idx in range.clone() {
+            if let FormatElement::ImportMetadata(metadata) = &elements[idx] {
+                // TODO: Check line has trailing ignore comment?
+                return SourceLine::Import(range, metadata);
+            }
+        }
+
         // Check if the line is comment-only.
         // e.g.
         // ```text
@@ -57,95 +61,6 @@ impl<'a> SourceLine<'a> {
         });
         if is_comment_only {
             return SourceLine::CommentOnly(range, line_mode);
-        }
-
-        // Check if the line contains an import statement.
-        // Sometimes, there might be leading comments in the same line,
-        // so we need to check all elements in the line to find an `ImportDeclaration`.
-        // ```text
-        // /* THIS */ import ...
-        // import ...
-        // ```
-        let mut has_import = false;
-        let mut source = None;
-        let mut is_side_effect = true;
-        let mut is_type_import = false;
-        let mut has_default_specifier = false;
-        let mut has_namespace_specifier = false;
-        let mut has_named_specifier = false;
-
-        for idx in range.clone() {
-            let element = &elements[idx];
-
-            // Special marker for `ImportDeclaration`
-            if let FormatElement::Tag(Tag::StartLabelled(id)) = element {
-                if *id == LabelId::of(JsLabels::ImportDeclaration) {
-                    has_import = true;
-                }
-                continue;
-            }
-            if !has_import {
-                continue;
-            }
-
-            match element {
-                FormatElement::Token { text } => match *text {
-                    "import" => {
-                        // Look ahead to determine import type (skip spaces)
-                        // Continue scanning to find all specifier types (default, namespace, named)
-                        let mut offset = 1;
-                        let mut first_token = true; // Track if this is the first token after "import"
-                        while idx + offset < elements.len() {
-                            if matches!(elements[idx + offset], FormatElement::Space) {
-                                offset += 1;
-                                continue;
-                            }
-
-                            match &elements[idx + offset] {
-                                FormatElement::Token { text } => match *text {
-                                    "type" if first_token => is_type_import = true,
-                                    "*" => has_namespace_specifier = true,
-                                    "{" => has_named_specifier = true,
-                                    "from" => break, // Stop when we reach "from"
-                                    _ => {}
-                                },
-                                FormatElement::Text { .. } => {
-                                    has_default_specifier = true;
-                                }
-                                _ => {}
-                            }
-                            first_token = false;
-                            offset += 1;
-                        }
-                    }
-                    "from" => {
-                        is_side_effect = false;
-                        source = None;
-                    }
-                    _ => {}
-                },
-                FormatElement::Text { text, .. } => {
-                    if source.is_none() {
-                        source = Some(text);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        if has_import && let Some(source) = source {
-            // TODO: Check line has trailing ignore comment?
-            return SourceLine::Import(
-                range,
-                ImportLineMetadata {
-                    source,
-                    is_side_effect,
-                    is_type_import,
-                    has_default_specifier,
-                    has_namespace_specifier,
-                    has_named_specifier,
-                },
-            );
         }
 
         // Otherwise, this line is neither of:
@@ -186,20 +101,3 @@ impl<'a> SourceLine<'a> {
     }
 }
 
-/// Import line metadata extracted during parsing.
-/// Just holds the information found, without interpretation.
-#[derive(Debug)]
-pub struct ImportLineMetadata<'a> {
-    /// Index of the import source in the original `elements` slice.
-    pub source: &'a str,
-    /// Whether this is a side-effect-only import (e.g., `import "foo"`).
-    pub is_side_effect: bool,
-    /// Whether this is a type-only import (e.g., `import type { Foo } from "foo"`).
-    pub is_type_import: bool,
-    /// Whether this import has a default specifier (e.g., `import Foo from "foo"`).
-    pub has_default_specifier: bool,
-    /// Whether this import has a namespace specifier (e.g., `import * as Foo from "foo"`).
-    pub has_namespace_specifier: bool,
-    /// Whether this import has named specifiers (e.g., `import { foo } from "foo"`).
-    pub has_named_specifier: bool,
-}

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -100,4 +100,3 @@ impl<'a> SourceLine<'a> {
         }
     }
 }
-

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -8,8 +8,9 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Formatter, prelude::*,
+        Formatter,
         format_element::{FormatElement, ImportDeclMetadata},
+        prelude::*,
         separated::FormatSeparatedIter,
         trivia::FormatLeadingComments,
     },
@@ -50,7 +51,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
             if f.options().sort_imports.is_some() {
                 let (mut has_default, mut has_namespace, mut has_named) = (false, false, false);
                 if let Some(specs) = &self.specifiers {
-                    for s in specs.iter() {
+                    for s in specs {
                         match s {
                             ImportDeclarationSpecifier::ImportDefaultSpecifier(_) => {
                                 has_default = true;

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -8,7 +8,10 @@ use crate::{
     ast_nodes::{AstNode, AstNodes},
     format_args,
     formatter::{
-        Formatter, prelude::*, separated::FormatSeparatedIter, trivia::FormatLeadingComments,
+        Formatter, prelude::*,
+        format_element::{FormatElement, ImportDeclMetadata},
+        separated::FormatSeparatedIter,
+        trivia::FormatLeadingComments,
     },
     print::semicolon::OptionalSemicolon,
     utils::string::{FormatLiteralStringToken, StringLiteralParentKind},
@@ -44,6 +47,32 @@ pub fn format_import_and_export_source_with_clause<'a>(
 impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
         let decl = &format_with(|f| {
+            if f.options().sort_imports.is_some() {
+                let (mut has_default, mut has_namespace, mut has_named) = (false, false, false);
+                if let Some(specs) = &self.specifiers {
+                    for s in specs.iter() {
+                        match s {
+                            ImportDeclarationSpecifier::ImportDefaultSpecifier(_) => {
+                                has_default = true;
+                            }
+                            ImportDeclarationSpecifier::ImportNamespaceSpecifier(_) => {
+                                has_namespace = true;
+                            }
+                            ImportDeclarationSpecifier::ImportSpecifier(_) => has_named = true,
+                        }
+                    }
+                }
+                let metadata = f.allocator().alloc(ImportDeclMetadata {
+                    source: self.source.value.as_str(),
+                    is_side_effect: self.specifiers.is_none(),
+                    is_type_import: self.import_kind.is_type(),
+                    has_default_specifier: has_default,
+                    has_namespace_specifier: has_namespace,
+                    has_named_specifier: has_named,
+                });
+                f.write_element(FormatElement::ImportMetadata(metadata));
+            }
+
             write!(f, ["import", space(), self.import_kind]);
 
             if let Some(specifiers) = self.specifiers() {


### PR DESCRIPTION
Currently, sort_imports manually re-parses IR to extract metadata about the imports.

This was a design choice intended to separate this transform layer without relying on the AST, but the implementation is prone to fragility and is inherently inefficient.

This is an experiment to see how much performance improvement can be achieved by integrating these processes.