### PR TITLE
refactor(str)!: rename `Atom` to `Str`

### DIFF
--- a/crates/oxc_allocator/src/string_builder.rs
+++ b/crates/oxc_allocator/src/string_builder.rs
@@ -141,8 +141,8 @@ impl<'a> StringBuilder<'a> {
     /// This is more efficient than creating a `StringBuilder`, and then making multiple [`push`] calls
     /// to fill it.
     ///
-    /// If you're not altering the `StringBuilder` after this call, and just converting it to an `Atom`,
-    /// `Atom::from_strs_array_in` may be slightly more efficient.
+    /// If you're not altering the `StringBuilder` after this call, and just converting it to a `Str`,
+    /// `Str::from_strs_array_in` may be slightly more efficient.
     ///
     /// # Panics
     ///

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -25,7 +25,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, UnstableAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Ident, SourceType, Span};
+use oxc_span::{ContentEq, GetSpan, GetSpanMut, Ident, SourceType, Span, Str};
 use oxc_syntax::{
     node::NodeId,
     operator::{
@@ -512,12 +512,12 @@ pub struct TemplateElementValue<'a> {
     /// A raw interpretation where backslashes do not have special meaning.
     /// For example, \t produces two characters – a backslash and a t.
     /// This interpretation of the template strings is stored in property .raw of the first argument (an Array).
-    pub raw: Atom<'a>,
+    pub raw: Str<'a>,
     /// A cooked interpretation where backslashes have special meaning.
     /// For example, \t produces a tab character.
     /// This interpretation of the template strings is stored as an Array in the first argument.
     /// cooked = None when template literal has invalid escape sequence
-    pub cooked: Option<Atom<'a>>,
+    pub cooked: Option<Str<'a>>,
 }
 
 /// Represents a member access expression, which can include computed member access,
@@ -1166,7 +1166,7 @@ pub struct Directive<'a> {
     /// Directive with any escapes unescaped
     pub expression: StringLiteral<'a>,
     /// Raw content of directive as it appears in source, any escapes left as is
-    pub directive: Atom<'a>,
+    pub directive: Str<'a>,
 }
 
 /// `#! /usr/bin/env node` in `#! /usr/bin/env node`
@@ -1178,7 +1178,7 @@ pub struct Directive<'a> {
 pub struct Hashbang<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
-    pub value: Atom<'a>,
+    pub value: Str<'a>,
 }
 
 /// `{ let foo = 1; }` in `if(true) { let foo = 1; }`

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -9,7 +9,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, UnstableAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
+use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span, Str};
 use oxc_syntax::node::NodeId;
 
 use super::{inherit_variants, js::*, literal::*, ts::*};
@@ -453,7 +453,7 @@ pub struct JSXIdentifier<'a> {
     pub span: Span,
     /// The name of the identifier.
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Str<'a>,
 }
 
 // 1.4 JSX Children
@@ -511,11 +511,11 @@ pub struct JSXText<'a> {
     /// Node location in source code.
     pub span: Span,
     /// The text content.
-    pub value: Atom<'a>,
+    pub value: Str<'a>,
 
     /// The raw string as it appears in source code.
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
-    pub raw: Option<Atom<'a>>,
+    pub raw: Option<Str<'a>>,
 }

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -11,7 +11,7 @@ use oxc_allocator::{Box, CloneIn, Dummy, TakeIn, UnstableAddress};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
+use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span, Str};
 use oxc_syntax::{
     node::NodeId,
     number::{BigintBase, NumberBase},
@@ -66,7 +66,7 @@ pub struct NumericLiteral<'a> {
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
     #[estree(json_safe)]
-    pub raw: Option<Atom<'a>>,
+    pub raw: Option<Str<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]
     #[estree(skip)]
@@ -89,13 +89,13 @@ pub struct StringLiteral<'a> {
     ///
     /// Any escape sequences in the raw code are unescaped.
     #[estree(via = StringLiteralValue)]
-    pub value: Atom<'a>,
+    pub value: Str<'a>,
 
     /// The raw string as it appears in source code.
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
-    pub raw: Option<Atom<'a>>,
+    pub raw: Option<Str<'a>>,
 
     /// The string value contains lone surrogates.
     ///
@@ -119,11 +119,11 @@ pub struct BigIntLiteral<'a> {
     pub span: Span,
     /// Bigint value in base 10 with no underscores
     #[estree(via = BigIntLiteralValue)]
-    pub value: Atom<'a>,
+    pub value: Str<'a>,
     /// The bigint as it appears in source code
     #[content_eq(skip)]
     #[estree(json_safe)]
-    pub raw: Option<Atom<'a>>,
+    pub raw: Option<Str<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]
     #[estree(skip)]
@@ -153,7 +153,7 @@ pub struct RegExpLiteral<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
-    pub raw: Option<Atom<'a>>,
+    pub raw: Option<Str<'a>>,
 }
 
 /// A regular expression
@@ -182,11 +182,11 @@ pub struct RegExpPattern<'a> {
     ///
     /// If `pattern` is defined, `pattern` and `text` must be in sync.
     /// i.e. If you alter the regexp by mutating `pattern`, you must regenerate `text` to match it,
-    /// using `format_atom!(&allocator, "{pattern}")`.
+    /// using `format_str!(&allocator, "{pattern}")`.
     ///
     /// `oxc_codegen` ignores `pattern` field, and prints `text`.
     #[estree(rename = "pattern")]
-    pub text: Atom<'a>,
+    pub text: Str<'a>,
     /// Parsed regexp pattern
     #[content_eq(skip)]
     #[estree(skip)]

--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -174,7 +174,7 @@
 //! If you are seeing compile-time errors in `src/ast/macros.rs`, this will be the cause.
 
 // Re-export AST types from other crates
-pub use oxc_span::{Atom, Language, LanguageVariant, ModuleKind, SourceType, Span};
+pub use oxc_span::{Language, LanguageVariant, ModuleKind, SourceType, Span, Str};
 pub use oxc_syntax::{
     number::{BigintBase, NumberBase},
     operator::{

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -24,7 +24,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, UnstableAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
+use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span, Str};
 use oxc_syntax::{node::NodeId, scope::ScopeId};
 
 use super::{inherit_variants, js::*, literal::*};
@@ -1150,7 +1150,7 @@ pub struct TSIndexSignatureName<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
     #[estree(json_safe)]
-    pub name: Atom<'a>,
+    pub name: Str<'a>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }
 

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use oxc_allocator::{Allocator, AllocatorAccessor, Box, FromIn, IntoIn, Vec};
-use oxc_span::{Atom, Ident, SPAN, Span};
+use oxc_span::{Ident, SPAN, Span, Str};
 use oxc_syntax::{
     comment_node::CommentNodeId, number::NumberBase, operator::UnaryOperator, scope::ScopeId,
 };
@@ -89,13 +89,6 @@ impl<'a> AstBuilder<'a> {
         Vec::from_array_in(array, self.allocator)
     }
 
-    /// Move a string slice into the memory arena, returning a reference to the slice
-    /// in the heap.
-    #[inline]
-    pub fn str(self, value: &str) -> &'a str {
-        self.allocator.alloc_str(value)
-    }
-
     /// Allocate an [`Ident`] from a string slice.
     #[inline]
     pub fn ident(self, value: &str) -> Ident<'a> {
@@ -119,27 +112,27 @@ impl<'a> AstBuilder<'a> {
         Ident::from_cow_in(value, self.allocator)
     }
 
-    /// Allocate an [`Atom`] from a string slice.
+    /// Allocate a [`Str`] from a string slice.
     #[inline]
-    pub fn atom(self, value: &str) -> Atom<'a> {
-        Atom::from_in(value, self.allocator)
+    pub fn str(self, value: &str) -> Str<'a> {
+        Str::from_in(value, self.allocator)
     }
 
-    /// Allocate an [`Atom`] from an array of string slices.
+    /// Allocate a [`Str`] from an array of string slices.
     #[inline]
-    pub fn atom_from_strs_array<const N: usize>(self, strings: [&str; N]) -> Atom<'a> {
-        Atom::from_strs_array_in(strings, self.allocator)
+    pub fn str_from_strs_array<const N: usize>(self, strings: [&str; N]) -> Str<'a> {
+        Str::from_strs_array_in(strings, self.allocator)
     }
 
-    /// Convert a [`Cow<'a, str>`] to an [`Atom<'a>`].
+    /// Convert a [`Cow<'a, str>`] to a [`Str<'a>`].
     ///
-    /// If the `Cow` borrows a string from arena, returns an `Atom` which references that same string,
+    /// If the `Cow` borrows a string from arena, returns a `Str` which references that same string,
     /// without allocating a new one.
     ///
-    /// If the `Cow` is owned, allocates the string into arena to generate a new `Atom`.
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Str`.
     #[inline]
-    pub fn atom_from_cow(self, value: &Cow<'a, str>) -> Atom<'a> {
-        Atom::from_cow_in(value, self.allocator)
+    pub fn str_from_cow(self, value: &Cow<'a, str>) -> Str<'a> {
+        Str::from_cow_in(value, self.allocator)
     }
 
     /// `0`
@@ -167,7 +160,7 @@ impl<'a> AstBuilder<'a> {
     /// `"use strict"` directive
     #[inline]
     pub fn use_strict_directive(self) -> Directive<'a> {
-        let use_strict = Atom::from("use strict");
+        let use_strict = Str::from("use strict");
         self.directive(SPAN, self.string_literal(SPAN, use_strict, None), use_strict)
     }
 

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{self, Display},
 };
 
-use oxc_span::{Atom, GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Ident, Span, Str};
 use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags, symbol::SymbolId};
 
 use crate::ast::*;
@@ -560,7 +560,7 @@ impl<'a> TemplateLiteral<'a> {
     }
 
     /// Get single quasi from `template`
-    pub fn single_quasi(&self) -> Option<Atom<'a>> {
+    pub fn single_quasi(&self) -> Option<Str<'a>> {
         if self.is_no_substitution_template() { self.quasis[0].value.cooked } else { None }
     }
 }
@@ -671,7 +671,7 @@ impl<'a> MemberExpression<'a> {
 
 impl<'a> ComputedMemberExpression<'a> {
     /// Returns the static property name of this member expression, if it has one, or `None` otherwise.
-    pub fn static_property_name(&self) -> Option<Atom<'a>> {
+    pub fn static_property_name(&self) -> Option<Str<'a>> {
         match &self.expression {
             Expression::StringLiteral(lit) => Some(lit.value),
             Expression::TemplateLiteral(lit) if lit.quasis.len() == 1 => lit.quasis[0].value.cooked,
@@ -1956,7 +1956,7 @@ impl<'a> ImportDeclarationSpecifier<'a> {
 
 impl<'a> ImportAttributeKey<'a> {
     /// Returns the string value of this import attribute key.
-    pub fn as_atom(&self) -> Atom<'a> {
+    pub fn as_arena_str(&self) -> Str<'a> {
         match self {
             Self::Identifier(identifier) => identifier.name.into(),
             Self::StringLiteral(literal) => literal.value,
@@ -2017,7 +2017,7 @@ impl<'a> ModuleExportName<'a> {
     /// - `export { foo }` => `"foo"`
     /// - `export { foo as bar }` => `"bar"`
     /// - `export { foo as "anything" }` => `"anything"`
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Str<'a> {
         match self {
             Self::IdentifierName(identifier) => identifier.name.into(),
             Self::IdentifierReference(identifier) => identifier.name.into(),

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{self, Display};
 
-use oxc_span::Atom;
+use oxc_span::Str;
 
 use crate::ast::*;
 
@@ -41,7 +41,7 @@ impl<'a> JSXElementName<'a> {
         }
     }
 
-    /// Get this [`JSXElementName`]'s identifier as an [`Atom`], if it is a plain identifier
+    /// Get this [`JSXElementName`]'s identifier as a [`Str`], if it is a plain identifier
     /// or identifier reference.
     ///
     /// e.g. `Foo` in `<Foo>`, or `div` in `<div>`.
@@ -50,7 +50,7 @@ impl<'a> JSXElementName<'a> {
     /// * `<this>`
     /// * `<Foo.bar>`
     /// * `<Foo:Bar>` - [namespaced identifiers](JSXElementName::NamespacedName)
-    pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
+    pub fn get_identifier_name(&self) -> Option<Str<'a>> {
         match self {
             Self::Identifier(id) => Some(id.as_ref().name),
             Self::IdentifierReference(id) => Some(id.as_ref().name.into()),

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use oxc_span::Atom;
+use oxc_span::Str;
 
 use crate::ast::*;
 
@@ -13,7 +13,7 @@ impl<'a> TSEnumMemberName<'a> {
     /// Get the name of this enum member.
     /// # Panics
     /// Panics if `self` is a `TemplateString` with no quasi.
-    pub fn static_name(&self) -> Atom<'a> {
+    pub fn static_name(&self) -> Str<'a> {
         match self {
             Self::Identifier(ident) => ident.name.into(),
             Self::String(lit) | Self::ComputedString(lit) => lit.value,
@@ -215,7 +215,7 @@ impl<'a> TSModuleDeclarationName<'a> {
     }
 
     /// Get the static name of this module declaration name.
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Str<'a> {
         match self {
             Self::Identifier(ident) => ident.name.into(),
             Self::StringLiteral(lit) => lit.value,

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -4,7 +4,7 @@
 //! including type checking, conversions, and tree traversal helpers.
 
 use oxc_allocator::{Address, GetAddress, UnstableAddress};
-use oxc_span::{Atom, GetSpan, Ident};
+use oxc_span::{GetSpan, Ident, Str};
 
 use super::{AstKind, ast::*};
 
@@ -626,7 +626,7 @@ impl<'a> MemberExpressionKind<'a> {
     /// Returns the property name of the member expression, otherwise `None`.
     ///
     /// Example: returns the `prop` in `obj.prop` or `obj["prop"]`.
-    pub fn static_property_name(&self) -> Option<Atom<'a>> {
+    pub fn static_property_name(&self) -> Option<Str<'a>> {
         match self {
             Self::Computed(member_expr) => member_expr.static_property_name(),
             Self::Static(member_expr) => Some(member_expr.property.name.into()),

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -14,7 +14,7 @@ use oxc_syntax::{
     symbol::SymbolId,
 };
 
-use oxc_span::{Atom, Ident};
+use oxc_span::{Ident, Str};
 
 use crate::{AstBuilder, ast::*};
 
@@ -126,7 +126,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: f64,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> Expression<'a> {
         Expression::NumericLiteral(self.alloc_numeric_literal(span, value, raw, base))
@@ -146,11 +146,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> Expression<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Expression::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
@@ -168,7 +168,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> Expression<'a> {
         Expression::RegExpLiteral(self.alloc_reg_exp_literal(span, regex, raw))
     }
@@ -186,10 +186,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> Expression<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Expression::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -208,11 +208,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> Expression<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Expression::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -3874,7 +3874,7 @@ impl<'a> AstBuilder<'a> {
         directive: A1,
     ) -> Directive<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Directive {
             node_id: Cell::new(NodeId::DUMMY),
@@ -3892,7 +3892,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn hashbang<A1>(self, span: Span, value: A1) -> Hashbang<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Hashbang { node_id: Cell::new(NodeId::DUMMY), span, value: value.into() }
     }
@@ -8107,10 +8107,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> ImportAttributeKey<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         ImportAttributeKey::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -8127,11 +8127,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> ImportAttributeKey<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         ImportAttributeKey::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -8700,10 +8700,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         ModuleExportName::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -8720,11 +8720,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         ModuleExportName::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -8837,7 +8837,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: f64,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> NumericLiteral<'a> {
         NumericLiteral { node_id: Cell::new(NodeId::DUMMY), span, value, raw, base }
@@ -8858,7 +8858,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: f64,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> Box<'a, NumericLiteral<'a>> {
         Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
@@ -8878,10 +8878,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> StringLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         StringLiteral {
             node_id: Cell::new(NodeId::DUMMY),
@@ -8906,10 +8906,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> Box<'a, StringLiteral<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Box::new_in(self.string_literal(span, value, raw), self.allocator)
     }
@@ -8929,11 +8929,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> StringLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         StringLiteral {
             node_id: Cell::new(NodeId::DUMMY),
@@ -8959,11 +8959,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> Box<'a, StringLiteral<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Box::new_in(
             self.string_literal_with_lone_surrogates(span, value, raw, lone_surrogates),
@@ -8986,11 +8986,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> BigIntLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         BigIntLiteral { node_id: Cell::new(NodeId::DUMMY), span, value: value.into(), raw, base }
     }
@@ -9010,11 +9010,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> Box<'a, BigIntLiteral<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Box::new_in(self.big_int_literal(span, value, raw, base), self.allocator)
     }
@@ -9033,7 +9033,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> RegExpLiteral<'a> {
         RegExpLiteral { node_id: Cell::new(NodeId::DUMMY), span, regex, raw }
     }
@@ -9052,7 +9052,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> Box<'a, RegExpLiteral<'a>> {
         Box::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
     }
@@ -9286,7 +9286,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn jsx_element_name_identifier<A1>(self, span: Span, name: A1) -> JSXElementName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXElementName::Identifier(self.alloc_jsx_identifier(span, name))
     }
@@ -9702,7 +9702,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn jsx_attribute_name_identifier<A1>(self, span: Span, name: A1) -> JSXAttributeName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXAttributeName::Identifier(self.alloc_jsx_identifier(span, name))
     }
@@ -9738,10 +9738,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> JSXAttributeValue<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXAttributeValue::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -9760,11 +9760,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> JSXAttributeValue<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXAttributeValue::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -9857,7 +9857,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn jsx_identifier<A1>(self, span: Span, name: A1) -> JSXIdentifier<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXIdentifier { node_id: Cell::new(NodeId::DUMMY), span, name: name.into() }
     }
@@ -9873,7 +9873,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_jsx_identifier<A1>(self, span: Span, name: A1) -> Box<'a, JSXIdentifier<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Box::new_in(self.jsx_identifier(span, name), self.allocator)
     }
@@ -9887,9 +9887,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_child_text<A1>(self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXChild<'a>
+    pub fn jsx_child_text<A1>(self, span: Span, value: A1, raw: Option<Str<'a>>) -> JSXChild<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXChild::Text(self.alloc_jsx_text(span, value, raw))
     }
@@ -10011,9 +10011,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_text<A1>(self, span: Span, value: A1, raw: Option<Atom<'a>>) -> JSXText<'a>
+    pub fn jsx_text<A1>(self, span: Span, value: A1, raw: Option<Str<'a>>) -> JSXText<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         JSXText { node_id: Cell::new(NodeId::DUMMY), span, value: value.into(), raw }
     }
@@ -10032,10 +10032,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> Box<'a, JSXText<'a>>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         Box::new_in(self.jsx_text(span, value, raw), self.allocator)
     }
@@ -10215,10 +10215,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSEnumMemberName::String(self.alloc_string_literal(span, value, raw))
     }
@@ -10237,11 +10237,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSEnumMemberName::String(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -10264,10 +10264,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSEnumMemberName::ComputedString(self.alloc_string_literal(span, value, raw))
     }
@@ -10286,11 +10286,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSEnumMemberName::ComputedString(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -10412,7 +10412,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: f64,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> TSLiteral<'a> {
         TSLiteral::NumericLiteral(self.alloc_numeric_literal(span, value, raw, base))
@@ -10432,11 +10432,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSLiteral::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
@@ -10454,10 +10454,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSLiteral::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -10476,11 +10476,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSLiteral::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -13698,7 +13698,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSIndexSignatureName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
@@ -13982,10 +13982,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSModuleDeclarationName::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -14002,11 +14002,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         value: A1,
-        raw: Option<Atom<'a>>,
+        raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Atom<'a>>,
+        A1: Into<Str<'a>>,
     {
         TSModuleDeclarationName::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -15558,7 +15558,7 @@ impl<'a> AstBuilder<'a> {
 /// Escape special characters for template element raw value.
 ///
 /// Escapes: backticks, `${`, backslashes, and carriage returns.
-fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Atom<'a> {
+fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Str<'a> {
     let bytes = raw.as_bytes();
     let mut extra_bytes = 0usize;
     for i in 0..bytes.len() {
@@ -15569,7 +15569,7 @@ fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Atom<'a> {
         };
     }
     if extra_bytes == 0 {
-        return ast.atom(raw);
+        return ast.str(raw);
     }
     let len = bytes.len() + extra_bytes;
     let layout = std::alloc::Layout::array::<u8>(len).unwrap();
@@ -15606,6 +15606,6 @@ fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Atom<'a> {
                 }
             }
         }
-        Atom::from(std::str::from_utf8_unchecked(escaped))
+        Str::from(std::str::from_utf8_unchecked(escaped))
     }
 }

--- a/crates/oxc_ast/src/serialize/jsx.rs
+++ b/crates/oxc_ast/src/serialize/jsx.rs
@@ -93,7 +93,7 @@ impl ESTree for JSXElementThisExpression<'_> {
         JSXIdentifier {
             span: self.0.span,
             node_id: Cell::new(NodeId::DUMMY),
-            name: Atom::from("this"),
+            name: Str::from("this"),
         }
         .serialize(serializer);
     }

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -55,7 +55,7 @@ impl ESTree for NullLiteralRaw<'_> {
 #[estree(
     ts_type = "string",
     raw_deser = r#"
-        let value = DESER[Atom](POS_OFFSET.value);
+        let value = DESER[Str](POS_OFFSET.value);
         if (DESER[bool](POS_OFFSET.lone_surrogates)) {
             value = value.replace(/\uFFFD(.{4})/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)));
         }
@@ -98,7 +98,7 @@ impl StringLiteralValue<'_, '_> {
 #[estree(
     ts_type = "bigint",
     raw_deser = "
-        const bigint = DESER[Atom](POS_OFFSET.value);
+        const bigint = DESER[Str](POS_OFFSET.value);
         BigInt(bigint)
     "
 )]

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -281,7 +281,7 @@ impl ESTree for TSGlobalDeclarationId<'_, '_> {
         let ident = IdentifierName {
             span: self.0.global_span,
             node_id: Cell::new(NodeId::DUMMY),
-            name: Atom::from("global").into(),
+            name: Str::from("global").into(),
         };
         ident.serialize(serializer);
     }

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -716,7 +716,7 @@ fn template_literal_escape_when_building_ast() {
     // backtick, ${, and backslash
     // Pass escape_raw: true to automatically escape the raw field
     let cooked = "hello`world${foo}\\bar";
-    let value = TemplateElementValue { raw: ast.atom(cooked), cooked: Some(ast.atom(cooked)) };
+    let value = TemplateElementValue { raw: ast.str(cooked), cooked: Some(ast.str(cooked)) };
     let element = ast.template_element(SPAN, value, true, true); // escape_raw: true
     let quasis = ast.vec1(element);
     let template_literal = ast.template_literal(SPAN, quasis, ast.vec());

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -118,11 +118,11 @@ fn try_fold_string_casing<'a>(
     };
 
     let result = match name {
-        "toLowerCase" => ctx.ast().atom(&value.cow_to_lowercase()),
-        "toUpperCase" => ctx.ast().atom(&value.cow_to_uppercase()),
-        "trim" => ctx.ast().atom(value.trim()),
-        "trimStart" => ctx.ast().atom(value.trim_start()),
-        "trimEnd" => ctx.ast().atom(value.trim_end()),
+        "toLowerCase" => ctx.ast().str(&value.cow_to_lowercase()),
+        "toUpperCase" => ctx.ast().str(&value.cow_to_uppercase()),
+        "trim" => ctx.ast().str(value.trim()),
+        "trimStart" => ctx.ast().str(value.trim_start()),
+        "trimEnd" => ctx.ast().str(value.trim_end()),
         _ => return None,
     };
     Some(ConstantValue::String(Cow::Borrowed(result.as_str())))

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -3105,7 +3105,7 @@ impl<'a> AstNode<'a, Directive<'a>> {
     }
 
     #[inline]
