### PR TITLE
fix(linter): ignore shadowed no-restricted-globals bindings

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -94,11 +94,9 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.scoping().root_unresolved_references().contains_key(&ident.name) {
-                let reference = ctx.scoping().get_reference(ident.reference_id());
-                if !reference.is_type() {
-                    ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
-                }
+            let reference = ctx.scoping().get_reference(ident.reference_id());
+            if reference.symbol_id().is_none() && !reference.is_type() {
+                ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
             }
         }
     }
@@ -130,6 +128,11 @@ fn test() {
         ("function fn() { var foo; }", Some(serde_json::json!(["foo"])), None),
         ("foo.bar", Some(serde_json::json!(["bar"])), None),
         ("foo", Some(serde_json::json!([{ "name": "bar", "message": "Use baz instead." }])), None),
+        (
+            "function test(history: {location: {pathname: string}}) {\n  const {location} = history\n  return location.pathname\n}\nexport {test}",
+            Some(serde_json::json!([{ "name": "location", "message": "Use router." }])),
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -199,6 +202,11 @@ fn test() {
         (
             "var foo = obj => hasOwnProperty(obj, 'name');",
             Some(serde_json::json!(["hasOwnProperty"])),
+            None,
+        ),
+        (
+            "const globalPath = location.pathname\nfunction test(history: {location: {pathname: string}}) {\n  const {location} = history\n  return location.pathname\n}\nexport {test, globalPath}",
+            Some(serde_json::json!([{ "name": "location", "message": "Use router." }])),
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'foo'.
@@ -153,5 +154,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_restricted_globals.tsx:1:18]
  1 │ var foo = obj => hasOwnProperty(obj, 'name');
    ·                  ──────────────
+   ╰────
+  help: Use a local variable or function parameter instead of the restricted global.
+
+  ⚠ eslint(no-restricted-globals): Unexpected use of 'location'. Use router.
+   ╭─[no_restricted_globals.tsx:1:20]
+ 1 │ const globalPath = location.pathname
+   ·                    ────────
+ 2 │ function test(history: {location: {pathname: string}}) {
    ╰────
   help: Use a local variable or function parameter instead of the restricted global.


### PR DESCRIPTION
Fixes #20807.

## Summary
- use the current `IdentifierReference` semantic binding to decide whether `no-restricted-globals` is looking at an unresolved/global reference
- keep local bindings with the same name from being reported just because another reference with that name is global
- add a regression that mixes a global `location` read with a destructured local `location`, plus the clean local-only case

## Testing
- `cargo test -p oxc_linter no_restricted_globals`
- `cargo fmt --all --check`

## AI disclosure
- This change was prepared with AI assistance and reviewed before submission.