### PR TITLE
refactor(oxlint/lsp): skip checking for existing capabilities

### DIFF
--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -238,64 +238,20 @@ impl ToolBuilder for ServerLinterBuilder {
         capabilities: &mut ServerCapabilities,
         backend_capabilities: &mut Capabilities,
     ) {
-        let mut code_action_kinds = capabilities
-            .code_action_provider
-            .as_ref()
-            .and_then(|cap| match cap {
-                CodeActionProviderCapability::Simple(_) => None,
-                CodeActionProviderCapability::Options(options) => options.code_action_kinds.clone(),
-            })
-            .unwrap_or_default();
-
-        if !code_action_kinds.contains(&CodeActionKind::QUICKFIX) {
-            code_action_kinds.push(CodeActionKind::QUICKFIX);
-        }
-        if !code_action_kinds.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC) {
-            code_action_kinds.push(CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC);
-        }
-        if !code_action_kinds.contains(&CodeActionKind::SOURCE_FIX_ALL) {
-            code_action_kinds.push(CodeActionKind::SOURCE_FIX_ALL);
-        }
-
-        // override code action kinds if the code action provider is already set
         capabilities.code_action_provider =
             Some(CodeActionProviderCapability::Options(CodeActionOptions {
-                code_action_kinds: Some(code_action_kinds),
-                work_done_progress_options: capabilities
-                    .code_action_provider
-                    .as_ref()
-                    .and_then(|cap| match cap {
-                        CodeActionProviderCapability::Simple(_) => None,
-                        CodeActionProviderCapability::Options(options) => {
-                            Some(options.work_done_progress_options)
-                        }
-                    })
-                    .unwrap_or_default(),
-                resolve_provider: capabilities.code_action_provider.as_ref().and_then(|cap| {
-                    match cap {
-                        CodeActionProviderCapability::Simple(_) => None,
-                        CodeActionProviderCapability::Options(options) => options.resolve_provider,
-                    }
-                }),
+                code_action_kinds: Some(vec![
+                    CodeActionKind::QUICKFIX,
+                    CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC,
+                    CodeActionKind::SOURCE_FIX_ALL,
+                ]),
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+                resolve_provider: None,
             }));
 
-        let mut commands = capabilities
-            .execute_command_provider
-            .as_ref()
-            .map_or(vec![], |opts| opts.commands.clone());
-
-        if !commands.contains(&FIX_ALL_COMMAND_ID.to_string()) {
-            commands.push(FIX_ALL_COMMAND_ID.to_string());
-        }
-
         capabilities.execute_command_provider = Some(ExecuteCommandOptions {
-            commands,
-            work_done_progress_options: WorkDoneProgressOptions {
-                work_done_progress: capabilities
-                    .execute_command_provider
-                    .as_ref()
-                    .and_then(|provider| provider.work_done_progress_options.work_done_progress),
-            },
+            commands: vec![FIX_ALL_COMMAND_ID.to_string()],
+            work_done_progress_options: WorkDoneProgressOptions::default(),
         });
 
         // The server supports pull and push diagnostics.
