### PR TITLE
refactor(ast_visit): remove special case for `BindingRestElement` from `Utf8ToUtf16Converter`

### DIFF
--- a/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
+++ b/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
@@ -413,8 +413,9 @@ impl<'a> VisitMut<'a> for Utf8ToUtf16Converter<'_> {
     }
 
     fn visit_binding_rest_element(&mut self, it: &mut BindingRestElement<'a>) {
-        // Custom implementation
-        self.convert_binding_rest_element(it);
+        self.convert_offset(&mut it.span.start);
+        walk_mut::walk_binding_rest_element(self, it);
+        self.convert_offset(&mut it.span.end);
     }
 
     fn visit_function(&mut self, it: &mut Function<'a>, flags: ScopeFlags) {

--- a/crates/oxc_ast_visit/src/utf8_to_utf16/visit.rs
+++ b/crates/oxc_ast_visit/src/utf8_to_utf16/visit.rs
@@ -39,22 +39,6 @@ impl Utf8ToUtf16Converter<'_> {
         self.convert_offset(&mut prop.span.end);
     }
 
-    pub(crate) fn convert_binding_rest_element(
-        &mut self,
-        rest_element: &mut BindingRestElement<'_>,
-    ) {
-        self.convert_offset(&mut rest_element.span.start);
-        match &mut rest_element.argument {
-            BindingPattern::BindingIdentifier(ident) => self.visit_binding_identifier(ident),
-            BindingPattern::ObjectPattern(pattern) => self.visit_object_pattern(pattern),
-            BindingPattern::ArrayPattern(pattern) => self.visit_array_pattern(pattern),
-            BindingPattern::AssignmentPattern(pattern) => {
-                self.visit_assignment_pattern(pattern);
-            }
-        }
-        self.convert_offset(&mut rest_element.span.end);
-    }
-
     pub(crate) fn convert_binding_property(&mut self, prop: &mut BindingProperty<'_>) {
         self.convert_offset(&mut prop.span.start);
 

--- a/tasks/ast_tools/src/generators/utf8_to_utf16.rs
+++ b/tasks/ast_tools/src/generators/utf8_to_utf16.rs
@@ -39,8 +39,6 @@ impl Generator for Utf8ToUtf16ConverterGenerator {
 /// * `TemplateLiteral`s and `TSTemplateLiteralType`s, where `quasis` and `expressions` are interleaved.
 /// * Decorators before `export` in `@dec export class C {}` / `@dec export default class {}`
 ///   have span before the start of `ExportNamedDeclaration` / `ExportDefaultDeclaration` span.
-/// * `BindingPattern` where `type_annotation` has span within `BindingPatternKind`.
-///   Except for `BindingRestElement`, where `type_annotation`'s span is after `BindingPatternKind`.
 /// * `FormalParameters` where span can include a `TSThisParameter` which is visited before it.
 /// * `TSGlobalDeclaration` which has a separate `Span` for `global` keyword.
 ///
@@ -55,8 +53,6 @@ fn generate(schema: &Schema, codegen: &Codegen) -> TokenStream {
     let custom_visitor_type_ids = [
         "FormalParameters",
         "ObjectProperty",
-        "BindingPattern",
-        "BindingRestElement",
         "BindingProperty",
         "ExportNamedDeclaration",
         "ExportDefaultDeclaration",


### PR DESCRIPTION
Belated follow-up after #15925.  
  
Now that the weirdness of `BindingPattern` has been fixed, `BindingRestElement` doesn't need any special treatment in `Utf8ToUtf16Converter` visitor. The auto-generated visitor does the same as what the custom one was doing. So remove the custom one.