### PR TITLE
feat(oxfmt): add `--log-formatted` flag to list changed files in write mode

### DIFF
--- a/apps/oxfmt/src/cli/command.rs
+++ b/apps/oxfmt/src/cli/command.rs
@@ -28,6 +28,9 @@ pub struct FormatCommand {
     pub ignore_options: IgnoreOptions,
     #[bpaf(external)]
     pub runtime_options: RuntimeOptions,
+    /// Log formatted (changed) file paths to stdout
+    #[bpaf(long("log-formatted"), switch, hide_usage)]
+    pub log_formatted: bool,
     /// Single file, path or list of paths.
     /// Glob patterns are also supported.
     /// (Be sure to quote them, otherwise your shell may expand them before passing.)

--- a/apps/oxfmt/src/cli/format.rs
+++ b/apps/oxfmt/src/cli/format.rs
@@ -66,8 +66,14 @@ impl CliRunner {
         let start_time = Instant::now();
 
         let cwd = self.cwd;
-        let FormatCommand { paths, mode, config_options, ignore_options, runtime_options } =
-            self.options;
+        let FormatCommand {
+            paths,
+            mode,
+            config_options,
+            ignore_options,
+            runtime_options,
+            log_formatted,
+        } = self.options;
         // If `napi` feature is disabled, there is no other mode.
         #[cfg_attr(not(feature = "napi"), expect(irrefutable_let_patterns))]
         let Mode::Cli(format_mode) = mode else {
@@ -176,8 +182,13 @@ impl CliRunner {
 
         // Spawn a thread to run formatting service with streaming entries
         rayon::spawn(move || {
-            let format_service =
-                FormatService::new(cwd, format_mode_clone, source_formatter, config_resolver);
+            let format_service = FormatService::new(
+                cwd,
+                format_mode_clone,
+                source_formatter,
+                config_resolver,
+                log_formatted,
+            );
             format_service.run_streaming(rx_entry, &tx_error, &tx_success);
         });
 
@@ -267,12 +278,10 @@ impl CliRunner {
                 CliRunResult::FormatMismatch
             }
             // Default (write) outputs only stats
-            (OutputMode::Write, changed_count) => {
-                // Each changed file is also NOT printed
-                debug_assert_eq!(
-                    changed_count, 0,
-                    "In write mode, changed_count should not be counted"
-                );
+            (OutputMode::Write, _) => {
+                if !changed_paths.is_empty() {
+                    utils::print_and_flush(stdout, "\n");
+                }
                 print_stats(stdout, stderr);
                 CliRunResult::FormatSucceeded
             }

--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -18,6 +18,7 @@ pub struct FormatService {
     format_mode: OutputMode,
     formatter: SourceFormatter,
     config_resolver: ConfigResolver,
+    log_formatted: bool,
 }
 
 impl FormatService {
@@ -26,11 +27,21 @@ impl FormatService {
         format_mode: OutputMode,
         formatter: SourceFormatter,
         config_resolver: ConfigResolver,
+        log_formatted: bool,
     ) -> Self
     where
         T: Into<Box<Path>>,
     {
-        Self { cwd: cwd.into(), format_mode, formatter, config_resolver }
+        Self { cwd: cwd.into(), format_mode, formatter, config_resolver, log_formatted }
+    }
+
+    /// Returns a display path relative to `cwd` with normalized separators.
+    fn display_path(&self, path: &Path) -> String {
+        path.strip_prefix(&self.cwd)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .cow_replace('\\', "/")
+            .to_string()
     }
 
     /// Process entries as they are received from the channel
@@ -91,21 +102,16 @@ impl FormatService {
             // Report result
             let result = match (&self.format_mode, is_changed) {
                 (OutputMode::Check | OutputMode::ListDifferent, true) => {
-                    let display_path = path
-                        // Show path relative to `cwd` for cleaner output
-                        .strip_prefix(&self.cwd)
-                        .unwrap_or(path)
-                        .to_string_lossy()
-                        // Normalize path separators for consistent output across platforms
-                        .cow_replace('\\', "/")
-                        .to_string();
-
+                    let display_path = self.display_path(path);
                     if matches!(self.format_mode, OutputMode::Check) {
                         let elapsed = start_time.unwrap().elapsed().as_millis();
                         SuccessResult::Changed(format!("{display_path} ({elapsed}ms)"))
                     } else {
                         SuccessResult::Changed(display_path)
                     }
+                }
+                (OutputMode::Write, true) if self.log_formatted => {
+                    SuccessResult::Changed(self.display_path(path))
                 }
                 _ => SuccessResult::Unchanged,
             };

--- a/apps/oxfmt/test/cli/log_formatted/__snapshots__/log_formatted.test.ts.snap
+++ b/apps/oxfmt/test/cli/log_formatted/__snapshots__/log_formatted.test.ts.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`log_formatted > should log changed file paths with --log-formatted 1`] = `
+"unformatted.js
+Finished in <variable>ms on 1 files using 1 threads."
+`;
+
+exports[`log_formatted > should log only changed files when mixed with already formatted 1`] = `
+"unformatted.js
+Finished in <variable>ms on 2 files using 1 threads."
+`;
+
+exports[`log_formatted > should not log paths when file is already formatted 1`] = `"Finished in <variable>ms on 1 files using 1 threads."`;
+
+exports[`log_formatted > should not log paths without --log-formatted flag 1`] = `"Finished in <variable>ms on 1 files using 1 threads."`;

--- a/apps/oxfmt/test/cli/log_formatted/fixtures/already_formatted.js
+++ b/apps/oxfmt/test/cli/log_formatted/fixtures/already_formatted.js
@@ -1,0 +1,1 @@
+class Foo {}

--- a/apps/oxfmt/test/cli/log_formatted/fixtures/unformatted.js
+++ b/apps/oxfmt/test/cli/log_formatted/fixtures/unformatted.js
@@ -1,0 +1,1 @@
+  class                 Foo {}

--- a/apps/oxfmt/test/cli/log_formatted/log_formatted.test.ts
+++ b/apps/oxfmt/test/cli/log_formatted/log_formatted.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { runCli } from "../utils";
+
+const fixturesDir = join(import.meta.dirname, "fixtures");
+
+async function runInTempDir(files: string[], args: string[]) {
+  const tempDir = await fs.mkdtemp(join(tmpdir(), "oxfmt-test-"));
+  try {
+    await fs.cp(fixturesDir, tempDir, { recursive: true });
+    const result = await runCli(tempDir, [...args, ...files]);
+    return {
+      stdout: result.stdout
+        .replace(/\d+(?:\.\d+)?s|\d+ms/g, "<variable>ms")
+        .replace(/\\/g, "/"),
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe("log_formatted", () => {
+  it("should log changed file paths with --log-formatted", async () => {
+    const result = await runInTempDir(
+      ["unformatted.js"],
+      ["--log-formatted"],
+    );
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should not log paths when file is already formatted", async () => {
+    const result = await runInTempDir(
+      ["already_formatted.js"],
+      ["--log-formatted"],
+    );
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should not log paths without --log-formatted flag", async () => {
+    const result = await runInTempDir(["unformatted.js"], []);
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should log only changed files when mixed with already formatted", async () => {
+    const result = await runInTempDir(
+      ["unformatted.js", "already_formatted.js"],
+      ["--log-formatted"],
+    );
+    expect(result.stdout).toMatchSnapshot();
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #20116.

- Add `--log-formatted` CLI flag that outputs changed file paths to stdout when running in write mode
- Existing behavior is unchanged — the flag is opt-in

### Usage

```sh
oxfmt . --log-formatted
```

Output (only changed file paths are listed, stats show total files processed):
```
src/index.ts
src/utils.ts
Finished in 19ms on 10 files using 12 threads.
```

### AI Disclosure

AI tools (Claude) were used to assist with this implementation. All code has been reviewed, tested, and understood by the contributor.

## Test plan

- [x] `cargo check` and `cargo clippy` pass for both `--no-default-features` and default features
- [x] E2E tests added: `test/cli/log_formatted/log_formatted.test.ts` (4 cases)
  - `--log-formatted` with unformatted file → path printed
  - `--log-formatted` with already formatted file → no path
  - Without flag → no path (existing behavior preserved)
  - Multiple files (mixed) → only changed file paths printed