### PR TITLE
feat(linter/prefer-readonly): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_readonly.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_readonly.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
     /// ```
     PreferReadonly(tsgolint),
     typescript,
-    nursery,
+    style,
     config = PreferReadonlyConfig,
 );
 


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the `style` category