### PR TITLE
feat(linter): implement `react/jsx-no-leaked-render` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2352,6 +2352,11 @@ impl RuleRunner for crate::rules::jest::valid_title::ValidTitle {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::react::jsx_no_leaked_render::JsxNoLeakedRender {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::react::button_has_type::ButtonHasType {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::JSXOpeningElement]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -403,6 +403,7 @@ pub use crate::rules::react::jsx_max_depth::JsxMaxDepth as ReactJsxMaxDepth;
 pub use crate::rules::react::jsx_no_comment_textnodes::JsxNoCommentTextnodes as ReactJsxNoCommentTextnodes;
 pub use crate::rules::react::jsx_no_constructed_context_values::JsxNoConstructedContextValues as ReactJsxNoConstructedContextValues;
 pub use crate::rules::react::jsx_no_duplicate_props::JsxNoDuplicateProps as ReactJsxNoDuplicateProps;
+pub use crate::rules::react::jsx_no_leaked_render::JsxNoLeakedRender as ReactJsxNoLeakedRender;
 pub use crate::rules::react::jsx_no_script_url::JsxNoScriptUrl as ReactJsxNoScriptUrl;
 pub use crate::rules::react::jsx_no_target_blank::JsxNoTargetBlank as ReactJsxNoTargetBlank;
 pub use crate::rules::react::jsx_no_undef::JsxNoUndef as ReactJsxNoUndef;
@@ -1096,6 +1097,7 @@ pub enum RuleEnum {
     JestValidDescribeCallback(JestValidDescribeCallback),
     JestValidExpect(JestValidExpect),
     JestValidTitle(JestValidTitle),
+    ReactJsxNoLeakedRender(ReactJsxNoLeakedRender),
     ReactButtonHasType(ReactButtonHasType),
     ReactCheckedRequiresOnchangeOrReadonly(ReactCheckedRequiresOnchangeOrReadonly),
     ReactDisplayName(ReactDisplayName),
@@ -1854,7 +1856,8 @@ const JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID: usize = JEST_REQUIRE_TO_THROW_MESSAGE_
 const JEST_VALID_DESCRIBE_CALLBACK_ID: usize = JEST_REQUIRE_TOP_LEVEL_DESCRIBE_ID + 1usize;
 const JEST_VALID_EXPECT_ID: usize = JEST_VALID_DESCRIBE_CALLBACK_ID + 1usize;
 const JEST_VALID_TITLE_ID: usize = JEST_VALID_EXPECT_ID + 1usize;
-const REACT_BUTTON_HAS_TYPE_ID: usize = JEST_VALID_TITLE_ID + 1usize;
+const REACT_JSX_NO_LEAKED_RENDER_ID: usize = JEST_VALID_TITLE_ID + 1usize;
+const REACT_BUTTON_HAS_TYPE_ID: usize = REACT_JSX_NO_LEAKED_RENDER_ID + 1usize;
 const REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID: usize = REACT_BUTTON_HAS_TYPE_ID + 1usize;
 const REACT_DISPLAY_NAME_ID: usize = REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID + 1usize;
 const REACT_EXHAUSTIVE_DEPS_ID: usize = REACT_DISPLAY_NAME_ID + 1usize;
@@ -2675,6 +2678,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JEST_VALID_DESCRIBE_CALLBACK_ID,
             Self::JestValidExpect(_) => JEST_VALID_EXPECT_ID,
             Self::JestValidTitle(_) => JEST_VALID_TITLE_ID,
+            Self::ReactJsxNoLeakedRender(_) => REACT_JSX_NO_LEAKED_RENDER_ID,
             Self::ReactButtonHasType(_) => REACT_BUTTON_HAS_TYPE_ID,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 REACT_CHECKED_REQUIRES_ONCHANGE_OR_READONLY_ID
@@ -3493,6 +3497,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::NAME,
             Self::JestValidExpect(_) => JestValidExpect::NAME,
             Self::JestValidTitle(_) => JestValidTitle::NAME,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::NAME,
             Self::ReactButtonHasType(_) => ReactButtonHasType::NAME,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::NAME
@@ -4327,6 +4332,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::CATEGORY,
             Self::JestValidExpect(_) => JestValidExpect::CATEGORY,
             Self::JestValidTitle(_) => JestValidTitle::CATEGORY,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::CATEGORY,
             Self::ReactButtonHasType(_) => ReactButtonHasType::CATEGORY,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::CATEGORY
@@ -5164,6 +5170,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::FIX,
             Self::JestValidExpect(_) => JestValidExpect::FIX,
             Self::JestValidTitle(_) => JestValidTitle::FIX,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::FIX,
             Self::ReactButtonHasType(_) => ReactButtonHasType::FIX,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::FIX
@@ -6071,6 +6078,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::documentation(),
             Self::JestValidExpect(_) => JestValidExpect::documentation(),
             Self::JestValidTitle(_) => JestValidTitle::documentation(),
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::documentation(),
             Self::ReactButtonHasType(_) => ReactButtonHasType::documentation(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::documentation()
@@ -7602,6 +7610,8 @@ impl RuleEnum {
                 .or_else(|| JestValidExpect::schema(generator)),
             Self::JestValidTitle(_) => JestValidTitle::config_schema(generator)
                 .or_else(|| JestValidTitle::schema(generator)),
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::config_schema(generator)
+                .or_else(|| ReactJsxNoLeakedRender::schema(generator)),
             Self::ReactButtonHasType(_) => ReactButtonHasType::config_schema(generator)
                 .or_else(|| ReactButtonHasType::schema(generator)),
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
@@ -8954,6 +8964,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => "jest",
             Self::JestValidExpect(_) => "jest",
             Self::JestValidTitle(_) => "jest",
+            Self::ReactJsxNoLeakedRender(_) => "react",
             Self::ReactButtonHasType(_) => "react",
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => "react",
             Self::ReactDisplayName(_) => "react",
@@ -10489,6 +10500,9 @@ impl RuleEnum {
             Self::JestValidTitle(_) => {
                 Ok(Self::JestValidTitle(JestValidTitle::from_configuration(value)?))
             }
+            Self::ReactJsxNoLeakedRender(_) => {
+                Ok(Self::ReactJsxNoLeakedRender(ReactJsxNoLeakedRender::from_configuration(value)?))
+            }
             Self::ReactButtonHasType(_) => {
                 Ok(Self::ReactButtonHasType(ReactButtonHasType::from_configuration(value)?))
             }
@@ -11955,6 +11969,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.to_configuration(),
             Self::JestValidExpect(rule) => rule.to_configuration(),
             Self::JestValidTitle(rule) => rule.to_configuration(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.to_configuration(),
             Self::ReactButtonHasType(rule) => rule.to_configuration(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.to_configuration(),
             Self::ReactDisplayName(rule) => rule.to_configuration(),
@@ -12671,6 +12686,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run(node, ctx),
             Self::JestValidExpect(rule) => rule.run(node, ctx),
             Self::JestValidTitle(rule) => rule.run(node, ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run(node, ctx),
             Self::ReactButtonHasType(rule) => rule.run(node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run(node, ctx),
             Self::ReactDisplayName(rule) => rule.run(node, ctx),
@@ -13385,6 +13401,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_once(ctx),
             Self::JestValidExpect(rule) => rule.run_once(ctx),
             Self::JestValidTitle(rule) => rule.run_once(ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_once(ctx),
             Self::ReactButtonHasType(rule) => rule.run_once(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_once(ctx),
             Self::ReactDisplayName(rule) => rule.run_once(ctx),
@@ -14167,6 +14184,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidExpect(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactButtonHasType(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
                 rule.run_on_jest_node(jest_node, ctx)
@@ -14913,6 +14931,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.should_run(ctx),
             Self::JestValidExpect(rule) => rule.should_run(ctx),
             Self::JestValidTitle(rule) => rule.should_run(ctx),
+            Self::ReactJsxNoLeakedRender(rule) => rule.should_run(ctx),
             Self::ReactButtonHasType(rule) => rule.should_run(ctx),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.should_run(ctx),
             Self::ReactDisplayName(rule) => rule.should_run(ctx),
@@ -15787,6 +15806,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::IS_TSGOLINT_RULE,
             Self::JestValidExpect(_) => JestValidExpect::IS_TSGOLINT_RULE,
             Self::JestValidTitle(_) => JestValidTitle::IS_TSGOLINT_RULE,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::IS_TSGOLINT_RULE,
             Self::ReactButtonHasType(_) => ReactButtonHasType::IS_TSGOLINT_RULE,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::IS_TSGOLINT_RULE
@@ -16748,6 +16768,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(_) => JestValidDescribeCallback::HAS_CONFIG,
             Self::JestValidExpect(_) => JestValidExpect::HAS_CONFIG,
             Self::JestValidTitle(_) => JestValidTitle::HAS_CONFIG,
+            Self::ReactJsxNoLeakedRender(_) => ReactJsxNoLeakedRender::HAS_CONFIG,
             Self::ReactButtonHasType(_) => ReactButtonHasType::HAS_CONFIG,
             Self::ReactCheckedRequiresOnchangeOrReadonly(_) => {
                 ReactCheckedRequiresOnchangeOrReadonly::HAS_CONFIG
@@ -17532,6 +17553,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.types_info(),
             Self::JestValidExpect(rule) => rule.types_info(),
             Self::JestValidTitle(rule) => rule.types_info(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.types_info(),
             Self::ReactButtonHasType(rule) => rule.types_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.types_info(),
             Self::ReactDisplayName(rule) => rule.types_info(),
@@ -18246,6 +18268,7 @@ impl RuleEnum {
             Self::JestValidDescribeCallback(rule) => rule.run_info(),
             Self::JestValidExpect(rule) => rule.run_info(),
             Self::JestValidTitle(rule) => rule.run_info(),
+            Self::ReactJsxNoLeakedRender(rule) => rule.run_info(),
             Self::ReactButtonHasType(rule) => rule.run_info(),
             Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => rule.run_info(),
             Self::ReactDisplayName(rule) => rule.run_info(),
@@ -19046,6 +19069,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestValidDescribeCallback(JestValidDescribeCallback::default()),
         RuleEnum::JestValidExpect(JestValidExpect::default()),
         RuleEnum::JestValidTitle(JestValidTitle::default()),
+        RuleEnum::ReactJsxNoLeakedRender(ReactJsxNoLeakedRender::default()),
         RuleEnum::ReactButtonHasType(ReactButtonHasType::default()),
         RuleEnum::ReactCheckedRequiresOnchangeOrReadonly(
             ReactCheckedRequiresOnchangeOrReadonly::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -402,6 +402,7 @@ pub(crate) mod react {
     pub mod jsx_no_comment_textnodes;
     pub mod jsx_no_constructed_context_values;
     pub mod jsx_no_duplicate_props;
+    pub mod jsx_no_leaked_render;
     pub mod jsx_no_script_url;
     pub mod jsx_no_target_blank;
     pub mod jsx_no_undef;

--- a/crates/oxc_linter/src/rules/react/jsx_no_leaked_render.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_leaked_render.rs
@@ -1,0 +1,1098 @@
+use oxc_ast::{
+    AstKind,
+    ast::{ConditionalExpression, Expression, LogicalExpression, LogicalOperator, UnaryOperator},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    fixer::{RuleFix, RuleFixer},
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn jsx_no_leaked_render_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Potential leaked value that might cause unintentionally rendered values or rendering crashes",
+    )
+    .with_help(
+        "Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`",
+    )
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum ValidStrategy {
+    Ternary,
+    Coerce,
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct JsxNoLeakedRender {
+    /// Allowed fix strategies. Possible values: `"ternary"`, `"coerce"`.
+    valid_strategies: Vec<ValidStrategy>,
+    /// When `true`, ignores logical expressions in JSX attribute values.
+    ignore_attributes: bool,
+}
+
+impl Default for JsxNoLeakedRender {
+    fn default() -> Self {
+        Self {
+            valid_strategies: vec![ValidStrategy::Ternary, ValidStrategy::Coerce],
+            ignore_attributes: false,
+        }
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow leaked values in JSX.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using the `&&` operator to conditionally render JSX may unintentionally
+    /// render values like `0`, `NaN`, or empty strings in the DOM. In React Native,
+    /// rendering these values can crash the app.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// const Component = ({ count }) => {
+    ///   return <div>{count && <span>There are {count} results</span>}</div>
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// const Component = ({ count }) => {
+    ///   return <div>{count ? <span>There are {count} results</span> : null}</div>
+    /// }
+    /// ```
+    JsxNoLeakedRender,
+    react,
+    nursery,
+    fix,
+    config = JsxNoLeakedRender,
+);
+
+impl Rule for JsxNoLeakedRender {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::JSXExpressionContainer(container) = node.kind() else { return };
+
+        if self.ignore_attributes {
+            let parent = ctx.nodes().parent_kind(node.id());
+            if matches!(parent, AstKind::JSXAttribute(_)) {
+                return;
+            }
+        }
+
+        let Some(expr) = container.expression.as_expression() else { return };
+
+        match expr {
+            Expression::LogicalExpression(logical) if logical.operator == LogicalOperator::And => {
+                check_and_expression(&self.valid_strategies, logical, expr, ctx);
+            }
+            Expression::ConditionalExpression(cond)
+                if self.valid_strategies == [ValidStrategy::Coerce] =>
+            {
+                check_conditional_expression(cond, ctx);
+            }
+            _ => {}
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.source_type().is_jsx()
+    }
+}
+
+fn check_and_expression<'a>(
+    strategies: &[ValidStrategy],
+    logical: &LogicalExpression<'a>,
+    expr: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) {
+    // {count > 0 && title} with ternary-only: all && in JSX must use ternary
+    if strategies == [ValidStrategy::Ternary] {
+        ctx.diagnostic_with_fix(jsx_no_leaked_render_diagnostic(logical.span), |fixer| {
+            fix_with_ternary(logical, ctx, fixer)
+        });
+        return;
+    }
+
+    let operands = collect_and_operands(expr);
+    let has_unsafe = operands[..operands.len() - 1].iter().any(|op| !is_safe_left_expression(op));
+
+    if !has_unsafe {
+        return;
+    }
+
+    let prefers_ternary = strategies.first() == Some(&ValidStrategy::Ternary);
+    if prefers_ternary {
+        ctx.diagnostic_with_fix(jsx_no_leaked_render_diagnostic(logical.span), |fixer| {
+            fix_with_ternary(logical, ctx, fixer)
+        });
+    } else {
+        ctx.diagnostic_with_fix(jsx_no_leaked_render_diagnostic(logical.span), |fixer| {
+            fix_with_coerce(expr, fixer)
+        });
+    }
+}
+
+fn check_conditional_expression<'a>(cond: &ConditionalExpression<'a>, ctx: &LintContext<'a>) {
+    // {count ? title : null} with coerce-only: ternary should use coerce
+    if !is_null_literal(&cond.alternate) {
+        return;
+    }
+
+    ctx.diagnostic_with_fix(jsx_no_leaked_render_diagnostic(cond.span), |fixer| {
+        fix_ternary_to_coerce(cond, ctx, fixer)
+    });
+}
+
+// `a && b && c` (parsed as `(a && b) && c`) → `[a, b, c]`
+fn collect_and_operands<'a, 'b>(expr: &'b Expression<'a>) -> Vec<&'b Expression<'a>> {
+    let mut operands = Vec::new();
+    let mut current = expr;
+    loop {
+        if let Expression::LogicalExpression(logical) = current
+            && logical.operator == LogicalOperator::And
+        {
+            operands.push(&logical.right);
+            current = &logical.left;
+            continue;
+        }
+        operands.push(current);
+        break;
+    }
+    operands.reverse();
+    operands
+}
+
+fn is_safe_left_expression(expr: &Expression) -> bool {
+    match expr {
+        // !x and !!x always produce boolean
+        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => true,
+        // Comparison/equality operators always produce boolean
+        Expression::BinaryExpression(binary) => {
+            binary.operator.is_compare() || binary.operator.is_equality()
+        }
+        // Boolean(x) call
+        Expression::CallExpression(call) => {
+            matches!(&call.callee, Expression::Identifier(ident) if ident.name == "Boolean")
+        }
+        // Empty string is falsy — right side is never rendered, so no leak
+        Expression::StringLiteral(s) if s.value.is_empty() => true,
+        _ => false,
+    }
+}
+
+fn is_null_literal(expr: &Expression) -> bool {
+    matches!(expr, Expression::NullLiteral(_))
+}
+
+fn fix_with_ternary<'a>(
+    logical: &LogicalExpression<'a>,
+    ctx: &LintContext<'a>,
+    fixer: RuleFixer<'_, 'a>,
+) -> RuleFix {
+    let source = ctx.source_text();
+    let left_text = get_ternary_condition_text(&logical.left, source);
+    let right_text = logical.right.span().source_text(source);
+    fixer.replace(logical.span, format!("{left_text} ? {right_text} : null"))
+}
+
+fn get_ternary_condition_text(expr: &Expression, source: &str) -> String {
+    if let Expression::UnaryExpression(outer) = expr
+        && outer.operator == UnaryOperator::LogicalNot
+        && let Expression::UnaryExpression(inner) = &outer.argument
+        && inner.operator == UnaryOperator::LogicalNot
+    {
+        let inner_expr = inner.argument.without_parentheses();
+        return inner_expr.span().source_text(source).to_string();
+    }
+    expr.span().source_text(source).to_string()
+}
+
+fn fix_with_coerce<'a>(expr: &Expression<'a>, fixer: RuleFixer<'_, 'a>) -> RuleFix {
+    let operands = collect_and_operands(expr);
+    let unsafe_count =
+        operands[..operands.len() - 1].iter().filter(|op| !is_safe_left_expression(op)).count();
+
+    let mut fix = fixer.new_fix_with_capacity(unsafe_count);
+    for operand in &operands[..operands.len() - 1] {
+        if !is_safe_left_expression(operand) {
+            fix.push(fixer.insert_text_before(&operand.span(), "!!"));
+        }
+    }
+    fix
+}
+
+fn fix_ternary_to_coerce<'a>(
+    cond: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
+    fixer: RuleFixer<'_, 'a>,
+) -> RuleFix {
+    let source = ctx.source_text();
+    let consequent_text = cond.consequent.span().source_text(source);
+    let coerced_test = coerce_test_text(&cond.test, source);
+    fixer.replace(cond.span, format!("{coerced_test} && {consequent_text}"))
+}
+
+fn coerce_test_text(expr: &Expression, source: &str) -> String {
+    if is_safe_left_expression(expr) {
+        return expr.span().source_text(source).to_string();
+    }
+
+    // For `a && b` test: coerce each unsafe operand
+    if let Expression::LogicalExpression(logical) = expr
+        && logical.operator == LogicalOperator::And
+    {
+        let operands = collect_and_operands(expr);
+        let parts: Vec<String> = operands
+            .iter()
+            .map(|op| {
+                let text = op.span().source_text(source);
+                if is_safe_left_expression(op) { text.to_string() } else { format!("!!{text}") }
+            })
+            .collect();
+        return parts.join(" && ");
+    }
+
+    format!("!!{}", expr.span().source_text(source))
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        // Boolean-safe left sides (default config)
+        (r"const C = () => <div>{!!count && <span />}</div>", None),
+        (r"const C = () => <div>{Boolean(count) && <span />}</div>", None),
+        (r"const C = () => <div>{count > 0 && <span />}</div>", None),
+        (r"const C = () => <div>{count !== 0 && <span />}</div>", None),
+        (r"const C = () => <div>{a === b && <span />}</div>", None),
+        (r"const C = () => <div>{!condition && <span />}</div>", None),
+        // Ternary is fine with default config
+        (r"const C = () => <div>{count ? <span /> : null}</div>", None),
+        // Coerce-only: coerced values are fine
+        (
+            r"const C = () => <div>{!!count && <span />}</div>",
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r"const C = () => <div>{Boolean(count) && <span />}</div>",
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Ternary-only: ternary is fine
+        (
+            r"const C = () => <div>{count ? <span /> : null}</div>",
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        // ignoreAttributes: attribute values are skipped
+        (
+            r"const C = () => <Foo checked={enabled && checked} />",
+            Some(serde_json::json!([{ "ignoreAttributes": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        // Boolean literals are flagged (redundant)
+        (r"const C = () => <div>{true && <span />}</div>", None),
+        // Default config: && with unsafe left side
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            None,
+        ),
+        // Default config: && with both strategies explicit
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])),
+        ),
+        // Ternary-only: ALL && are flagged even with boolean-safe left side
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ someCondition, title }) => {
+              return <div>{!someCondition && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!!count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count > 0 && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{0 != count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, total, title }) => {
+              return <div>{count < total && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title, somethingElse }) => {
+              return <div>{!!(count && somethingElse) && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        // Coerce-only: && with unsafe left side
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ connection, hasError, hasErrorUpdate}) => {
+              return <div>{connection && (hasError || hasErrorUpdate)}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Coerce-only: ternary with null alternate should use coerce
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!count ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, somethingElse, title }) => {
+              return <div>{count && somethingElse ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Chained && with coerce
+        (
+            r#"
+            const Component = ({ items, somethingElse, title }) => {
+              return <div>{items.length > 0 && somethingElse && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const MyComponent = () => {
+              const items = []
+              const breakpoint = { phones: true }
+              return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])),
+        ),
+        // Coerce-only with ternary inside &&
+        (
+            r#"
+            const MyComponent = () => {
+              return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Attribute values (default: not ignored)
+        (
+            r#"
+            const Component = ({ enabled, checked }) => {
+              return <CheckBox checked={enabled && checked} />
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const isOpen = 0;
+            const Component = () => {
+              return <Popover open={isOpen && items.length > 0} />
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // ignoreAttributes: still checks children inside attribute JSX
+        (
+            r#"
+            const Component = ({ enabled }) => {
+              return (
+                <Foo bar={
+                  <Something>{enabled && <MuchWow />}</Something>
+                } />
+              )
+            }
+        "#,
+            Some(serde_json::json!([{ "ignoreAttributes": true }])),
+        ),
+    ];
+
+    let fix = vec![
+        // Default config: fix with ternary (preferred first strategy)
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count ? title : null}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count ? <span>There are {count} results</span> : null}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length ? <List elements={elements}/> : null}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+            }
+        "#,
+            None,
+        ),
+        // Explicit ["coerce", "ternary"]: first strategy is coerce
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])),
+        ),
+        // Ternary-only fixes
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count ? <span>There are {count} results</span> : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length ? <List elements={elements}/> : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        // Ternary-only: strips ! for non-negated, keeps ! for negated
+        (
+            r#"
+            const Component = ({ someCondition, title }) => {
+              return <div>{!someCondition && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ someCondition, title }) => {
+              return <div>{!someCondition ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        // Ternary-only: strips !! from left side
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!!count && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count > 0 && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count > 0 ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{0 != count && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{0 != count ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, total, title }) => {
+              return <div>{count < total && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, total, title }) => {
+              return <div>{count < total ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title, somethingElse }) => {
+              return <div>{!!(count && somethingElse) && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title, somethingElse }) => {
+              return <div>{count && somethingElse ? title : null}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["ternary"] }])),
+        ),
+        // Coerce-only fixes: add !! before unsafe operands
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!!count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count }) => {
+              return <div>{count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count }) => {
+              return <div>{!!count && <span>There are {count} results</span>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{!!elements.length && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ nestedCollection }) => {
+              return <div>{!!nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ elements }) => {
+              return <div>{!!elements[0] && <List elements={elements}/>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ numberA, numberB }) => {
+              return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ connection, hasError, hasErrorUpdate}) => {
+              return <div>{connection && (hasError || hasErrorUpdate)}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ connection, hasError, hasErrorUpdate}) => {
+              return <div>{!!connection && (hasError || hasErrorUpdate)}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Coerce-only: convert ternary with null to coerce
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{count ? title : null}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!!count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!count ? title : null}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, title }) => {
+              return <div>{!count && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const Component = ({ count, somethingElse, title }) => {
+              return <div>{count && somethingElse ? title : null}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ count, somethingElse, title }) => {
+              return <div>{!!count && !!somethingElse && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Chained && with coerce: only coerce unsafe operands
+        (
+            r#"
+            const Component = ({ items, somethingElse, title }) => {
+              return <div>{items.length > 0 && somethingElse && title}</div>
+            }
+        "#,
+            r#"
+            const Component = ({ items, somethingElse, title }) => {
+              return <div>{items.length > 0 && !!somethingElse && title}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        (
+            r#"
+            const MyComponent = () => {
+              const items = []
+              const breakpoint = { phones: true }
+              return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+            }
+        "#,
+            r#"
+            const MyComponent = () => {
+              const items = []
+              const breakpoint = { phones: true }
+              return <div>{items.length > 0 && !!breakpoint.phones && <span />}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce", "ternary"] }])),
+        ),
+        (
+            r#"
+            const MyComponent = () => {
+              return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+            }
+        "#,
+            r#"
+            const MyComponent = () => {
+              return <div>{!!maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // Attribute values
+        (
+            r#"
+            const Component = ({ enabled, checked }) => {
+              return <CheckBox checked={enabled && checked} />
+            }
+        "#,
+            r#"
+            const Component = ({ enabled, checked }) => {
+              return <CheckBox checked={enabled ? checked : null} />
+            }
+        "#,
+            None,
+        ),
+        (
+            r#"
+            const isOpen = 0;
+            const Component = () => {
+              return <Popover open={isOpen && items.length > 0} />
+            }
+        "#,
+            r#"
+            const isOpen = 0;
+            const Component = () => {
+              return <Popover open={!!isOpen && items.length > 0} />
+            }
+        "#,
+            Some(serde_json::json!([{ "validStrategies": ["coerce"] }])),
+        ),
+        // ignoreAttributes: still fixes children inside attribute JSX
+        (
+            r#"
+            const Component = ({ enabled }) => {
+              return (
+                <Foo bar={
+                  <Something>{enabled && <MuchWow />}</Something>
+                } />
+              )
+            }
+        "#,
+            r#"
+            const Component = ({ enabled }) => {
+              return (
+                <Foo bar={
+                  <Something>{enabled ? <MuchWow /> : null}</Something>
+                } />
+              )
+            }
+        "#,
+            Some(serde_json::json!([{ "ignoreAttributes": true }])),
+        ),
+    ];
+
+    Tester::new(JsxNoLeakedRender::NAME, JsxNoLeakedRender::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/react_jsx_no_leaked_render.snap
+++ b/crates/oxc_linter/src/snapshots/react_jsx_no_leaked_render.snap
@@ -1,0 +1,325 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:1:23]
+ 1 │ const C = () => <div>{true && <span />}</div>
+   ·                       ────────────────
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{count && title}</div>
+   ·                            ──────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count }) => {
+ 3 │               return <div>{count && <span>There are {count} results</span>}</div>
+   ·                            ───────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ nestedCollection }) => {
+ 3 │               return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                            ────────────────────────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ numberA, numberB }) => {
+ 3 │               return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                            ────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ numberA, numberB }) => {
+ 3 │               return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                            ────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{count && title}</div>
+   ·                            ──────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count }) => {
+ 3 │               return <div>{count && <span>There are {count} results</span>}</div>
+   ·                            ───────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ nestedCollection }) => {
+ 3 │               return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                            ────────────────────────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ numberA, numberB }) => {
+ 3 │               return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                            ────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ someCondition, title }) => {
+ 3 │               return <div>{!someCondition && title}</div>
+   ·                            ───────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{!!count && title}</div>
+   ·                            ────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{count > 0 && title}</div>
+   ·                            ──────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{0 != count && title}</div>
+   ·                            ───────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, total, title }) => {
+ 3 │               return <div>{count < total && title}</div>
+   ·                            ──────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title, somethingElse }) => {
+ 3 │               return <div>{!!(count && somethingElse) && title}</div>
+   ·                            ───────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{count && title}</div>
+   ·                            ──────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count }) => {
+ 3 │               return <div>{count && <span>There are {count} results</span>}</div>
+   ·                            ───────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements.length && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ nestedCollection }) => {
+ 3 │               return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+   ·                            ────────────────────────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ elements }) => {
+ 3 │               return <div>{elements[0] && <List elements={elements}/>}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ numberA, numberB }) => {
+ 3 │               return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+   ·                            ────────────────────────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ connection, hasError, hasErrorUpdate}) => {
+ 3 │               return <div>{connection && (hasError || hasErrorUpdate)}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{count ? title : null}</div>
+   ·                            ────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, title }) => {
+ 3 │               return <div>{!count ? title : null}</div>
+   ·                            ─────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ count, somethingElse, title }) => {
+ 3 │               return <div>{count && somethingElse ? title : null}</div>
+   ·                            ─────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const Component = ({ items, somethingElse, title }) => {
+ 3 │               return <div>{items.length > 0 && somethingElse && title}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:5:28]
+ 4 │               const breakpoint = { phones: true }
+ 5 │               return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+   ·                            ─────────────────────────────────────────────────
+ 6 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:28]
+ 2 │             const MyComponent = () => {
+ 3 │               return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+   ·                            ──────────────────────────────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:3:41]
+ 2 │             const Component = ({ enabled, checked }) => {
+ 3 │               return <CheckBox checked={enabled && checked} />
+   ·                                         ──────────────────
+ 4 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:4:37]
+ 3 │             const Component = () => {
+ 4 │               return <Popover open={isOpen && items.length > 0} />
+   ·                                     ──────────────────────────
+ 5 │             }
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`
+
+  ⚠ eslint-plugin-react(jsx-no-leaked-render): Potential leaked value that might cause unintentionally rendered values or rendering crashes
+   ╭─[jsx_no_leaked_render.tsx:5:31]
+ 4 │                 <Foo bar={
+ 5 │                   <Something>{enabled && <MuchWow />}</Something>
+   ·                               ──────────────────────
+ 6 │                 } />
+   ╰────
+  help: Coerce the expression to a boolean using `!!` or use a ternary `? ... : null`


### PR DESCRIPTION
Implements the [`react/jsx-no-leaked-render`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md) rule.

Part of #1022.

## What the rule does

Prevents potential leaked values from being rendered in JSX. Using the `&&` operator to conditionally render may unintentionally render `0`, `NaN`, or other falsy non-boolean values in the DOM. In React Native, this can crash the app.

```jsx
// Bad
{count && <span />}

// Good
{count ? <span /> : null}
{!!count && <span />}
```

## Configuration

- **`validStrategies`**: `["ternary"]`, `["coerce"]`, or both (default: `["ternary", "coerce"]`)
- **`ignoreAttributes`**: skip attribute values when `true` (default: `false`)

## What's included

- Detection of unsafe `&&` left-side operands (identifiers, member expressions, numeric/boolean literals, `||` sub-expressions)
- Chained `&&` operand analysis (`a > 0 && b && <C />` only flags `b`)
- Ternary-only mode: flags all `&&` in JSX regardless of left-side safety
- Coerce-only mode: flags `&&` with unsafe left side + flags `cond ? x : null` ternaries
- Auto-fix: ternary (`count ? <X /> : null`) or coerce (`!!count && <X />`)
- `ignoreAttributes` support (still checks children inside attribute JSX)
- Verified identical behavior against ESLint's `react/jsx-no-leaked-render` across all patterns

## AI Disclosure

Implementation generated with Claude Code (Opus 4.6). Reviewed, tested, and verified against ESLint by me.