### PR TITLE
fix(formatter): Use `hard_space` for `as_or_satisfies`

### DIFF
--- a/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
+++ b/crates/oxc_formatter/src/print/as_or_satisfies_expression.rs
@@ -59,12 +59,12 @@ fn format_as_or_satisfies_expression<'a>(
         {
             write!(f, [FormatNodeWithoutTrailingComments(expression)]);
             write!(f, [FormatTrailingComments::Comments(block_comments)]);
-            write!(f, [space(), token(operation), space(), token("const")]);
+            write!(f, [space(), token(operation), hard_space(), token("const")]);
         } else if block_comments.is_empty() {
             write!(f, [FormatNodeWithoutTrailingComments(expression)]);
-            write!(f, [space(), token(operation), space(), type_annotation]);
+            write!(f, [space(), token(operation), hard_space(), type_annotation]);
         } else {
-            write!(f, [expression, space(), token(operation), space(), type_annotation]);
+            write!(f, [expression, space(), token(operation), hard_space(), type_annotation]);
         }
     });
 

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 591/601 (98.34%)
+ts compatibility: 592/601 (98.50%)
 
 # Failed
 
@@ -6,7 +6,6 @@ ts compatibility: 591/601 (98.34%)
 | :-------- | :--------------: | :---------: |
 | typescript/arrow/comments.ts | 💥✨ | 44.44% |
 | typescript/arrow/comments/issue-11100.ts | 💥 | 84.00% |
-| typescript/as/break-after-keyword/18148.ts | 💥 | 82.22% |
 | typescript/class/empty-method-body.ts | 💥 | 80.00% |
 | typescript/comments/mapped_types.ts | 💥 | 96.77% |
 | typescript/comments/method_types.ts | 💥 | 82.05% |


### PR DESCRIPTION
The same as #20858, but for `as` and `satisfies`.

Theoretically, there may be other cases where this has an impact, but I haven't been able to find any existing tests that demonstrate it.
