### PR TITLE
perf(ast_tools): use `StructsAndEnums` iterator where possible

### DIFF
--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -23,7 +23,7 @@ use crate::{
     output::{Output, output_path},
     schema::{
         Def, Discriminant, EnumDef, FieldDef, PointerKind, PrimitiveDef, Schema, StructDef,
-        TypeDef, TypeId, Visibility,
+        StructOrEnum, TypeDef, TypeId, Visibility,
         extensions::layout::{GetLayout, GetOffset, Layout, Niche, Offset, PlatformLayout},
     },
     utils::{format_cow, number_lit},
@@ -607,7 +607,7 @@ impl LayoutCalculator<'_> {
 fn generate_assertions(schema: &Schema) -> Vec<Output> {
     let mut assertions = FxHashMap::default();
 
-    for type_def in &schema.types {
+    for type_def in schema.structs_and_enums() {
         generate_layout_assertions(type_def, &mut assertions, schema);
     }
 
@@ -628,18 +628,17 @@ fn generate_assertions(schema: &Schema) -> Vec<Output> {
 
 /// Generate layout assertions for a type.
 fn generate_layout_assertions<'s>(
-    type_def: &TypeDef,
+    type_def: StructOrEnum<'s>,
     assertions: &mut FxHashMap<&'s str, (/* 64 bit */ TokenStream, /* 32 bit */ TokenStream)>,
     schema: &'s Schema,
 ) {
     match type_def {
-        TypeDef::Struct(struct_def) => {
+        StructOrEnum::Struct(struct_def) => {
             generate_layout_assertions_for_struct(struct_def, assertions, schema);
         }
-        TypeDef::Enum(enum_def) => {
+        StructOrEnum::Enum(enum_def) => {
             generate_layout_assertions_for_enum(enum_def, assertions, schema);
         }
-        _ => {}
     }
 }
 

--- a/tasks/ast_tools/src/generators/traverse/ancestor.rs
+++ b/tasks/ast_tools/src/generators/traverse/ancestor.rs
@@ -15,7 +15,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::{
-    schema::{Def, FieldDef, Schema, StructDef, TypeDef},
+    schema::{Def, FieldDef, Schema, StructDef, StructOrEnum, TypeDef},
     utils::upper_case_first,
 };
 
@@ -285,15 +285,18 @@ pub fn generate_ancestor(schema: &Schema) -> TokenStream {
 /// so we filter to types in the `oxc_ast` crate with import path starting with `::ast::`.
 fn field_is_visited(field: &FieldDef, schema: &Schema) -> bool {
     let inner_type = field.type_def(schema).innermost_type(schema);
-    is_ast_type_with_visitor(inner_type, schema)
+    if let Some(inner_type) = inner_type.as_struct_or_enum() {
+        is_ast_type_with_visitor(inner_type, schema)
+    } else {
+        false
+    }
 }
 
 /// Check if a type is an AST type (from `oxc_ast::ast::*`) with a visitor.
-pub fn is_ast_type_with_visitor(type_def: &TypeDef, schema: &Schema) -> bool {
+pub fn is_ast_type_with_visitor(type_def: StructOrEnum<'_>, schema: &Schema) -> bool {
     match type_def {
-        TypeDef::Struct(s) => s.visit.has_visitor() && is_ast_file(s.file(schema)),
-        TypeDef::Enum(e) => e.visit.has_visitor() && is_ast_file(e.file(schema)),
-        _ => false,
+        StructOrEnum::Struct(s) => s.visit.has_visitor() && is_ast_file(s.file(schema)),
+        StructOrEnum::Enum(e) => e.visit.has_visitor() && is_ast_file(e.file(schema)),
     }
 }
 

--- a/tasks/ast_tools/src/generators/traverse/mod.rs
+++ b/tasks/ast_tools/src/generators/traverse/mod.rs
@@ -14,7 +14,7 @@ use quote::quote;
 use crate::{
     Codegen, Generator, TRAVERSE_CRATE_PATH,
     output::{Output, output_path},
-    schema::{Def, Schema, TypeDef},
+    schema::{Def, Schema, StructOrEnum},
 };
 
 use self::ancestor::is_ast_type_with_visitor;
@@ -95,15 +95,14 @@ pub(super) fn generate_traverse_trait(
     let ctx_use = &config.ctx_use;
     let mut methods = quote!();
 
-    for type_def in &schema.types {
+    for type_def in schema.structs_and_enums() {
         if !is_ast_type_with_visitor(type_def, schema) {
             continue;
         }
 
         let (visitor_names, ty) = match type_def {
-            TypeDef::Struct(s) => (s.visit.visitor_names.as_ref().unwrap(), s.ty(schema)),
-            TypeDef::Enum(e) => (e.visit.visitor_names.as_ref().unwrap(), e.ty(schema)),
-            _ => continue,
+            StructOrEnum::Struct(s) => (s.visit.visitor_names.as_ref().unwrap(), s.ty(schema)),
+            StructOrEnum::Enum(e) => (e.visit.visitor_names.as_ref().unwrap(), e.ty(schema)),
         };
 
         let snake_name = traverse_snake_name(visitor_names);

--- a/tasks/ast_tools/src/generators/traverse/walk.rs
+++ b/tasks/ast_tools/src/generators/traverse/walk.rs
@@ -11,7 +11,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::{
-    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
+    schema::{Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef},
     utils::{create_ident, upper_case_first},
 };
 
@@ -60,18 +60,17 @@ pub(super) fn generate_walk(schema: &Schema, config: &WalkConfig) -> TokenStream
     let ctx_ty = &config.ctx_ty;
     let walk_generics = walk_generics_tokens(config);
 
-    for type_def in &schema.types {
+    for type_def in schema.structs_and_enums() {
         if !is_ast_type_with_visitor(type_def, schema) {
             continue;
         }
         match type_def {
-            TypeDef::Struct(struct_def) => {
+            StructOrEnum::Struct(struct_def) => {
                 walk_methods.extend(generate_walk_for_struct(struct_def, schema, config));
             }
-            TypeDef::Enum(enum_def) => {
+            StructOrEnum::Enum(enum_def) => {
                 walk_methods.extend(generate_walk_for_enum(enum_def, schema, config));
             }
-            _ => {}
         }
     }
 

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -12,7 +12,7 @@ use crate::{
         should_skip_enum_variant, should_skip_field,
     },
     output::Output,
-    schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, TypeId},
+    schema::{Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId},
     utils::{FxIndexSet, format_cow, write_it},
 };
 
@@ -51,7 +51,7 @@ fn generate_ts_type_defs(schema: &Schema, codegen: &Codegen) -> String {
 
     let mut code = String::new();
     let mut ast_node_names: Vec<String> = vec![];
-    for type_def in &schema.types {
+    for type_def in schema.structs_and_enums() {
         if type_def.generates_derive(estree_derive_id) {
             generate_ts_type_def(type_def, &mut code, &mut ast_node_names, program_type_id, schema);
         }
@@ -70,7 +70,7 @@ fn generate_ts_type_defs(schema: &Schema, codegen: &Codegen) -> String {
 ///
 /// Push type defs to `code`.
 fn generate_ts_type_def(
-    type_def: &TypeDef,
+    type_def: StructOrEnum<'_>,
     code: &mut String,
     ast_node_names: &mut Vec<String>,
     program_type_id: TypeId,
@@ -78,18 +78,16 @@ fn generate_ts_type_def(
 ) {
     // Skip TS def generation if `#[estree(no_ts_def)]` attribute
     let no_ts_def = match type_def {
-        TypeDef::Struct(struct_def) => &struct_def.estree.no_ts_def,
-        TypeDef::Enum(enum_def) => &enum_def.estree.no_ts_def,
-        _ => unreachable!(),
+        StructOrEnum::Struct(struct_def) => &struct_def.estree.no_ts_def,
+        StructOrEnum::Enum(enum_def) => &enum_def.estree.no_ts_def,
     };
 
     if !no_ts_def {
         let ts_def = match type_def {
-            TypeDef::Struct(struct_def) => {
+            StructOrEnum::Struct(struct_def) => {
                 generate_ts_type_def_for_struct(struct_def, ast_node_names, program_type_id, schema)
             }
-            TypeDef::Enum(enum_def) => generate_ts_type_def_for_enum(enum_def, schema),
-            _ => unreachable!(),
+            StructOrEnum::Enum(enum_def) => generate_ts_type_def_for_enum(enum_def, schema),
         };
 
         if let Some(ts_def) = ts_def {
@@ -99,9 +97,8 @@ fn generate_ts_type_def(
 
     // Add additional custom TS def if provided via `#[estree(add_ts_def = "...")]` attribute
     let add_ts_def = match type_def {
-        TypeDef::Struct(struct_def) => &struct_def.estree.add_ts_def,
-        TypeDef::Enum(enum_def) => &enum_def.estree.add_ts_def,
-        _ => unreachable!(),
+        StructOrEnum::Struct(struct_def) => &struct_def.estree.add_ts_def,
+        StructOrEnum::Enum(enum_def) => &enum_def.estree.add_ts_def,
     };
     if let Some(add_ts_def) = add_ts_def {
         write_it!(code, "export {add_ts_def};\n\n");

--- a/tasks/ast_tools/src/schema/defs/type.rs
+++ b/tasks/ast_tools/src/schema/defs/type.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 
 use super::{
     BoxDef, CellDef, Def, Derives, EnumDef, OptionDef, PointerDef, PrimitiveDef, Schema, StructDef,
-    TypeId, VecDef,
+    StructOrEnum, TypeId, VecDef,
 };
 
 /// Type definition for a type.
@@ -145,6 +145,14 @@ impl TypeDef {
     pub fn as_enum_mut(&mut self) -> Option<&mut EnumDef> {
         match self {
             Self::Enum(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    pub fn as_struct_or_enum(&self) -> Option<StructOrEnum<'_>> {
+        match self {
+            Self::Struct(def) => Some(StructOrEnum::Struct(def)),
+            Self::Enum(def) => Some(StructOrEnum::Enum(def)),
             _ => None,
         }
     }


### PR DESCRIPTION
Similar to #20944. In loops where a generator is only interested in structs and enums, use the `StructsAndEnums` iterator which exits early, rather than pointlessly continuing iterating over all types.