### PR TITLE
fix(oxlint/lsp): error on unknown command

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -542,13 +542,8 @@ impl Tool for ServerLinter {
         }
     }
 
-    /// Check if the linter should know about the given command
-    fn is_responsible_for_command(&self, command: &str) -> bool {
-        command == FIX_ALL_COMMAND_ID
-    }
-
     /// Tries to execute the given command with the provided arguments.
-    /// If the command is not recognized, returns `Ok(None)`.
+    /// If the command is not recognized, returns `Err(ErrorCode)`.
     /// If the command is recognized and executed it can return:
     /// - `Ok(Some(WorkspaceEdit))` if the command was executed successfully and produced a workspace edit.
     /// - `Ok(None)` if the command was executed successfully but did not produce any workspace edit.
@@ -561,7 +556,7 @@ impl Tool for ServerLinter {
         arguments: Vec<serde_json::Value>,
     ) -> Result<Option<WorkspaceEdit>, ErrorCode> {
         if command != FIX_ALL_COMMAND_ID {
-            return Ok(None);
+            return Err(ErrorCode::InvalidParams);
         }
 
         let args = FixAllCommandArgs::try_from(arguments).map_err(|_| ErrorCode::InvalidParams)?;

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -59,17 +59,13 @@ impl Tool for FakeTool {
         "FakeTool"
     }
 
-    fn is_responsible_for_command(&self, command: &str) -> bool {
-        command == FAKE_COMMAND
-    }
-
     fn execute_command(
         &self,
         command: &str,
         arguments: Vec<serde_json::Value>,
     ) -> Result<Option<WorkspaceEdit>, ErrorCode> {
         if command != FAKE_COMMAND {
-            return Err(ErrorCode::MethodNotFound);
+            return Err(ErrorCode::InvalidParams);
         }
 
         if !arguments.is_empty() {
@@ -973,11 +969,11 @@ mod test_suite {
         let execute_command_request = execute_command_request("invalid.command", &[], 3);
         server.send_request(execute_command_request).await;
 
-        // Should not return an error, but a null result
+        // Should return an error
         let execute_command_response = server.recv_response().await;
-        assert!(execute_command_response.is_ok());
+        assert!(execute_command_response.is_error());
         assert_eq!(execute_command_response.id(), &Id::Number(3));
-        assert_eq!(execute_command_response.result().unwrap(), &json!(null));
+        assert_eq!(execute_command_response.error().unwrap().code, ErrorCode::InvalidParams);
 
         server.shutdown(4).await;
     }

--- a/crates/oxc_language_server/src/tool.rs
+++ b/crates/oxc_language_server/src/tool.rs
@@ -57,15 +57,8 @@ pub trait Tool: Send + Sync {
         options: serde_json::Value,
     ) -> ToolRestartChanges;
 
-    /// Check if this tool is responsible for handling the given command.
-    /// TODO: this is not needed anymore, we have only one tool per server,
-    /// we can remove this method and directly call execute_command on the tool.
-    fn is_responsible_for_command(&self, _command: &str) -> bool {
-        false
-    }
-
     /// Tries to execute the given command with the provided arguments.
-    /// If the command is not recognized, returns `Ok(None)`.
+    /// If the command is not recognized, returns `Err(ErrorCode)`.
     /// If the command is recognized and executed it can return:
     /// - `Ok(Some(WorkspaceEdit))` if the command was executed successfully and produced a workspace edit.
     /// - `Ok(None)` if the command was executed successfully but did not produce any workspace edit.
@@ -77,7 +70,7 @@ pub trait Tool: Send + Sync {
         _command: &str,
         _arguments: Vec<serde_json::Value>,
     ) -> Result<Option<WorkspaceEdit>, ErrorCode> {
-        Ok(None)
+        Err(ErrorCode::InvalidParams)
     }
 
     /// Get code actions or commands provided by this tool for the given URI and range.

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -374,10 +374,9 @@ impl WorkspaceWorker {
     }
 
     /// Execute a command for the workspace.
-    /// Currently, only the `oxc.fixAll` command is supported.
     ///
     /// # Errors
-    /// Returns `ErrorCode` when the command is found but could not be executed.
+    /// Returns `ErrorCode` when the command is not found or could not be executed.
     pub async fn execute_command(
         &self,
         command: &str,
@@ -387,10 +386,7 @@ impl WorkspaceWorker {
         let Some(tool) = tool_guard.as_ref() else {
             return Ok(None);
         };
-        if tool.is_responsible_for_command(command) {
-            return tool.execute_command(command, arguments);
-        }
-        Ok(None)
+        tool.execute_command(command, arguments)
     }
 }
 
@@ -427,8 +423,9 @@ mod tests {
     use std::str::FromStr;
 
     use std::sync::Arc;
-    use tower_lsp_server::ls_types::{
-        CodeActionContext, CodeActionOrCommand, FileChangeType, FileEvent, Range, Uri,
+    use tower_lsp_server::{
+        jsonrpc::ErrorCode,
+        ls_types::{CodeActionContext, CodeActionOrCommand, FileChangeType, FileEvent, Range, Uri},
     };
 
     use crate::{
@@ -501,8 +498,8 @@ mod tests {
 
         // Test command not found
         let result = worker.execute_command("unknown.command", vec![]).await;
-        assert!(result.is_ok());
-        assert!(result.ok().unwrap().is_none());
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), ErrorCode::InvalidParams);
 
         // Test command found but no arguments
         let result = worker.execute_command(FAKE_COMMAND, vec![]).await;


### PR DESCRIPTION
> ## Pull request overview
> 
> Adjusts LSP workspace command execution so unknown/unsupported commands surface as errors (instead of silently returning `null`), by removing the pre-dispatch “responsible tool” check and updating tests accordingly.