### PR TITLE
feat(linter/dot-notation): move rule from nursery to style

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/dot_notation.rs
+++ b/crates/oxc_linter/src/rules/typescript/dot_notation.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
     /// ```
     DotNotation(tsgolint),
     typescript,
-    nursery,
+    style,
     config = DotNotationConfig,
 );
 


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the style category