### PR TITLE
perf(napi/parser, linter/plugins): faster deserialization of `raw` fields

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -3243,30 +3243,37 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3279,17 +3286,20 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3301,17 +3311,20 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       __proto__: NodeProto,
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3820,14 +3833,18 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     __proto__: NodeProto,
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -517,5 +517,6 @@ pub struct JSXText<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
+    #[estree(from_span)]
     pub raw: Option<Str<'a>>,
 }

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -65,7 +65,7 @@ pub struct NumericLiteral<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
-    #[estree(json_safe)]
+    #[estree(json_safe, from_span)]
     pub raw: Option<Str<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]
@@ -95,6 +95,7 @@ pub struct StringLiteral<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
+    #[estree(from_span)]
     pub raw: Option<Str<'a>>,
 
     /// The string value contains lone surrogates.
@@ -122,7 +123,7 @@ pub struct BigIntLiteral<'a> {
     pub value: Str<'a>,
     /// The bigint as it appears in source code
     #[content_eq(skip)]
-    #[estree(json_safe)]
+    #[estree(json_safe, from_span)]
     pub raw: Option<Str<'a>>,
     /// The base representation used by the literal in source code
     #[content_eq(skip)]
@@ -153,6 +154,7 @@ pub struct RegExpLiteral<'a> {
     ///
     /// `None` when this ast node is not constructed from the parser.
     #[content_eq(skip)]
+    #[estree(from_span)]
     pub raw: Option<Str<'a>>,
 }
 

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -2314,22 +2314,32 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
     },
     value = deserializeStr(pos + 16);
   deserializeBool(pos + 12) &&
@@ -2339,13 +2349,18 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
     },
     bigint = deserializeStr(pos + 16);
   node.value = BigInt(bigint);
@@ -2354,13 +2369,18 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
     },
     regex = deserializeRegExp(pos + 16),
     value = null;
@@ -2767,12 +2787,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -2597,24 +2597,34 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       parent,
     }),
     value = deserializeStr(pos + 16);
@@ -2626,14 +2636,19 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
       parent,
     }),
     bigint = deserializeStr(pos + 16);
@@ -2644,14 +2659,19 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
       parent,
     }),
     regex = deserializeRegExp(pos + 16),
@@ -3100,12 +3120,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     parent,
   };
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -2574,26 +2574,33 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       range: [start, end],
     },
     value = deserializeStr(pos + 16);
@@ -2604,15 +2611,18 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
     },
     bigint = deserializeStr(pos + 16);
@@ -2622,15 +2632,18 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
     },
     regex = deserializeRegExp(pos + 16),
@@ -3081,13 +3094,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
   };
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -2860,28 +2860,35 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -2894,16 +2901,19 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -2915,16 +2925,19 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3417,13 +3430,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -2570,22 +2570,32 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
     },
     value = deserializeStr(pos + 16);
   deserializeBool(pos + 12) &&
@@ -2595,13 +2605,18 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
     },
     bigint = deserializeStr(pos + 16);
   node.value = BigInt(bigint);
@@ -2610,13 +2625,18 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let node = {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
     },
     regex = deserializeRegExp(pos + 16),
     value = null;
@@ -3020,12 +3040,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
   };
 }
 

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -2868,24 +2868,34 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       parent,
     }),
     value = deserializeStr(pos + 16);
@@ -2897,14 +2907,19 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
       parent,
     }),
     bigint = deserializeStr(pos + 16);
@@ -2915,14 +2930,19 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let previousParent = parent,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: deserializeU32(pos),
-      end: deserializeU32(pos + 4),
+      start,
+      end,
       parent,
     }),
     regex = deserializeRegExp(pos + 16),
@@ -3369,12 +3389,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     parent,
   };
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -2855,26 +2855,33 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       range: [start, end],
     },
     value = deserializeStr(pos + 16);
@@ -2885,15 +2892,18 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
     },
     bigint = deserializeStr(pos + 16);
@@ -2903,15 +2913,18 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     node = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
     },
     regex = deserializeRegExp(pos + 16),
