### PR TITLE
perf(ast_tools): introduce `Structs` iterator and use it where possible

### DIFF
--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -797,9 +797,7 @@ fn template(krate: &str, assertions_64: &TokenStream, assertions_32: &TokenStrea
 /// `#[ast]` macro will re-order struct fields in order we provide here.
 fn generate_struct_details(schema: &Schema) -> Output {
     let mut map = PhfMapGen::new();
-    for type_def in &schema.types {
-        let TypeDef::Struct(struct_def) = type_def else { continue };
-
+    for struct_def in schema.structs() {
         // Get layout indexes of fields in source order.
         // If struct as written already has fields in layout order, then no-reordering is required,
         // in which case output `None`.

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -81,9 +81,7 @@ impl Generator for AstKindGenerator {
         let mut as_methods = quote!();
 
         let mut next_index = 0u16;
-        for type_def in &schema.types {
-            let Some(struct_def) = type_def.as_struct() else { continue };
-
+        for struct_def in schema.structs() {
             if !struct_def.kind.has_kind {
                 continue;
             }

--- a/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer_lazy.rs
@@ -362,10 +362,8 @@ impl<'s> CacheKeyOffsets<'s> {
         // Calculate cache key offset for all structs
         let mut cache_key_offsets = Self { offsets, estree_derive_id, span_type_id, schema };
 
-        for type_def in &schema.types {
-            if let TypeDef::Struct(struct_def) = type_def
-                && struct_def.generates_derive(estree_derive_id)
-            {
+        for struct_def in schema.structs() {
+            if struct_def.generates_derive(estree_derive_id) {
                 cache_key_offsets.calculate_struct_key_offset(struct_def);
             }
         }

--- a/tasks/ast_tools/src/generators/traverse/ancestor.rs
+++ b/tasks/ast_tools/src/generators/traverse/ancestor.rs
@@ -33,8 +33,7 @@ pub fn generate_ancestor(schema: &Schema) -> TokenStream {
 
     let mut discriminant = 1u16;
 
-    for type_def in &schema.types {
-        let TypeDef::Struct(struct_def) = type_def else { continue };
+    for struct_def in schema.structs() {
         if !struct_def.visit.has_visitor() {
             continue;
         }

--- a/tasks/ast_tools/src/generators/utf8_to_utf16.rs
+++ b/tasks/ast_tools/src/generators/utf8_to_utf16.rs
@@ -64,9 +64,7 @@ fn generate(schema: &Schema, codegen: &Codegen) -> TokenStream {
     ]
     .map(|type_name| schema.type_names[type_name]);
 
-    let methods = schema.types.iter().filter_map(|type_def| {
-        let struct_def = type_def.as_struct()?;
-
+    let methods = schema.structs().filter_map(|struct_def| {
         // Skip `Comment` because we handle adjusting comment spans separately
         if struct_def.id == comment_type_id {
             return None;

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -95,6 +95,11 @@ impl Schema {
     pub fn structs_and_enums(&self) -> StructsAndEnums<'_> {
         StructsAndEnums::new(self)
     }
+
+    /// Get iterator over all structs.
+    pub fn structs(&self) -> Structs<'_> {
+        Structs::new(self)
+    }
 }
 
 /// Methods for getting a specific type def (e.g. [`StructDef`]) for a [`TypeId`].
@@ -261,3 +266,33 @@ impl<'s> Iterator for StructsAndEnums<'s> {
 }
 
 impl FusedIterator for StructsAndEnums<'_> {}
+
+/// Iterator over structs.
+pub struct Structs<'s> {
+    iter: slice::Iter<'s, TypeDef>,
+}
+
+impl<'s> Structs<'s> {
+    fn new(schema: &'s Schema) -> Self {
+        Self { iter: schema.types.iter() }
+    }
+}
+
+impl<'s> Iterator for Structs<'s> {
+    type Item = &'s StructDef;
+
+    fn next(&mut self) -> Option<&'s StructDef> {
+        for type_def in &mut self.iter {
+            match type_def {
+                TypeDef::Struct(struct_def) => return Some(struct_def),
+                TypeDef::Enum(_) => {}
+                // Structs and enums are always first in `Schema::types`,
+                // so if we encounter a different type, iteration is done
+                _ => break,
+            }
+        }
+        None
+    }
+}
+
+impl FusedIterator for Structs<'_> {}


### PR DESCRIPTION
Many generators in `ast_tools` loop over all structs in the AST. Previously they iterated over all types in the schema, and skipped types which aren't structs. This is inefficient, as all structs and enums are at the start of the `types` `Vec`. Once the loop finds any other type (e.g. `Option`, `Box`, primitive), it's not possible for there to be further structs after it.

Introduce a `Structs` iterator which iterates only over structs, and terminates iteration early as soon as a type which isn't a struct or enum is found. This shortens code in many places, and reduces pointless iteration.