### PR TITLE
fix(linter): avoid no-restricted-globals shadowing false positive

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -1,6 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::IsGlobalReference;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
@@ -94,11 +95,13 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.scoping().root_unresolved_references().contains_key(&ident.name) {
-                let reference = ctx.scoping().get_reference(ident.reference_id());
-                if !reference.is_type() {
-                    ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
-                }
+            if !ident.is_global_reference(ctx.scoping()) {
+                return;
+            }
+
+            let reference = ctx.scoping().get_reference(ident.reference_id());
+            if !reference.is_type() {
+                ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
             }
         }
     }
@@ -130,6 +133,11 @@ fn test() {
         ("function fn() { var foo; }", Some(serde_json::json!(["foo"])), None),
         ("foo.bar", Some(serde_json::json!(["bar"])), None),
         ("foo", Some(serde_json::json!([{ "name": "bar", "message": "Use baz instead." }])), None),
+        (
+            "function test(history: { location: { pathname: string } }) {\n  const { location } = history;\n  return location.pathname;\n}\nexport { test };",
+            Some(serde_json::json!([{ "name": "location", "message": "Use router." }])),
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -199,6 +207,11 @@ fn test() {
         (
             "var foo = obj => hasOwnProperty(obj, 'name');",
             Some(serde_json::json!(["hasOwnProperty"])),
+            None,
+        ),
+        (
+            "const globalPath = location.pathname;\nfunction test(history: { location: { pathname: string } }) {\n  const { location } = history;\n  return location.pathname;\n}\nexport { test, globalPath };",
+            Some(serde_json::json!([{ "name": "location", "message": "Use router." }])),
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -155,3 +155,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                  ──────────────
    ╰────
   help: Use a local variable or function parameter instead of the restricted global.
+
+  ⚠ eslint(no-restricted-globals): Unexpected use of 'location'. Use router.
+   ╭─[no_restricted_globals.tsx:1:20]
+ 1 │ const globalPath = location.pathname;
+   ·                    ────────
+ 2 │ function test(history: { location: { pathname: string } }) {
+   ╰────
+  help: Use a local variable or function parameter instead of the restricted global.


### PR DESCRIPTION
Fixes #20807.

## Summary
- use the existing IsGlobalReference helper so 
o-restricted-globals checks the current reference instead of any unresolved identifier with the same name
- keep reporting only the unresolved global location access when a later local binding shadows that name in the same file
- add pass/fail coverage for the mixed global-plus-shadowed-local case from the issue report

## Testing
- cargo test -p oxc_linter --lib no_restricted_globals
- cargo fmt --all --check