### PR TITLE
feat(linter/prefer-string-starts-ends-with): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_string_starts_ends_with.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
     /// ```
     PreferStringStartsEndsWith(tsgolint),
     typescript,
-    nursery,
+    style,
     config = PreferStringStartsEndsWithConfig,
 );
 


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the `style` category