-    pub fn directive(&self) -> Atom<'a> {
+    pub fn directive(&self) -> Str<'a> {
         self.inner.directive
     }
 
@@ -3126,7 +3126,7 @@ impl<'a> AstNode<'a, Hashbang<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Atom<'a> {
+    pub fn value(&self) -> Str<'a> {
         self.inner.value
     }
 
@@ -6330,7 +6330,7 @@ impl<'a> AstNode<'a, NumericLiteral<'a>> {
     }
 
     #[inline]
-    pub fn raw(&self) -> Option<Atom<'a>> {
+    pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
     }
 
@@ -6356,12 +6356,12 @@ impl<'a> AstNode<'a, StringLiteral<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Atom<'a> {
+    pub fn value(&self) -> Str<'a> {
         self.inner.value
     }
 
     #[inline]
-    pub fn raw(&self) -> Option<Atom<'a>> {
+    pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
     }
 
@@ -6387,12 +6387,12 @@ impl<'a> AstNode<'a, BigIntLiteral<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Atom<'a> {
+    pub fn value(&self) -> Str<'a> {
         self.inner.value
     }
 
     #[inline]
-    pub fn raw(&self) -> Option<Atom<'a>> {
+    pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
     }
 
@@ -6423,7 +6423,7 @@ impl<'a> AstNode<'a, RegExpLiteral<'a>> {
     }
 
     #[inline]
-    pub fn raw(&self) -> Option<Atom<'a>> {
+    pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
     }
 
@@ -7083,7 +7083,7 @@ impl<'a> AstNode<'a, JSXIdentifier<'a>> {
     }
 
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Str<'a> {
         self.inner.name
     }
 
@@ -7173,12 +7173,12 @@ impl<'a> AstNode<'a, JSXText<'a>> {
     }
 
     #[inline]
-    pub fn value(&self) -> Atom<'a> {
+    pub fn value(&self) -> Str<'a> {
         self.inner.value
     }
 
     #[inline]
-    pub fn raw(&self) -> Option<Atom<'a>> {
+    pub fn raw(&self) -> Option<Str<'a>> {
         self.inner.raw
     }
 
@@ -9274,7 +9274,7 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     #[inline]
-    pub fn name(&self) -> Atom<'a> {
+    pub fn name(&self) -> Str<'a> {
         self.inner.name
     }
 

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -219,7 +219,9 @@ impl<'a> Format<'a> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
             write!(f, "{");
 
             if self.len() > 1
-                || self.first().is_some_and(|attribute| attribute.key.as_atom().as_str() != "type")
+                || self
+                    .first()
+                    .is_some_and(|attribute| attribute.key.as_arena_str().as_str() != "type")
                 || f.comments().has_comment_before(self.parent().span().end)
             {
                 write!(

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 use oxc_allocator::CloneIn;
 use oxc_ast::ast::*;
 use oxc_ecmascript::{ToInt32, ToUint32};
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{GetSpan, SPAN, Str};
 use oxc_syntax::{
     number::{NumberBase, ToJsString},
     operator::{BinaryOperator, UnaryOperator},
@@ -73,7 +73,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                     }
                     ConstantValue::String(v) => {
-                        self.ast.expression_string_literal(SPAN, self.ast.atom(&v), None)
+                        self.ast.expression_string_literal(SPAN, self.ast.str(&v), None)
                     }
                 }),
             );
@@ -96,7 +96,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         expr: &Expression<'a>,
         enum_name: &str,
-        prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
+        prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
         self.evaluate(expr, enum_name, prev_members)
     }
