### PR TITLE
perf(ast_tools): introduce `StructsMut` iterator and use it where possible

### DIFF
--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -49,10 +49,8 @@ impl Generator for AstKindGenerator {
     /// Enums do not have an `AstKind`, unless included in `ENUMS_WHITE_LIST`.
     fn prepare(&self, schema: &mut Schema, _codegen: &Codegen) {
         // Set `has_kind = true` for all visited structs
-        for type_def in &mut schema.types {
-            if let TypeDef::Struct(struct_def) = type_def {
-                struct_def.kind.has_kind = struct_def.visit.has_visitor();
-            }
+        for struct_def in schema.structs_mut() {
+            struct_def.kind.has_kind = struct_def.visit.has_visitor();
         }
 
         // Set `has_kind = false` for structs in black list

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -100,6 +100,11 @@ impl Schema {
     pub fn structs(&self) -> Structs<'_> {
         Structs::new(self)
     }
+
+    /// Get iterator over all structs as mutable references.
+    pub fn structs_mut(&mut self) -> StructsMut<'_> {
+        StructsMut::new(self)
+    }
 }
 
 /// Methods for getting a specific type def (e.g. [`StructDef`]) for a [`TypeId`].
@@ -296,3 +301,33 @@ impl<'s> Iterator for Structs<'s> {
 }
 
 impl FusedIterator for Structs<'_> {}
+
+/// Iterator over structs, which produces mutable references.
+pub struct StructsMut<'s> {
+    iter: slice::IterMut<'s, TypeDef>,
+}
+
+impl<'s> StructsMut<'s> {
+    fn new(schema: &'s mut Schema) -> Self {
+        Self { iter: schema.types.iter_mut() }
+    }
+}
+
+impl<'s> Iterator for StructsMut<'s> {
+    type Item = &'s mut StructDef;
+
+    fn next(&mut self) -> Option<&'s mut StructDef> {
+        for type_def in &mut self.iter {
+            match type_def {
+                TypeDef::Struct(struct_def) => return Some(struct_def),
+                TypeDef::Enum(_) => {}
+                // Structs and enums are always first in `Schema::types`,
+                // so if we encounter a different type, iteration is done
+                _ => break,
+            }
+        }
+        None
+    }
+}
+
+impl FusedIterator for StructsMut<'_> {}


### PR DESCRIPTION
Same as #20943. Introduce a `StructsMut` iterator, which is more efficient than iterating through all types.