### PR TITLE
refactor(ast): simplify ESTree serialization of `Ident`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -236,7 +236,6 @@ pub use match_expression;
 pub struct IdentifierName<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
-    #[estree(json_safe)]
     pub name: Ident<'a>,
 }
 
@@ -257,7 +256,6 @@ pub struct IdentifierReference<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
     /// The name of the identifier being referenced.
-    #[estree(json_safe)]
     pub name: Ident<'a>,
     /// Reference ID
     ///
@@ -287,7 +285,6 @@ pub struct BindingIdentifier<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
     /// The identifier name being bound.
-    #[estree(json_safe)]
     pub name: Ident<'a>,
     /// Unique identifier for this binding.
     ///
@@ -314,7 +311,6 @@ pub struct BindingIdentifier<'a> {
 pub struct LabelIdentifier<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
-    #[estree(json_safe)]
     pub name: Ident<'a>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -74,7 +74,7 @@ impl ESTree for IdentifierName<'_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_field("name", &self.name);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_span(self.span);
@@ -87,7 +87,7 @@ impl ESTree for IdentifierReference<'_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_field("name", &self.name);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_span(self.span);
@@ -100,7 +100,7 @@ impl ESTree for BindingIdentifier<'_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_field("name", &self.name);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_span(self.span);
@@ -113,7 +113,7 @@ impl ESTree for LabelIdentifier<'_> {
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_field("name", &self.name);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
         state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
         state.serialize_span(self.span);

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -7,7 +7,7 @@ use oxc_allocator::{
     ident_hash, pack_len_hash,
 };
 #[cfg(feature = "serialize")]
-use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
+use oxc_estree::{ESTree, JsonSafeString, Serializer as ESTreeSerializer};
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer as SerdeSerializer};
 
@@ -435,7 +435,8 @@ impl Serialize for Ident<'_> {
 impl ESTree for Ident<'_> {
     #[inline] // Because it just delegates
     fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
-        ESTree::serialize(self.as_str(), serializer);
+        // `Ident`s are always JSON-safe
+        ESTree::serialize(&JsonSafeString(self.as_str()), serializer);
     }
 }
 


### PR DESCRIPTION
`Ident` is always JSON-safe (cannot contain characters which require escaping in JSON). Remove `#[estree(json_safe)]` from fields containing `Ident`, and apply the JSON-safe optimization as part of `Ident`'s `ESTree` impl.

This also fixes one `Ident` we'd missed flagging as JSON-safe previously - the `Ident` in `PrivateIdentifier` - which will be a small perf boost.