@@ -104,7 +104,7 @@ impl<'a> IsolatedDeclarations<'a> {
     fn evaluate_ref(
         expr: &Expression<'a>,
         enum_name: &str,
-        prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
+        prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
         match expr {
             match_member_expression!(Expression) => {
@@ -138,7 +138,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         expr: &Expression<'a>,
         enum_name: &str,
-        prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
+        prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
         match expr {
             Expression::Identifier(_)
@@ -173,7 +173,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         expr: &BinaryExpression<'a>,
         enum_name: &str,
-        prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
+        prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
         let left = self.evaluate(&expr.left, enum_name, prev_members)?;
         let right = self.evaluate(&expr.right, enum_name, prev_members)?;
@@ -238,7 +238,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         expr: &UnaryExpression<'a>,
         enum_name: &str,
-        prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
+        prev_members: &FxHashMap<Str<'a>, ConstantValue>,
     ) -> Option<ConstantValue> {
         let value = self.evaluate(&expr.argument, enum_name, prev_members)?;
 

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -13,7 +13,7 @@ use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::{Atom, GetSpan, IdentHashSet, SPAN, SourceType};
+use oxc_span::{GetSpan, IdentHashSet, SPAN, SourceType, Str};
 
 use crate::{diagnostics::function_with_assigning_properties, scope::ScopeTree};
 
@@ -432,12 +432,12 @@ impl<'a> IsolatedDeclarations<'a> {
     }
 
     fn remove_function_overloads_implementation(stmts: &mut Vec<&Statement<'a>>) {
-        let mut last_function_name: Option<Atom<'a>> = None;
+        let mut last_function_name: Option<Str<'a>> = None;
         let mut is_export_default_function_overloads = false;
 
         stmts.retain(move |&stmt| match stmt {
             Statement::FunctionDeclaration(func) => {
-                let name: Atom<'a> = func
+                let name: Str<'a> = func
                     .id
                     .as_ref()
                     .unwrap_or_else(|| {
@@ -459,7 +459,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Statement::ExportNamedDeclaration(decl) => {
                 if let Some(Declaration::FunctionDeclaration(func)) = &decl.declaration {
-                    let name: Atom<'a> = func
+                    let name: Str<'a> = func
                         .id
                         .as_ref()
                         .unwrap_or_else(|| {
@@ -501,7 +501,7 @@ impl<'a> IsolatedDeclarations<'a> {
     /// Collect exported names from a namespace declaration into `assignable_properties`.
     fn collect_namespace_properties(
         decl: &TSModuleDeclaration<'a>,
-        assignable_properties: &mut FxHashMap<&'a str, FxHashSet<Atom<'a>>>,
+        assignable_properties: &mut FxHashMap<&'a str, FxHashSet<Str<'a>>>,
     ) {
         if decl.kind != TSModuleDeclarationKind::Namespace {
             return;
@@ -549,7 +549,7 @@ impl<'a> IsolatedDeclarations<'a> {
     }
 
     fn report_error_for_expando_function(&self, stmts: &ArenaVec<'a, Statement<'a>>) {
-        let mut assignable_properties_for_namespace = FxHashMap::<&str, FxHashSet<Atom>>::default();
+        let mut assignable_properties_for_namespace = FxHashMap::<&str, FxHashSet<Str>>::default();
         let mut can_expando_function_names = IdentHashSet::default();
         for stmt in stmts {
             match stmt {

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::{Box as ArenaBox, CloneIn, TakeIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{GetSpan, SPAN, Str};
 
 use crate::{IsolatedDeclarations, diagnostics::default_export_inferred};
 
@@ -21,11 +21,11 @@ impl<'a> IsolatedDeclarations<'a> {
         ))
     }
 
-    pub(crate) fn create_unique_name(&self, name: &str) -> Atom<'a> {
-        let mut binding = self.ast.atom(name);
+    pub(crate) fn create_unique_name(&self, name: &str) -> Str<'a> {
+        let mut binding = self.ast.str(name);
         let mut i = 1;
         while self.scope.has_reference(&binding) {
-            binding = self.ast.atom(format!("{name}_{i}").as_str());
+            binding = self.ast.str(format!("{name}_{i}").as_str());
             i += 1;
         }
         binding

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -9,7 +9,7 @@ use oxc_ast::{
     },
 };
 use oxc_ast_visit::Visit;
-use oxc_span::{Atom, GetSpan, SPAN};
+use oxc_span::{GetSpan, SPAN, Str};
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 use crate::{IsolatedDeclarations, diagnostics::type_containing_private_name};
@@ -41,8 +41,8 @@ use crate::{IsolatedDeclarations, diagnostics::type_containing_private_name};
 pub struct FunctionReturnType<'a> {
     ast: AstBuilder<'a>,
     return_expression: Option<Option<Expression<'a>>>,
-    value_bindings: Vec<Atom<'a>>,
-    type_bindings: Vec<Atom<'a>>,
+    value_bindings: Vec<Str<'a>>,
+    type_bindings: Vec<Str<'a>>,
     return_statement_count: u8,
     scope_depth: u32,
 }
@@ -90,7 +90,7 @@ impl<'a> FunctionReturnType<'a> {
             }
             _ => None,
         } {
-            let reference_name: Atom = reference_name.into();
+            let reference_name: Str = reference_name.into();
             let is_defined_in_current_scope = if is_value {
                 visitor.value_bindings.contains(&reference_name)
             } else {

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk::*};
-use oxc_span::Atom;
+use oxc_span::Str;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 bitflags! {
@@ -20,8 +20,8 @@ bitflags! {
 /// Declaration scope.
 #[derive(Debug)]
 struct Scope<'a> {
-    bindings: FxHashMap<Atom<'a>, KindFlags>,
-    references: FxHashMap<Atom<'a>, KindFlags>,
+    bindings: FxHashMap<Str<'a>, KindFlags>,
+    references: FxHashMap<Str<'a>, KindFlags>,
     flags: ScopeFlags,
 }
 
@@ -59,12 +59,12 @@ impl<'a> ScopeTree<'a> {
         scope.references.get(name).iter().any(|flags| flags.contains(KindFlags::Value))
     }
 
-    fn add_binding(&mut self, name: Atom<'a>, flags: KindFlags) {
+    fn add_binding(&mut self, name: Str<'a>, flags: KindFlags) {
         let scope = self.levels.last_mut().unwrap();
         scope.bindings.insert(name, flags);
     }
 
-    fn add_reference(&mut self, name: Atom<'a>, flags: KindFlags) {
+    fn add_reference(&mut self, name: Str<'a>, flags: KindFlags) {
         let scope = self.levels.last_mut().unwrap();
         scope.references.entry(name).and_modify(|f| *f |= flags).or_insert(flags);
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/ignored.rs
@@ -458,7 +458,7 @@ impl NoUnusedVars {
 
 #[cfg(test)]
 mod test {
-    use oxc_span::Atom;
+    use oxc_span::Str;
 
     use super::super::NoUnusedVars;
     use super::{IgnoreReason, Ignored};
@@ -485,7 +485,7 @@ mod test {
 
         assert_eq!(rule.is_ignored_var("_x"), Ignored::from_reason(IgnoreReason::NamePattern));
         assert_eq!(
-            rule.is_ignored_var(&Atom::from("_x")),
+            rule.is_ignored_var(&Str::from("_x")),
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
         assert_eq!(rule.is_ignored_var("notIgnored"), Ignored::not_ignored());
@@ -496,11 +496,11 @@ mod test {
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
         assert_eq!(
-            rule.is_ignored_arg(&Atom::from("ignored")),
+            rule.is_ignored_arg(&Str::from("ignored")),
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
         assert_eq!(
-            rule.is_ignored_arg(&Atom::from("alsoIgnored")),
+            rule.is_ignored_arg(&Str::from("alsoIgnored")),
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
 
@@ -519,7 +519,7 @@ mod test {
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
         assert_eq!(
-            rule.is_ignored_array_destructured(&Atom::from("_x")),
+            rule.is_ignored_array_destructured(&Str::from("_x")),
             Ignored::from_reason(IgnoreReason::NamePattern)
         );
         assert_eq!(rule.is_ignored_array_destructured("notIgnored"), Ignored::not_ignored());

--- a/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_computed_key.rs
@@ -1,7 +1,7 @@
 use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
@@ -13,10 +13,10 @@ use crate::{
     utils::pad_fix_with_token_boundary,
 };
 
-fn no_useless_computed_key_diagnostic(span: Span, raw: Option<Atom>) -> OxcDiagnostic {
+fn no_useless_computed_key_diagnostic(span: Span, raw: Option<Str>) -> OxcDiagnostic {
     // false positive, if we remove the closure, `borrowed data escapes outside of function `raw` escapes the function body here`
     #[expect(clippy::redundant_closure)]
-    let key = raw.unwrap_or_else(|| Atom::empty());
+    let key = raw.unwrap_or_else(|| Str::empty());
     OxcDiagnostic::warn(format!("Unnecessarily computed property `{key}` found."))
         .with_help("Replace the computed property with a plain identifier or string literal")
         .with_label(span)
@@ -239,7 +239,7 @@ fn report_useless_computed_key(
     diagnostic_span: Span,
     member_span: Span,
     key_span: Span,
-    raw: Option<Atom>,
+    raw: Option<Str>,
 ) {
     ctx.diagnostic_with_fix(no_useless_computed_key_diagnostic(diagnostic_span, raw), |fixer| {
         let Some(raw) = raw else {

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{Span, Str};
 
 use crate::{context::LintContext, fixer::RuleFixer, rule::Rule, utils::get_node_name};
 
@@ -170,7 +170,7 @@ impl PreferMockPromiseShorthand {
         // if arguments is more than one, just report it instead of fixing it.
         if call_expr.arguments.len() <= 1 {
             ctx.diagnostic_with_fix(
-                use_mock_shorthand(Atom::from(prefer_name).as_str(), property_span),
+                use_mock_shorthand(Str::from(prefer_name).as_str(), property_span),
                 |fixer| {
                     let content = Self::fix(fixer, prefer_name, call_expr);
                     let span = Span::new(property_span.start, fix_span.end);
@@ -178,7 +178,7 @@ impl PreferMockPromiseShorthand {
                 },
             );
         } else {
-            ctx.diagnostic(use_mock_shorthand(Atom::from(prefer_name).as_str(), property_span));
+            ctx.diagnostic(use_mock_shorthand(Str::from(prefer_name).as_str(), property_span));
         }
     }
 

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, CompactStr, Span};
+use oxc_span::{CompactStr, Span, Str};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde_json::Value;
@@ -211,7 +211,7 @@ impl NoAsyncEndpointHandlers {
     fn check_endpoint_arg<'a>(
         &self,
         ctx: &LintContext<'a>,
-        endpoint: Option<Atom<'a>>,
+        endpoint: Option<Str<'a>>,
         arg: &Expression<'a>,
     ) {
         let mut visited = FxHashSet::default();
@@ -221,7 +221,7 @@ impl NoAsyncEndpointHandlers {
     fn check_endpoint_expr<'a>(
         &self,
         ctx: &LintContext<'a>,
-        endpoint: Option<Atom<'a>>,
+        endpoint: Option<Str<'a>>,
         id_name: Option<&str>,
         registered_at: Option<Span>,
         arg: &Expression<'a>,
@@ -296,7 +296,7 @@ impl NoAsyncEndpointHandlers {
     fn check_function<'a>(
         &self,
         ctx: &LintContext<'a>,
-        endpoint: Option<Atom<'a>>,
+        endpoint: Option<Str<'a>>,
         registered_at: Option<Span>,
         id_name: Option<&str>,
         f: &Function<'a>,
@@ -321,7 +321,7 @@ impl NoAsyncEndpointHandlers {
     fn check_arrow<'a>(
         &self,
         ctx: &LintContext<'a>,
-        endpoint: Option<Atom<'a>>,
+        endpoint: Option<Str<'a>>,
         registered_at: Option<Span>,
         id_name: Option<&str>,
         f: &ArrowFunctionExpression<'a>,

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -23,7 +23,7 @@ use oxc_ast_visit::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{ReferenceId, ScopeId, Semantic, SymbolId};
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 use oxc_syntax::scope::ScopeFlags;
 
 use crate::{
@@ -894,11 +894,11 @@ impl<'a> From<&IdentifierReference<'a>> for Name<'a> {
 #[derive(Debug)]
 struct Dependency<'a> {
     span: Span,
-    name: Atom<'a>,
+    name: Str<'a>,
     reference_id: ReferenceId,
     // the symbol id that this dependency is referring to
     symbol_id: Option<SymbolId>,
-    chain: Vec<Atom<'a>>,
+    chain: Vec<Str<'a>>,
 }
 
 impl Hash for Dependency<'_> {
@@ -920,7 +920,7 @@ impl Eq for Dependency<'_> {}
 impl Dependency<'_> {
     #[expect(clippy::inherent_to_string)]
     fn to_string(&self) -> String {
-        std::iter::once(&self.name).chain(self.chain.iter()).map(oxc_span::Atom::as_str).join(".")
+        std::iter::once(&self.name).chain(self.chain.iter()).map(oxc_span::Str::as_str).join(".")
     }
 
     fn contains(&self, other: &Self) -> bool {
@@ -928,7 +928,7 @@ impl Dependency<'_> {
     }
 }
 
-fn chain_contains(a: &[Atom<'_>], b: &[Atom<'_>]) -> bool {
+fn chain_contains(a: &[Str<'_>], b: &[Str<'_>]) -> bool {
     for (index, part) in b.iter().enumerate() {
         let Some(other) = a.get(index) else { return false };
         if other != part {
@@ -970,7 +970,7 @@ fn concat_members<'a, 'b>(
         return Ok(None);
     };
 
-    let new_chain = Vec::from([Atom::from(member_expr.property.name)]);
+    let new_chain = Vec::from([Str::from(member_expr.property.name)]);
 
     Ok(Some(Dependency {
         span: member_expr.span,
@@ -982,7 +982,7 @@ fn concat_members<'a, 'b>(
 }
 
 fn is_identifier_a_dependency<'a>(
-    ident_name: Atom<'a>,
+    ident_name: Str<'a>,
     ident_reference_id: ReferenceId,
     ident_span: Span,
     ctx: &'_ LintContext<'a>,
@@ -999,7 +999,7 @@ fn is_identifier_a_dependency<'a>(
     )
 }
 fn is_identifier_a_dependency_impl<'a>(
-    ident_name: Atom<'a>,
+    ident_name: Str<'a>,
     ident_reference_id: ReferenceId,
     ident_span: Span,
     ctx: &'_ LintContext<'a>,
@@ -1059,7 +1059,7 @@ fn is_identifier_a_dependency_impl<'a>(
 // https://github.com/facebook/react/blob/fee786a057774ab687aff765345dd86fce534ab2/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js#L164
 fn is_stable_value<'a, 'b>(
     node: &'b AstNode<'a>,
-    ident_name: Atom<'a>,
+    ident_name: Str<'a>,
     ident_reference_id: ReferenceId,
     ctx: &'b LintContext<'a>,
     component_scope_id: ScopeId,
@@ -1439,9 +1439,9 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
                 if is_parent_call_expr {
                     self.found_dependencies.insert(source);
                 } else {
-                    let new_chain = Vec::from([Atom::from(it.property.name)]);
+                    let new_chain = Vec::from([Str::from(it.property.name)]);
 
-                    let mut destructured_props: Vec<Atom<'a>> = vec![];
+                    let mut destructured_props: Vec<Str<'a>> = vec![];
                     let mut did_see_ref = false;
                     let needs_full_chain = self
                         .iter_destructure_bindings(|id| {
@@ -1514,7 +1514,7 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
         let reference_id = ident.reference_id();
         let symbol_id = self.semantic.scoping().get_reference(reference_id).symbol_id();
 
-        let mut destructured_props: Vec<Atom<'a>> = vec![];
+        let mut destructured_props: Vec<Str<'a>> = vec![];
         let mut did_see_ref = false;
         let needs_full_identifier = self
             .iter_destructure_bindings(|id| {
@@ -1614,7 +1614,7 @@ mod fix {
         AstBuilder,
         ast::{ArrayExpression, Expression},
     };
-    use oxc_span::{Atom, GetSpan, SPAN};
+    use oxc_span::{GetSpan, SPAN, Str};
 
     use crate::{
         fixer::{RuleFix, RuleFixer},
@@ -1636,7 +1636,7 @@ mod fix {
         for name in names {
             vec.push(
                 ast_builder
-                    .expression_identifier(SPAN, Atom::from_cow_in(&name.name, &alloc))
+                    .expression_identifier(SPAN, Str::from_cow_in(&name.name, &alloc))
                     .into(),
             );
         }

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, Span};
+use oxc_span::{Span, Str};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -64,7 +64,7 @@ impl Rule for JsxNoDuplicateProps {
             return;
         };
 
-        let mut props: FxHashMap<Atom, Span> = FxHashMap::default();
+        let mut props: FxHashMap<Str, Span> = FxHashMap::default();
 
         for attr in &jsx_opening_elem.attributes {
             let JSXAttributeItem::Attribute(jsx_attr) = attr else {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use oxc_ast::{AstKind, ast::JSXAttributeItem};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -70,16 +70,16 @@ impl Rule for JsxPropsNoSpreadMulti {
             let spread_attrs =
                 jsx_opening_el.attributes.iter().filter_map(JSXAttributeItem::as_spread);
 
-            let mut identifier_names: FxHashMap<Atom, Span> = FxHashMap::default();
+            let mut identifier_names: FxHashMap<Str, Span> = FxHashMap::default();
             let mut member_expressions = Vec::new();
-            let mut duplicate_spreads: FxHashMap<Atom, Vec<Span>> = FxHashMap::default();
+            let mut duplicate_spreads: FxHashMap<Str, Vec<Span>> = FxHashMap::default();
 
             for spread_attr in spread_attrs {
                 let argument_without_parenthesized = spread_attr.argument.without_parentheses();
 
                 if let Some(identifier_name) = argument_without_parenthesized
                     .get_identifier_reference()
-                    .map(|arg| Atom::from(arg.name))
+                    .map(|arg| Str::from(arg.name))
                 {
                     identifier_names
                         .entry(identifier_name)

--- a/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/class_literal_property_style.rs
@@ -12,7 +12,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -132,7 +132,7 @@ fn check_fields_mode<'a>(class_body: &ClassBody<'a>, ctx: &LintContext<'a>) {
 }
 
 fn check_getters_mode<'a>(class_body: &ClassBody<'a>, ctx: &LintContext<'a>) {
-    let mut excluded_properties: FxHashSet<Atom<'a>> = FxHashSet::default();
+    let mut excluded_properties: FxHashSet<Str<'a>> = FxHashSet::default();
     for element in &class_body.body {
         if let ClassElement::MethodDefinition(method) = element
             && method.kind == MethodDefinitionKind::Constructor
@@ -209,26 +209,26 @@ fn property_keys_match(a: &PropertyKey<'_>, b: &PropertyKey<'_>) -> bool {
     }
 }
 
-fn assigned_this_property_name<'a>(left: &AssignmentTarget<'a>) -> Option<Atom<'a>> {
+fn assigned_this_property_name<'a>(left: &AssignmentTarget<'a>) -> Option<Str<'a>> {
     let is_this_object =
         |expr: &Expression<'_>| matches!(expr.without_parentheses(), Expression::ThisExpression(_));
 
     match left {
         AssignmentTarget::StaticMemberExpression(expr) if is_this_object(&expr.object) => {
-            Some(expr.property.name.as_atom())
+            Some(expr.property.name.as_arena_str())
         }
         AssignmentTarget::ComputedMemberExpression(expr) if is_this_object(&expr.object) => {
             expr.static_property_name()
         }
         AssignmentTarget::PrivateFieldExpression(expr) if is_this_object(&expr.object) => {
-            Some(expr.field.name.as_atom())
+            Some(expr.field.name.as_arena_str())
         }
         _ => None,
     }
 }
 
 struct ConstructorAssignmentCollector<'set, 'a> {
-    excluded_properties: &'set mut FxHashSet<Atom<'a>>,
+    excluded_properties: &'set mut FxHashSet<Str<'a>>,
 }
 
 impl<'a> Visit<'a> for ConstructorAssignmentCollector<'_, 'a> {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -9,7 +9,7 @@ use oxc_ast_visit::Visit;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::ScopeFlags;
-use oxc_span::{Atom, Span};
+use oxc_span::{Span, Str};
 use rustc_hash::FxHashSet;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
@@ -110,8 +110,8 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
 struct AssignmentVisitor<'a, 'b> {
     ctx: &'b LintContext<'a>,
     parameter_properties: Vec<&'b FormalParameter<'a>>,
-    assigned_before_unnecessary: FxHashSet<Atom<'a>>,
-    assigned_before_constructor: FxHashSet<Atom<'a>>,
+    assigned_before_unnecessary: FxHashSet<Str<'a>>,
+    assigned_before_constructor: FxHashSet<Str<'a>>,
 }
 
 impl<'a> Visit<'a> for AssignmentVisitor<'a, '_> {
@@ -226,7 +226,7 @@ fn is_unnecessary_assignment_operator(operator: AssignmentOperator) -> bool {
     )
 }
 
-fn get_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Atom<'a>> {
+fn get_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Str<'a>> {
     match assignment_target {
         AssignmentTarget::StaticMemberExpression(expr)
             if matches!(&expr.object, Expression::ThisExpression(_)) =>

--- a/crates/oxc_linter/src/rules/typescript/parameter_properties.rs
+++ b/crates/oxc_linter/src/rules/typescript/parameter_properties.rs
@@ -12,7 +12,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 
 use crate::{
     AstNode,
@@ -181,7 +181,7 @@ impl ParameterProperties {
     }
 
     fn check_prefer_parameter_property<'a>(&self, class: &Class<'a>, ctx: &LintContext<'a>) {
-        let mut property_nodes_by_name = FxHashMap::<Atom<'a>, PropertyNodes<'a>>::default();
+        let mut property_nodes_by_name = FxHashMap::<Str<'a>, PropertyNodes<'a>>::default();
 
         for element in &class.body.body {
             let ClassElement::PropertyDefinition(property) = element else { continue };
@@ -272,7 +272,7 @@ fn modifier_from_property(property: &PropertyDefinition<'_>) -> Option<Modifier>
 
 fn constructor_assignment<'a>(
     statement: &'a Statement<'a>,
-) -> Option<(&'a AssignmentExpression<'a>, Atom<'a>)> {
+) -> Option<(&'a AssignmentExpression<'a>, Str<'a>)> {
     let Statement::ExpressionStatement(expression_statement) = statement else {
         return None;
     };

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -259,7 +259,7 @@ fn to_string_literal_text(fixer: RuleFixer, text: &str) -> String {
     let mut codegen = fixer.codegen().with_options(CodegenOptions::default());
     let alloc = Allocator::default();
     let ast = AstBuilder::new(&alloc);
-    codegen.print_expression(&ast.expression_string_literal(SPAN, ast.atom(text), None));
+    codegen.print_expression(&ast.expression_string_literal(SPAN, ast.str(text), None));
     codegen.into_source_text()
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -421,7 +421,7 @@ impl PreferKeyboardEventKey {
                 let ast = AstBuilder::new(&alloc);
                 codegen.print_expression(&ast.expression_string_literal(
                     SPAN,
-                    ast.atom(&key_name),
+                    ast.str(&key_name),
                     None,
                 ));
                 let key_str = codegen.into_source_text();

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -92,7 +92,7 @@ impl Rule for PreferStringReplaceAll {
                         let ast = AstBuilder::new(&alloc);
                         codegen.print_expression(&ast.expression_string_literal(
                             SPAN,
-                            ast.atom(&k),
+                            ast.str(&k),
                             None,
                         ));
                         fixer.replace(pattern.span(), codegen.into_source_text())

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -118,7 +118,7 @@ fn do_fix<'a>(
     let alloc = Allocator::default();
     let ast = AstBuilder::new(&alloc);
     content.print_str(&format!(r"{}.{}(", fixer.source_range(target_span), method));
-    content.print_expression(&ast.expression_string_literal(SPAN, ast.atom(&argument), None));
+    content.print_expression(&ast.expression_string_literal(SPAN, ast.str(&argument), None));
     content.print_str(r")");
     fixer.replace(call_expr.span, content.into_source_text())
 }

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, FormalParameter},
 };
-use oxc_span::Atom;
+use oxc_span::Str;
 
 /// Check if the given node is registering an endpoint handler or middleware to
 /// a route or Express application object. If it is, it
@@ -19,7 +19,7 @@ use oxc_span::Atom;
 /// ```
 pub fn as_endpoint_registration<'a, 'n>(
     node: &'n AstKind<'a>,
-) -> Option<(Option<Atom<'a>>, &'n [Argument<'a>])> {
+) -> Option<(Option<Str<'a>>, &'n [Argument<'a>])> {
     let call = node.as_call_expression()?;
     let callee = call.callee.as_member_expression()?;
     let method_name = callee.static_property_name()?;

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -11,7 +11,7 @@ use oxc_allocator::{Allocator, BitSet, HashSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, SymbolId};
-use oxc_span::{Atom, CompactStr, Ident, SourceType};
+use oxc_span::{CompactStr, Ident, SourceType, Str};
 
 pub(crate) mod base54;
 mod keep_names;
@@ -605,7 +605,7 @@ impl<'t> Mangler<'t> {
         program: &Program<'a>,
         allocator: &'a Allocator,
         symbols_len: usize,
-    ) -> (HashSet<'a, Atom<'a>>, Option<BitSet<'a>>) {
+    ) -> (HashSet<'a, Str<'a>>, Option<BitSet<'a>>) {
         let mut exported_symbols = BitSet::new_in(symbols_len, allocator);
         let mut exported_names = HashSet::new_in(allocator);
         for statement in &program.body {
@@ -614,12 +614,12 @@ impl<'t> Mangler<'t> {
             if let Declaration::VariableDeclaration(decl) = decl {
                 for decl in &decl.declarations {
                     if let Some(id) = decl.id.get_binding_identifier() {
-                        exported_names.insert(id.name.as_atom());
+                        exported_names.insert(id.name.as_arena_str());
                         exported_symbols.set_bit(id.symbol_id().index());
                     }
                 }
             } else if let Some(id) = decl.id() {
-                exported_names.insert(id.name.as_atom());
+                exported_names.insert(id.name.as_arena_str());
                 exported_symbols.set_bit(id.symbol_id().index());
             }
         }

--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -5160,8 +5160,8 @@ impl<'a, 't> DirectiveWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn directive(self) -> &'t Atom<'a> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_DIRECTIVE_DIRECTIVE) as *const Atom<'a>) }
+    pub fn directive(self) -> &'t Str<'a> {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_DIRECTIVE_DIRECTIVE) as *const Str<'a>) }
     }
 }
 
@@ -16144,9 +16144,9 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Atom<'a> {
+    pub fn name(self) -> &'t Str<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Atom<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
         }
     }
 }

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -2,12 +2,12 @@ use oxc_allocator::Box as ArenaBox;
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::BoundNames;
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{SPAN, Span, Str};
 use oxc_syntax::symbol::SymbolId;
 
 pub struct KeepVar<'a> {
     ast: AstBuilder<'a>,
-    vars: std::vec::Vec<(Atom<'a>, Span, Option<SymbolId>)>,
+    vars: std::vec::Vec<(Str<'a>, Span, Option<SymbolId>)>,
     all_hoisted: bool,
 }
 

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -378,7 +378,7 @@ impl<'a> PeepholeOptimizations {
                     .span()
                     .merge_within(e.right.span(), e.span)
                     .unwrap_or(SPAN);
-                let value = ctx.ast.atom_from_strs_array([&left_str, &right_str]);
+                let value = ctx.ast.str_from_strs_array([&left_str, &right_str]);
                 let right = ctx.ast.expression_string_literal(span, value, None);
                 let left = left_binary_expr.left.take_in(ctx.ast);
                 return Some(ctx.ast.expression_binary(e.span, left, e.operator, right));
@@ -411,14 +411,14 @@ impl<'a> PeepholeOptimizations {
                     .quasis
                     .first_mut()
                     .expect("template literal must have at least one quasi");
-                left_last_quasi.value.raw = ctx.ast.atom_from_strs_array([
+                left_last_quasi.value.raw = ctx.ast.str_from_strs_array([
                     left_last_quasi.value.raw.as_str(),
                     right_first_quasi.value.raw.as_str(),
                 ]);
                 let new_cooked = if let (Some(cooked1), Some(cooked2)) =
                     (left_last_quasi.value.cooked, right_first_quasi.value.cooked)
                 {
-                    Some(ctx.ast.atom_from_strs_array([cooked1.as_str(), cooked2.as_str()]))
+                    Some(ctx.ast.str_from_strs_array([cooked1.as_str(), cooked2.as_str()]))
                 } else {
                     None
                 };
@@ -438,11 +438,11 @@ impl<'a> PeepholeOptimizations {
                     left.quasis.last_mut().expect("template literal must have at least one quasi");
                 let new_raw = last_quasi.value.raw.to_string()
                     + &Self::escape_string_for_template_literal(&right_str);
-                last_quasi.value.raw = ctx.ast.atom(&new_raw);
+                last_quasi.value.raw = ctx.ast.str(&new_raw);
                 let new_cooked = last_quasi
                     .value
                     .cooked
-                    .map(|cooked| ctx.ast.atom(&(cooked.as_str().to_string() + &right_str)));
+                    .map(|cooked| ctx.ast.str(&(cooked.as_str().to_string() + &right_str)));
                 last_quasi.value.cooked = new_cooked;
                 return Some(left_expr.take_in(ctx.ast));
             }
@@ -456,11 +456,11 @@ impl<'a> PeepholeOptimizations {
                     .expect("template literal must have at least one quasi");
                 let new_raw = Self::escape_string_for_template_literal(&left_str).into_owned()
                     + first_quasi.value.raw.as_str();
-                first_quasi.value.raw = ctx.ast.atom(&new_raw);
+                first_quasi.value.raw = ctx.ast.str(&new_raw);
                 let new_cooked = first_quasi
                     .value
                     .cooked
-                    .map(|cooked| ctx.ast.atom(&(left_str.into_owned() + cooked.as_str())));
+                    .map(|cooked| ctx.ast.str(&(left_str.into_owned() + cooked.as_str())));
                 first_quasi.value.cooked = new_cooked;
                 return Some(right_expr.take_in(ctx.ast));
             }
@@ -749,12 +749,12 @@ impl<'a> PeepholeOptimizations {
             let escaped = Self::escape_string_for_template_literal(&str);
             let next_raw = next_quasi.as_ref().map(|q| q.value.raw.as_str()).unwrap_or_default();
             quasi.value.raw =
-                ctx.ast.atom_from_strs_array([quasi.value.raw.as_str(), &escaped, next_raw]);
+                ctx.ast.str_from_strs_array([quasi.value.raw.as_str(), &escaped, next_raw]);
             let new_cooked = if let (Some(cooked1), Some(cooked2)) =
                 (quasi.value.cooked, next_quasi.as_ref().map(|q| q.value.cooked))
             {
                 let cooked2_str = cooked2.map(|c| c.as_str()).unwrap_or_default();
-                Some(ctx.ast.atom_from_strs_array([cooked1.as_str(), &str, cooked2_str]))
+                Some(ctx.ast.str_from_strs_array([cooked1.as_str(), &str, cooked2_str]))
             } else {
                 None
             };

--- a/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
@@ -21,7 +21,7 @@ impl<'a> PeepholeOptimizations {
                 let PropertyKey::PrivateIdentifier(private_id) = &prop.key else {
                     return true;
                 };
-                let name: Atom = private_id.name.into();
+                let name: Str = private_id.name.into();
                 if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name) {
                     return true;
                 }
@@ -31,14 +31,14 @@ impl<'a> PeepholeOptimizations {
                 let PropertyKey::PrivateIdentifier(private_id) = &method.key else {
                     return true;
                 };
-                let name: Atom = private_id.name.into();
+                let name: Str = private_id.name.into();
                 ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name)
             }
             ClassElement::AccessorProperty(accessor) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &accessor.key else {
                     return true;
                 };
-                let name: Atom = private_id.name.into();
+                let name: Str = private_id.name.into();
                 if ctx.state.class_symbols_stack.is_private_member_used_in_current_class(&name) {
                     return true;
                 }
@@ -54,7 +54,7 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
-    pub fn get_declared_private_symbols(body: &ClassBody<'a>) -> impl Iterator<Item = Atom<'a>> {
+    pub fn get_declared_private_symbols(body: &ClassBody<'a>) -> impl Iterator<Item = Str<'a>> {
         body.body.iter().filter_map(|element| match element {
             ClassElement::PropertyDefinition(prop) => {
                 let PropertyKey::PrivateIdentifier(private_id) = &prop.key else {

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -319,17 +319,17 @@ impl<'a> PeepholeOptimizations {
                     debug_assert_eq!(quasi_strs.len(), 1);
                     return Some(ctx.ast.expression_string_literal(
                         span,
-                        ctx.ast.atom_from_cow(&quasi_strs.pop().unwrap()),
+                        ctx.ast.str_from_cow(&quasi_strs.pop().unwrap()),
                         None,
                     ));
                 }
 
                 let mut quasis = ctx.ast.vec_from_iter(quasi_strs.into_iter().map(|s| {
-                    let cooked = ctx.ast.atom_from_cow(&s);
+                    let cooked = ctx.ast.str_from_cow(&s);
                     ctx.ast.template_element(
                         SPAN,
                         TemplateElementValue {
-                            raw: ctx.ast.atom(&Self::escape_string_for_template_literal(&s)),
+                            raw: ctx.ast.str(&Self::escape_string_for_template_literal(&s)),
                             cooked: Some(cooked),
                         },
                         false,
@@ -562,7 +562,7 @@ impl<'a> PeepholeOptimizations {
                     s.value.as_str().char_at(Some(property.into()))
                 {
                     s.span = span;
-                    s.value = ctx.ast.atom(&c.to_string());
+                    s.value = ctx.ast.str(&c.to_string());
                     s.raw = None;
                     Some(object.take_in(ctx.ast))
                 } else {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1259,7 +1259,7 @@ impl<'a> PeepholeOptimizations {
     pub fn substitute_template_literal(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::TemplateLiteral(t) = expr else { return };
         let Some(val) = t.to_js_string(ctx) else { return };
-        *expr = ctx.ast.expression_string_literal(t.span(), ctx.ast.atom_from_cow(&val), None);
+        *expr = ctx.ast.expression_string_literal(t.span(), ctx.ast.str_from_cow(&val), None);
         ctx.state.changed = true;
     }
 
@@ -1543,7 +1543,7 @@ impl<'a> PeepholeOptimizations {
                 expr.span(),
                 ctx.ast.expression_string_literal(
                     expr.span(),
-                    ctx.ast.atom(&concatenated_string),
+                    ctx.ast.str(&concatenated_string),
                     None,
                 ),
                 ctx.ast.identifier_name(expr.span(), "split"),
@@ -1552,7 +1552,7 @@ impl<'a> PeepholeOptimizations {
             NONE,
             ctx.ast.vec1(Argument::from(ctx.ast.expression_string_literal(
                 expr.span(),
-                ctx.ast.atom(delimiter),
+                ctx.ast.str(delimiter),
                 None,
             ))),
             false,

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -2,7 +2,7 @@ use oxc_ecmascript::constant_evaluation::ConstantValue;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_data_structures::stack::NonEmptyStack;
-use oxc_span::{Atom, SourceType};
+use oxc_span::{SourceType, Str};
 use oxc_syntax::symbol::SymbolId;
 
 use crate::{CompressOptions, symbol_value::SymbolValues};
@@ -42,7 +42,7 @@ impl MinifierState<'_> {
 
 /// Stack to track class symbol information
 pub struct ClassSymbolsStack<'a> {
-    stack: NonEmptyStack<FxHashSet<Atom<'a>>>,
+    stack: NonEmptyStack<FxHashSet<Str<'a>>>,
 }
 
 impl<'a> ClassSymbolsStack<'a> {
@@ -61,7 +61,7 @@ impl<'a> ClassSymbolsStack<'a> {
     }
 
     /// Exit the current class scope
-    pub fn pop_class_scope(&mut self, declared_private_symbols: impl Iterator<Item = Atom<'a>>) {
+    pub fn pop_class_scope(&mut self, declared_private_symbols: impl Iterator<Item = Str<'a>>) {
         let mut used_private_symbols = self.stack.pop();
         declared_private_symbols.for_each(|name| {
             used_private_symbols.remove(&name);
@@ -71,12 +71,12 @@ impl<'a> ClassSymbolsStack<'a> {
     }
 
     /// Add a private member to the current class scope
-    pub fn push_private_member_to_current_class(&mut self, name: Atom<'a>) {
+    pub fn push_private_member_to_current_class(&mut self, name: Str<'a>) {
         self.stack.last_mut().insert(name);
     }
 
     /// Check if a private member is used in the current class scope
-    pub fn is_private_member_used_in_current_class(&self, name: &Atom<'a>) -> bool {
+    pub fn is_private_member_used_in_current_class(&self, name: &Str<'a>) -> bool {
         self.stack.last().contains(name)
     }
 }

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -10,7 +10,7 @@ use oxc_ecmascript::{
     },
 };
 use oxc_semantic::{IsGlobalReference, SymbolId};
-use oxc_span::format_atom;
+use oxc_span::format_str;
 use oxc_syntax::{reference::ReferenceId, scope::ScopeFlags};
 
 use crate::{
@@ -190,11 +190,11 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 self.ast.expression_numeric_literal(span, n, None, number_base)
             }
             ConstantValue::BigInt(bigint) => {
-                let value = format_atom!(self.ast.allocator, "{bigint}");
+                let value = format_str!(self.ast.allocator, "{bigint}");
                 self.ast.expression_big_int_literal(span, value, None, BigintBase::Decimal)
             }
             ConstantValue::String(s) => {
-                self.ast.expression_string_literal(span, self.ast.atom_from_cow(&s), None)
+                self.ast.expression_string_literal(span, self.ast.str_from_cow(&s), None)
             }
             ConstantValue::Boolean(b) => self.ast.expression_boolean_literal(span, b),
             ConstantValue::Undefined => self.ast.void_0(span),

--- a/crates/oxc_minifier/tests/ecmascript/array_join.rs
+++ b/crates/oxc_minifier/tests/ecmascript/array_join.rs
@@ -24,7 +24,7 @@ fn test() {
     elements.push(ArrayExpressionElement::BigIntLiteral(ast.alloc(ast.big_int_literal(
         SPAN,
         "42",
-        Some(Atom::from("42n")),
+        Some(Str::from("42n")),
         BigintBase::Decimal,
     ))));
     let array = ast.array_expression(SPAN, elements.clone_in(&allocator));

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -34,7 +34,7 @@ fn test() {
         object_with_to_string.to_js_string(&WithoutGlobalReferenceInformation {});
 
     let bigint_with_separators =
-        ast.expression_big_int_literal(SPAN, "10", Some(Atom::from("1_0n")), BigintBase::Decimal);
+        ast.expression_big_int_literal(SPAN, "10", Some(Str::from("1_0n")), BigintBase::Decimal);
     let bigint_with_separators_string =
         bigint_with_separators.to_js_string(&WithoutGlobalReferenceInformation {});
 

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -3,7 +3,7 @@ use oxc_allocator::{Box, TakeIn, Vec};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::{Atom, GetSpan, Ident, Span};
+use oxc_span::{GetSpan, Ident, Span, Str};
 use oxc_syntax::{
     number::{BigintBase, NumberBase},
     precedence::Precedence,
@@ -152,7 +152,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// # Panics
     pub(crate) fn parse_private_identifier(&mut self) -> PrivateIdentifier<'a> {
         let span = self.cur_token().span();
-        let name = Atom::from(self.cur_string());
+        let name = Str::from(self.cur_string());
         self.bump_any();
         self.ast.private_identifier(span, name)
     }
@@ -389,7 +389,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => return self.unexpected(),
         };
         self.bump_any();
-        self.ast.numeric_literal(span, value, Some(Atom::from(src)), base)
+        self.ast.numeric_literal(span, value, Some(Str::from(src)), base)
     }
 
     pub(crate) fn parse_literal_bigint(&mut self) -> BigIntLiteral<'a> {
@@ -409,7 +409,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let value = parse_big_int(src, number_kind, has_separator, self.ast.allocator);
 
         self.bump_any();
-        self.ast.big_int_literal(span, value, Some(Atom::from(raw)), base)
+        self.ast.big_int_literal(span, value, Some(Str::from(raw)), base)
     }
 
     pub(crate) fn parse_literal_regexp(&mut self) -> RegExpLiteral<'a> {
@@ -438,13 +438,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             None
         };
 
-        let pattern = RegExpPattern { text: Atom::from(pattern_text), pattern };
+        let pattern = RegExpPattern { text: Str::from(pattern_text), pattern };
 
         if flags.contains(RegExpFlags::U | RegExpFlags::V) {
             self.error(diagnostics::reg_exp_flag_u_and_v(span));
         }
 
-        self.ast.reg_exp_literal(span, RegExp { pattern, flags }, Some(Atom::from(raw)))
+        self.ast.reg_exp_literal(span, RegExp { pattern, flags }, Some(Str::from(raw)))
     }
 
     #[cfg(feature = "regular_expression")]
@@ -477,7 +477,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.unexpected();
         }
         let span = self.cur_token().span();
-        let raw = Atom::from(self.cur_src());
+        let raw = Str::from(self.cur_src());
         let value = self.cur_string();
         let lone_surrogates = self.cur_token().lone_surrogates();
         self.bump_any();
@@ -608,7 +608,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         // Get `raw`
         let raw_span = self.cur_token().span();
-        let mut raw = Atom::from(
+        let mut raw = Str::from(
             &self.source_text[raw_span.start as usize + 1..(raw_span.end - end_offset) as usize],
         );
 
@@ -618,9 +618,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // so we can skip searching for `\r` in common case where contains no escapes.
         let (cooked, lone_surrogates) = if self.cur_token().escaped() {
             // `cooked = None` when template literal has invalid escape sequence
-            let cooked = self.cur_template_string().map(Atom::from);
+            let cooked = self.cur_template_string().map(Str::from);
             if cooked.is_some() && raw.contains('\r') {
-                raw = self.ast.atom(&raw.cow_replace("\r\n", "\n").cow_replace('\r', "\n"));
+                raw = self.ast.str(&raw.cow_replace("\r\n", "\n").cow_replace('\r', "\n"));
             }
             (cooked, self.cur_token().lone_surrogates())
         } else {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -370,7 +370,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let mut keys = FxHashMap::default();
         for e in &with_entries {
-            let key = e.key.as_atom().as_str();
+            let key = e.key.as_arena_str().as_str();
             let span = e.key.span();
             if let Some(old_span) = keys.insert(key, span) {
                 self.error(diagnostics::redeclaration(key, old_span, span));

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 
 use super::{VariableDeclarationParent, grammar::CoverGrammar};
 use crate::{
@@ -19,7 +19,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any();
             let span = self.end_span(span);
             let src = &self.source_text[span.start as usize + 2..span.end as usize];
-            Some(self.ast.hashbang(span, Atom::from(src)))
+            Some(self.ast.hashbang(span, Str::from(src)))
         } else {
             None
         }
@@ -87,7 +87,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         let src = &self.source_text
                             [string.span.start as usize + 1..string.span.end as usize - 1];
                         let directive =
-                            self.ast.directive(expr.span, (*string).clone(), Atom::from(src));
+                            self.ast.directive(expr.span, (*string).clone(), Str::from(src));
                         directives.push(directive);
                         continue;
                     }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -2,7 +2,7 @@
 
 use oxc_allocator::{Allocator, Box, Dummy, Vec};
 use oxc_ast::ast::*;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 
 use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
@@ -481,8 +481,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {
         let span = self.cur_token().span();
-        let raw = Atom::from(self.cur_src());
-        let value = Atom::from(self.cur_string());
+        let raw = Str::from(self.cur_src());
+        let value = Str::from(self.cur_string());
         self.bump_any();
         self.ast.alloc_jsx_text(span, value, Some(raw))
     }

--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -10,7 +10,7 @@ use num_bigint::BigInt;
 use num_traits::Num;
 
 use oxc_allocator::Allocator;
-use oxc_span::{Atom, format_atom};
+use oxc_span::{Str, format_str};
 
 use super::kind::Kind;
 
@@ -397,13 +397,13 @@ pub fn parse_big_int<'a>(
     kind: Kind,
     has_sep: bool,
     allocator: &'a Allocator,
-) -> Atom<'a> {
+) -> Str<'a> {
     let s = if has_sep { s.cow_replace('_', "") } else { Cow::Borrowed(s) };
     debug_assert!(!s.contains('_'));
 
     let radix = match kind {
         // Skip parsing with `BigInt` - it's already in decimal form, and underscores are removed
-        Kind::Decimal => return Atom::from_cow_in(&s, allocator),
+        Kind::Decimal => return Str::from_cow_in(&s, allocator),
         Kind::Binary => 2,
         Kind::Octal => 8,
         Kind::Hex => 16,
@@ -416,7 +416,7 @@ pub fn parse_big_int<'a>(
     // We already have a string, so we can just use that directly.
     // Lexer already checked `s` represents a valid BigInt, so `unwrap` cannot fail.
     let bigint = BigInt::from_str_radix(s, radix).unwrap();
-    format_atom!(allocator, "{bigint}")
+    format_str!(allocator, "{bigint}")
 }
 
 #[cfg(test)]

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -77,7 +77,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         errors
     }
 
-    fn add_module_request(&mut self, name: Atom<'a>, requested_module: RequestedModule) {
+    fn add_module_request(&mut self, name: Str<'a>, requested_module: RequestedModule) {
         self.module_record
             .requested_modules
             .entry(name)
@@ -105,7 +105,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record.star_export_entries.push(entry);
     }
 
-    fn add_export_binding(&mut self, name: Atom<'a>, span: Span) {
+    fn add_export_binding(&mut self, name: Str<'a>, span: Span) {
         if let Some(old_node) = self.module_record.exported_bindings.insert(name, span) {
             self.exported_bindings_duplicated.push(NameSpan::new(name, old_node));
         }

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 
 use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
-use oxc_span::{Atom, ContentEq, Span};
+use oxc_span::{ContentEq, Span, Str};
 
 /// The root of the `PatternParser` result.
 #[ast]
@@ -169,8 +169,8 @@ pub struct UnicodePropertyEscape<'a> {
     pub negative: bool,
     /// `true` if `UnicodeSetsMode` and `name` matches unicode property of strings.
     pub strings: bool,
-    pub name: Atom<'a>,
-    pub value: Option<Atom<'a>>,
+    pub name: Str<'a>,
+    pub value: Option<Str<'a>>,
 }
 
 /// The `.`.
@@ -263,7 +263,7 @@ pub struct ClassString<'a> {
 pub struct CapturingGroup<'a> {
     pub span: Span,
     /// Group name to be referenced by [`NamedReference`].
-    pub name: Option<Atom<'a>>,
+    pub name: Option<Str<'a>>,
     pub body: Disjunction<'a>,
 }
 
@@ -323,7 +323,7 @@ pub struct IndexedReference {
 #[generate_derive(CloneIn, ContentEq)]
 pub struct NamedReference<'a> {
     pub span: Span,
-    pub name: Atom<'a>,
+    pub name: Str<'a>,
 }
 
 // See `oxc_ast/src/lib.rs` for the details

--- a/crates/oxc_regular_expression/src/parser/flags_parser.rs
+++ b/crates/oxc_regular_expression/src/parser/flags_parser.rs
@@ -30,7 +30,7 @@ impl<'a> FlagsParser<'a> {
             if unique_flags.contains(&cp) {
                 return Err(diagnostics::duplicated_flags(
                     self.span_factory.create(span_start, span_end),
-                    &self.reader.atom(span_start, span_end),
+                    &self.reader.str(span_start, span_end),
                 ));
             }
             if char::try_from(cp)
@@ -38,7 +38,7 @@ impl<'a> FlagsParser<'a> {
             {
                 return Err(diagnostics::unknown_flag(
                     self.span_factory.create(span_start, span_end),
-                    &self.reader.atom(span_start, span_end),
+                    &self.reader.str(span_start, span_end),
                     &["d", "g", "i", "m", "s", "u", "v", "y"],
                 ));
             }

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::{Allocator, Box, Vec};
 use oxc_diagnostics::Result;
-use oxc_span::Atom as SpanAtom;
+use oxc_span::Str;
 
 use crate::{
     ast, diagnostics,
@@ -545,7 +545,7 @@ impl<'a> PatternParser<'a> {
                 // It is a Syntax Error if GroupSpecifiersThatMatch(GroupName) is empty.
                 if !self.state.capturing_group_names.contains(name.as_str()) {
                     let names: std::vec::Vec<&str> =
-                        self.state.capturing_group_names.iter().map(SpanAtom::as_str).collect();
+                        self.state.capturing_group_names.iter().map(Str::as_str).collect();
                     return Err(diagnostics::invalid_named_reference(
                         self.span_factory.create(span_start, self.reader.offset()),
                         &names,
@@ -1841,7 +1841,7 @@ impl<'a> PatternParser<'a> {
     /// Returns: `(name, Option<value>, is_strings_related_unicode_property)`
     fn consume_unicode_property_value_expression(
         &mut self,
-    ) -> Result<Option<(SpanAtom<'a>, Option<SpanAtom<'a>>, bool)>> {
+    ) -> Result<Option<(Str<'a>, Option<Str<'a>>, bool)>> {
         let checkpoint = self.reader.checkpoint();
 
         // UnicodePropertyName=UnicodePropertyValue
@@ -1900,7 +1900,7 @@ impl<'a> PatternParser<'a> {
         Ok(None)
     }
 
-    fn consume_unicode_property_name(&mut self) -> Option<SpanAtom<'a>> {
+    fn consume_unicode_property_name(&mut self) -> Option<Str<'a>> {
         let span_start = self.reader.offset();
 
         let checkpoint = self.reader.checkpoint();
@@ -1912,10 +1912,10 @@ impl<'a> PatternParser<'a> {
             return None;
         }
 
-        Some(self.reader.atom(span_start, self.reader.offset()))
+        Some(self.reader.str(span_start, self.reader.offset()))
     }
 
-    fn consume_unicode_property_value(&mut self) -> Option<SpanAtom<'a>> {
+    fn consume_unicode_property_value(&mut self) -> Option<Str<'a>> {
         let span_start = self.reader.offset();
 
         let checkpoint = self.reader.checkpoint();
@@ -1927,14 +1927,14 @@ impl<'a> PatternParser<'a> {
             return None;
         }
 
-        Some(self.reader.atom(span_start, self.reader.offset()))
+        Some(self.reader.str(span_start, self.reader.offset()))
     }
 
     // ```
     // GroupName[UnicodeMode] ::
     //   < RegExpIdentifierName[?UnicodeMode] >
     // ```
-    fn consume_group_name(&mut self) -> Result<Option<SpanAtom<'a>>> {
+    fn consume_group_name(&mut self) -> Result<Option<Str<'a>>> {
         let span_start = self.reader.offset();
 
         if !self.reader.eat('<') {
@@ -1958,12 +1958,12 @@ impl<'a> PatternParser<'a> {
     //   RegExpIdentifierStart[?UnicodeMode]
     //   RegExpIdentifierName[?UnicodeMode] RegExpIdentifierPart[?UnicodeMode]
     // ```
-    fn consume_reg_exp_idenfigier_name(&mut self) -> Result<Option<SpanAtom<'a>>> {
+    fn consume_reg_exp_idenfigier_name(&mut self) -> Result<Option<Str<'a>>> {
         let span_start = self.reader.offset();
 
         if self.consume_reg_exp_idenfigier_start()?.is_some() {
             while self.consume_reg_exp_idenfigier_part()?.is_some() {}
-            return Ok(Some(self.reader.atom(span_start, self.reader.offset())));
+            return Ok(Some(self.reader.str(span_start, self.reader.offset())));
         }
 
         Ok(None)

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/state.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/state.rs
@@ -1,4 +1,4 @@
-use oxc_span::Atom;
+use oxc_span::Str;
 use rustc_hash::FxHashSet;
 
 use crate::parser::reader::Reader;
@@ -13,7 +13,7 @@ pub struct State<'a> {
     pub named_capture_groups: bool,
     // Other states
     pub num_of_capturing_groups: u32,
-    pub capturing_group_names: FxHashSet<Atom<'a>>,
+    pub capturing_group_names: FxHashSet<Str<'a>>,
 }
 
 type DuplicatedNamedCapturingGroupOffsets = Vec<(u32, u32)>;
@@ -54,7 +54,7 @@ impl<'a> State<'a> {
 /// Returns: Result<(num_of_left_parens, capturing_group_names), duplicated_named_capturing_group_offsets>
 fn parse_capturing_groups<'a>(
     reader: &mut Reader<'a>,
-) -> Result<(u32, FxHashSet<Atom<'a>>), DuplicatedNamedCapturingGroupOffsets> {
+) -> Result<(u32, FxHashSet<Str<'a>>), DuplicatedNamedCapturingGroupOffsets> {
     // Count only normal CapturingGroup(named, unnamed)
     //   (?<name>...), (...)
     // IgnoreGroup, and LookaroundAssertions are ignored
@@ -64,7 +64,7 @@ fn parse_capturing_groups<'a>(
 
     // Track all named groups with their depth and alternative path
     let mut named_groups: Vec<NamedGroupInfo<'a>> = Vec::new();
-    let mut group_names: FxHashSet<Atom<'a>> = FxHashSet::default();
+    let mut group_names: FxHashSet<Str<'a>> = FxHashSet::default();
 
     // Track alternatives and depth
     let mut tracker = AlternativeTracker::new();
@@ -115,7 +115,7 @@ fn parse_capturing_groups<'a>(
                 let span_end = reader.offset();
 
                 if reader.eat('>') {
-                    let group_name = reader.atom(span_start, span_end);
+                    let group_name = reader.str(span_start, span_end);
                     let alternative_path = tracker.get_alternative_path();
 
                     // Check for duplicates with existing groups
@@ -209,7 +209,7 @@ impl AlternativeTracker {
 /// Tracks information about a named capturing group
 #[derive(Debug, Clone)]
 struct NamedGroupInfo<'a> {
-    name: Atom<'a>,
+    name: Str<'a>,
     span: (u32, u32),
     alternative_path: Vec<u32>,
 }

--- a/crates/oxc_regular_expression/src/parser/reader/mod.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/mod.rs
@@ -110,7 +110,7 @@ mod test {
             let s1 = reader.offset();
             assert!(reader.eat('^'));
             let e1 = reader.offset();
-            assert_eq!(&reader.atom(s1, e1), "^");
+            assert_eq!(&reader.str(s1, e1), "^");
 
             while reader.peek() != Some('@' as u32) {
                 reader.advance();
@@ -119,7 +119,7 @@ mod test {
             assert!(reader.eat('@'));
             assert!(reader.eat('@'));
             let e2 = reader.offset();
-            assert_eq!(&reader.atom(s2, e2), "@@");
+            assert_eq!(&reader.str(s2, e2), "@@");
 
             while reader.peek() != Some('$' as u32) {
                 reader.advance();
@@ -128,7 +128,7 @@ mod test {
             assert!(reader.eat('$'));
             let e3 = reader.offset();
 
-            assert_eq!(&reader.atom(s3, e3), "$");
+            assert_eq!(&reader.str(s3, e3), "$");
         }
     }
 

--- a/crates/oxc_regular_expression/src/parser/reader/reader_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/reader_impl.rs
@@ -1,5 +1,5 @@
 use oxc_diagnostics::Result;
-use oxc_span::Atom;
+use oxc_span::Str;
 
 use crate::parser::reader::{
     Options,
@@ -152,7 +152,7 @@ impl<'a> Reader<'a> {
         false
     }
 
-    pub fn atom(&self, start: u32, end: u32) -> Atom<'a> {
-        Atom::from(&self.source_text[start as usize..end as usize])
+    pub fn str(&self, start: u32, end: u32) -> Str<'a> {
+        Str::from(&self.source_text[start as usize..end as usize])
     }
 }

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -387,7 +387,7 @@ pub fn check_number_literal(lit: &NumericLiteral, ctx: &SemanticBuilder<'_>) {
     // NumericLiteral :: legacy_octalIntegerLiteral
     // DecimalIntegerLiteral :: NonOctalDecimalIntegerLiteral
     // * It is a Syntax Error if the source text matched by this production is strict mode code.
-    fn leading_zero(s: Option<Atom>) -> bool {
+    fn leading_zero(s: Option<Str>) -> bool {
         if let Some(s) = s {
             let mut chars = s.bytes();
             if let Some(first) = chars.next()

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::BoundNames;
-use oxc_span::{Atom, GetSpan, Span};
+use oxc_span::{GetSpan, Span, Str};
 
 use crate::{builder::SemanticBuilder, diagnostics};
 
@@ -104,7 +104,7 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
 }
 
 fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
-    let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
+    let mut idents: FxHashMap<Str<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
         if let Some(old_span) = idents.insert(ident.name.into(), ident.span) {
             ctx.error(diagnostics::redeclaration(&ident.name, old_span, ident.span));

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -278,7 +278,7 @@ impl<'a> Semantic<'a> {
 mod tests {
     use oxc_allocator::Allocator;
     use oxc_ast::{AstKind, ast::VariableDeclarationKind};
-    use oxc_span::{Atom, Ident, SourceType};
+    use oxc_span::{Ident, SourceType, Str};
 
     use super::*;
 
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn test_reference_resolutions_simple_read_write() {
         let alloc = Allocator::default();
-        let target_symbol_name = Atom::from("a");
+        let target_symbol_name = Str::from("a");
         let typescript = SourceType::ts();
         let sources = [
             // simple cases

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -11,8 +11,8 @@ pub use cmp::ContentEq;
 pub use edit_distance::{best_match, min_edit_distance};
 pub use oxc_str::ident;
 pub use oxc_str::{
-    ArenaIdentHashMap, Atom, CompactStr, Ident, IdentHashMap, IdentHashSet,
-    MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN, format_atom, format_compact_str, format_ident,
+    ArenaIdentHashMap, CompactStr, Ident, IdentHashMap, IdentHashSet,
+    MAX_INLINE_LEN as STR_MAX_INLINE_LEN, Str, format_compact_str, format_ident, format_str,
 };
 pub use source_type::{
     FileExtension, Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension,
@@ -32,14 +32,14 @@ mod generated {
 pub mod __internal {
     // Used by `format_compact_str!` macro defined in `oxc_str`
     pub use compact_str::format_compact;
-    // Used by `format_atom!` and `format_ident!` macros defined in `oxc_str`
+    // Used by `format_str!` and `format_ident!` macros defined in `oxc_str`
     pub use oxc_allocator::StringBuilder as ArenaStringBuilder;
 }
 
 // Additional trait implementations for types re-exported from oxc_str
 use std::ops::Index;
 
-impl ContentEq for Atom<'_> {
+impl ContentEq for Str<'_> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         self == other

--- a/crates/oxc_str/src/compact_str.rs
+++ b/crates/oxc_str/src/compact_str.rs
@@ -11,13 +11,15 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Maximum length for inline string, which can be created with [`CompactStr::new_const`].
 pub const MAX_INLINE_LEN: usize = 16;
 
-/// Lifetimeless version of [`crate::Atom`] which owns its own string data allocation.
+/// Lifetimeless version of [`Str`] which owns its own string data allocation.
 ///
 /// [`CompactStr`] is immutable. Use [`CompactStr::into_string`] for a mutable
 /// [`String`].
 ///
 /// Currently implemented as just a wrapper around [`compact_str::CompactString`],
 /// but will be reduced in size with a custom implementation later.
+///
+/// [`Str`]: crate::Str
 #[derive(Clone, Eq, PartialOrd, Ord)]
 pub struct CompactStr(CompactString);
 

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -11,7 +11,7 @@ use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
-use crate::{Atom, CompactStr};
+use crate::{CompactStr, Str};
 
 /// An identifier string for oxc_allocator with a precomputed hash.
 ///
@@ -129,11 +129,11 @@ impl<'a> Ident<'a> {
         unsafe { str::from_utf8_unchecked(slice::from_raw_parts(self.ptr.as_ptr(), len)) }
     }
 
-    /// Convert this [`Ident`] into an [`Atom`].
+    /// Convert this [`Ident`] into a [`Str`].
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
-    pub fn as_atom(&self) -> Atom<'a> {
-        Atom::from(self.as_str())
+    pub fn as_arena_str(&self) -> Str<'a> {
+        Str::from(self.as_str())
     }
 
     /// Convert this [`Ident`] into a [`String`].
@@ -271,18 +271,18 @@ impl<'a> From<Ident<'a>> for &'a str {
     }
 }
 
-impl<'a> From<Ident<'a>> for Atom<'a> {
+impl<'a> From<Ident<'a>> for Str<'a> {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     fn from(s: Ident<'a>) -> Self {
-        s.as_atom()
+        s.as_arena_str()
     }
 }
 
-impl<'a> From<Atom<'a>> for Ident<'a> {
+impl<'a> From<Str<'a>> for Ident<'a> {
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    fn from(s: Atom<'a>) -> Self {
+    fn from(s: Str<'a>) -> Self {
         Self::from(s.as_str())
     }
 }
@@ -388,9 +388,9 @@ impl PartialEq<&Ident<'_>> for Ident<'_> {
     }
 }
 
-impl PartialEq<Atom<'_>> for Ident<'_> {
+impl PartialEq<Str<'_>> for Ident<'_> {
     #[inline]
-    fn eq(&self, other: &Atom<'_>) -> bool {
+    fn eq(&self, other: &Str<'_>) -> bool {
         self.as_str() == other.as_str()
     }
 }

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -1,19 +1,19 @@
 //! String types for oxc.
 //!
-//! This crate provides [`Atom`], [`Ident`], and [`CompactStr`] types for efficient string handling.
+//! This crate provides [`Str`], [`Ident`], and [`CompactStr`] types for efficient string handling.
 
-mod atom;
 mod compact_str;
 pub mod ident;
+mod str;
 
-pub use atom::Atom;
 pub use compact_str::{CompactStr, MAX_INLINE_LEN};
 pub use ident::{ArenaIdentHashMap, Ident, IdentHashMap, IdentHashSet};
+pub use str::Str;
 
 #[doc(hidden)]
 pub mod __internal {
     // Used by `format_compact_str!` macro defined in `compact_str.rs`
     pub use compact_str::format_compact;
-    // Used by `format_atom!` and `format_ident!` macros
+    // Used by `format_str!` and `format_ident!` macros
     pub use oxc_allocator::StringBuilder as ArenaStringBuilder;
 }

--- a/crates/oxc_str/src/str.rs
+++ b/crates/oxc_str/src/str.rs
@@ -14,28 +14,28 @@ use crate::CompactStr;
 
 /// An inlinable string for oxc_allocator.
 ///
-/// Use [CompactStr] with [Atom::to_compact_str] or [Atom::into_compact_str] for
+/// Use [CompactStr] with [Str::to_compact_str] or [Str::into_compact_str] for
 /// the lifetimeless form.
 #[repr(transparent)]
 #[derive(Clone, Copy, Eq)]
-pub struct Atom<'a>(&'a str);
+pub struct Str<'a>(&'a str);
 
-impl Atom<'static> {
-    /// Get an [`Atom`] containing a static string.
+impl Str<'static> {
+    /// Get a [`Str`] containing a static string.
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
     pub const fn new_const(s: &'static str) -> Self {
-        Atom(s)
+        Str(s)
     }
 
-    /// Get an [`Atom`] containing the empty string (`""`).
+    /// Get a [`Str`] containing the empty string (`""`).
     #[inline]
     pub const fn empty() -> Self {
         Self::new_const("")
     }
 }
 
-impl<'a> Atom<'a> {
+impl<'a> Str<'a> {
     /// Borrow a string slice.
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
@@ -43,29 +43,29 @@ impl<'a> Atom<'a> {
         self.0
     }
 
-    /// Convert this [`Atom`] into a [`String`].
+    /// Convert this [`Str`] into a [`String`].
     ///
-    /// This is the explicit form of [`Into<String>`], which [`Atom`] also implements.
+    /// This is the explicit form of [`Into<String>`], which [`Str`] also implements.
     #[inline]
     pub fn into_string(self) -> String {
         String::from(self.as_str())
     }
 
-    /// Convert this [`Atom`] into a [`CompactStr`].
+    /// Convert this [`Str`] into a [`CompactStr`].
     ///
-    /// This is the explicit form of [`Into<CompactStr>`], which [`Atom`] also implements.
+    /// This is the explicit form of [`Into<CompactStr>`], which [`Str`] also implements.
     #[inline]
     pub fn into_compact_str(self) -> CompactStr {
         CompactStr::new(self.as_str())
     }
 
-    /// Convert this [`Atom`] into a [`CompactStr`] without consuming `self`.
+    /// Convert this [`Str`] into a [`CompactStr`] without consuming `self`.
     #[inline]
     pub fn to_compact_str(self) -> CompactStr {
         CompactStr::new(self.as_str())
     }
 
-    /// Create new [`Atom`] from a fixed-size array of `&str`s concatenated together,
+    /// Create new [`Str`] from a fixed-size array of `&str`s concatenated together,
     /// allocated in the given `allocator`.
     ///
     /// # Panics
@@ -75,10 +75,10 @@ impl<'a> Atom<'a> {
     /// # Example
     /// ```
     /// use oxc_allocator::Allocator;
-    /// use oxc_str::Atom;
+    /// use oxc_str::Str;
     ///
     /// let allocator = Allocator::new();
-    /// let s = Atom::from_strs_array_in(["hello", " ", "world", "!"], &allocator);
+    /// let s = Str::from_strs_array_in(["hello", " ", "world", "!"], &allocator);
     /// assert_eq!(s.as_str(), "hello world!");
     /// ```
     // `#[inline(always)]` because want compiler to be able to optimize where some of `strings`
@@ -88,80 +88,80 @@ impl<'a> Atom<'a> {
     pub fn from_strs_array_in<const N: usize>(
         strings: [&str; N],
         allocator: &'a Allocator,
-    ) -> Atom<'a> {
+    ) -> Str<'a> {
         Self::from(allocator.alloc_concat_strs_array(strings))
     }
 
-    /// Convert a [`Cow<'a, str>`] to an [`Atom<'a>`].
+    /// Convert a [`Cow<'a, str>`] to a [`Str<'a>`].
     ///
-    /// If the `Cow` borrows a string from arena, returns an `Atom` which references that same string,
+    /// If the `Cow` borrows a string from arena, returns a `Str` which references that same string,
     /// without allocating a new one.
     ///
-    /// If the `Cow` is owned, allocates the string into arena to generate a new `Atom`.
+    /// If the `Cow` is owned, allocates the string into arena to generate a new `Str`.
     #[inline]
-    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &'a Allocator) -> Atom<'a> {
+    pub fn from_cow_in(value: &Cow<'a, str>, allocator: &'a Allocator) -> Str<'a> {
         match value {
-            Cow::Borrowed(s) => Atom::from(*s),
-            Cow::Owned(s) => Atom::from_in(s, allocator),
+            Cow::Borrowed(s) => Str::from(*s),
+            Cow::Owned(s) => Str::from_in(s, allocator),
         }
     }
 }
 
-impl<'new_alloc> CloneIn<'new_alloc> for Atom<'_> {
-    type Cloned = Atom<'new_alloc>;
+impl<'new_alloc> CloneIn<'new_alloc> for Str<'_> {
+    type Cloned = Str<'new_alloc>;
 
     #[inline]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        Atom::from_in(self.as_str(), allocator)
+        Str::from_in(self.as_str(), allocator)
     }
 }
 
-impl<'a> Dummy<'a> for Atom<'a> {
-    /// Create a dummy [`Atom`].
+impl<'a> Dummy<'a> for Str<'a> {
+    /// Create a dummy [`Str`].
     #[expect(clippy::inline_always)]
     #[inline(always)]
     fn dummy(_allocator: &'a Allocator) -> Self {
-        Atom::empty()
+        Str::empty()
     }
 }
 
-impl<'alloc> FromIn<'alloc, &Atom<'alloc>> for Atom<'alloc> {
+impl<'alloc> FromIn<'alloc, &Str<'alloc>> for Str<'alloc> {
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
-    fn from_in(s: &Atom<'alloc>, _: &'alloc Allocator) -> Self {
+    fn from_in(s: &Str<'alloc>, _: &'alloc Allocator) -> Self {
         *s
     }
 }
 
-impl<'alloc> FromIn<'alloc, &str> for Atom<'alloc> {
+impl<'alloc> FromIn<'alloc, &str> for Str<'alloc> {
     #[inline]
     fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {
         Self::from(allocator.alloc_str(s))
     }
 }
 
-impl<'alloc> FromIn<'alloc, String> for Atom<'alloc> {
+impl<'alloc> FromIn<'alloc, String> for Str<'alloc> {
     #[inline]
     fn from_in(s: String, allocator: &'alloc Allocator) -> Self {
         Self::from_in(s.as_str(), allocator)
     }
 }
 
-impl<'alloc> FromIn<'alloc, &String> for Atom<'alloc> {
+impl<'alloc> FromIn<'alloc, &String> for Str<'alloc> {
     #[inline]
     fn from_in(s: &String, allocator: &'alloc Allocator) -> Self {
         Self::from_in(s.as_str(), allocator)
     }
 }
 
-impl<'alloc> FromIn<'alloc, Cow<'_, str>> for Atom<'alloc> {
+impl<'alloc> FromIn<'alloc, Cow<'_, str>> for Str<'alloc> {
     #[inline]
     fn from_in(s: Cow<'_, str>, allocator: &'alloc Allocator) -> Self {
         Self::from_in(&*s, allocator)
     }
 }
 
-impl<'a> From<&'a str> for Atom<'a> {
+impl<'a> From<&'a str> for Str<'a> {
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
     fn from(s: &'a str) -> Self {
@@ -169,43 +169,43 @@ impl<'a> From<&'a str> for Atom<'a> {
     }
 }
 
-impl<'alloc> From<ArenaStringBuilder<'alloc>> for Atom<'alloc> {
+impl<'alloc> From<ArenaStringBuilder<'alloc>> for Str<'alloc> {
     #[inline]
     fn from(s: ArenaStringBuilder<'alloc>) -> Self {
         Self::from(s.into_str())
     }
 }
 
-impl<'a> From<Atom<'a>> for &'a str {
+impl<'a> From<Str<'a>> for &'a str {
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
-    fn from(s: Atom<'a>) -> Self {
+    fn from(s: Str<'a>) -> Self {
         s.as_str()
     }
 }
 
-impl From<Atom<'_>> for CompactStr {
+impl From<Str<'_>> for CompactStr {
     #[inline]
-    fn from(val: Atom<'_>) -> Self {
+    fn from(val: Str<'_>) -> Self {
         val.into_compact_str()
     }
 }
 
-impl From<Atom<'_>> for String {
+impl From<Str<'_>> for String {
     #[inline]
-    fn from(val: Atom<'_>) -> Self {
+    fn from(val: Str<'_>) -> Self {
         val.into_string()
     }
 }
 
-impl<'a> From<Atom<'a>> for Cow<'a, str> {
+impl<'a> From<Str<'a>> for Cow<'a, str> {
     #[inline]
-    fn from(value: Atom<'a>) -> Self {
+    fn from(value: Str<'a>) -> Self {
         Cow::Borrowed(value.as_str())
     }
 }
 
-impl Deref for Atom<'_> {
+impl Deref for Str<'_> {
     type Target = str;
 
     #[expect(clippy::inline_always)]
@@ -215,7 +215,7 @@ impl Deref for Atom<'_> {
     }
 }
 
-impl AsRef<str> for Atom<'_> {
+impl AsRef<str> for Str<'_> {
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
     fn as_ref(&self) -> &str {
@@ -223,7 +223,7 @@ impl AsRef<str> for Atom<'_> {
     }
 }
 
-impl Borrow<str> for Atom<'_> {
+impl Borrow<str> for Str<'_> {
     #[expect(clippy::inline_always)]
     #[inline(always)] // Because this is a no-op
     fn borrow(&self) -> &str {
@@ -231,55 +231,55 @@ impl Borrow<str> for Atom<'_> {
     }
 }
 
-impl<T: AsRef<str>> PartialEq<T> for Atom<'_> {
+impl<T: AsRef<str>> PartialEq<T> for Str<'_> {
     #[inline]
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
 }
 
-impl PartialEq<Atom<'_>> for &str {
+impl PartialEq<Str<'_>> for &str {
     #[inline]
-    fn eq(&self, other: &Atom<'_>) -> bool {
+    fn eq(&self, other: &Str<'_>) -> bool {
         *self == other.as_str()
     }
 }
 
-impl PartialEq<str> for Atom<'_> {
+impl PartialEq<str> for Str<'_> {
     #[inline]
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
     }
 }
 
-impl PartialEq<Atom<'_>> for Cow<'_, str> {
+impl PartialEq<Str<'_>> for Cow<'_, str> {
     #[inline]
-    fn eq(&self, other: &Atom<'_>) -> bool {
+    fn eq(&self, other: &Str<'_>) -> bool {
         self.as_ref() == other.as_str()
     }
 }
 
-impl hash::Hash for Atom<'_> {
+impl hash::Hash for Str<'_> {
     #[inline]
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
         self.as_str().hash(hasher);
     }
 }
 
-impl fmt::Debug for Atom<'_> {
+impl fmt::Debug for Str<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
-impl fmt::Display for Atom<'_> {
+impl fmt::Display for Str<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
 #[cfg(feature = "serialize")]
-impl Serialize for Atom<'_> {
+impl Serialize for Str<'_> {
     #[inline] // Because it just delegates
     fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(self.as_str(), serializer)
@@ -287,19 +287,19 @@ impl Serialize for Atom<'_> {
 }
 
 #[cfg(feature = "serialize")]
-impl ESTree for Atom<'_> {
+impl ESTree for Str<'_> {
     #[inline] // Because it just delegates
     fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
         ESTree::serialize(self.as_str(), serializer);
     }
 }
 
-/// Creates an [`Atom`] using interpolation of runtime expressions.
+/// Creates a [`Str`] using interpolation of runtime expressions.
 ///
 /// Identical to [`std`'s `format!` macro](std::format), except:
 ///
 /// * First argument is the allocator.
-/// * Produces an [`Atom`] instead of a [`String`].
+/// * Produces a [`Str`] instead of a [`String`].
 ///
 /// The string is built in the arena, without allocating an intermediate `String`.
 ///
@@ -311,22 +311,22 @@ impl ESTree for Atom<'_> {
 ///
 /// ```
 /// use oxc_allocator::Allocator;
-/// use oxc_str::format_atom;
+/// use oxc_str::format_str;
 /// let allocator = Allocator::new();
 ///
 /// let s1 = "foo";
 /// let s2 = "bar";
-/// let formatted = format_atom!(&allocator, "{s1}.{s2}");
+/// let formatted = format_str!(&allocator, "{s1}.{s2}");
 /// assert_eq!(formatted, "foo.bar");
 /// ```
 #[macro_export]
-macro_rules! format_atom {
+macro_rules! format_str {
     ($alloc:expr, $($arg:tt)*) => {{
         use ::std::{write, fmt::Write};
-        use $crate::{Atom, __internal::ArenaStringBuilder};
+        use $crate::{Str, __internal::ArenaStringBuilder};
 
         let mut s = ArenaStringBuilder::new_in($alloc);
         write!(s, $($arg)*).unwrap();
-        Atom::from(s)
+        Str::from(s)
     }}
 }

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -3,7 +3,7 @@
 use oxc_allocator::{Allocator, HashMap, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{Atom, Span};
+use oxc_span::{Span, Str};
 
 /// ESM Module Record
 ///
@@ -27,7 +27,7 @@ pub struct ModuleRecord<'a> {
     ///   export ExportFromClause FromClause
     ///
     /// Keyed by ModuleSpecifier, valued by all node occurrences
-    pub requested_modules: HashMap<'a, Atom<'a>, Vec<'a, RequestedModule>>,
+    pub requested_modules: HashMap<'a, Str<'a>, Vec<'a, RequestedModule>>,
 
     /// `[[ImportEntries]]`
     ///
@@ -55,7 +55,7 @@ pub struct ModuleRecord<'a> {
     pub star_export_entries: Vec<'a, ExportEntry<'a>>,
 
     /// Local exported bindings
-    pub exported_bindings: HashMap<'a, Atom<'a>, Span>,
+    pub exported_bindings: HashMap<'a, Str<'a>, Span>,
 
     /// Dynamic import expressions `import(specifier)`.
     pub dynamic_imports: Vec<'a, DynamicImport>,
@@ -89,7 +89,7 @@ impl<'a> ModuleRecord<'a> {
 pub struct NameSpan<'a> {
     /// Name
     #[estree(rename = "value")]
-    pub name: Atom<'a>,
+    pub name: Str<'a>,
 
     /// Span
     pub span: Span,
@@ -97,7 +97,7 @@ pub struct NameSpan<'a> {
 
 impl<'a> NameSpan<'a> {
     /// Constructor
-    pub fn new(name: Atom<'a>, span: Span) -> Self {
+    pub fn new(name: Str<'a>, span: Span) -> Self {
         Self { span, name }
     }
 }
@@ -385,7 +385,7 @@ impl<'a> ExportLocalName<'a> {
     }
 
     /// Get the bound name of this export. [`None`] for [`ExportLocalName::Null`].
-    pub fn name(&self) -> Option<Atom<'a>> {
+    pub fn name(&self) -> Option<Str<'a>> {
         match self {
             Self::Name(name) | Self::Default(name) => Some(name.name),
             Self::Null => None,

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -76,7 +76,7 @@ use oxc_ast::{
     ast::{Argument, CallExpression, Expression},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
-use oxc_span::{Atom, SPAN, Span};
+use oxc_span::{SPAN, Span, Str};
 use oxc_traverse::BoundIdentifier;
 
 use crate::context::TraverseCtx;
@@ -328,8 +328,8 @@ pub fn helper_load<'a>(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<
 // Internal methods
 impl<'a> HelperLoaderStore<'a> {
     // Construct string directly in arena without an intermediate temp allocation
-    fn get_runtime_source(&self, helper: Helper, ctx: &TraverseCtx<'a>) -> Atom<'a> {
-        ctx.ast.atom_from_strs_array([&self.module_name, "/helpers/", helper.name()])
+    fn get_runtime_source(&self, helper: Helper, ctx: &TraverseCtx<'a>) -> Str<'a> {
+        ctx.ast.str_from_strs_array([&self.module_name, "/helpers/", helper.name()])
     }
 
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -1,6 +1,6 @@
 //! Utility transform to add `import` / `require` statements to top of program.
 //!
-//! `ModuleImportsStore` contains an `IndexMap<Atom<'a>, Vec<ImportKind<'a>>>`.
+//! `ModuleImportsStore` contains an `IndexMap<Str<'a>, Vec<ImportKind<'a>>>`.
 //! It is stored on `TransformState`.
 //!
 //! Other transforms can add `import`s / `require`s to the store by calling methods of `ModuleImportsStore`:
@@ -10,17 +10,17 @@
 //! ```rs
 //! // import { jsx as _jsx } from 'react';
 //! ctx.state.module_imports.add_named_import(
-//!     Atom::from("react"),
-//!     Atom::from("jsx"),
-//!     Atom::from("_jsx"),
+//!     Str::from("react"),
+//!     Str::from("jsx"),
+//!     Str::from("_jsx"),
 //!     symbol_id
 //! );
 //!
 //! // ESM: import React from 'react';
 //! // CJS: var _React = require('react');
 //! ctx.state.module_imports.add_default_import(
-//!     Atom::from("react"),
-//!     Atom::from("React"),
+//!     Str::from("react"),
+//!     Str::from("React"),
 //!     symbol_id
 //! );
 //! ```
@@ -34,14 +34,14 @@ use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
-use oxc_span::{Atom, SPAN};
+use oxc_span::{SPAN, Str};
 use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::BoundIdentifier;
 
 use crate::context::TraverseCtx;
 
 pub struct NamedImport<'a> {
-    imported: Atom<'a>,
+    imported: Str<'a>,
     local: BoundIdentifier<'a>,
 }
 
@@ -56,7 +56,7 @@ pub enum Import<'a> {
 /// to produce output that's the same as Babel's.
 /// Substitute `FxHashMap` once we don't need to match Babel's output exactly.
 pub struct ModuleImportsStore<'a> {
-    pub(crate) imports: IndexMap<Atom<'a>, Vec<Import<'a>>>,
+    pub(crate) imports: IndexMap<Str<'a>, Vec<Import<'a>>>,
 }
 
 // Public methods
@@ -74,12 +74,7 @@ impl<'a> ModuleImportsStore<'a> {
     /// * `var named_import = require('source');`
     ///
     /// If `front` is `true`, `import`/`require` is added to front of the `import`s/`require`s.
-    pub fn add_default_import(
-        &mut self,
-        source: Atom<'a>,
-        local: BoundIdentifier<'a>,
-        front: bool,
-    ) {
+    pub fn add_default_import(&mut self, source: Str<'a>, local: BoundIdentifier<'a>, front: bool) {
         self.add_import(source, Import::Default(local), front);
     }
 
@@ -92,8 +87,8 @@ impl<'a> ModuleImportsStore<'a> {
     /// Adding named `require`s is not supported, and will cause a panic later on.
     pub fn add_named_import(
         &mut self,
-        source: Atom<'a>,
-        imported: Atom<'a>,
+        source: Str<'a>,
+        imported: Str<'a>,
         local: BoundIdentifier<'a>,
         front: bool,
     ) {
@@ -120,7 +115,7 @@ impl<'a> ModuleImportsStore<'a> {
     /// If `front` is `true`, `import`/`require` is added to front of the `import`s/`require`s.
     /// TODO(improve-on-babel): `front` option is only required to pass one of Babel's tests. Output
     /// without it is still valid. Remove this once our output doesn't need to match Babel exactly.
-    fn add_import(&mut self, source: Atom<'a>, import: Import<'a>, front: bool) {
+    fn add_import(&mut self, source: Str<'a>, import: Import<'a>, front: bool) {
         match self.imports.entry(source) {
             IndexMapEntry::Occupied(mut entry) => {
                 entry.get_mut().push(import);
@@ -140,7 +135,7 @@ impl<'a> ModuleImportsStore<'a> {
     }
 
     pub(crate) fn get_import(
-        source: Atom<'a>,
+        source: Str<'a>,
         names: Vec<Import<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
@@ -171,7 +166,7 @@ impl<'a> ModuleImportsStore<'a> {
     }
 
     pub(crate) fn get_require(
-        source: Atom<'a>,
+        source: Str<'a>,
         names: std::vec::Vec<Import<'a>>,
         require_symbol_id: Option<SymbolId>,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -371,14 +371,14 @@ impl<'a> LegacyDecorator<'a> {
 
                 let getter_key = PropertyKey::from(assignment);
                 let setter_key = PropertyKey::from(reference);
-                let storage_name = ctx.ast.atom_from_strs_array([
+                let storage_name = ctx.ast.str_from_strs_array([
                     "_",
                     &get_var_name_from_node(&setter_key),
                     "_computed_accessor_storage",
                 ]);
                 (storage_name, getter_key, setter_key)
             } else {
-                let storage_name = ctx.ast.atom_from_strs_array([
+                let storage_name = ctx.ast.str_from_strs_array([
                     "_",
                     &get_var_name_from_node(&accessor.key),
                     "_accessor_storage",
@@ -457,7 +457,7 @@ impl<'a> LegacyDecorator<'a> {
         kind: MethodDefinitionKind,
         computed: bool,
         is_static: bool,
-        storage_name: Atom<'a>,
+        storage_name: Str<'a>,
         object_binding: Option<&BoundIdentifier<'a>>,
         class_scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
@@ -494,7 +494,7 @@ impl<'a> LegacyDecorator<'a> {
             (params, stmt)
         } else {
             let value_binding = ctx.generate_binding(
-                Atom::from("value").into(),
+                Str::from("value").into(),
                 scope_id,
                 SymbolFlags::FunctionScopedVariable,
             );

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -1027,7 +1027,7 @@ impl<'a> ObjectRestSpread<'a> {
                 if expr.is_literal() {
                     let span = expr.span();
                     let s = expr.to_js_string(&WithoutGlobalReferenceInformation {}).unwrap();
-                    let s = ctx.ast.atom_from_cow(&s);
+                    let s = ctx.ast.str_from_cow(&s);
                     let expr = ctx.ast.expression_string_literal(span, s, None);
                     return Some(ArrayExpressionElement::from(expr));
                 }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -582,7 +582,7 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
             Expression::from(ctx.ast.member_expression_static(
                 SPAN,
                 super_binding.create_read_expression(ctx),
-                ctx.ast.identifier_name(SPAN, Atom::from("call")),
+                ctx.ast.identifier_name(SPAN, Str::from("call")),
                 false,
             )),
             NONE,

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -297,7 +297,7 @@ impl<'a> ClassProperties<'a> {
         call_expr.callee = Expression::from(ctx.ast.member_expression_static(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, Atom::from("call")),
+            ctx.ast.identifier_name(SPAN, Str::from("call")),
             // Make sure the `callee` can access `call` safely. i.e `callee?.()` -> `callee?.call()`
             mem::replace(&mut call_expr.optional, false),
         ));
@@ -1774,7 +1774,7 @@ impl<'a> ClassProperties<'a> {
         let callee = Expression::from(ctx.ast.member_expression_static(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, Atom::from("bind")),
+            ctx.ast.identifier_name(SPAN, Str::from("bind")),
             false,
         ));
         let arguments = ctx.ast.vec1(Argument::from(context));
@@ -2172,7 +2172,7 @@ impl<'a> ClassProperties<'a> {
         private_name: &str,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let message = ctx.ast.atom_from_strs_array(["#", private_name]);
+        let message = ctx.ast.str_from_strs_array(["#", private_name]);
         let message = ctx.ast.expression_string_literal(SPAN, message, None);
         helper_call_expr(helper, SPAN, ctx.ast.vec1(Argument::from(message)), ctx)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -363,7 +363,7 @@ impl<'a> ClassProperties<'a> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, Atom::from("writable")),
+                    ctx.ast.property_key_static_identifier(SPAN, Str::from("writable")),
                     ctx.ast.expression_boolean_literal(SPAN, true),
                     false,
                     false,
@@ -372,7 +372,7 @@ impl<'a> ClassProperties<'a> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, Atom::from("value")),
+                    ctx.ast.property_key_static_identifier(SPAN, Str::from("value")),
                     value,
                     false,
                     false,

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -40,7 +40,7 @@ where
 
 /// Create `IdentifierName` for `_`.
 pub(super) fn create_underscore_ident_name<'a>(ctx: &TraverseCtx<'a>) -> IdentifierName<'a> {
-    ctx.ast.identifier_name(SPAN, Atom::from("_"))
+    ctx.ast.identifier_name(SPAN, Str::from("_"))
 }
 
 /// Debug assert that an `Expression` is not `ParenthesizedExpression` or TS syntax

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -227,11 +227,11 @@ impl<'a> Keys<'a> {
     ///
     /// Returned key will be either `_`, or `_<integer>` starting with `_2`.
     #[inline]
-    fn get_unique(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn get_unique(&mut self, ctx: &TraverseCtx<'a>) -> Str<'a> {
         #[expect(clippy::if_not_else)]
         if !self.underscore {
             self.underscore = true;
-            Atom::from("_")
+            Str::from("_")
         } else {
             self.get_unique_slow(ctx)
         }
@@ -240,7 +240,7 @@ impl<'a> Keys<'a> {
     // `#[cold]` and `#[inline(never)]` as it should be very rare to need a key other than `#_`.
     #[cold]
     #[inline(never)]
-    fn get_unique_slow(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn get_unique_slow(&mut self, ctx: &TraverseCtx<'a>) -> Str<'a> {
         // Source text length is limited to `u32::MAX` so impossible to have more than `u32::MAX`
         // private keys. So `u32` is sufficient here.
         let mut i = 2u32;
@@ -254,7 +254,7 @@ impl<'a> Keys<'a> {
             i += 1;
         }
 
-        let key = ctx.ast.atom_from_strs_array(["_", num_str]);
+        let key = ctx.ast.str_from_strs_array(["_", num_str]);
         self.numbered.push(&key.as_str()[1..]);
 
         key

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -46,7 +46,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-display-name/src/index.ts>
 
 use oxc_ast::ast::*;
-use oxc_span::{Atom, SPAN};
+use oxc_span::{SPAN, Str};
 use oxc_traverse::{Ancestor, Traverse};
 
 use crate::{context::TraverseCtx, state::TransformState};
@@ -107,14 +107,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName {
                     // whereas we also handle e.g. `{"foo-bar": React.createClass({})}`,
                     // so we diverge from Babel here, but that's probably an improvement
                     if let Some(name) = prop.key().static_name() {
-                        break ctx.ast.atom(&name);
+                        break ctx.ast.str(&name);
                     }
                     return;
                 }
                 // `export default React.createClass({})`
                 // Uses the current file name as the display name.
                 Ancestor::ExportDefaultDeclarationDeclaration(_) => {
-                    break ctx.ast.atom(&ctx.state.filename);
+                    break ctx.ast.str(&ctx.state.filename);
                 }
                 // Stop crawling up when hit a statement
                 _ if ancestor.is_parent_of_statement() => return,
@@ -152,11 +152,7 @@ impl<'a> ReactDisplayName {
     }
 
     /// Add key value `displayName: name` to the `React.createClass` object.
-    fn add_display_name(
-        obj_expr: &mut ObjectExpression<'a>,
-        name: Atom<'a>,
-        ctx: &TraverseCtx<'a>,
-    ) {
+    fn add_display_name(obj_expr: &mut ObjectExpression<'a>, name: Str<'a>, ctx: &TraverseCtx<'a>) {
         const DISPLAY_NAME: &str = "displayName";
         // Not safe with existing display name.
         let not_safe = obj_expr.properties.iter().any(|prop| {

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -93,7 +93,7 @@ use oxc_allocator::{
 };
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
-use oxc_span::{Atom, Ident, SPAN, Span};
+use oxc_span::{Ident, SPAN, Span, Str};
 use oxc_syntax::{
     identifier::{is_identifier_name, is_white_space_single_line},
     keyword::is_reserved_keyword,
@@ -149,7 +149,7 @@ struct ClassicBindings<'a> {
 }
 
 struct AutomaticScriptBindings<'a> {
-    jsx_runtime_importer: Atom<'a>,
+    jsx_runtime_importer: Str<'a>,
     react_importer_len: u32,
     require_create_element: Option<BoundIdentifier<'a>>,
     require_jsx: Option<BoundIdentifier<'a>>,
@@ -157,7 +157,7 @@ struct AutomaticScriptBindings<'a> {
 }
 
 impl<'a> AutomaticScriptBindings<'a> {
-    fn new(jsx_runtime_importer: Atom<'a>, react_importer_len: u32, is_development: bool) -> Self {
+    fn new(jsx_runtime_importer: Str<'a>, react_importer_len: u32, is_development: bool) -> Self {
         Self {
             jsx_runtime_importer,
             react_importer_len,
@@ -194,7 +194,7 @@ impl<'a> AutomaticScriptBindings<'a> {
     fn add_require_statement(
         &self,
         variable_name: &str,
-        source: Atom<'a>,
+        source: Str<'a>,
         front: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
@@ -206,7 +206,7 @@ impl<'a> AutomaticScriptBindings<'a> {
 }
 
 struct AutomaticModuleBindings<'a> {
-    jsx_runtime_importer: Atom<'a>,
+    jsx_runtime_importer: Str<'a>,
     react_importer_len: u32,
     import_create_element: Option<BoundIdentifier<'a>>,
     import_fragment: Option<BoundIdentifier<'a>>,
@@ -216,7 +216,7 @@ struct AutomaticModuleBindings<'a> {
 }
 
 impl<'a> AutomaticModuleBindings<'a> {
-    fn new(jsx_runtime_importer: Atom<'a>, react_importer_len: u32, is_development: bool) -> Self {
+    fn new(jsx_runtime_importer: Str<'a>, react_importer_len: u32, is_development: bool) -> Self {
         Self {
             jsx_runtime_importer,
             react_importer_len,
@@ -288,18 +288,18 @@ impl<'a> AutomaticModuleBindings<'a> {
     fn add_import_statement(
         &self,
         name: &'static str,
-        source: Atom<'a>,
+        source: Str<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_root_scope(name, SymbolFlags::Import);
-        ctx.state.module_imports.add_named_import(source, Atom::from(name), binding.clone(), false);
+        ctx.state.module_imports.add_named_import(source, Str::from(name), binding.clone(), false);
         binding
     }
 }
 
 #[inline]
-fn get_import_source(jsx_runtime_importer: &str, react_importer_len: u32) -> Atom<'_> {
-    Atom::from(&jsx_runtime_importer[..react_importer_len as usize])
+fn get_import_source(jsx_runtime_importer: &str, react_importer_len: u32) -> Str<'_> {
+    Str::from(&jsx_runtime_importer[..react_importer_len as usize])
 }
 
 /// Pragma used in classic mode.
@@ -307,15 +307,15 @@ fn get_import_source(jsx_runtime_importer: &str, react_importer_len: u32) -> Ato
 /// `Double` is first as it's most common.
 enum Pragma<'a> {
     /// `React.createElement`
-    Double(Atom<'a>, Atom<'a>),
+    Double(Str<'a>, Str<'a>),
     /// `createElement`
-    Single(Atom<'a>),
+    Single(Str<'a>),
     /// `foo.bar.qux`
-    Multiple(Vec<Atom<'a>>),
+    Multiple(Vec<Str<'a>>),
     /// `this`, `this.foo`, `this.foo.bar.qux`
-    This(Vec<Atom<'a>>),
+    This(Vec<Str<'a>>),
     /// `import.meta`, `import.meta.foo`, `import.meta.foo.bar.qux`
-    ImportMeta(Vec<Atom<'a>>),
+    ImportMeta(Vec<Str<'a>>),
 }
 
 impl<'a> Pragma<'a> {
@@ -339,7 +339,7 @@ impl<'a> Pragma<'a> {
             }
         }
 
-        Self::Double(Atom::from("React"), Atom::from(default_property_name))
+        Self::Double(Str::from("React"), Str::from(default_property_name))
     }
 
     /// Parse without `TransformCtx` - skips error reporting for invalid pragma.
@@ -356,11 +356,11 @@ impl<'a> Pragma<'a> {
             return pragma;
         }
 
-        Self::Double(Atom::from("React"), Atom::from(default_property_name))
+        Self::Double(Str::from("React"), Str::from(default_property_name))
     }
 
     fn parse_impl(pragma: &str, ast: AstBuilder<'a>) -> Option<Self> {
-        let strs_to_atoms = |parts: &[&str]| parts.iter().map(|part| ast.atom(part)).collect();
+        let strs_to_arena_strs = |parts: &[&str]| parts.iter().map(|part| ast.str(part)).collect();
 
         let parts = pragma.split('.').collect::<Vec<_>>();
         let [root, tail @ ..] = &parts[..] else {
@@ -372,7 +372,7 @@ impl<'a> Pragma<'a> {
                 if !tail.iter().all(|part| is_identifier_name(part)) {
                     return None;
                 }
-                return Some(Self::This(strs_to_atoms(tail)));
+                return Some(Self::This(strs_to_arena_strs(tail)));
             }
             "import" => {
                 let ["meta", rest @ ..] = tail else {
@@ -381,7 +381,7 @@ impl<'a> Pragma<'a> {
                 if !rest.iter().all(|part| is_identifier_name(part)) {
                     return None;
                 }
-                return Some(Self::ImportMeta(strs_to_atoms(rest)));
+                return Some(Self::ImportMeta(strs_to_arena_strs(rest)));
             }
             _ => {
                 if is_reserved_keyword(root) || !is_identifier_name(root) {
@@ -394,9 +394,9 @@ impl<'a> Pragma<'a> {
         }
 
         Some(match &parts[..] {
-            [first, second] => Self::Double(ast.atom(first), ast.atom(second)),
-            [only] => Self::Single(ast.atom(only)),
-            parts => Self::Multiple(strs_to_atoms(parts)),
+            [first, second] => Self::Double(ast.str(first), ast.str(second)),
+            [only] => Self::Single(ast.str(only)),
+            parts => Self::Multiple(strs_to_arena_strs(parts)),
         })
     }
     fn create_expression(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
@@ -426,8 +426,8 @@ impl<'a> Pragma<'a> {
             Self::ImportMeta(parts) => {
                 let object = ctx.ast.expression_meta_property(
                     SPAN,
-                    ctx.ast.identifier_name(SPAN, Atom::from("import")),
-                    ctx.ast.identifier_name(SPAN, Atom::from("meta")),
+                    ctx.ast.identifier_name(SPAN, Str::from("import")),
+                    ctx.ast.identifier_name(SPAN, Str::from("meta")),
                 );
                 (object, parts.iter())
             }
@@ -471,7 +471,7 @@ impl<'a> JsxImpl<'a> {
                             }
                             Ok(source_len) => source_len,
                         };
-                        let jsx_runtime_importer = ast.atom(&format!(
+                        let jsx_runtime_importer = ast.str(&format!(
                             "{}/jsx-{}runtime",
                             import_source,
                             if is_development { "dev-" } else { "" }
@@ -480,9 +480,9 @@ impl<'a> JsxImpl<'a> {
                     }
                     None => {
                         let jsx_runtime_importer = if is_development {
-                            Atom::from("react/jsx-dev-runtime")
+                            Str::from("react/jsx-dev-runtime")
                         } else {
-                            Atom::from("react/jsx-runtime")
+                            Str::from("react/jsx-runtime")
                         };
                         (jsx_runtime_importer, "react".len() as u32)
                     }
@@ -798,7 +798,7 @@ impl<'a> JsxImpl<'a> {
                 if self.options.throw_if_namespace {
                     ctx.state.error(diagnostics::namespace_does_not_support(namespaced.span));
                 }
-                let namespace_name = ctx.ast.atom_from_strs_array([
+                let namespace_name = ctx.ast.str_from_strs_array([
                     &namespaced.namespace.name,
                     ":",
                     &namespaced.name.name,
@@ -814,7 +814,7 @@ impl<'a> JsxImpl<'a> {
             Bindings::Classic(bindings) => bindings.pragma_frag.create_expression(ctx),
             Bindings::AutomaticScript(bindings) => {
                 let object_ident = bindings.require_jsx(ctx);
-                let property_name = Atom::from("Fragment");
+                let property_name = Str::from("Fragment");
                 create_static_member_expression(object_ident, property_name, ctx)
             }
             Bindings::AutomaticModule(bindings) => {
@@ -834,14 +834,14 @@ impl<'a> JsxImpl<'a> {
             Bindings::Classic(bindings) => bindings.pragma.create_expression(ctx),
             Bindings::AutomaticScript(bindings) => {
                 let (ident, property_name) = if has_key_after_props_spread {
-                    (bindings.require_create_element(ctx), Atom::from("createElement"))
+                    (bindings.require_create_element(ctx), Str::from("createElement"))
                 } else {
                     let property_name = if bindings.is_development {
-                        Atom::from("jsxDEV")
+                        Str::from("jsxDEV")
                     } else if jsxs {
-                        Atom::from("jsxs")
+                        Str::from("jsxs")
                     } else {
-                        Atom::from("jsx")
+                        Str::from("jsx")
                     };
                     (bindings.require_jsx(ctx), property_name)
                 };
@@ -887,10 +887,10 @@ impl<'a> JsxImpl<'a> {
                 Self::decode_entities(s.value.as_str(), &mut decoded, s.value.len(), ctx);
                 let jsx_text = if let Some(decoded) = decoded {
                     // Text contains HTML entities which were decoded.
-                    // `decoded` contains the decoded string as an `ArenaString`. Convert it to `Atom`.
-                    Atom::from(decoded)
+                    // `decoded` contains the decoded string as an `ArenaString`. Convert it to `Str`.
+                    Str::from(decoded)
                 } else {
-                    // No HTML entities needed to be decoded. Use the original `Atom` without copying.
+                    // No HTML entities needed to be decoded. Use the original `Str` without copying.
                     s.value
                 };
                 ctx.ast.expression_string_literal(s.span, jsx_text, None)
@@ -971,7 +971,7 @@ impl<'a> JsxImpl<'a> {
                 }
             }
             JSXAttributeName::NamespacedName(namespaced) => {
-                let name = ctx.ast.atom(&namespaced.to_string());
+                let name = ctx.ast.str(&namespaced.to_string());
                 PropertyKey::from(ctx.ast.expression_string_literal(namespaced.span, name, None))
             }
         }
@@ -998,9 +998,9 @@ impl<'a> JsxImpl<'a> {
     ///
     /// <https://github.com/microsoft/TypeScript/blob/f0374ce2a9c465e27a15b7fa4a347e2bd9079450/src/compiler/transformers/jsx.ts#L557-L608>
     fn fixup_whitespace_and_decode_entities(
-        text: Atom<'a>,
+        text: Str<'a>,
         ctx: &TraverseCtx<'a>,
-    ) -> Option<Atom<'a>> {
+    ) -> Option<Str<'a>> {
         // Avoid copying strings in the common case where there's only 1 line of text,
         // and it contains no HTML entities that need decoding.
         //
@@ -1013,7 +1013,7 @@ impl<'a> JsxImpl<'a> {
         //
         // When first line containing some text is found:
         // * If it contains HTML entities, decode them and write decoded text to accumulator `acc`.
-        // * Otherwise, store trimmed text in `only_line` as an `Atom<'a>`.
+        // * Otherwise, store trimmed text in `only_line` as a `Str<'a>`.
         //
         // When another line containing some text is found:
         // * If accumulator isn't already initialized, initialize it, starting with `only_line`.
@@ -1021,20 +1021,20 @@ impl<'a> JsxImpl<'a> {
         // * Decode current line into the accumulator.
         //
         // At the end:
-        // * If accumulator is initialized, convert the `ArenaString` to an `Atom` and return it.
+        // * If accumulator is initialized, convert the `ArenaString` to a `Str` and return it.
         // * If `only_line` contains a string, that means only 1 line contained text, and that line
         //   didn't contain any HTML entities which needed decoding.
-        //   So we can just return the `Atom` that's in `only_line` (without any copying).
+        //   So we can just return the `Str` that's in `only_line` (without any copying).
 
         let mut acc: Option<ArenaStringBuilder> = None;
-        let mut only_line: Option<Atom<'a>> = None;
+        let mut only_line: Option<Str<'a>> = None;
         let mut first_non_whitespace: Option<usize> = Some(0);
         let mut last_non_whitespace: Option<usize> = None;
         for (index, c) in text.char_indices() {
             if is_line_terminator(c) {
                 if let (Some(first), Some(last)) = (first_non_whitespace, last_non_whitespace) {
                     Self::add_line_of_jsx_text(
-                        Atom::from(&text.as_str()[first..last]),
+                        Str::from(&text.as_str()[first..last]),
                         &mut acc,
                         &mut only_line,
                         text.len(),
@@ -1052,7 +1052,7 @@ impl<'a> JsxImpl<'a> {
 
         if let Some(first) = first_non_whitespace {
             Self::add_line_of_jsx_text(
-                Atom::from(&text.as_str()[first..]),
+                Str::from(&text.as_str()[first..]),
                 &mut acc,
                 &mut only_line,
                 text.len(),
@@ -1060,13 +1060,13 @@ impl<'a> JsxImpl<'a> {
             );
         }
 
-        if let Some(acc) = acc { Some(Atom::from(acc)) } else { only_line }
+        if let Some(acc) = acc { Some(Str::from(acc)) } else { only_line }
     }
 
     fn add_line_of_jsx_text(
-        trimmed_line: Atom<'a>,
+        trimmed_line: Str<'a>,
         acc: &mut Option<ArenaStringBuilder<'a>>,
-        only_line: &mut Option<Atom<'a>>,
+        only_line: &mut Option<Str<'a>>,
         text_len: usize,
         ctx: &TraverseCtx<'a>,
     ) {
@@ -1200,7 +1200,7 @@ impl<'a> JsxImpl<'a> {
 /// Create `IdentifierReference` for var name in current scope which is read from
 fn get_read_identifier_reference<'a>(
     span: Span,
-    name: Atom<'a>,
+    name: Str<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
     let name = Ident::from(name);
@@ -1211,7 +1211,7 @@ fn get_read_identifier_reference<'a>(
 
 fn create_static_member_expression<'a>(
     object_ident: IdentifierReference<'a>,
-    property_name: Atom<'a>,
+    property_name: Str<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let object = Expression::Identifier(ctx.alloc(object_ident));

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -185,7 +185,7 @@ impl<'a> JsxSource<'a> {
         let filename_var = self.filename_var.as_ref()?;
 
         let id = filename_var.create_binding_pattern(ctx);
-        let source_path = ctx.ast.atom(&ctx.state.source_path.to_string_lossy());
+        let source_path = ctx.ast.str(&ctx.state.source_path.to_string_lossy());
         let init = ctx.ast.expression_string_literal(SPAN, source_path, None);
         let decl = ctx.ast.variable_declarator(
             SPAN,

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -17,7 +17,7 @@ use oxc_ast_visit::{
     walk::{walk_call_expression, walk_declaration},
 };
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
-use oxc_span::{Atom, GetSpan, Ident, SPAN};
+use oxc_span::{GetSpan, Ident, SPAN, Str};
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_traverse::{Ancestor, BoundIdentifier, Traverse};
 
@@ -46,7 +46,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
         let first_part = parts.next().unwrap();
         let Some(second_part) = parts.next() else {
             // Handle simple identifier reference
-            return Self::Identifier(ast.identifier_reference(SPAN, ast.atom(input)));
+            return Self::Identifier(ast.identifier_reference(SPAN, ast.str(input)));
         };
 
         if first_part == "import" {
@@ -54,13 +54,13 @@ impl<'a> RefreshIdentifierResolver<'a> {
             let mut expr = ast.expression_meta_property(
                 SPAN,
                 ast.identifier_name(SPAN, "import"),
-                ast.identifier_name(SPAN, ast.atom(second_part)),
+                ast.identifier_name(SPAN, ast.str(second_part)),
             );
             if let Some(property) = parts.next() {
                 expr = Expression::from(ast.member_expression_static(
                     SPAN,
                     expr,
-                    ast.identifier_name(SPAN, ast.atom(property)),
+                    ast.identifier_name(SPAN, ast.str(property)),
                     false,
                 ));
             }
@@ -68,8 +68,8 @@ impl<'a> RefreshIdentifierResolver<'a> {
         }
 
         // Handle `window.$RefreshReg$` member expression
-        let object = ast.identifier_reference(SPAN, ast.atom(first_part));
-        let property = ast.identifier_name(SPAN, ast.atom(second_part));
+        let object = ast.identifier_reference(SPAN, ast.str(first_part));
+        let property = ast.identifier_name(SPAN, ast.str(second_part));
         Self::Member((object, property))
     }
 
@@ -116,7 +116,7 @@ pub struct ReactRefresh<'a> {
     refresh_sig: RefreshIdentifierResolver<'a>,
     emit_full_signatures: bool,
     // States
-    registrations: Vec<(BoundIdentifier<'a>, Atom<'a>)>,
+    registrations: Vec<(BoundIdentifier<'a>, Str<'a>)>,
     /// Used to wrap call expression with signature.
     /// (eg: hoc(() => {}) -> _s1(hoc(_s1(() => {}))))
     last_signature: Option<(BindingIdentifier<'a>, ArenaVec<'a, Argument<'a>>)>,
@@ -318,7 +318,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             return;
         }
 
-        let hook_name: Atom = match &call_expr.callee {
+        let hook_name: Str = match &call_expr.callee {
             Expression::Identifier(ident) => ident.name.into(),
             Expression::StaticMemberExpression(member) => member.property.name.into(),
             _ => return,
@@ -423,7 +423,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 impl<'a> ReactRefresh<'a> {
     fn create_registration(
         &mut self,
-        persistent_id: Atom<'a>,
+        persistent_id: Str<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> AssignmentTarget<'a> {
         let binding = ctx.generate_uid_in_root_scope("c", SymbolFlags::FunctionScopedVariable);
@@ -509,7 +509,7 @@ impl<'a> ReactRefresh<'a> {
             *expr = ctx.ast.expression_assignment(
                 SPAN,
                 AssignmentOperator::Assign,
-                self.create_registration(ctx.ast.atom(inferred_name), ctx),
+                self.create_registration(ctx.ast.str(inferred_name), ctx),
                 expr.take_in(ctx.ast),
             );
         }
@@ -539,7 +539,7 @@ impl<'a> ReactRefresh<'a> {
         let key = self.function_signature_keys.remove(&scope_id)?;
 
         let key = if self.emit_full_signatures {
-            ctx.ast.atom(&key)
+            ctx.ast.str(&key)
         } else {
             // Prefer to hash when we can (e.g. outside of ASTExplorer).
             // This makes it deterministically compact, even if there's
@@ -576,7 +576,7 @@ impl<'a> ReactRefresh<'a> {
             let hashed_key_bytes = unsafe { hashed_key.as_mut_str().as_bytes_mut() };
             let encoded_bytes = BASE64_STANDARD.encode_slice(hash, hashed_key_bytes).unwrap();
             debug_assert_eq!(encoded_bytes, ENCODED_LEN);
-            Atom::from(hashed_key)
+            Str::from(hashed_key)
         };
 
         let callee_list = self.non_builtin_hooks_callee.remove(&scope_id).unwrap_or_default();

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -294,7 +294,7 @@ pub struct StyledComponents<'a> {
     /// Hash of the current file for component ID generation
     component_id_prefix: Option<String>,
     /// Filename or directory name is used for `displayName`
-    block_name: Option<Atom<'a>>,
+    block_name: Option<Str<'a>>,
 }
 
 impl StyledComponents<'_> {
@@ -537,7 +537,7 @@ impl<'a> StyledComponents<'a> {
 
     // Infers the component name from the parent variable declarator, assignment expression,
     // or object property.
-    fn get_component_name(ctx: &TraverseCtx<'a>) -> Option<Atom<'a>> {
+    fn get_component_name(ctx: &TraverseCtx<'a>) -> Option<Str<'a>> {
         let mut assignment_name = None;
 
         for ancestor in ctx.ancestors() {
@@ -597,7 +597,7 @@ impl<'a> StyledComponents<'a> {
     }
 
     /// `<namespace__>sc-<file_hash>-<component_count>`
-    fn get_component_id(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn get_component_id(&mut self, ctx: &TraverseCtx<'a>) -> Str<'a> {
         // Cache `<namespace__>sc-<file_hash>-` part as it's the same each time
         let prefix = if let Some(prefix) = self.component_id_prefix.as_deref() {
             prefix
@@ -624,7 +624,7 @@ impl<'a> StyledComponents<'a> {
         let mut buffer = itoa::Buffer::new();
         let count = buffer.format(self.component_count);
         self.component_count += 1;
-        ctx.ast.atom_from_strs_array([prefix, count])
+        ctx.ast.str_from_strs_array([prefix, count])
     }
 
     /// Generates a unique file hash based on the source path or source code.
@@ -657,7 +657,7 @@ impl<'a> StyledComponents<'a> {
     }
 
     /// Returns the block name based on the file stem or parent directory name.
-    fn get_block_name(&mut self, ctx: &TraverseCtx<'a>) -> Option<Atom<'a>> {
+    fn get_block_name(&mut self, ctx: &TraverseCtx<'a>) -> Option<Str<'a>> {
         if !self.options.file_name {
             return None;
         }
@@ -679,23 +679,23 @@ impl<'a> StyledComponents<'a> {
                     file_stem
                 };
 
-            ctx.ast.atom(block_name)
+            ctx.ast.str(block_name)
         }))
     }
 
     /// Returns the display name which infers the component name or gets from the file name.
-    fn get_display_name(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
+    fn get_display_name(&mut self, ctx: &TraverseCtx<'a>) -> Str<'a> {
         let component_name = Self::get_component_name(ctx);
 
         let Some(block_name) = self.get_block_name(ctx) else {
-            return component_name.unwrap_or(Atom::from(""));
+            return component_name.unwrap_or(Str::from(""));
         };
 
         if let Some(component_name) = component_name {
             if block_name == component_name {
                 component_name
             } else {
-                ctx.ast.atom_from_strs_array([&block_name, "__", &component_name])
+                ctx.ast.str_from_strs_array([&block_name, "__", &component_name])
             }
         } else {
             block_name
@@ -793,7 +793,7 @@ impl<'a> StyledComponents<'a> {
     //     ^^^^^^^^^^
     fn create_object_property(
         key: &'static str,
-        value: Atom<'a>,
+        value: Str<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let key = ctx.ast.property_key_static_identifier(SPAN, key);
@@ -949,7 +949,7 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                 // Set `raw` for previous quasi to `output`
                 // SAFETY: Output is all picked from the original `raw` values and is guaranteed to be valid UTF-8.
                 let output_str = unsafe { std::str::from_utf8_unchecked(&output) };
-                quasis[quasi_index - 1].value.raw = ast.atom(output_str);
+                quasis[quasi_index - 1].value.raw = ast.str(output_str);
                 output.clear();
                 is_first_output = false;
             }
@@ -1093,7 +1093,7 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
     // Update last quasi.
     // SAFETY: Output is all picked from the original `raw` values and is guaranteed to be valid UTF-8.
     let output_str = unsafe { std::str::from_utf8_unchecked(&output) };
-    quasis.last_mut().unwrap().value.raw = ast.atom(output_str);
+    quasis.last_mut().unwrap().value.raw = ast.str(output_str);
 
     // Remove quasis that are marked for removal, and the expressions following them.
     // TODO: Remove scopes, symbols, and references for removed `Expression`s.
@@ -1152,7 +1152,7 @@ mod tests {
             SPAN,
             ast.vec1(ast.template_element(
                 SPAN,
-                TemplateElementValue { raw: ast.atom(input), cooked: Some(ast.atom(input)) },
+                TemplateElementValue { raw: ast.str(input), cooked: Some(ast.str(input)) },
                 true,
                 false,
             )),

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -167,7 +167,7 @@ impl<'a> RegExp {
             Argument::from(ctx.ast.expression_string_literal(SPAN, pattern_text, None)),
             Argument::from(ctx.ast.expression_string_literal(
                 SPAN,
-                ctx.ast.atom(flags.to_inline_string().as_str()),
+                ctx.ast.str(flags.to_inline_string().as_str()),
                 None,
             )),
         ]);

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -2,7 +2,7 @@ use oxc_allocator::{TakeIn, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::{Reference, SymbolFlags};
-use oxc_span::{Atom, GetSpan, SPAN, Span};
+use oxc_span::{GetSpan, SPAN, Span, Str};
 use oxc_syntax::{
     operator::AssignmentOperator,
     reference::ReferenceFlags,
@@ -616,7 +616,7 @@ impl<'a> TypeScriptAnnotations<'a> {
 
 struct Assignment<'a> {
     span: Span,
-    name: Atom<'a>,
+    name: Str<'a>,
     symbol_id: SymbolId,
 }
 

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -8,7 +8,7 @@ use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_ecmascript::{ToInt32, ToUint32};
 use oxc_semantic::{ScopeFlags, ScopeId};
-use oxc_span::{Atom, Ident, IdentHashMap, SPAN, Span};
+use oxc_span::{Ident, IdentHashMap, SPAN, Span, Str};
 use oxc_syntax::{
     number::{NumberBase, ToJsString},
     operator::{AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator},
@@ -20,7 +20,7 @@ use oxc_traverse::{BoundIdentifier, Traverse};
 use crate::{context::TraverseCtx, state::TransformState};
 
 /// enum member values (or None if it can't be evaluated at build time) keyed by names
-type PrevMembers<'a> = FxHashMap<Atom<'a>, Option<ConstantValue<'a>>>;
+type PrevMembers<'a> = FxHashMap<Str<'a>, Option<ConstantValue<'a>>>;
 
 pub struct TypeScriptEnum<'a> {
     enums: IdentHashMap<'a, PrevMembers<'a>>,
@@ -357,7 +357,7 @@ impl<'a> TypeScriptEnum<'a> {
 #[derive(Debug, Clone, Copy)]
 enum ConstantValue<'a> {
     Number(f64),
-    String(Atom<'a>),
+    String(Str<'a>),
 }
 
 impl<'a> TypeScriptEnum<'a> {
@@ -392,7 +392,7 @@ impl<'a> TypeScriptEnum<'a> {
                     return Some(ConstantValue::Number(f64::NAN));
                 }
 
-                if let Some(value) = prev_members.get(&Atom::from(ident.name)) {
+                if let Some(value) = prev_members.get(&Str::from(ident.name)) {
                     return *value;
                 }
 
@@ -440,7 +440,7 @@ impl<'a> TypeScriptEnum<'a> {
                             }
                         }
                     }
-                    Atom::from(value.into_str())
+                    Str::from(value.into_str())
                 };
                 Some(ConstantValue::String(value))
             }
@@ -466,16 +466,16 @@ impl<'a> TypeScriptEnum<'a> {
         {
             let left_string = match left {
                 ConstantValue::String(str) => str,
-                ConstantValue::Number(v) => ctx.ast.atom(&v.to_js_string()),
+                ConstantValue::Number(v) => ctx.ast.str(&v.to_js_string()),
             };
 
             let right_string = match right {
                 ConstantValue::String(str) => str,
-                ConstantValue::Number(v) => ctx.ast.atom(&v.to_js_string()),
+                ConstantValue::Number(v) => ctx.ast.str(&v.to_js_string()),
             };
 
             return Some(ConstantValue::String(
-                ctx.ast.atom_from_strs_array([&left_string, &right_string]),
+                ctx.ast.str_from_strs_array([&left_string, &right_string]),
             ));
         }
 
@@ -591,7 +591,7 @@ impl<'a, 'ctx, 'members> IdentifierReferenceRename<'a, 'ctx, 'members> {
 impl IdentifierReferenceRename<'_, '_, '_> {
     fn should_reference_enum_member(&self, ident: &IdentifierReference<'_>) -> bool {
         // Don't need to rename the identifier if it's not a member of the enum,
-        if !self.previous_enum_members.contains_key(&Atom::from(ident.name)) {
+        if !self.previous_enum_members.contains_key(&Str::from(ident.name)) {
             return false;
         }
 

--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{
     ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration, ImportExpression,
     StringLiteral, TemplateLiteral,
 };
-use oxc_span::Atom;
+use oxc_span::Str;
 use oxc_traverse::Traverse;
 
 use crate::{TypeScriptOptions, context::TraverseCtx, state::TransformState};
@@ -20,13 +20,13 @@ pub struct TypeScriptRewriteExtensions {
     mode: RewriteExtensionsMode,
 }
 
-/// Given a specifier value, compute the replacement atom if the extension
+/// Given a specifier value, compute the replacement `Str` if the extension
 /// should be rewritten/removed. Returns `None` when no rewriting is needed.
 fn rewritten_specifier<'a>(
     value: &'a str,
     mode: RewriteExtensionsMode,
     ctx: &TraverseCtx<'a>,
-) -> Option<Atom<'a>> {
+) -> Option<Str<'a>> {
     if !value.contains(['/', '\\']) {
         return None;
     }
@@ -41,9 +41,9 @@ fn rewritten_specifier<'a>(
     };
 
     Some(if mode.is_remove() {
-        Atom::from(without_extension)
+        Str::from(without_extension)
     } else {
-        ctx.ast.atom_from_strs_array([without_extension, replace])
+        ctx.ast.str_from_strs_array([without_extension, replace])
     })
 }
 

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -15,7 +15,7 @@ pub fn create_member_callee<'a>(
     span: Span,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
+    let property = ctx.ast.identifier_name(SPAN, Str::from(property));
     Expression::from(ctx.ast.member_expression_static(span, object, property, false))
 }
 
@@ -82,7 +82,7 @@ pub fn create_prototype_member<'a>(
     span: Span,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
+    let property = ctx.ast.identifier_name(SPAN, Str::from("prototype"));
     let static_member = ctx.ast.member_expression_static(span, object, property, false);
     Expression::from(static_member)
 }
@@ -94,7 +94,7 @@ pub fn create_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, ctx.ast.atom(property));
+    let property = ctx.ast.identifier_name(SPAN, ctx.ast.str(property));
     Expression::from(ctx.ast.member_expression_static(span, object, property, false))
 }
 
@@ -198,7 +198,7 @@ pub fn create_class_constructor_with_params<'a>(
     create_class_method(
         ctx.ast.vec(),
         PropertyKey::StaticIdentifier(
-            ctx.ast.alloc_identifier_name(SPAN, Atom::from("constructor")),
+            ctx.ast.alloc_identifier_name(SPAN, Str::from("constructor")),
         ),
         MethodDefinitionKind::Constructor,
         params,

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -91,12 +91,12 @@ impl InjectImportSpecifier {
     }
 }
 
-/// Wrapper around `DotDefine` which caches the `Atom` to replace with.
-/// `value_atom` is populated lazily when first replacement happens.
-/// If no replacement is made, `value_atom` remains `None`.
+/// Wrapper around `DotDefine` which caches the `Str` to replace with.
+/// `value_str` is populated lazily when first replacement happens.
+/// If no replacement is made, `value_str` remains `None`.
 struct DotDefineState<'a> {
     dot_define: DotDefine,
-    value_atom: Option<Atom<'a>>,
+    value_str: Option<Str<'a>>,
 }
 
 impl From<&InjectImport> for DotDefineState<'_> {
@@ -104,7 +104,7 @@ impl From<&InjectImport> for DotDefineState<'_> {
         let parts = inject.specifier.local().split('.').map(CompactStr::from).collect::<Vec<_>>();
         let value = inject.replace_value.clone().unwrap();
         let dot_define = DotDefine { parts, value };
-        Self { dot_define, value_atom: None }
+        Self { dot_define, value_str: None }
     }
 }
 
@@ -212,7 +212,7 @@ impl<'a> InjectGlobalVariables<'a> {
     fn inject_imports(&mut self, injects: &[InjectImport], program: &mut Program<'a>) {
         let imports = injects.iter().map(|inject| {
             let specifiers = Some(self.ast.vec1(self.inject_import_to_specifier(inject)));
-            let source = self.ast.string_literal(SPAN, self.ast.atom(&inject.source), None);
+            let source = self.ast.string_literal(SPAN, self.ast.str(&inject.source), None);
             let kind = ImportOrExportKind::Value;
             let import_decl = self
                 .ast
@@ -228,7 +228,7 @@ impl<'a> InjectGlobalVariables<'a> {
             InjectImportSpecifier::Specifier { imported, local } => {
                 let imported = match imported {
                     Some(imported_name) => {
-                        let imported_name = self.ast.atom(imported_name);
+                        let imported_name = self.ast.str(imported_name);
                         if identifier::is_identifier_name(&imported_name) {
                             self.ast.module_export_name_identifier_name(SPAN, imported_name)
                         } else {
@@ -243,18 +243,18 @@ impl<'a> InjectGlobalVariables<'a> {
                 self.ast.import_declaration_specifier_import_specifier(
                     SPAN,
                     imported,
-                    self.ast.binding_identifier(SPAN, self.ast.atom(local)),
+                    self.ast.binding_identifier(SPAN, self.ast.str(local)),
                     ImportOrExportKind::Value,
                 )
             }
             InjectImportSpecifier::DefaultSpecifier { local } => {
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
-                let local = self.ast.binding_identifier(SPAN, self.ast.atom(local));
+                let local = self.ast.binding_identifier(SPAN, self.ast.str(local));
                 self.ast.import_declaration_specifier_import_default_specifier(SPAN, local)
             }
             InjectImportSpecifier::NamespaceSpecifier { local } => {
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
-                let local = self.ast.binding_identifier(SPAN, self.ast.atom(local));
+                let local = self.ast.binding_identifier(SPAN, self.ast.str(local));
                 self.ast.import_declaration_specifier_import_namespace_specifier(SPAN, local)
             }
         }
@@ -263,7 +263,7 @@ impl<'a> InjectGlobalVariables<'a> {
     fn replace_dot_defines(&mut self, expr: &mut Expression<'a>, ctx: &TraverseCtx<'a>) {
         match expr {
             Expression::StaticMemberExpression(member) => {
-                for DotDefineState { dot_define, value_atom } in &mut self.dot_defines {
+                for DotDefineState { dot_define, value_str } in &mut self.dot_defines {
                     if ReplaceGlobalDefines::is_dot_define(
                         ctx.scoping(),
                         ctx.current_scope_flags(),
@@ -271,14 +271,14 @@ impl<'a> InjectGlobalVariables<'a> {
                         DotDefineMemberExpression::StaticMemberExpression(member),
                     ) {
                         // If this is first replacement made for this dot define,
-                        // create `Atom` for replacement, and record in `replaced_dot_defines`
-                        let value_atom = *value_atom.get_or_insert_with(|| {
+                        // create `Str` for replacement, and record in `replaced_dot_defines`
+                        let value_str = *value_str.get_or_insert_with(|| {
                             self.replaced_dot_defines
                                 .push((dot_define.parts[0].clone(), dot_define.value.clone()));
-                            self.ast.atom(dot_define.value.as_str())
+                            self.ast.str(dot_define.value.as_str())
                         });
 
-                        let value = self.ast.expression_identifier(SPAN, value_atom);
+                        let value = self.ast.expression_identifier(SPAN, value_str);
                         *expr = value;
                         self.mark_as_changed();
                         break;
@@ -288,21 +288,21 @@ impl<'a> InjectGlobalVariables<'a> {
             Expression::MetaProperty(meta_property) => {
                 // Check if this is import.meta and if it should be replaced
                 if meta_property.meta.name == "import" && meta_property.property.name == "meta" {
-                    for DotDefineState { dot_define, value_atom } in &mut self.dot_defines {
+                    for DotDefineState { dot_define, value_str } in &mut self.dot_defines {
                         // Check if dot_define is exactly ["import", "meta"]
                         if dot_define.parts.len() == 2
                             && dot_define.parts[0].as_str() == "import"
                             && dot_define.parts[1].as_str() == "meta"
                         {
                             // If this is first replacement made for this dot define,
-                            // create `Atom` for replacement, and record in `replaced_dot_defines`
-                            let value_atom = *value_atom.get_or_insert_with(|| {
+                            // create `Str` for replacement, and record in `replaced_dot_defines`
+                            let value_str = *value_str.get_or_insert_with(|| {
                                 self.replaced_dot_defines
                                     .push((dot_define.parts[0].clone(), dot_define.value.clone()));
-                                self.ast.atom(dot_define.value.as_str())
+                                self.ast.str(dot_define.value.as_str())
                             });
 
-                            let value = self.ast.expression_identifier(SPAN, value_atom);
+                            let value = self.ast.expression_identifier(SPAN, value_str);
                             *expr = value;
                             self.mark_as_changed();
                             break;

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -67,7 +67,7 @@ pub struct ModuleRunnerTransform<'a> {
     /// Import bindings used to determine which identifiers should be transformed.
     /// The key is a symbol id that belongs to the import binding.
     /// The value is a tuple of (Binding, Property).
-    import_bindings: FxHashMap<SymbolId, (BoundIdentifier<'a>, Option<Atom<'a>>)>,
+    import_bindings: FxHashMap<SymbolId, (BoundIdentifier<'a>, Option<Str<'a>>)>,
 
     // Collect deps and dynamic deps for Vite
     deps: FxHashSet<String>,
@@ -618,7 +618,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         span: Span,
         binding: &BoundIdentifier<'a>,
         ident: BindingIdentifier<'a>,
-        key: Atom<'a>,
+        key: Str<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> ArrayExpressionElement<'a> {
         let BindingIdentifier { name, symbol_id, .. } = ident;
@@ -667,7 +667,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &TraverseCtx<'a>,
     ) -> Argument<'a> {
         let value = ctx.ast.expression_array(SPAN, elements);
-        let key = ctx.ast.property_key_static_identifier(SPAN, Atom::from("importedNames"));
+        let key = ctx.ast.property_key_static_identifier(SPAN, Str::from("importedNames"));
         let imported_names = ctx.ast.object_property_kind_object_property(
             SPAN,
             PropertyKind::Init,
@@ -819,7 +819,7 @@ fn create_compute_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let expression = ctx.ast.expression_string_literal(SPAN, ctx.ast.atom(property), None);
+    let expression = ctx.ast.expression_string_literal(SPAN, ctx.ast.str(property), None);
     Expression::from(ctx.ast.member_expression_computed(span, object, expression, false))
 }
 
@@ -829,7 +829,7 @@ pub fn create_member_callee<'a>(
     property: &'static str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
+    let property = ctx.ast.identifier_name(SPAN, Str::from(property));
     Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
 }
 
@@ -840,7 +840,7 @@ pub fn create_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, ctx.ast.atom(property));
+    let property = ctx.ast.identifier_name(SPAN, ctx.ast.str(property));
     Expression::from(ctx.ast.member_expression_static(span, object, property, false))
 }
 

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -22,7 +22,7 @@ use oxc_syntax::reference::Reference;
 #[derive(Debug, Clone)]
 pub struct ReplaceGlobalDefinesConfig(Arc<ReplaceGlobalDefinesConfigImpl>);
 
-static THIS_ATOM: Atom<'static> = Atom::new_const("this");
+static THIS_STR: Str<'static> = Str::new_const("this");
 
 #[derive(Debug)]
 struct IdentifierDefine {
@@ -792,7 +792,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
                         None
                     }
                     Expression::ThisExpression(_) if should_replace_this_expr => {
-                        cur_part_name = THIS_ATOM.as_str();
+                        cur_part_name = THIS_STR.as_str();
                         None
                     }
                     Expression::MetaProperty(meta) => {
@@ -868,10 +868,10 @@ pub enum DotDefineMemberExpression<'b, 'ast: 'b> {
 }
 
 impl<'b, 'a> DotDefineMemberExpression<'b, 'a> {
-    fn name(&self) -> Option<Atom<'a>> {
+    fn name(&self) -> Option<Str<'a>> {
         match self {
             DotDefineMemberExpression::StaticMemberExpression(expr) => {
-                Some(expr.property.name.as_atom())
+                Some(expr.property.name.as_arena_str())
             }
             DotDefineMemberExpression::ComputedMemberExpression(expr) => {
                 static_property_name_of_computed_expr(expr).copied()
@@ -889,7 +889,7 @@ impl<'b, 'a> DotDefineMemberExpression<'b, 'a> {
 
 fn static_property_name_of_computed_expr<'b, 'a: 'b>(
     expr: &'b ComputedMemberExpression<'a>,
-) -> Option<&'b Atom<'a>> {
+) -> Option<&'b Str<'a>> {
     match &expr.expression {
         Expression::StringLiteral(lit) => Some(&lit.value),
         Expression::TemplateLiteral(lit) if lit.expressions.is_empty() && lit.quasis.len() == 1 => {

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -5160,8 +5160,8 @@ impl<'a, 't> DirectiveWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn directive(self) -> &'t Atom<'a> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_DIRECTIVE_DIRECTIVE) as *const Atom<'a>) }
+    pub fn directive(self) -> &'t Str<'a> {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_DIRECTIVE_DIRECTIVE) as *const Str<'a>) }
     }
 }
 
@@ -16144,9 +16144,9 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Atom<'a> {
+    pub fn name(self) -> &'t Str<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Atom<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
         }
     }
 }

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -8,7 +8,7 @@ use oxc::{
     allocator::{Allocator, FromIn, Vec},
     ast::ast::{Comment, Program},
     diagnostics::{LabeledSpan, NamedSource, OxcDiagnostic, Severity},
-    span::{Atom, Span, format_atom},
+    span::{Span, Str, format_str},
     syntax::module_record::{DynamicImport, ExportEntry, ImportEntry, ModuleRecord, NameSpan},
 };
 use oxc_ast_macros::ast;
@@ -63,10 +63,10 @@ impl RawTransferMetadata {
 #[estree(no_type, no_ts_def)]
 pub struct Error<'a> {
     pub severity: ErrorSeverity,
-    pub message: Atom<'a>,
+    pub message: Str<'a>,
     pub labels: Vec<'a, ErrorLabel<'a>>,
-    pub help_message: Option<Atom<'a>>,
-    pub codeframe: Atom<'a>,
+    pub help_message: Option<Str<'a>>,
+    pub codeframe: Str<'a>,
 }
 
 impl<'a> Error<'a> {
@@ -102,11 +102,11 @@ impl<'a> Error<'a> {
         );
 
         let severity = ErrorSeverity::from(diagnostic.severity);
-        let message = Atom::from_in(diagnostic.message.as_ref(), allocator);
+        let message = Str::from_in(diagnostic.message.as_ref(), allocator);
         let help_message =
-            diagnostic.help.as_ref().map(|help| Atom::from_in(help.as_ref(), allocator));
+            diagnostic.help.as_ref().map(|help| Str::from_in(help.as_ref(), allocator));
         let report = diagnostic.with_source_code(Arc::clone(named_source));
-        let codeframe = format_atom!(allocator, "{report:?}");
+        let codeframe = format_str!(allocator, "{report:?}");
 
         #[expect(clippy::inconsistent_struct_constructor)] // `#[ast]` macro re-orders struct fields
         Self { severity, message, labels, help_message, codeframe }
@@ -137,14 +137,14 @@ impl From<Severity> for ErrorSeverity {
 #[generate_derive(ESTree)]
 #[estree(no_type, no_ts_def)]
 pub struct ErrorLabel<'a> {
-    pub message: Option<Atom<'a>>,
+    pub message: Option<Str<'a>>,
     pub span: Span,
 }
 
 impl<'a> FromIn<'a, &LabeledSpan> for ErrorLabel<'a> {
     fn from_in(label: &LabeledSpan, allocator: &'a Allocator) -> Self {
         Self {
-            message: label.label().map(|message| Atom::from_in(message, allocator)),
+            message: label.label().map(|message| Str::from_in(message, allocator)),
             #[expect(clippy::cast_possible_truncation)]
             span: Span::sized(label.offset() as u32, label.len() as u32),
         }
@@ -156,7 +156,7 @@ impl<'a> FromIn<'a, &LabeledSpan> for ErrorLabel<'a> {
 // These types and the `From` impl mirror the implementation in `types.rs` and `convert.rs`.
 // However, a lot of the data can be left as is, because it's already in the arena,
 // and that's what raw transfer needs - unlike the other implementation which requires owned types.
-// In particular, there's no need to copy or convert the many `Atom`s in `ModuleRecord`.
+// In particular, there's no need to copy or convert the many `Str`s in `ModuleRecord`.
 
 #[ast]
 #[generate_derive(ESTree)]

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -498,7 +498,7 @@ impl<'s> StructSerializerGenerator<'s> {
             let value = match field.type_def(self.schema) {
                 TypeDef::Primitive(primitive_def) => match primitive_def.name() {
                     "&str" => Some(quote!( JsonSafeString(#self_path.#field_name_ident) )),
-                    "Atom" | "Ident" => {
+                    "Str" | "Ident" => {
                         Some(quote!( JsonSafeString(#self_path.#field_name_ident.as_str()) ))
                     }
                     _ => None,
@@ -510,7 +510,7 @@ impl<'s> StructSerializerGenerator<'s> {
                         "&str" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s))
                         }),
-                        "Atom" | "Ident" => Some(quote! {
+                        "Str" | "Ident" => Some(quote! {
                             #self_path.#field_name_ident.map(|s| JsonSafeString(s.as_str()))
                         }),
                         _ => None,
@@ -520,7 +520,7 @@ impl<'s> StructSerializerGenerator<'s> {
 
             value.unwrap_or_else(|| {
                 panic!(
-                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str`, `Atom`, or `Ident`: {}::{}",
+                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str`, `Str`, or `Ident`: {}::{}",
                     struct_def.name(),
                     field.name(),
                 )

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -280,7 +280,7 @@ impl LayoutCalculator<'_> {
     /// as `u64` fields that come before it on 64-bit systems, and will have same alignment as
     /// `u32`s that come after it on 32-bit systems. So it never results in padding on either platform.
     ///
-    /// Note: "usize" here also includes pointer-aligned types e.g. `Box`, `Vec`, `Atom`, `&str`.
+    /// Note: "usize" here also includes pointer-aligned types e.g. `Box`, `Vec`, `Str`, `&str`.
     /// "u64" includes other 8-byte aligned types e.g. `f64`, `Span`.
     fn calculate_struct(&mut self, type_id: TypeId) -> Layout {
         // Get layout of fields' types and calculate optimal field order
@@ -525,7 +525,7 @@ impl LayoutCalculator<'_> {
     ///
     /// Primitives have varying layouts. Some have niches, most don't.
     fn calculate_primitive(primitive_def: &PrimitiveDef) -> Layout {
-        // `&str` and `Atom` are a `NonNull` pointer + `usize` pair. Niche for 0 on the pointer field
+        // `&str` and `Str` are a `NonNull` pointer + `usize` pair. Niche for 0 on the pointer field
         let str_layout = Layout {
             layout_64: PlatformLayout::from_size_align_niche(16, 8, Niche::new(0, 8, 1, 0)),
             layout_32: PlatformLayout::from_size_align_niche(8, 4, Niche::new(0, 4, 1, 0)),
@@ -559,7 +559,7 @@ impl LayoutCalculator<'_> {
             "f32" => Layout::from_type::<f32>(),
             "f64" => Layout::from_type::<f64>(),
             "&str" => str_layout,
-            "Atom" => str_layout,
+            "Str" => str_layout,
             // `Ident` is `NonNull<u8>` + `u64` on 64-bit, `NonNull<u8>` + `u32` + `u32` on 32-bit.
             // Niche for 0 on the pointer field.
             "Ident" => Layout {

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -91,7 +91,7 @@ impl Generator for AstBuilderGenerator {
             };
 
             ///@@line_break
-            use oxc_span::{Atom, Ident};
+            use oxc_span::{Ident, Str};
 
             ///@@line_break
             use crate::{AstBuilder, ast::*};
@@ -105,7 +105,7 @@ impl Generator for AstBuilderGenerator {
             /// Escape special characters for template element raw value.
             ///
             /// Escapes: backticks, `${`, backslashes, and carriage returns.
-            fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Atom<'a> {
+            fn escape_template_element_raw<'a>(raw: &str, ast: AstBuilder<'a>) -> Str<'a> {
                 let bytes = raw.as_bytes();
                 // Calculate size needed for escaped string
                 let mut extra_bytes = 0usize;
@@ -117,7 +117,7 @@ impl Generator for AstBuilderGenerator {
                     };
                 }
                 if extra_bytes == 0 {
-                    return ast.atom(raw);
+                    return ast.str(raw);
                 }
                 // Allocate directly in arena
                 let len = bytes.len() + extra_bytes;
@@ -138,7 +138,7 @@ impl Generator for AstBuilderGenerator {
                             b => { *escaped.get_unchecked_mut(j) = b; j += 1; }
                         }
                     }
-                    Atom::from(std::str::from_utf8_unchecked(escaped))
+                    Str::from(std::str::from_utf8_unchecked(escaped))
                 }
             }
         };
@@ -166,7 +166,7 @@ struct Param<'d> {
     is_node_id: bool,
     /// * `None` if param is not generic.
     /// * `Some(GenericType::Into)` if is generic and uses `Into`
-    ///   e.g. `name: A where A: Into<Atom<'a>>`.
+    ///   e.g. `name: A where A: Into<Str<'a>>`.
     /// * `Some(GenericType::IntoIn)` if is generic and uses `IntoIn`
     ///   e.g. `type_annotation: T1 where T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>`.
     generic_type: Option<GenericType>,
@@ -387,7 +387,7 @@ fn get_struct_params<'s>(
     bool,           // Has default fields
 ) {
     let mut generic_count = 0u32;
-    let mut atom_generic_count = 0u32;
+    let mut str_generic_count = 0u32;
     let mut has_default_fields = false;
 
     let mut generics = vec![];
@@ -415,10 +415,10 @@ fn get_struct_params<'s>(
 
             let generic_details = match type_def {
                 TypeDef::Primitive(primitive_def)
-                    if matches!(primitive_def.name(), "Atom" | "Ident") =>
+                    if matches!(primitive_def.name(), "Str" | "Ident") =>
                 {
-                    atom_generic_count += 1;
-                    Some((format_ident!("A{atom_generic_count}"), GenericType::Into))
+                    str_generic_count += 1;
+                    Some((format_ident!("A{str_generic_count}"), GenericType::Into))
                 }
                 TypeDef::Box(_) => {
                     generic_count += 1;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -821,7 +821,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, code: &mut String, schema: &
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse deserializer for `&str`
-        "Atom" | "Ident" => return,
+        "Str" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return uint8[pos] === 1;",
@@ -1255,8 +1255,8 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl DeserializeFunctionName for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Atom" | "Ident") {
-            // Use 1 deserializer for `&str`, `Atom`, and `Ident`
+        if matches!(type_name, "&str" | "Str" | "Ident") {
+            // Use 1 deserializer for `&str`, `Str`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {
             // Use zeroed type's deserializer for `NonZero*` types

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -571,7 +571,7 @@ impl<'s> LocalCacheTypes<'s> {
                 }
             }
             TypeDef::Primitive(primitive_def) => {
-                matches!(primitive_def.name(), "&str" | "Atom" | "Ident")
+                matches!(primitive_def.name(), "&str" | "Str" | "Ident")
             }
             TypeDef::Vec(_) => true,
             TypeDef::Option(option_def) => {
@@ -900,7 +900,7 @@ fn generate_primitive(primitive_def: &PrimitiveDef, state: &mut State, schema: &
     #[expect(clippy::match_same_arms)]
     let ret = match primitive_def.name() {
         // Reuse constructor for `&str`
-        "Atom" | "Ident" => return,
+        "Str" | "Ident" => return,
         // Dummy type
         "PointerAlign" => return,
         "bool" => "return ast.buffer[pos] === 1;",
@@ -1249,8 +1249,8 @@ impl_deser_name_concat!(VecDef, "Vec");
 impl FunctionNames for PrimitiveDef {
     fn plain_name<'s>(&'s self, _schema: &'s Schema) -> Cow<'s, str> {
         let type_name = self.name();
-        if matches!(type_name, "&str" | "Atom" | "Ident") {
-            // Use 1 constructor for `&str`, `Atom`, and `Ident`
+        if matches!(type_name, "&str" | "Str" | "Ident") {
+            // Use 1 constructor for `&str`, `Str`, and `Ident`
             Cow::Borrowed("Str")
         } else if let Some(type_name) = type_name.strip_prefix("NonZero") {
             // Use zeroed type's constructor for `NonZero*` types

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -401,7 +401,7 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
             | "i8" | "i16" | "i32" | "i64" | "i128" | "isize"
             | "f32" | "f64" => "number",
             "bool" => "boolean",
-            "&str" | "Atom" | "Ident" => "string",
+            "&str" | "Str" | "Ident" => "string",
             name => name,
         }),
         TypeDef::Option(option_def) => {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -68,7 +68,7 @@
 //! * `Vec`: [`VecDef`]
 //! * `Cell`: [`CellDef`]
 //! * Primitive types: [`PrimitiveDef`] - e.g. `u32`, `&str`
-//! * Special types: [`PrimitiveDef`] - e.g. `Atom`
+//! * Special types: [`PrimitiveDef`] - e.g. `Str`
 //!
 //! The types are linked up to each other, so that all struct fields ([`FieldDef`]s) contain
 //! the [`TypeId`] of the type that field contains. Ditto enum variants ([`VariantDef`]s).

--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -27,7 +27,7 @@
 //!
 //! * Primitives (e.g. `f64`, `&str`).
 //! * Known types (`Vec`, `Box`, `Option`, `Cell`).
-//! * Special cases (`Atom`, `RegExpFlags`, `ScopeId`, `SymbolId`, `ReferenceId`).
+//! * Special cases (`Str`, `RegExpFlags`, `ScopeId`, `SymbolId`, `ReferenceId`).
 //!
 //! Each [`TypeDef`] contains a [`FileId`], indicating which file the type was defined in.
 //!

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -253,7 +253,7 @@ impl<'c> Parser<'c> {
             "AtomicIsize" => primitive("AtomicIsize"),
             "AtomicPtr" => primitive("AtomicPtr"),
             "&str" => primitive("&str"),
-            "Atom" => primitive("Atom"),
+            "Str" => primitive("Str"),
             "Ident" => primitive("Ident"),
             "NodeId" => primitive("NodeId"),
             // TODO: Remove the need for this by adding

--- a/tasks/ast_tools/src/schema/defs/primitive.rs
+++ b/tasks/ast_tools/src/schema/defs/primitive.rs
@@ -7,7 +7,7 @@ use super::{Containers, Def, Derives, Schema, TypeDef, TypeId, extensions::layou
 ///
 /// Includes:
 /// * Built-ins e.g. `u8`, `&str`.
-/// * Special Oxc types e.g. `ScopeId`, `Atom`.
+/// * Special Oxc types e.g. `ScopeId`, `Str`.
 #[derive(Debug)]
 pub struct PrimitiveDef {
     pub id: TypeId,
@@ -49,7 +49,7 @@ impl Def for PrimitiveDef {
     /// Get if type has a lifetime.
     #[expect(unused_variables)]
     fn has_lifetime(&self, schema: &Schema) -> bool {
-        matches!(self.name(), "&str" | "Atom" | "Ident")
+        matches!(self.name(), "&str" | "Str" | "Ident")
     }
 
     /// Get type signature (including lifetimes).
@@ -64,11 +64,11 @@ impl Def for PrimitiveDef {
                     quote!(&'a str)
                 }
             }
-            "Atom" => {
+            "Str" => {
                 if anon {
-                    quote!(Atom<'_>)
+                    quote!(Str<'_>)
                 } else {
-                    quote!(Atom<'a>)
+                    quote!(Str<'a>)
                 }
             }
             "Ident" => {

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -79,7 +79,7 @@ pub struct ESTreeStructField {
     pub flatten: bool,
     /// No not flatten field. Overrides `#[estree(flatten)]` on the type of the field.
     pub no_flatten: bool,
-    /// `true` for fields containing a `&str` or `Atom` which does not need escaping in JSON
+    /// `true` for fields containing a `&str` or `Str` which does not need escaping in JSON
     pub json_safe: bool,
     /// `true` if field is only included in JS ESTree AST (not TS-ESTree AST).
     pub is_js: bool,

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -176,7 +176,7 @@ struct PostTransformChecker<'a, 's> {
     scope_ids_map: IdMapping<ScopeId>,
     symbol_ids_map: IdMapping<SymbolId>,
     reference_ids_map: IdMapping<ReferenceId>,
-    reference_names: Vec<Atom<'a>>,
+    reference_names: Vec<Str<'a>>,
     errors: Errors,
 }
 
@@ -576,7 +576,7 @@ struct SemanticIdsCollector<'a, 'e> {
     scope_ids: Vec<Option<ScopeId>>,
     symbol_ids: Vec<Option<SymbolId>>,
     reference_ids: Vec<Option<ReferenceId>>,
-    reference_names: Vec<Atom<'a>>,
+    reference_names: Vec<Str<'a>>,
     errors: &'e mut Errors,
 }
 
@@ -596,8 +596,7 @@ impl<'a, 'e> SemanticIdsCollector<'a, 'e> {
     fn collect(
         mut self,
         program: &Program<'a>,
-    ) -> (Vec<Option<ScopeId>>, Vec<Option<SymbolId>>, Vec<Option<ReferenceId>>, Vec<Atom<'a>>)
-    {
+    ) -> (Vec<Option<ScopeId>>, Vec<Option<SymbolId>>, Vec<Option<ReferenceId>>, Vec<Str<'a>>) {
         if !program.source_type.is_typescript_definition() {
             self.visit_program(program);
         }


### PR DESCRIPTION
Pure refactor.

Rename `Atom` to `Str`. The name "Atom" is a leftover from when we used to intern strings (years ago), and is misleading now.

Just call it `Str`. This follows the naming convention we have for arena-allocated versions of other types e.g. `Box`, `Vec`, `HashMap` - which we name the same as the native equivalents but with a lifetime (`Box<'a>` not `ArenaBox<'a>`, so `Str<'a>` not `ArenaStr<'a>`).

Rename all variables that contained "atom", and methods which relate to `Str`s to match the new type name.

Rename `as_atom` methods to `as_arena_str`. The longer name is required here to disambiguate from `as_str` methods which return a `&str`.

Some variables called "atom" still exist in `oxc_regular_expression` crate - that's a different meaning of "atom" - the meaning defined in regexp spec.

The diff of this PR is large but it's 100% renaming. No substantive or unrelated changes whatsoever.