### PR TITLE
feat(linter/prefer-find): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_find.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_find.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// ```
     PreferFind(tsgolint),
     typescript,
-    nursery,
+    style,
 );
 
 impl Rule for PreferFind {}


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the `style` category