### PR TITLE
feat(linter/consistent-return): move rule from nursery to suspicious

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_return.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_return.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
     /// ```
     ConsistentReturn(tsgolint),
     typescript,
-    nursery,
+    suspicious,
     config = ConsistentReturnConfig,
 );
 


### PR DESCRIPTION
This rule has been published for ~6 weeks, and we've had little to no reports highlighting issues, so this PR moves it out of nursery to the suspicious category