### PR TITLE
fix(oxlint/cli): skip parsing base config again for nested config search

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -27,6 +27,16 @@ pub enum DiscoveredConfig {
     Js(PathBuf),
 }
 
+impl DiscoveredConfig {
+    pub fn path(&self) -> &Path {
+        match self {
+            DiscoveredConfig::Json(path)
+            | DiscoveredConfig::Jsonc(path)
+            | DiscoveredConfig::Js(path) => path,
+        }
+    }
+}
+
 /// Discover config files by walking UP from each file's directory to ancestors.
 ///
 /// Used by CLI where we have specific files to lint and need to find configs
@@ -37,6 +47,7 @@ pub enum DiscoveredConfig {
 /// - Returns paths to any `.oxlintrc.json`, `.oxlintrc.jsonc`, or `oxlint.config.ts` files found
 pub fn discover_configs_in_ancestors<P: AsRef<Path>>(
     files: &[P],
+    base_config_path: &Path,
 ) -> impl IntoIterator<Item = DiscoveredConfig> {
     let mut config_paths = FxHashSet::<DiscoveredConfig>::default();
     let mut visited_dirs = FxHashSet::default();
@@ -52,6 +63,10 @@ pub fn discover_configs_in_ancestors<P: AsRef<Path>>(
                 break;
             }
             for config in find_configs_in_directory(dir) {
+                if config.path() == base_config_path {
+                    // Skip the base config file (e.g., root oxlintrc) to avoid duplicate loading
+                    continue;
+                }
                 config_paths.insert(config);
             }
             current = dir.parent();
@@ -650,7 +665,7 @@ impl<'a> ConfigLoader<'a> {
         // Discover config files by walking up from each file's directory
         let config_paths: Vec<_> =
             paths.iter().map(|p| Path::new(p.as_ref()).to_path_buf()).collect();
-        let discovered_configs = discover_configs_in_ancestors(&config_paths);
+        let discovered_configs = discover_configs_in_ancestors(&config_paths, &oxlintrc.path);
 
         let (configs, errors) = self.load_many(discovered_configs, Some(cwd));
 

--- a/apps/oxlint/src/snapshots/fixtures__cli__cross_module_nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__cross_module_nested_config_@oxlint.snap
@@ -35,7 +35,7 @@ working directory: fixtures/cli/cross_module_nested_config
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 4 files with 93 rules using 1 threads.
+Finished in <variable>ms on 4 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__extends_config_overrides@oxlint.snap
@@ -40,7 +40,7 @@ working directory: fixtures/cli/extends_config
   help: Provide an `href` for the `a` element.
 
 Found 1 warning and 3 errors.
-Finished in <variable>ms on 2 files with 93 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_symlink_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__ignore_patterns_symlink_ .@oxlint.snap
@@ -6,7 +6,7 @@ arguments:
 working directory: fixtures/cli/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------
@@ -16,7 +16,7 @@ arguments: .
 working directory: fixtures/cli/ignore_patterns_symlink
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 93 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__cli_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli_issue_10054@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/cli
            ╰─────────╯ imports the current file
 
 Found 0 warnings and 2 errors.
-Finished in <variable>ms on 2 files with 93 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_object/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_object/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/oxlint.config.ts.
+Failed to parse oxlint configuration file.
 
   x Relative JS plugin specifiers are not supported in configs provided via `extends` in `oxlint.config.ts`.
   | 

--- a/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_override/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_override/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/oxlint.config.ts.
+Failed to parse oxlint configuration file.
 
   x Relative JS plugin specifiers are not supported in configs provided via `extends` in `oxlint.config.ts`.
   | 

--- a/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_string/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_config_extends_js_plugins_relative_banned_string/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/oxlint.config.ts.
+Failed to parse oxlint configuration file.
 
   x Relative JS plugin specifiers are not supported in configs provided via `extends` in `oxlint.config.ts`.
   | 

--- a/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
+++ b/apps/oxlint/test/fixtures/lint_createOnce_error/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/.oxlintrc.json.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Error: Whoops!

--- a/apps/oxlint/test/fixtures/overrides_missing_rule/output.snap.md
+++ b/apps/oxlint/test/fixtures/overrides_missing_rule/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/.oxlintrc.json.
+Failed to build configuration.
 
   x Rule 'missing' not found in plugin 'basic-custom-plugin'
 ```

--- a/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_invalid/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/.oxlintrc.json.
+Failed to parse oxlint configuration file.
 
   x Failed to load JS plugin: ./plugin.ts
   |   Plugin alias 'eslint-plugin-invalid' is not valid. Must not start with 'eslint-plugin-', or be of form '@scope/eslint-plugin' or '@scope/eslint-plugin-name'.

--- a/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
+++ b/apps/oxlint/test/fixtures/plugin_name_alias_reserved/output.snap.md
@@ -3,7 +3,7 @@
 
 # stdout
 ```
-Failed to build configuration from <fixture>/.oxlintrc.json.
+Failed to parse oxlint configuration file.
 
   x Plugin name 'jsdoc' is reserved, and cannot be used for JS plugins.
   | 

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -298,8 +298,7 @@ impl ConfigStore {
     /// Returns the total number of rules, inclusive of JS Plugin rules, optionally filtering out tsgolint rules if type_aware_enabled is false.
     pub fn number_of_rules(&self, type_aware_enabled: bool) -> Option<usize> {
         // If there are nested configs the number of rules may vary per-file, so return `None`.
-        // Note: this is `> 1` due to https://github.com/oxc-project/oxc/issues/16356
-        if self.nested_configs.len() > 1 {
+        if !self.nested_configs.is_empty() {
             return None;
         }
 
@@ -1069,9 +1068,6 @@ mod test {
             ConfigStore::new(base.clone(), FxHashMap::default(), ExternalPluginStore::default());
 
         let mut nested_configs = FxHashMap::default();
-        // Add the base config to nested_configs, as that's how it actually works right now.
-        // TODO: Can remove this addition of the base config when we fix https://github.com/oxc-project/oxc/issues/16356
-        nested_configs.insert(PathBuf::new(), base.clone());
         // Then add another so we have more than just the base config here.
         nested_configs.insert(PathBuf::from("nested"), base);
 


### PR DESCRIPTION
Added a skip check for the base config to avoid parsing it again. Very useful for JS config or JS plugins, where we need roundtrips to JS integrations.

closes https://github.com/oxc-project/oxc/issues/16356