### PR TITLE
chore(oxlint): bump min tsgolint version to 0.18.0

### DIFF
--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -45,7 +45,7 @@
     }
   },
   "peerDependencies": {
-    "oxlint-tsgolint": ">=0.15.0"
+    "oxlint-tsgolint": ">=0.18.0"
   },
   "peerDependenciesMeta": {
     "oxlint-tsgolint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,7 +296,7 @@ importers:
   npm/oxlint:
     dependencies:
       oxlint-tsgolint:
-        specifier: '>=0.15.0'
+        specifier: '>=0.18.0'
         version: 0.18.0
 
   npm/oxlint-plugin-eslint: {}


### PR DESCRIPTION
the latest version has important bug fixes ect which users should be aware of to avoid false negatives/positives when running oxlint