### PR TITLE
feat(linter/prefer-regexp-exec): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_regexp_exec.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_regexp_exec.rs
@@ -30,7 +30,7 @@ declare_oxc_lint!(
     /// ```
     PreferRegexpExec(tsgolint),
     typescript,
-    nursery,
+    style,
 );
 
 impl Rule for PreferRegexpExec {}


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the `style` category