### PR TITLE
perf(parser): defer calculation of `Modifier` spans

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -849,7 +849,7 @@ pub fn modifier_cannot_be_used_here(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("'{}' modifier cannot be used here.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -865,14 +865,14 @@ pub fn modifier_only_on_property_declaration_or_index_signature(
             modifier.kind
         ),
     )
-    .with_label(modifier.span)
+    .with_label(modifier.span())
     .with_allowed_modifier_help(allowed)
 }
 
 #[cold]
 pub fn accessibility_modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
     ts_error("1028", "Accessibility modifier already seen.")
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_help("Remove the duplicate modifier.")
 }
 
@@ -885,13 +885,13 @@ pub fn modifier_must_precede_other_modifier(
         "1029",
         format!("'{}' modifier must precede '{}' modifier.", modifier.kind, other_modifier),
     )
-    .with_label(modifier.span)
+    .with_label(modifier.span())
 }
 
 #[cold]
 pub fn modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
     ts_error("1030", format!("'{}' modifier already seen.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_help("Remove the duplicate modifier.")
 }
 
@@ -903,7 +903,7 @@ pub fn cannot_appear_on_class_elements(
         "1031",
         format!("'{}' modifier cannot appear on class elements of this kind.", modifier.kind),
     )
-    .with_label(modifier.span)
+    .with_label(modifier.span())
     .with_allowed_modifier_help(allowed)
 }
 
