### PR TITLE
docs(linter/jsdoc/require-property): fix typo

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
     ///  */
     ///
     /// /**
-    ///  * @namespace {Object} SomeNamesoace
+    ///  * @namespace {Object} SomeNamespace
     ///  */
     /// ```
     ///


### PR DESCRIPTION
I found (maybe) typo issue on this specific url

url: [require-property](https://oxc.rs/docs/guide/usage/linter/rules/jsdoc/require-property.html)