### PR TITLE
fix(linter): handle shadowed locals in no-restricted-globals

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -94,11 +94,9 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.scoping().root_unresolved_references().contains_key(&ident.name) {
-                let reference = ctx.scoping().get_reference(ident.reference_id());
-                if !reference.is_type() {
-                    ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
-                }
+            let reference = ctx.scoping().get_reference(ident.reference_id());
+            if reference.symbol_id().is_none() && !reference.is_type() {
+                ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
             }
         }
     }
@@ -136,6 +134,11 @@ fn test() {
         ("foo", Some(serde_json::json!(["foo"])), None),
         ("function fn() { foo; }", Some(serde_json::json!(["foo"])), None),
         ("function fn() { foo; }", Some(serde_json::json!(["foo"])), None),
+        (
+            "location; function test(location) { location; }",
+            Some(serde_json::json!(["location"])),
+            None,
+        ),
         (
             "event",
             Some(serde_json::json!(["foo", "event"])),

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
    ╭─[no_restricted_globals.tsx:1:1]
  1 │ foo
@@ -20,6 +19,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_restricted_globals.tsx:1:17]
  1 │ function fn() { foo; }
    ·                 ───
+   ╰────
+  help: Use a local variable or function parameter instead of the restricted global.
+
+  ⚠ eslint(no-restricted-globals): Unexpected use of 'location'.
+   ╭─[no_restricted_globals.tsx:1:1]
+ 1 │ location; function test(location) { location; }
+   · ────────
    ╰────
   help: Use a local variable or function parameter instead of the restricted global.
 


### PR DESCRIPTION
Fixes #20807