### PR TITLE
feat(parser): support `turbopack` magic comments

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -92,6 +92,11 @@ pub enum CommentContent {
     /// `v8 ignore`, `c8 ignore`, `node:coverage`, `istanbul ignore`
     /// <https://github.com/oxc-project/oxc/issues/10091>
     CoverageIgnore = 9,
+
+    /// Turbopack magic comment
+    /// e.g. `/* turbopackOptional: true */`
+    /// <https://nextjs.org/docs/app/guides/lazy-loading#turbopackoptional-turbopack-only>
+    Turbopack = 10,
 }
 
 bitflags! {
@@ -265,6 +270,12 @@ impl Comment {
     #[inline]
     pub fn is_webpack(self) -> bool {
         self.content == CommentContent::Webpack
+    }
+
+    /// Is turbopack magic comment.
+    #[inline]
+    pub fn is_turbopack(self) -> bool {
+        self.content == CommentContent::Turbopack
     }
 
     /// Is vite special comment.

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -256,6 +256,17 @@ impl TriviaBuilder {
                 }
                 // Fall through to check for coverage ignore patterns
             }
+            b't' => {
+                // Check for turbopack comments
+                if bytes[start..].starts_with(b"turbopack")
+                    && start + 9 < bytes.len()
+                    && bytes[start + 9].is_ascii_uppercase()
+                {
+                    comment.content = CommentContent::Turbopack;
+                    return;
+                }
+                // Fall through to check for coverage ignore patterns
+            }
             b'v' | b'c' | b'n' | b'i' => {
                 // Check coverage ignore patterns: "v8 ignore", "c8 ignore", "node:coverage", "istanbul ignore"
                 let rest = &bytes[start..];
@@ -602,6 +613,7 @@ token /* Trailing 1 */
             ("/* @__NO_SIDE_EFFECTS__ */", CommentContent::NoSideEffects),
             ("/* #__PURE__ */", CommentContent::Pure),
             ("/* #__NO_SIDE_EFFECTS__ */", CommentContent::NoSideEffects),
+            ("/* turbopackOptional: true */", CommentContent::Turbopack),
         ];
 
         for (source_text, expected) in data {


### PR DESCRIPTION
Parses comment like [`turbopackOptional: true`](https://nextjs.org/docs/app/guides/lazy-loading#turbopackoptional-turbopack-only) so it won't get thrown away.