### PR TITLE
refactor(parser): make `Modifier` `Copy`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -845,7 +845,7 @@ pub fn import_requires_a_specifier(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn modifier_cannot_be_used_here(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("'{}' modifier cannot be used here.", modifier.kind))
@@ -855,7 +855,7 @@ pub fn modifier_cannot_be_used_here(
 
 #[cold]
 pub fn modifier_only_on_property_declaration_or_index_signature(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error(
@@ -870,7 +870,7 @@ pub fn modifier_only_on_property_declaration_or_index_signature(
 }
 
 #[cold]
-pub fn accessibility_modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
+pub fn accessibility_modifier_already_seen(modifier: Modifier) -> OxcDiagnostic {
     ts_error("1028", "Accessibility modifier already seen.")
         .with_label(modifier.span())
         .with_help("Remove the duplicate modifier.")
@@ -878,7 +878,7 @@ pub fn accessibility_modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic
 
 #[cold]
 pub fn modifier_must_precede_other_modifier(
-    modifier: &Modifier,
+    modifier: Modifier,
     other_modifier: ModifierKind,
 ) -> OxcDiagnostic {
     ts_error(
@@ -889,14 +889,14 @@ pub fn modifier_must_precede_other_modifier(
 }
 
 #[cold]
-pub fn modifier_already_seen(modifier: &Modifier) -> OxcDiagnostic {
+pub fn modifier_already_seen(modifier: Modifier) -> OxcDiagnostic {
     ts_error("1030", format!("'{}' modifier already seen.", modifier.kind))
         .with_label(modifier.span())
         .with_help("Remove the duplicate modifier.")
 }
 
 pub fn cannot_appear_on_class_elements(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error(
@@ -908,7 +908,7 @@ pub fn cannot_appear_on_class_elements(
 }
 
 pub fn cannot_appear_on_a_type_member(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1070", format!("'{}' modifier cannot appear on a type member.", modifier.kind))
@@ -918,7 +918,7 @@ pub fn cannot_appear_on_a_type_member(
 
 #[cold]
 pub fn cannot_appear_on_a_type_parameter(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1273", format!("'{}' modifier cannot be used on a type parameter.", modifier.kind))
@@ -941,7 +941,7 @@ pub fn can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
 }
 
 pub fn cannot_appear_on_a_parameter(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1090", format!("'{}' modifier cannot appear on a parameter.", modifier.kind))
@@ -956,7 +956,7 @@ pub fn parameter_property_cannot_be_binding_pattern(span: Span) -> OxcDiagnostic
 }
 
 pub fn cannot_appear_on_an_index_signature(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("1071", format!("'{}' modifier cannot appear on an index signature.", modifier.kind))
@@ -964,7 +964,7 @@ pub fn cannot_appear_on_an_index_signature(
         .with_allowed_modifier_help(allowed)
 }
 
-pub fn accessor_modifier(modifier: &Modifier, allowed: Option<ModifierKinds>) -> OxcDiagnostic {
+pub fn accessor_modifier(modifier: Modifier, allowed: Option<ModifierKinds>) -> OxcDiagnostic {
     ts_error(
         "1243",
         format!("'accessor' modifier cannot be used with '{}' modifier.", modifier.kind),
@@ -981,7 +981,7 @@ pub fn readonly_in_array_or_tuple_type(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn accessibility_modifier_on_private_property(
-    modifier: &Modifier,
+    modifier: Modifier,
     _allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("18010", "An accessibility modifier cannot be used with a private identifier.")
@@ -1127,7 +1127,7 @@ pub fn rest_after_tuple_member_name(span: Span) -> OxcDiagnostic {
 
 #[cold]
 pub fn parameter_modifiers_in_ts(
-    modifier: &Modifier,
+    modifier: Modifier,
     allowed: Option<ModifierKinds>,
 ) -> OxcDiagnostic {
     ts_error("8012", "Parameter modifiers can only be used in TypeScript files.")
@@ -1239,10 +1239,7 @@ pub fn invalid_rest_assignment_target(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn modifiers_cannot_appear_here(
-    modifier: &Modifier,
-    _: Option<ModifierKinds>,
-) -> OxcDiagnostic {
+pub fn modifiers_cannot_appear_here(modifier: Modifier, _: Option<ModifierKinds>) -> OxcDiagnostic {
     ts_error("1184", "Modifiers cannot appear here.").with_label(modifier.span())
 }
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -518,7 +518,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             _ => {
                 if self.at(Kind::Export) {
-                    self.error(diagnostics::modifier_already_seen(&Modifier::new(
+                    self.error(diagnostics::modifier_already_seen(Modifier::new(
                         self.cur_token().start(),
                         ModifierKind::Export,
                     )));

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -12,7 +12,7 @@ use oxc_span::Span;
 
 use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Modifier {
     pub span_start: u32,
     pub kind: ModifierKind,
@@ -23,7 +23,7 @@ impl Modifier {
         Self { span_start, kind }
     }
 
-    pub const fn span(&self) -> Span {
+    pub const fn span(self) -> Span {
         Span::new(self.span_start, self.span_start + self.kind.len())
     }
 }
@@ -408,7 +408,7 @@ impl<C: Config> ParserImpl<'_, C> {
         while let Some(modifier_kind) = self.get_modifier() {
             let modifier = Modifier::new(self.start_span(), modifier_kind);
             self.bump_any();
-            self.check_modifier(modifiers.kinds(), &modifier);
+            self.check_modifier(modifiers.kinds(), modifier);
             modifiers.add(modifier.kind, modifier.span_start);
         }
         modifiers
@@ -458,7 +458,7 @@ impl<C: Config> ParserImpl<'_, C> {
             permit_const_as_modifier,
             stop_on_start_of_class_static_block,
         ) {
-            self.check_modifier(modifiers.kinds(), &modifier);
+            self.check_modifier(modifiers.kinds(), modifier);
             modifiers.add(modifier.kind, modifier.span_start);
         }
 
@@ -621,7 +621,7 @@ const fn get_illegal_preceding_modifiers(kind: ModifierKind) -> ModifierKinds {
 
 impl<C: Config> ParserImpl<'_, C> {
     #[inline]
-    fn check_modifier(&mut self, existing_kinds: ModifierKinds, modifier: &Modifier) {
+    fn check_modifier(&mut self, existing_kinds: ModifierKinds, modifier: Modifier) {
         // Do a quick check that this modifier is not illegal in this position.
         //
         // This is just 2 instructions:
@@ -641,7 +641,7 @@ impl<C: Config> ParserImpl<'_, C> {
     /// Create an error for an illegal modifier.
     #[cold]
     #[inline(never)]
-    fn illegal_modifier_error(&mut self, existing_kinds: ModifierKinds, modifier: &Modifier) {
+    fn illegal_modifier_error(&mut self, existing_kinds: ModifierKinds, modifier: Modifier) {
         const ACCESSIBILITY_KINDS: ModifierKinds = ModifierKinds::new([
             ModifierKind::Public,
             ModifierKind::Private,
@@ -686,7 +686,7 @@ impl<C: Config> ParserImpl<'_, C> {
         strict: bool,
         create_diagnostic: F,
     ) where
-        F: Fn(&Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
+        F: Fn(Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
     {
         if modifiers.kinds().has_any_not_in(allowed) {
             // Invalid modifiers are rare, so handle this case in `#[cold]` function.
@@ -700,7 +700,7 @@ impl<C: Config> ParserImpl<'_, C> {
                 strict: bool,
                 create_diagnostic: F,
             ) where
-                F: Fn(&Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
+                F: Fn(Modifier, Option<ModifierKinds>) -> OxcDiagnostic,
             {
                 // Sort modifiers to produce errors in source code order
                 let mut disallowed_modifiers = modifiers
@@ -711,7 +711,7 @@ impl<C: Config> ParserImpl<'_, C> {
 
                 debug_assert!(!disallowed_modifiers.is_empty());
 
-                for modifier in &disallowed_modifiers {
+                for modifier in disallowed_modifiers {
                     parser.error(create_diagnostic(modifier, strict.then_some(allowed)));
                 }
             }


### PR DESCRIPTION
#20823 reduced `Modifier` to 8 bytes. So it's now pointless passing around `&Modifier`s (also 8 bytes).

Make `Modifier` `Copy` and pass around owned `Modifier`s instead.