### PR TITLE
docs(linter): highlight that tsconfig is not respected in type aware linting

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -127,7 +127,11 @@ pub struct BasicOptions {
     /// Oxlint automatically discovers the relevant `tsconfig.json` for each file.
     /// Use this only when your project uses a non-standard tsconfig name or location.
     ///
-    /// NOTE: Type checking and Type aware rules will still use the tsconfig discovered automatically, and will not be affected by this option.
+    /// ::: warning
+    /// Avoid using this this option. It can cause differences between import resolution,
+    /// and type-aware linting. Type aware linting **does not** respect this option,
+    /// and will always discover the appropriate `tsconfig.json` for each file automatically.
+    /// :::
     #[bpaf(argument("./tsconfig.json"), hide_usage)]
     pub tsconfig: Option<PathBuf>,
 

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -22,7 +22,7 @@ search: false
 - **`    --tsconfig`**=_`<./tsconfig.json>`_ &mdash; 
   Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-  NOTE: Type checking and Type aware rules will still use the tsconfig discovered automatically, and will not be affected by this option.
+  ::: warning Avoid using this this option. It can cause differences between import resolution, and type-aware linting. Type aware linting **does not** respect this option, and will always discover the appropriate `tsconfig.json` for each file automatically. :::
 - **`    --init`** &mdash; 
   Initialize oxlint configuration with default values
 


### PR DESCRIPTION
Related: https://github.com/oxc-project/tsgolint/issues/852