### PR TITLE
fix(ast_tools): correct error message and doc comment

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -521,7 +521,7 @@ impl<'s> StructSerializerGenerator<'s> {
 
             value.unwrap_or_else(|| {
                 panic!(
-                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str`, `Str`, or `Ident`: {}::{}",
+                    "`#[estree(json_safe)]` is only valid on struct fields containing a `&str`, `Str`, `Ident`, or `Option` of one of those: {}::{}",
                     struct_def.name(),
                     field.name(),
                 )

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -79,7 +79,8 @@ pub struct ESTreeStructField {
     pub flatten: bool,
     /// No not flatten field. Overrides `#[estree(flatten)]` on the type of the field.
     pub no_flatten: bool,
-    /// `true` for fields containing a `&str` or `Str` which does not need escaping in JSON
+    /// `true` for fields containing a `&str`, `Str`, `Ident`, or `Option` of one of those,
+    /// which does not need escaping in JSON.
     pub json_safe: bool,
     /// `true` for fields containing a `&str`, `Str`, `Ident`, or `Option` of one of those,
     /// whose contents can be derived from a slice of source text with `Span` for the struct.


### PR DESCRIPTION
Correct an incorrect error message, and a doc comment which was out of date after the introduction of `Ident` type.