### PR TITLE
perf(parser): add `Modifiers::contains_accessibility`

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -201,7 +201,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             None
         };
 
-        if (modifiers.accessibility().is_some()
+        if (modifiers.contains_accessibility()
             || modifiers.contains_readonly()
             || modifiers.contains_override())
             && !pattern.is_binding_identifier()

--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -154,6 +154,15 @@ mod modifiers {
         }
 
         #[inline]
+        pub fn contains_accessibility(&self) -> bool {
+            self.kinds.intersects(ModifierKinds::new([
+                ModifierKind::Private,
+                ModifierKind::Protected,
+                ModifierKind::Public,
+            ]))
+        }
+
+        #[inline]
         pub fn accessibility(&self) -> Option<TSAccessibility> {
             self.kinds.accessibility()
         }


### PR DESCRIPTION
Add `Modifiers::contains_accessibility` method.

`modifiers.contains_accessibility()` is cheaper than `modifiers.accessibility().is_some()`. This shaves a few instructions off `parse_formal_parameter_with_decorators`.