### PR TITLE
feat(linter/no-unnecessary-type-conversion): move rule from nursery to suspicious

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_conversion.rs
@@ -28,7 +28,7 @@ declare_oxc_lint!(
     /// ```
     NoUnnecessaryTypeConversion(tsgolint),
     typescript,
-    nursery,
+    suspicious,
 );
 
 impl Rule for NoUnnecessaryTypeConversion {}


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the suspicious category