### PR TITLE
refactor(ast_tools): simplify `StructsAndEnums` iterator

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -24,7 +24,6 @@ src:
   - 'crates/oxc_ast_macros/src/lib.rs'
   - 'crates/oxc_ast_visit/src/**/*.rs'
   - 'crates/oxc_codegen/src/**/*.rs'
-  - 'crates/oxc_data_structures/src/**/*.rs'
   - 'crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs'
   - 'crates/oxc_formatter/src/ast_nodes/generated/format.rs'
   - 'crates/oxc_linter/src/**/*.rs'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,6 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_codegen",
- "oxc_data_structures",
  "oxc_index",
  "oxc_minifier",
  "oxc_parser",

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -28,8 +28,6 @@ oxc_parser = { workspace = true, optional = true }
 oxc_span = { workspace = true, features = ["serialize"], optional = true }
 oxc_syntax = { workspace = true, features = ["serialize"], optional = true }
 
-oxc_data_structures = { workspace = true, features = ["slice_iter"] }
-
 bitflags = { workspace = true }
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 convert_case = { workspace = true }

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -5,7 +5,6 @@ use rustc_hash::FxHashMap;
 #[expect(unused_imports)]
 use serde::Serialize;
 
-use oxc_data_structures::slice_iter::SliceIter;
 use oxc_index::{IndexVec, define_index_type};
 
 mod defs;
@@ -247,19 +246,16 @@ impl<'s> Iterator for StructsAndEnums<'s> {
     type Item = StructOrEnum<'s>;
 
     fn next(&mut self) -> Option<StructOrEnum<'s>> {
-        if let Some(type_def) = self.iter.next() {
-            match type_def {
-                TypeDef::Struct(struct_def) => Some(StructOrEnum::Struct(struct_def)),
-                TypeDef::Enum(enum_def) => Some(StructOrEnum::Enum(enum_def)),
-                _ => {
-                    // Structs and enums are always first in `Schema::types`,
-                    // so if we encounter a different type, iteration is done.
-                    self.iter.advance_to_end();
-                    None
-                }
+        let type_def = self.iter.next()?;
+
+        match type_def {
+            TypeDef::Struct(struct_def) => Some(StructOrEnum::Struct(struct_def)),
+            TypeDef::Enum(enum_def) => Some(StructOrEnum::Enum(enum_def)),
+            _ => {
+                // Structs and enums are always first in `Schema::types`,
+                // so if we encounter a different type, iteration is done
+                None
             }
-        } else {
-            None
         }
     }
 }


### PR DESCRIPTION
Refactor. Simplify and shorten the code for `StructsAndEnums` iterator in `ast_tools`.