### PR TITLE
fix(linter/eslint-vitest-plugin): remove pending fix status for require-local-test-context-for-concurrent-snapshot

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -84,8 +84,7 @@ declare_oxc_lint!(
     /// ```
     RequireLocalTestContextForConcurrentSnapshots,
     vitest,
-    correctness,
-    pending
+    correctness
 );
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {


### PR DESCRIPTION
Related to https://github.com/oxc-project/oxc/issues/4656

# Summary

The [OG rule don't have fix capabilities](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/require-local-test-context-for-concurrent-snapshots.md). I have tracked the addition of [pending status to this commit](https://github.com/oxc-project/oxc/commit/0ac420d6f91f82b756e1395cee3dfe06e9eb9d64#diff-3069ba10730ff66c5d546086116121f47f692cf7113416c91e9017f491b8e5ef), looks that it has been introduced by error.  