@@ -3358,13 +3371,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
   };
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -3152,28 +3152,35 @@ function deserializeNullLiteral(pos) {
 }
 
 function deserializeNumericLiteral(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "Literal",
     value: deserializeF64(pos + 32),
-    raw: deserializeOptionStr(pos + 16),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };
 }
 
 function deserializeStringLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3186,16 +3193,19 @@ function deserializeStringLiteral(pos) {
 }
 
 function deserializeBigIntLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 32),
+      raw:
+        uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       bigint: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3207,16 +3217,19 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  let start,
-    end,
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
     previousParent = parent,
     node = (parent = {
       type: "Literal",
       value: null,
-      raw: deserializeOptionStr(pos + 48),
+      raw:
+        uint32[(pos + 48) >> 2] === 0 && uint32[(pos + 52) >> 2] === 0
+          ? null
+          : sourceText.slice(start, end),
       regex: null,
-      start: (start = deserializeU32(pos)),
-      end: (end = deserializeU32(pos + 4)),
+      start,
+      end,
       range: [start, end],
       parent,
     }),
@@ -3707,13 +3720,17 @@ function deserializeJSXSpreadChild(pos) {
 }
 
 function deserializeJSXText(pos) {
-  let start, end;
+  let start = deserializeU32(pos),
+    end = deserializeU32(pos + 4);
   return {
     type: "JSXText",
     value: deserializeStr(pos + 16),
-    raw: deserializeOptionStr(pos + 32),
-    start: (start = deserializeU32(pos)),
-    end: (end = deserializeU32(pos + 4)),
+    raw:
+      uint32[(pos + 32) >> 2] === 0 && uint32[(pos + 36) >> 2] === 0
+        ? null
+        : sourceText.slice(start, end),
+    start,
+    end,
     range: [start, end],
     parent,
   };

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -149,6 +149,7 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::Tag("flatten") => struct_def.fields[field_index].estree.flatten = true,
             AttrPart::Tag("no_flatten") => struct_def.fields[field_index].estree.no_flatten = true,
             AttrPart::Tag("json_safe") => struct_def.fields[field_index].estree.json_safe = true,
+            AttrPart::Tag("from_span") => struct_def.fields[field_index].estree.from_span = true,
             AttrPart::String("rename", value) => {
                 struct_def.fields[field_index].estree.rename = Some(value);
             }

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -701,6 +701,45 @@ impl<'s> StructDeserializerGenerator<'s> {
             }
 
             field_name.clone()
+        } else if field.estree.from_span {
+            // Derive value from `sourceText.slice(start, end)` instead of deserializing.
+            // Field must be `Str`, `Ident`, `&str`, or `Option` containing one of those types.
+            let (inner_type, prefix) = if let TypeDef::Option(option_def) = field_type {
+                let inner_type = option_def.inner_type(self.schema);
+                let (none_condition, _) =
+                    get_option_none_condition_and_offset(option_def, inner_type, field_offset);
+                (inner_type, format!("({none_condition}) ? null : "))
+            } else {
+                (field_type, String::new())
+            };
+
+            if inner_type.as_primitive().is_none_or(|primitive_def| {
+                !matches!(primitive_def.name(), "Str" | "Ident" | "&str")
+            }) {
+                panic!(
+                    "`#[estree(from_span)]` can only be on a field of type `Str`, `Ident`, `&str`, or `Option` containing one of those types: `{}::{}`",
+                    struct_def.name(),
+                    field.name(),
+                );
+            }
+
+            // Check that struct has a `span: Span` field, and that it is flattened, so `start` and `end` are available
+            assert!(
+                struct_def.fields.iter().any(|field| {
+                    field.type_id == self.span_type_id
+                        && field.name() == "span"
+                        && should_flatten_field(field, self.schema)
+                }),
+                "`#[estree(from_span)]` can only be used on a field of a struct with a flattened `span: Span` field: `{}::{}`",
+                struct_def.name(),
+                field.name(),
+            );
+
+            inline = true;
+            self.dependent_field_names.insert("start".to_string());
+            self.dependent_field_names.insert("end".to_string());
+
+            format!("{prefix}sourceText.slice(start, end)")
         } else if let Some(converter_name) = &field.estree.via {
             let converter = self.schema.meta_by_name(converter_name);
             self.apply_converter(converter, struct_def, struct_offset).unwrap()
@@ -933,32 +972,9 @@ fn generate_option(
 
     let fn_name = option_def.deser_name(schema);
     let inner_fn_name = inner_type.deser_name(schema);
-    let inner_layout = inner_type.layout_64();
 
-    let (none_condition, payload_offset) = if option_def.layout_64().size == inner_layout.size {
-        let niche = inner_layout.niche.clone().unwrap();
-        let none_condition = match niche.size {
-            1 => format!("uint8[{}] === {}", pos_offset(niche.offset), niche.value()),
-            // 2 => format!("uint16[{}] === {}", pos_offset_shift(niche.offset, 1), niche.value()),
-            4 => format!("uint32[{}] === {}", pos_offset_shift(niche.offset, 2), niche.value()),
-            8 => {
-                // TODO: Use `float64[pos >> 3] === 0` instead of
-                // `uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0`?
-                let value = niche.value();
-                format!(
-                    "uint32[{}] === {} && uint32[{}] === {}",
-                    pos_offset_shift(niche.offset, 2),
-                    value & u128::from(u32::MAX),
-                    pos_offset_shift(niche.offset + 4, 2),
-                    value >> 32,
-                )
-            }
-            size => panic!("Invalid niche size: {size}"),
-        };
-        (none_condition, Cow::Borrowed("pos"))
-    } else {
-        ("uint8[pos] === 0".to_string(), pos_offset(inner_layout.align))
-    };
+    let (none_condition, payload_offset) =
+        get_option_none_condition_and_offset(option_def, inner_type, 0);
 
     #[rustfmt::skip]
     write_it!(code, "
@@ -967,6 +983,41 @@ fn generate_option(
             return {inner_fn_name}({payload_offset});
         }}
     ");
+}
+
+/// Get condition for `Option`'s `None` value and offset of `Option`'s payload.
+fn get_option_none_condition_and_offset(
+    option_def: &OptionDef,
+    inner_type: &TypeDef,
+    offset: u32,
+) -> (String, Cow<'static, str>) {
+    let inner_layout = inner_type.layout_64();
+
+    if option_def.layout_64().size == inner_layout.size {
+        let niche = inner_layout.niche.clone().unwrap();
+        let niche_offset = offset + niche.offset;
+        let none_condition = match niche.size {
+            1 => format!("uint8[{}] === {}", pos_offset(niche_offset), niche.value()),
+            // 2 => format!("uint16[{}] === {}", pos_offset_shift(offset, 1), niche.value()),
+            4 => format!("uint32[{}] === {}", pos_offset_shift(niche_offset, 2), niche.value()),
+            8 => {
+                // TODO: Use `float64[pos >> 3] === 0` instead of
+                // `uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0`?
+                let value = niche.value();
+                format!(
+                    "uint32[{}] === {} && uint32[{}] === {}",
+                    pos_offset_shift(niche_offset, 2),
+                    value & u128::from(u32::MAX),
+                    pos_offset_shift(niche_offset + 4, 2),
+                    value >> 32,
+                )
+            }
+            size => panic!("Invalid niche size: {size}"),
+        };
+        (none_condition, pos_offset(offset))
+    } else {
+        (format!("uint8[{}] === 0", pos_offset(offset)), pos_offset(offset + inner_layout.align))
+    }
 }
 
 /// Generate deserialize function for a `Box`.

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -81,6 +81,9 @@ pub struct ESTreeStructField {
     pub no_flatten: bool,
     /// `true` for fields containing a `&str` or `Str` which does not need escaping in JSON
     pub json_safe: bool,
+    /// `true` for fields containing a `&str`, `Str`, `Ident`, or `Option` of one of those,
+    /// whose contents can be derived from a slice of source text with `Span` for the struct.
+    pub from_span: bool,
     /// `true` if field is only included in JS ESTree AST (not TS-ESTree AST).
     pub is_js: bool,
     /// `true` if field is only included in TS-ESTree AST (not JS ESTree AST).


### PR DESCRIPTION
`raw` field of `NumericLiteral`, `StringLiteral`, `BigIntLiteral`, `RegExpLiteral`, and `JSXText` are slices of source text.

So in raw transfer deserializer, skip going through `deserializeStr`, which can be slow when source contains any non-ASCII characters. Instead just slice the string from the source text directly with `sourceText.slice(start, end)`.

String decoding is the slowest part of raw transfer, so this should be a significant speed gain.