@@ -875,8 +831,7 @@ impl ServerLinter {
 #[cfg(test)]
 mod tests_builder {
     use tower_lsp_server::ls_types::{
-        CodeActionKind, CodeActionOptions, CodeActionProviderCapability, ExecuteCommandOptions,
-        ServerCapabilities, WorkDoneProgressOptions,
+        CodeActionKind, CodeActionProviderCapability, ServerCapabilities,
     };
 
     use oxc_language_server::{Capabilities, DiagnosticMode, ToolBuilder};
@@ -887,7 +842,7 @@ mod tests_builder {
     };
 
     #[test]
-    fn test_server_capabilities_empty_capabilities() {
+    fn test_server_capabilities_default_providers() {
         let builder = ServerLinterBuilder::default();
         let mut capabilities = ServerCapabilities::default();
 
@@ -906,126 +861,6 @@ mod tests_builder {
         }
 
         // Should set execute command provider with fix all command
-        let execute_command_provider = capabilities.execute_command_provider.as_ref().unwrap();
-        assert!(execute_command_provider.commands.contains(&FIX_ALL_COMMAND_ID.to_string()));
-        assert_eq!(execute_command_provider.commands.len(), 1);
-    }
-
-    #[test]
-    fn test_server_capabilities_with_existing_code_action_kinds() {
-        let builder = ServerLinterBuilder::default();
-        let mut capabilities = ServerCapabilities {
-            code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
-                code_action_kinds: Some(vec![CodeActionKind::REFACTOR]),
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-                resolve_provider: Some(true),
-            })),
-            ..Default::default()
-        };
-
-        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
-
-        match &capabilities.code_action_provider {
-            Some(CodeActionProviderCapability::Options(options)) => {
-                let code_action_kinds = options.code_action_kinds.as_ref().unwrap();
-                assert!(code_action_kinds.contains(&CodeActionKind::REFACTOR));
-                assert!(code_action_kinds.contains(&CodeActionKind::QUICKFIX));
-                assert!(code_action_kinds.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC));
-                assert!(code_action_kinds.contains(&CodeActionKind::SOURCE_FIX_ALL));
-                assert_eq!(code_action_kinds.len(), 4);
-                assert_eq!(options.resolve_provider, Some(true));
-            }
-            _ => panic!("Expected code action provider options"),
-        }
-    }
-
-    #[test]
-    fn test_server_capabilities_with_existing_quickfix_kind() {
-        let builder = ServerLinterBuilder::default();
-        let mut capabilities = ServerCapabilities {
-            code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
-                code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-                resolve_provider: None,
-            })),
-            ..Default::default()
-        };
-
-        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
-
-        match &capabilities.code_action_provider {
-            Some(CodeActionProviderCapability::Options(options)) => {
-                let code_action_kinds = options.code_action_kinds.as_ref().unwrap();
-                assert!(code_action_kinds.contains(&CodeActionKind::QUICKFIX));
-                assert!(code_action_kinds.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC));
-                assert!(code_action_kinds.contains(&CodeActionKind::SOURCE_FIX_ALL));
-                assert_eq!(code_action_kinds.len(), 3);
-            }
-            _ => panic!("Expected code action provider options"),
-        }
-    }
-
-    #[test]
-    fn test_server_capabilities_with_simple_code_action_provider() {
-        let builder = ServerLinterBuilder::default();
-        let mut capabilities = ServerCapabilities {
-            code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-            ..Default::default()
-        };
-
-        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
-
-        // Should override with options
-        match &capabilities.code_action_provider {
-            Some(CodeActionProviderCapability::Options(options)) => {
-                let code_action_kinds = options.code_action_kinds.as_ref().unwrap();
-                assert!(code_action_kinds.contains(&CodeActionKind::QUICKFIX));
-                assert!(code_action_kinds.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC));
-                assert!(code_action_kinds.contains(&CodeActionKind::SOURCE_FIX_ALL));
-                assert_eq!(code_action_kinds.len(), 3);
-            }
-            _ => panic!("Expected code action provider options"),
-        }
-    }
-
-    #[test]
-    fn test_server_capabilities_with_existing_commands() {
-        let builder = ServerLinterBuilder::default();
-        let mut capabilities = ServerCapabilities {
-            execute_command_provider: Some(ExecuteCommandOptions {
-                commands: vec!["existing.command".to_string()],
-                work_done_progress_options: WorkDoneProgressOptions {
-                    work_done_progress: Some(true),
-                },
-            }),
-            ..Default::default()
-        };
-
-        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
-
-        let execute_command_provider = capabilities.execute_command_provider.as_ref().unwrap();
-        assert!(execute_command_provider.commands.contains(&"existing.command".to_string()));
-        assert!(execute_command_provider.commands.contains(&FIX_ALL_COMMAND_ID.to_string()));
-        assert_eq!(execute_command_provider.commands.len(), 2);
-        assert_eq!(
-            execute_command_provider.work_done_progress_options.work_done_progress,
-            Some(true)
-        );
-    }
-
-    #[test]
-    fn test_server_capabilities_with_existing_fix_all_command() {
-        let builder = ServerLinterBuilder::default();
-        let mut capabilities = ServerCapabilities {
-            execute_command_provider: Some(ExecuteCommandOptions {
-                commands: vec![FIX_ALL_COMMAND_ID.to_string()],
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-            }),
-            ..Default::default()
-        };
-
-        builder.server_capabilities(&mut capabilities, &mut Capabilities::default());
-
         let execute_command_provider = capabilities.execute_command_provider.as_ref().unwrap();
         assert!(execute_command_provider.commands.contains(&FIX_ALL_COMMAND_ID.to_string()));
         assert_eq!(execute_command_provider.commands.len(), 1);


### PR DESCRIPTION
Because `oxc_language_server::run_server` can now only hold one tool, there is no need to check for already defined capabilities