### PR TITLE
refactor(napi/parser, linter/plugins): shorten raw transfer deserializers for `Option`s

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -6160,13 +6160,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -6202,8 +6202,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -6223,8 +6222,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -6252,8 +6252,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -6373,23 +6372,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -6409,18 +6408,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -6456,13 +6456,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -6478,8 +6478,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -6487,8 +6488,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -6496,8 +6498,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -6509,8 +6512,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -6542,13 +6546,13 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeOptionTSAccessibility(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSAccessibility(pos);
+  return uint8[pos] === 3 ? null : deserializeTSAccessibility(pos);
 }
 
 function deserializeVecTSClassImplements(pos) {
@@ -6624,8 +6628,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -6641,8 +6644,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -6650,8 +6654,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -6679,8 +6684,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -6696,13 +6700,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -6734,8 +6736,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -6771,8 +6774,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6984,8 +6986,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -7057,8 +7058,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -7070,13 +7070,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -7084,8 +7084,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -4579,8 +4579,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -4840,13 +4841,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -4882,8 +4883,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -4903,8 +4903,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -4932,8 +4933,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5053,23 +5053,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5089,18 +5089,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -5136,13 +5137,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -5158,8 +5159,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -5167,8 +5169,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -5176,8 +5179,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -5189,8 +5193,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -5222,8 +5227,9 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
@@ -5287,8 +5293,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -5304,8 +5309,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -5313,8 +5319,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -5342,8 +5349,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -5359,13 +5365,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -5397,8 +5401,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -5434,8 +5439,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -5647,8 +5651,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -5720,8 +5723,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -5733,13 +5735,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -5747,8 +5749,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -5760,8 +5761,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -5116,8 +5116,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5377,13 +5378,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5419,8 +5420,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5440,8 +5440,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -5469,8 +5470,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5590,23 +5590,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5626,18 +5626,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -5673,13 +5674,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -5695,8 +5696,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -5704,8 +5706,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -5713,8 +5716,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -5726,8 +5730,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -5759,8 +5764,9 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
@@ -5824,8 +5830,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -5841,8 +5846,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -5850,8 +5856,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -5879,8 +5886,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -5896,13 +5902,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -5934,8 +5938,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -5971,8 +5976,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6184,8 +6188,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6257,8 +6260,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6270,13 +6272,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6284,8 +6286,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6297,8 +6298,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -5121,8 +5121,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5382,13 +5383,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5424,8 +5425,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5445,8 +5445,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -5474,8 +5475,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5595,23 +5595,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5631,18 +5631,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -5678,13 +5679,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -5700,8 +5701,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -5709,8 +5711,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -5718,8 +5721,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -5731,8 +5735,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -5764,8 +5769,9 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
@@ -5829,8 +5835,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -5846,8 +5851,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -5855,8 +5861,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -5884,8 +5891,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -5901,13 +5907,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -5939,8 +5943,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -5976,8 +5981,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6189,8 +6193,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6262,8 +6265,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6275,13 +6277,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6289,8 +6291,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6302,8 +6303,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -5661,8 +5661,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5922,13 +5923,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5964,8 +5965,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5985,8 +5985,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -6014,8 +6015,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -6135,23 +6135,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -6171,18 +6171,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -6218,13 +6219,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -6240,8 +6241,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -6249,8 +6251,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -6258,8 +6261,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -6271,8 +6275,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -6304,8 +6309,9 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeBoxClassBody(pos) {
@@ -6369,8 +6375,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -6386,8 +6391,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -6395,8 +6401,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -6424,8 +6431,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -6441,13 +6447,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -6479,8 +6483,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -6516,8 +6521,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6729,8 +6733,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6802,8 +6805,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6815,13 +6817,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6829,8 +6831,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6842,8 +6843,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -4888,8 +4888,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5149,13 +5150,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5191,8 +5192,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5212,8 +5212,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -5241,8 +5242,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5362,23 +5362,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5398,18 +5398,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -5445,13 +5446,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -5467,8 +5468,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -5476,8 +5478,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -5485,8 +5488,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -5498,8 +5502,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -5531,13 +5536,13 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeOptionTSAccessibility(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSAccessibility(pos);
+  return uint8[pos] === 3 ? null : deserializeTSAccessibility(pos);
 }
 
 function deserializeVecTSClassImplements(pos) {
@@ -5613,8 +5618,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -5630,8 +5634,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -5639,8 +5644,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -5668,8 +5674,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -5685,13 +5690,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -5723,8 +5726,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -5760,8 +5764,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -5973,8 +5976,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6046,8 +6048,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6059,13 +6060,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6073,8 +6074,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6086,8 +6086,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -5452,8 +5452,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5713,13 +5714,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5755,8 +5756,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5776,8 +5776,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -5805,8 +5806,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5926,23 +5926,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5962,18 +5962,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -6009,13 +6010,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -6031,8 +6032,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -6040,8 +6042,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -6049,8 +6052,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -6062,8 +6066,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -6095,13 +6100,13 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeOptionTSAccessibility(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSAccessibility(pos);
+  return uint8[pos] === 3 ? null : deserializeTSAccessibility(pos);
 }
 
 function deserializeVecTSClassImplements(pos) {
@@ -6177,8 +6182,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -6194,8 +6198,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -6203,8 +6208,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -6232,8 +6238,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -6249,13 +6254,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -6287,8 +6290,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -6324,8 +6328,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6537,8 +6540,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6610,8 +6612,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6623,13 +6624,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6637,8 +6638,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6650,8 +6650,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -5461,8 +5461,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -5722,13 +5723,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -5764,8 +5765,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -5785,8 +5785,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -5814,8 +5815,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -5935,23 +5935,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -5971,18 +5971,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -6018,13 +6019,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -6040,8 +6041,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -6049,8 +6051,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -6058,8 +6061,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -6071,8 +6075,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -6104,13 +6109,13 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeOptionTSAccessibility(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSAccessibility(pos);
+  return uint8[pos] === 3 ? null : deserializeTSAccessibility(pos);
 }
 
 function deserializeVecTSClassImplements(pos) {
@@ -6186,8 +6191,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -6203,8 +6207,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -6212,8 +6217,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -6241,8 +6247,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -6258,13 +6263,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -6296,8 +6299,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -6333,8 +6337,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -6546,8 +6549,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -6619,8 +6621,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -6632,13 +6633,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -6646,8 +6647,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -6659,8 +6659,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -6025,8 +6025,9 @@ function deserializeVecComment(pos) {
 }
 
 function deserializeOptionHashbang(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeHashbang(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeHashbang(pos);
 }
 
 function deserializeVecDirective(pos) {
@@ -6286,13 +6287,13 @@ function deserializeBoxTSTypeParameterInstantiation(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterInstantiation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterInstantiation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterInstantiation(pos);
 }
 
 function deserializeOptionStr(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeStr(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0 ? null : deserializeStr(pos);
 }
 
 function deserializeBoxComputedMemberExpression(pos) {
@@ -6328,8 +6329,7 @@ function deserializeBoxObjectAssignmentTarget(pos) {
 }
 
 function deserializeOptionAssignmentTargetMaybeDefault(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeAssignmentTargetMaybeDefault(pos);
+  return uint8[pos] === 51 ? null : deserializeAssignmentTargetMaybeDefault(pos);
 }
 
 function deserializeVecOptionAssignmentTargetMaybeDefault(pos) {
@@ -6349,8 +6349,9 @@ function deserializeBoxAssignmentTargetRest(pos) {
 }
 
 function deserializeOptionBoxAssignmentTargetRest(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxAssignmentTargetRest(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxAssignmentTargetRest(pos);
 }
 
 function deserializeVecAssignmentTargetProperty(pos) {
@@ -6378,8 +6379,7 @@ function deserializeBoxAssignmentTargetPropertyProperty(pos) {
 }
 
 function deserializeOptionExpression(pos) {
-  if (uint8[pos] === 51) return null;
-  return deserializeExpression(pos);
+  return uint8[pos] === 51 ? null : deserializeExpression(pos);
 }
 
 function deserializeBoxBlockStatement(pos) {
@@ -6499,23 +6499,23 @@ function deserializeBoxTSTypeAnnotation(pos) {
 }
 
 function deserializeOptionBoxTSTypeAnnotation(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeAnnotation(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeAnnotation(pos);
 }
 
 function deserializeOptionStatement(pos) {
-  if (uint8[pos] === 70) return null;
-  return deserializeStatement(pos);
+  return uint8[pos] === 70 ? null : deserializeStatement(pos);
 }
 
 function deserializeOptionForStatementInit(pos) {
-  if (uint8[pos] === 65) return null;
-  return deserializeForStatementInit(pos);
+  return uint8[pos] === 65 ? null : deserializeForStatementInit(pos);
 }
 
 function deserializeOptionLabelIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeLabelIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeLabelIdentifier(pos);
 }
 
 function deserializeVecSwitchCase(pos) {
@@ -6535,18 +6535,19 @@ function deserializeBoxCatchClause(pos) {
 }
 
 function deserializeOptionBoxCatchClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxCatchClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxCatchClause(pos);
 }
 
 function deserializeOptionBoxBlockStatement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBlockStatement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBlockStatement(pos);
 }
 
 function deserializeOptionCatchParameter(pos) {
-  if (uint8[pos + 16] === 4) return null;
-  return deserializeCatchParameter(pos);
+  return uint8[pos + 16] === 4 ? null : deserializeCatchParameter(pos);
 }
 
 function deserializeBoxBindingIdentifier(pos) {
@@ -6582,13 +6583,13 @@ function deserializeBoxBindingRestElement(pos) {
 }
 
 function deserializeOptionBoxBindingRestElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxBindingRestElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxBindingRestElement(pos);
 }
 
 function deserializeOptionBindingPattern(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeBindingPattern(pos);
+  return uint8[pos] === 4 ? null : deserializeBindingPattern(pos);
 }
 
 function deserializeVecOptionBindingPattern(pos) {
@@ -6604,8 +6605,9 @@ function deserializeVecOptionBindingPattern(pos) {
 }
 
 function deserializeOptionBindingIdentifier(pos) {
-  if (uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0) return null;
-  return deserializeBindingIdentifier(pos);
+  return uint32[(pos + 16) >> 2] === 0 && uint32[(pos + 20) >> 2] === 0
+    ? null
+    : deserializeBindingIdentifier(pos);
 }
 
 function deserializeBoxTSTypeParameterDeclaration(pos) {
@@ -6613,8 +6615,9 @@ function deserializeBoxTSTypeParameterDeclaration(pos) {
 }
 
 function deserializeOptionBoxTSTypeParameterDeclaration(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSTypeParameterDeclaration(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSTypeParameterDeclaration(pos);
 }
 
 function deserializeBoxTSThisParameter(pos) {
@@ -6622,8 +6625,9 @@ function deserializeBoxTSThisParameter(pos) {
 }
 
 function deserializeOptionBoxTSThisParameter(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSThisParameter(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxTSThisParameter(pos);
 }
 
 function deserializeBoxFormalParameters(pos) {
@@ -6635,8 +6639,9 @@ function deserializeBoxFunctionBody(pos) {
 }
 
 function deserializeOptionBoxFunctionBody(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxFunctionBody(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxFunctionBody(pos);
 }
 
 function deserializeVecFormalParameter(pos) {
@@ -6668,13 +6673,13 @@ function deserializeBoxExpression(pos) {
 }
 
 function deserializeOptionBoxExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxExpression(pos);
 }
 
 function deserializeOptionTSAccessibility(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSAccessibility(pos);
+  return uint8[pos] === 3 ? null : deserializeTSAccessibility(pos);
 }
 
 function deserializeVecTSClassImplements(pos) {
@@ -6750,8 +6755,7 @@ function deserializeBoxTSNamespaceExportDeclaration(pos) {
 }
 
 function deserializeOptionImportPhase(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeImportPhase(pos);
+  return uint8[pos] === 2 ? null : deserializeImportPhase(pos);
 }
 
 function deserializeVecImportDeclarationSpecifier(pos) {
@@ -6767,8 +6771,9 @@ function deserializeVecImportDeclarationSpecifier(pos) {
 }
 
 function deserializeOptionVecImportDeclarationSpecifier(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeVecImportDeclarationSpecifier(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeVecImportDeclarationSpecifier(pos);
 }
 
 function deserializeBoxWithClause(pos) {
@@ -6776,8 +6781,9 @@ function deserializeBoxWithClause(pos) {
 }
 
 function deserializeOptionBoxWithClause(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxWithClause(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxWithClause(pos);
 }
 
 function deserializeBoxImportSpecifier(pos) {
@@ -6805,8 +6811,7 @@ function deserializeVecImportAttribute(pos) {
 }
 
 function deserializeOptionDeclaration(pos) {
-  if (uint8[pos] === 31) return null;
-  return deserializeDeclaration(pos);
+  return uint8[pos] === 31 ? null : deserializeDeclaration(pos);
 }
 
 function deserializeVecExportSpecifier(pos) {
@@ -6822,13 +6827,11 @@ function deserializeVecExportSpecifier(pos) {
 }
 
 function deserializeOptionStringLiteral(pos) {
-  if (uint8[pos + 12] === 2) return null;
-  return deserializeStringLiteral(pos);
+  return uint8[pos + 12] === 2 ? null : deserializeStringLiteral(pos);
 }
 
 function deserializeOptionModuleExportName(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeModuleExportName(pos);
+  return uint8[pos] === 3 ? null : deserializeModuleExportName(pos);
 }
 
 function deserializeF64(pos) {
@@ -6860,8 +6863,9 @@ function deserializeBoxJSXClosingElement(pos) {
 }
 
 function deserializeOptionBoxJSXClosingElement(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxJSXClosingElement(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxJSXClosingElement(pos);
 }
 
 function deserializeVecJSXAttributeItem(pos) {
@@ -6897,8 +6901,7 @@ function deserializeBoxJSXSpreadAttribute(pos) {
 }
 
 function deserializeOptionJSXAttributeValue(pos) {
-  if (uint8[pos] === 4) return null;
-  return deserializeJSXAttributeValue(pos);
+  return uint8[pos] === 4 ? null : deserializeJSXAttributeValue(pos);
 }
 
 function deserializeBoxJSXExpressionContainer(pos) {
@@ -7110,8 +7113,7 @@ function deserializeBoxTSQualifiedName(pos) {
 }
 
 function deserializeOptionTSType(pos) {
-  if (uint8[pos] === 38) return null;
-  return deserializeTSType(pos);
+  return uint8[pos] === 38 ? null : deserializeTSType(pos);
 }
 
 function deserializeVecTSTypeParameter(pos) {
@@ -7183,8 +7185,7 @@ function deserializeVecTSIndexSignatureName(pos) {
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSModuleDeclarationBody(pos);
+  return uint8[pos] === 2 ? null : deserializeTSModuleDeclarationBody(pos);
 }
 
 function deserializeBoxTSModuleBlock(pos) {
@@ -7196,13 +7197,13 @@ function deserializeBoxTSTypeParameter(pos) {
 }
 
 function deserializeOptionBoxObjectExpression(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxObjectExpression(pos);
+  return uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0
+    ? null
+    : deserializeBoxObjectExpression(pos);
 }
 
 function deserializeOptionTSImportTypeQualifier(pos) {
-  if (uint8[pos] === 2) return null;
-  return deserializeTSImportTypeQualifier(pos);
+  return uint8[pos] === 2 ? null : deserializeTSImportTypeQualifier(pos);
 }
 
 function deserializeBoxTSImportTypeQualifiedName(pos) {
@@ -7210,8 +7211,7 @@ function deserializeBoxTSImportTypeQualifiedName(pos) {
 }
 
 function deserializeOptionTSMappedTypeModifierOperator(pos) {
-  if (uint8[pos] === 3) return null;
-  return deserializeTSMappedTypeModifierOperator(pos);
+  return uint8[pos] === 3 ? null : deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {
@@ -7223,8 +7223,9 @@ function deserializeU32(pos) {
 }
 
 function deserializeOptionNameSpan(pos) {
-  if (uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0) return null;
-  return deserializeNameSpan(pos);
+  return uint32[(pos + 8) >> 2] === 0 && uint32[(pos + 12) >> 2] === 0
+    ? null
+    : deserializeNameSpan(pos);
 }
 
 function deserializeVecError(pos) {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -979,8 +979,7 @@ fn generate_option(
     #[rustfmt::skip]
     write_it!(code, "
         function {fn_name}(pos) {{
-            if ({none_condition}) return null;
-            return {inner_fn_name}({payload_offset});
+            return ({none_condition}) ? null : {inner_fn_name}({payload_offset});
         }}
     ");
 }


### PR DESCRIPTION
Refactor. Just shorten the code generated for deserializing `Option`s in raw transfer deserializer.