@@ -912,7 +912,7 @@ pub fn cannot_appear_on_a_type_member(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1070", format!("'{}' modifier cannot appear on a type member.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -922,7 +922,7 @@ pub fn cannot_appear_on_a_type_parameter(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1273", format!("'{}' modifier cannot be used on a type parameter.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -945,7 +945,7 @@ pub fn cannot_appear_on_a_parameter(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1090", format!("'{}' modifier cannot appear on a parameter.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -960,7 +960,7 @@ pub fn cannot_appear_on_an_index_signature(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1071", format!("'{}' modifier cannot appear on an index signature.", modifier.kind))
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -969,7 +969,7 @@ pub fn accessor_modifier(modifier: &Modifier, allowed: Option<ModifierKinds>) ->
         "1243",
         format!("'accessor' modifier cannot be used with '{}' modifier.", modifier.kind),
     )
-    .with_label(modifier.span)
+    .with_label(modifier.span())
     .with_allowed_modifier_help(allowed.map(|a| a.without(ModifierKind::Accessor)))
 }
 
@@ -985,7 +985,7 @@ pub fn accessibility_modifier_on_private_property(
     _allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("18010", "An accessibility modifier cannot be used with a private identifier.")
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_help("Private identifiers are enforced at runtime, while accessibility modifiers only affect type checking, so using both is redundant.")
 }
 
@@ -1131,7 +1131,7 @@ pub fn parameter_modifiers_in_ts(
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("8012", "Parameter modifiers can only be used in TypeScript files.")
-        .with_label(modifier.span)
+        .with_label(modifier.span())
         .with_allowed_modifier_help(allowed)
 }
 
@@ -1243,7 +1243,7 @@ pub fn modifiers_cannot_appear_here(
     modifier: &Modifier,
     _: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
-    ts_error("1184", "Modifiers cannot appear here.").with_label(modifier.span)
+    ts_error("1184", "Modifiers cannot appear here.").with_label(modifier.span())
 }
 
 #[cold]

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -327,9 +327,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             false,
             |modifier, _| {
                 match modifier.kind {
-                    ModifierKind::Const => diagnostics::const_class_member(modifier.span),
+                    ModifierKind::Const => diagnostics::const_class_member(modifier.span()),
                     ModifierKind::In | ModifierKind::Out => {
-                        diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(modifier.kind, modifier.span)
+                        diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(modifier.kind, modifier.span())
                     }
                     _ => unreachable!(),
                 }
@@ -463,7 +463,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         if let Some(modifier) = modifiers.get(ModifierKind::Declare) {
-            self.error(diagnostics::declare_constructor(modifier.span));
+            self.error(diagnostics::declare_constructor(modifier.span()));
         }
 
         let value = self.parse_method(

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -519,7 +519,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => {
                 if self.at(Kind::Export) {
                     self.error(diagnostics::modifier_already_seen(&Modifier::new(
-                        self.cur_token().span(),
+                        self.cur_token().start(),
                         ModifierKind::Export,
                     )));
                     self.bump_any();

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -14,13 +14,17 @@ use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
 #[derive(Debug)]
 pub struct Modifier {
-    pub span: Span,
+    pub span_start: u32,
     pub kind: ModifierKind,
 }
 
 impl Modifier {
-    pub fn new(span: Span, kind: ModifierKind) -> Self {
-        Self { span, kind }
+    pub fn new(span_start: u32, kind: ModifierKind) -> Self {
+        Self { span_start, kind }
+    }
+
+    pub const fn span(&self) -> Span {
+        Span::new(self.span_start, self.span_start + self.kind.len())
     }
 }
 
@@ -96,7 +100,7 @@ mod modifiers {
                 // (in `add` method). `kinds.iter()` only yields kinds whose bit is set. So `offsets[kind as usize]`
                 // must be initialized.
                 let start = unsafe { self.offsets[kind as usize].assume_init() };
-                Modifier { span: Span::new(start, start + kind.len()), kind }
+                Modifier::new(start, kind)
             })
         }
 
@@ -106,7 +110,7 @@ mod modifiers {
                 // SAFETY: Bits in `kinds` are set and the corresponding offset in `offsets` are initialized together
                 // (in `add` method). Here, bit for `kind` is set, so `offsets[kind as usize]` must be initialized.
                 let start = unsafe { self.offsets[kind as usize].assume_init() };
-                Some(Modifier { span: Span::new(start, start + kind.len()), kind })
+                Some(Modifier::new(start, kind))
             } else {
                 None
             }
@@ -240,8 +244,8 @@ impl ModifierKind {
     }
 
     /// Get length of this modifier keyword in bytes.
-    pub fn len(self) -> u32 {
-        u32::from(MODIFIER_LENGTHS[self as usize])
+    pub const fn len(self) -> u32 {
+        MODIFIER_LENGTHS[self as usize] as u32
     }
 }
 
@@ -402,11 +406,10 @@ impl<C: Config> ParserImpl<'_, C> {
     pub(crate) fn eat_modifiers_before_declaration(&mut self) -> Modifiers {
         let mut modifiers = Modifiers::empty();
         while let Some(modifier_kind) = self.get_modifier() {
-            let span = self.start_span();
+            let modifier = Modifier::new(self.start_span(), modifier_kind);
             self.bump_any();
-            let modifier = Modifier::new(self.end_span(span), modifier_kind);
             self.check_modifier(modifiers.kinds(), &modifier);
-            modifiers.add(modifier.kind, modifier.span.start);
+            modifiers.add(modifier.kind, modifier.span_start);
         }
         modifiers
     }
@@ -435,12 +438,12 @@ impl<C: Config> ParserImpl<'_, C> {
         }
     }
 
-    fn modifier(&mut self, kind: Kind, span: Span) -> Modifier {
+    fn modifier(&mut self, kind: Kind, span_start: u32) -> Modifier {
         let modifier_kind = ModifierKind::try_from(kind).unwrap_or_else(|()| {
             self.set_unexpected();
             ModifierKind::Abstract // Dummy value
         });
-        Modifier { span, kind: modifier_kind }
+        Modifier::new(span_start, modifier_kind)
     }
 
     pub(crate) fn parse_modifiers(
@@ -456,7 +459,7 @@ impl<C: Config> ParserImpl<'_, C> {
             stop_on_start_of_class_static_block,
         ) {
             self.check_modifier(modifiers.kinds(), &modifier);
-            modifiers.add(modifier.kind, modifier.span.start);
+            modifiers.add(modifier.kind, modifier.span_start);
         }
 
         modifiers
@@ -468,7 +471,7 @@ impl<C: Config> ParserImpl<'_, C> {
         permit_const_as_modifier: bool,
         stop_on_start_of_class_static_block: bool,
     ) -> Option<Modifier> {
-        let span = self.start_span();
+        let span_start = self.start_span();
         let kind = self.cur_kind();
 
         if kind == Kind::Const {
@@ -492,7 +495,7 @@ impl<C: Config> ParserImpl<'_, C> {
         {
             return None;
         }
-        Some(self.modifier(kind, self.end_span(span)))
+        Some(self.modifier(kind, span_start))
     }
 
     pub(crate) fn parse_contextual_modifier(&mut self, kind: Kind) -> bool {
@@ -704,7 +707,7 @@ impl<C: Config> ParserImpl<'_, C> {
                     .iter()
                     .filter(|modifier| !allowed.contains(modifier.kind))
                     .collect::<Vec<_>>();
-                disallowed_modifiers.sort_unstable_by_key(|modifier| modifier.span.start);
+                disallowed_modifiers.sort_unstable_by_key(|modifier| modifier.span_start);
 
                 debug_assert!(!disallowed_modifiers.is_empty());
 


### PR DESCRIPTION
Small perf optimization.

The `Span` of a modifier is only required when an error is raised (cold path).

Don't eagerly calculate and store the full span in `Modifier`, only store the span's start. Calculate the span's end lazily only when it's needed (which it only is if source contains syntax errors).