### PR TITLE
fix(linter): trim newlines around script block in partial loaders to prevent false BOF/EOF in JS plugins

### DIFF
--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -4,7 +4,10 @@ use oxc_span::{SourceType, Span};
 
 use crate::loader::JavaScriptSource;
 
-use super::{COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_start};
+use super::{
+    COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_start,
+    trim_script_block_newlines,
+};
 
 const ASTRO_SPLIT: &str = "---";
 
@@ -62,8 +65,8 @@ impl<'a> AstroPartialLoader<'a> {
         let mut pointer = start;
 
         loop {
-            let js_start;
-            let js_end;
+            let mut js_start;
+            let mut js_end;
             // find opening "<script"
             if let Some(offset) = find_script_start(
                 self.source_text,
@@ -92,6 +95,12 @@ impl<'a> AstroPartialLoader<'a> {
             {
                 js_end = pointer + offset;
                 pointer += offset + SCRIPT_END.len();
+
+                trim_script_block_newlines(
+                    self.source_text.as_bytes(),
+                    &mut js_start,
+                    &mut js_end,
+                );
             } else {
                 break;
             }
@@ -129,7 +138,7 @@ mod test {
         let sources = parse_astro(source_text);
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].source_text.trim(), r#"console.log("Hi");"#);
-        assert_eq!(sources[0].start, 51);
+        assert_eq!(sources[0].start, 52);
     }
 
     #[test]
@@ -154,7 +163,23 @@ mod test {
         );
         assert_eq!(sources[0].start, 12);
         assert_eq!(sources[1].source_text.trim(), r#"console.log("Hi");"#);
-        assert_eq!(sources[1].start, 141);
+        assert_eq!(sources[1].start, 142);
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed() {
+        let source_text = "<script>\nconsole.log('hi');\n</script>";
+        let sources = parse_astro(source_text);
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_text, "console.log('hi');");
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed_crlf() {
+        let source_text = "<script>\r\nconsole.log('hi');\r\n</script>";
+        let sources = parse_astro(source_text);
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_text, "console.log('hi');");
     }
 
     #[test]
@@ -174,7 +199,7 @@ mod test {
         assert!(sources[0].source_text.is_empty());
         assert_eq!(sources[0].start, 102);
         assert_eq!(sources[1].source_text.trim(), r#"console.log("Hi");"#);
-        assert_eq!(sources[1].start, 129);
+        assert_eq!(sources[1].start, 130);
     }
 
     #[test]
@@ -208,6 +233,6 @@ mod test {
         assert!(sources[0].source_text.is_empty());
         assert_eq!(sources[0].start, 104);
         assert_eq!(sources[1].source_text.trim(), r#"console.log("Hi");"#);
-        assert_eq!(sources[1].start, 122);
+        assert_eq!(sources[1].start, 123);
     }
 }

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -96,11 +96,7 @@ impl<'a> AstroPartialLoader<'a> {
                 js_end = pointer + offset;
                 pointer += offset + SCRIPT_END.len();
 
-                trim_script_block_newlines(
-                    self.source_text.as_bytes(),
-                    &mut js_start,
-                    &mut js_end,
-                );
+                trim_script_block_newlines(self.source_text.as_bytes(), &mut js_start, &mut js_end);
             } else {
                 break;
             }

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -39,6 +39,28 @@ impl PartialLoader {
     }
 }
 
+/// Trim one leading newline and one trailing newline from the script block content range.
+///
+/// This prevents false "beginning of file" / "end of file" detection in external (JS) plugins,
+/// which see the extracted script block as a standalone file.
+/// See: <https://github.com/oxc-project/oxc/issues/20896>
+fn trim_script_block_newlines(source: &[u8], js_start: &mut usize, js_end: &mut usize) {
+    if let Some(content) = source.get(*js_start..*js_end) {
+        if content.starts_with(b"\r\n") {
+            *js_start += 2;
+        } else if content.starts_with(b"\n") {
+            *js_start += 1;
+        }
+    }
+    if let Some(content) = source.get(*js_start..*js_end) {
+        if content.ends_with(b"\r\n") {
+            *js_end -= 2;
+        } else if content.ends_with(b"\n") {
+            *js_end -= 1;
+        }
+    }
+}
+
 /// Find closing angle for situations where there is another `>` in between.
 /// e.g. `<script generic="T extends Record<string, string>">`
 /// or `<script attribute="text with > inside">`

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -6,7 +6,7 @@ use crate::loader::JavaScriptSource;
 
 use super::{
     COMMENT_END, COMMENT_START, SCRIPT_END, SCRIPT_START, find_script_closing_angle,
-    find_script_start,
+    find_script_start, trim_script_block_newlines,
 };
 
 pub struct SveltePartialLoader<'a> {
@@ -59,12 +59,14 @@ impl<'a> SveltePartialLoader<'a> {
         let is_ts = content.contains("ts");
 
         *pointer += offset + 1;
-        let js_start = *pointer;
+        let mut js_start = *pointer;
 
         // find "</script>"
         let offset = script_end_finder.find(&self.source_text.as_bytes()[*pointer..])?;
-        let js_end = *pointer + offset;
+        let mut js_end = *pointer + offset;
         *pointer += offset + SCRIPT_END.len();
+
+        trim_script_block_newlines(self.source_text.as_bytes(), &mut js_start, &mut js_end);
 
         let source_text = &self.source_text[js_start..js_end];
         let source_type = SourceType::mjs().with_typescript(is_ts);
@@ -108,6 +110,20 @@ mod test {
         let result = parse_svelte(source_text);
         assert_eq!(result.source_text, "b");
         assert_eq!(result.start, 79);
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed() {
+        let source_text = "<script>\nimport { onMount } from 'svelte';\n</script>";
+        let result = parse_svelte(source_text);
+        assert_eq!(result.source_text, "import { onMount } from 'svelte';");
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed_crlf() {
+        let source_text = "<script>\r\nimport { onMount } from 'svelte';\r\n</script>";
+        let result = parse_svelte(source_text);
+        assert_eq!(result.source_text, "import { onMount } from 'svelte';");
     }
 
     #[test]

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -6,7 +6,7 @@ use crate::frameworks::FrameworkOptions;
 
 use super::{
     COMMENT_END, COMMENT_START, JavaScriptSource, SCRIPT_END, SCRIPT_START,
-    find_script_closing_angle, find_script_start,
+    find_script_closing_angle, find_script_start, trim_script_block_newlines,
 };
 
 pub struct VuePartialLoader<'a> {
@@ -75,13 +75,15 @@ impl<'a> VuePartialLoader<'a> {
         }
 
         *pointer += offset + 1;
-        let js_start = *pointer;
+        let mut js_start = *pointer;
 
         // find "</script>"
         let script_end_finder: Finder<'_> = Finder::new(SCRIPT_END);
         let offset = script_end_finder.find(&self.source_text.as_bytes()[*pointer..])?;
-        let js_end = *pointer + offset;
+        let mut js_end = *pointer + offset;
         *pointer += offset + SCRIPT_END.len();
+
+        trim_script_block_newlines(self.source_text.as_bytes(), &mut js_start, &mut js_end);
 
         let source_text = &self.source_text[js_start..js_end];
         // NOTE: loader checked that source_text.len() is less than u32::MAX
@@ -313,6 +315,79 @@ mod test {
         let result: JavaScriptSource<'_> = parse_vue(source_text);
         assert_eq!(result.source_text, "b");
         assert_eq!(result.start, 79);
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed() {
+        let source_text = "<template>\n  <div>test</div>\n</template>\n\n<script setup lang=\"ts\">\nimport { ref } from 'vue';\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "import { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_leading_newline_trimmed_crlf() {
+        let source_text = "<script>\r\nimport { ref } from 'vue';\r\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "import { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_no_leading_newline_no_trim() {
+        let source_text = "<script>console.log('hi')</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "console.log('hi')");
+    }
+
+    #[test]
+    fn test_trailing_newline_trimmed() {
+        let source_text = "<script>\nimport { ref } from 'vue';\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "import { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_trailing_newline_trimmed_crlf() {
+        let source_text = "<script>\r\nimport { ref } from 'vue';\r\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "import { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_newline_only_script_block() {
+        let source_text = "<script>\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "");
+    }
+
+    #[test]
+    fn test_two_newlines_only_trims_one_each() {
+        let source_text = "<script>\n\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "");
+    }
+
+    #[test]
+    fn test_multiple_blank_lines_preserved() {
+        let source_text = "<script>\n\n\nimport { ref } from 'vue';\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.source_text, "\n\nimport { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_start_offset_after_trim() {
+        let source_text = "<script>\nimport { ref } from 'vue';\n</script>";
+        let result = parse_vue(source_text);
+        assert_eq!(result.start, 9);
+        assert_eq!(result.source_text, "import { ref } from 'vue';");
+    }
+
+    #[test]
+    fn test_issue_20896_repro() {
+        let source_text = "<template>\n  <div>test</div>\n</template>\n\n<script setup lang=\"ts\">\nimport { ref } from 'vue';\n\nconst test = ref();\n\n\n// ok\ntest.value = 'a';\n</script>";
+        let result = parse_vue(source_text);
+        assert!(!result.source_text.starts_with('\n'));
+        assert!(result.source_text.starts_with("import"));
+        assert!(!result.source_text.ends_with('\n'));
     }
 
     #[test]


### PR DESCRIPTION

fixes https://github.com/oxc-project/oxc/issues/20896