### PR TITLE
feat(linter/consistent-type-exports): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_exports.rs
@@ -44,7 +44,7 @@ declare_oxc_lint!(
     /// ```
     ConsistentTypeExports(tsgolint),
     typescript,
-    nursery,
+    style,
     config = ConsistentTypeExportsConfig,
 );
 


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the style category