### PR TITLE
refactor(formatter): Remove `HardSpace` IR

### DIFF
--- a/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/to_prettier_doc.rs
@@ -81,7 +81,7 @@ struct PrinterState {
     /// Mirrors the printer's `pending_space` flag.
     /// See: `PrinterState::pending_space` in `printer/mod.rs`
     ///
-    /// Set by `Space`/`HardSpace` elements.
+    /// Set by `Space` elements.
     /// Consumed (flushed as `" "`) before the next visible content.
     /// Boolean semantics naturally deduplicates consecutive spaces.
     pending_space: bool,
@@ -124,7 +124,7 @@ fn convert_elements(
 
     for element in elements {
         match element {
-            FormatElement::Space | FormatElement::HardSpace => {
+            FormatElement::Space => {
                 printer.pending_space = true;
                 printer.last_was_hardline = false;
             }
@@ -262,11 +262,7 @@ fn convert_elements(
                     // This mirrors the printer's boolean idempotency (`Space + Space` = one space).
                     if !matches!(
                         interned.first(),
-                        Some(
-                            FormatElement::Space
-                                | FormatElement::HardSpace
-                                | FormatElement::Line(LineMode::SoftOrSpace)
-                        )
+                        Some(FormatElement::Space | FormatElement::Line(LineMode::SoftOrSpace))
                     ) {
                         concat_string(current_children_mut(&mut stack)?, " ");
                     }

--- a/crates/oxc_formatter/src/formatter/builders.rs
+++ b/crates/oxc_formatter/src/formatter/builders.rs
@@ -548,71 +548,6 @@ pub const fn space() -> Space {
     Space
 }
 
-/// Inserts a single space.
-/// The main difference with space is that
-/// it always adds a space even when it's the last element of a group.
-///
-/// # Examples
-///
-/// ```text
-/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
-/// use biome_formatter::prelude::*;
-///
-/// # fn test() {
-/// let context = SimpleFormatContext::new(SimpleFormatOptions {
-///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..SimpleFormatOptions::default()
-/// });
-///
-/// let elements = format!(context, [
-///     group(&format_args![
-///         token("nineteen_characters"),
-///         soft_line_break(),
-///         token("1"),
-///         hard_space(),
-///     ])
-/// ])?;
-/// assert_eq!(
-///     "nineteen_characters\n1",
-///     elements.print()?.as_code()
-/// );
-/// # Ok(())
-/// # }
-/// ```
-/// # Examples
-///
-/// Without HardSpace
-///
-/// ```text
-/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
-/// use biome_formatter::prelude::*;
-///
-/// # fn test() {
-/// let context = SimpleFormatContext::new(SimpleFormatOptions {
-///     line_width: LineWidth::try_from(20).unwrap(),
-///     ..SimpleFormatOptions::default()
-/// });
-///
-/// let elements = format!(context, [
-///     group(&format_args![
-///         token("nineteen_characters"),
-///         soft_line_break(),
-///         token("1"),
-///         space(),
-///     ])
-/// ])?;
-/// assert_eq!(
-///     "nineteen_characters1",
-///     elements.print()?.as_code()
-/// );
-/// # Ok(())
-/// # }
-/// ```
-#[inline]
-pub const fn hard_space() -> HardSpace {
-    HardSpace
-}
-
 /// Optionally inserts a single space if the given condition is true.
 ///
 /// # Examples
@@ -644,14 +579,6 @@ impl Format<'_> for Space {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct HardSpace;
-
-impl Format<'_> for HardSpace {
-    fn fmt(&self, f: &mut Formatter) {
-        f.write_element(FormatElement::HardSpace);
-    }
-}
 /// It adds a level of indentation to the given content
 ///
 /// It doesn't add any line breaks at the edges of the content, meaning that
@@ -1372,104 +1299,6 @@ pub fn soft_line_indent_or_space<'ast>(content: &impl Format<'ast>) -> BlockInde
     BlockIndent { content: Argument::new(content), mode: IndentMode::SoftLineOrSpace }
 }
 
-/// It functions similarly to soft_line_indent_or_space, but instead of a regular space, it inserts a hard space.
-///
-/// # Examples
-///
-/// Indents the content by one level and puts in new lines if the enclosing `Group` doesn't
-/// fit on a single line. Otherwise, just inserts a space.
-///
-/// ```text
-/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
-/// use biome_formatter::prelude::*;
-///
-/// # fn test() {
-/// let context = SimpleFormatContext::new(SimpleFormatOptions {
-///     line_width: LineWidth::try_from(10).unwrap(),
-///     ..SimpleFormatOptions::default()
-/// });
-///
-/// let elements = format!(context, [
-///     group(&format_args![
-///         token("name"),
-///         space(),
-///         token("="),
-///         soft_line_indent_or_hard_space(&format_args![
-///             token("firstName"),
-///             space(),
-///             token("+"),
-///             space(),
-///             token("lastName"),
-///         ]),
-///     ])
-/// ])?;
-///
-/// assert_eq!(
-///     "name =\n\tfirstName + lastName",
-///     elements.print()?.as_code()
-/// );
-/// # Ok(())
-/// # }
-/// ```
-///
-/// Only adds a space if the enclosing `Group` fits on a single line
-/// ```text
-/// use biome_formatter::{format, format_args};
-/// use biome_formatter::prelude::*;
-///
-/// # fn test() {
-/// let elements = format!(SimpleFormatContext::default(), [
-///     group(&format_args![
-///         token("a"),
-///         space(),
-///         token("="),
-///         soft_line_indent_or_hard_space(&token("10")),
-///     ])
-/// ])?;
-///
-/// assert_eq!(
-///     "a = 10",
-///     elements.print()?.as_code()
-/// );
-/// # Ok(())
-/// # }
-/// ```
-///
-/// It enforces a space after the "=" assignment operators
-/// ```text
-/// use biome_formatter::{format, format_args, LineWidth, SimpleFormatOptions};
-/// use biome_formatter::prelude::*;
-///
-/// # fn test() {
-/// let context = SimpleFormatContext::new(SimpleFormatOptions {
-///     line_width: LineWidth::try_from(8).unwrap(),
-///     ..SimpleFormatOptions::default()
-/// });
-///
-/// let elements = format!(context, [
-///     group(&format_args![
-///         token("value"),
-///         soft_line_break_or_space(),
-///         token("="),
-///         soft_line_indent_or_hard_space(&format_args![
-///             token("10"),
-///         ]),
-///     ])
-/// ])?;
-///
-/// assert_eq!(
-///     "value\n=\n\t10",
-///     elements.print()?.as_code()
-/// );
-/// # Ok(())
-/// # }
-/// ```
-#[inline]
-#[expect(unused)]
-pub fn soft_line_indent_or_hard_space<'ast>(content: &impl Format<'ast>) -> BlockIndent<'_, 'ast> {
-    BlockIndent { content: Argument::new(content), mode: IndentMode::HardSpace }
-}
-
 #[derive(Copy, Clone)]
 pub struct BlockIndent<'fmt, 'ast> {
     content: Argument<'fmt, 'ast>,
@@ -1481,7 +1310,6 @@ enum IndentMode {
     Soft,
     Block,
     SoftSpace,
-    HardSpace,
     SoftLineOrSpace,
 }
 
@@ -1495,7 +1323,6 @@ impl<'ast> Format<'ast> for BlockIndent<'_, 'ast> {
             IndentMode::SoftLineOrSpace | IndentMode::SoftSpace => {
                 write!(f, soft_line_break_or_space());
             }
-            IndentMode::HardSpace => write!(f, [hard_space(), soft_line_break()]),
         }
 
         let elements_length = f.elements().len();
@@ -1514,7 +1341,7 @@ impl<'ast> Format<'ast> for BlockIndent<'_, 'ast> {
             IndentMode::Soft => write!(f, [soft_line_break()]),
             IndentMode::Block => write!(f, [hard_line_break()]),
             IndentMode::SoftSpace => write!(f, [soft_line_break_or_space()]),
-            IndentMode::SoftLineOrSpace | IndentMode::HardSpace => (),
+            IndentMode::SoftLineOrSpace => (),
         }
     }
 }
@@ -1526,7 +1353,6 @@ impl std::fmt::Debug for BlockIndent<'_, '_> {
             IndentMode::Block => "HardBlockIndent",
             IndentMode::SoftLineOrSpace => "SoftLineIndentOrSpace",
             IndentMode::SoftSpace => "SoftSpaceBlockIndent",
-            IndentMode::HardSpace => "HardSpaceBlockIndent",
         };
 
         f.debug_tuple(name).field(&"{{content}}").finish()

--- a/crates/oxc_formatter/src/formatter/format_element/document.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/document.rs
@@ -205,7 +205,6 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
 
             match element {
                 element @ (FormatElement::Space
-                | FormatElement::HardSpace
                 | FormatElement::Token { .. }
                 | FormatElement::Text { .. }) => {
                     if !in_text {
@@ -215,7 +214,7 @@ impl<'a> Format<'a> for &[FormatElement<'a>] {
                     in_text = true;
 
                     match element {
-                        FormatElement::Space | FormatElement::HardSpace => {
+                        FormatElement::Space => {
                             write!(f, [token(" ")]);
                         }
                         element if element.is_text() => {

--- a/crates/oxc_formatter/src/formatter/format_element/mod.rs
+++ b/crates/oxc_formatter/src/formatter/format_element/mod.rs
@@ -63,7 +63,6 @@ const _: () = {
 pub enum FormatElement<'a> {
     /// A space token, see [crate::builders::space] for documentation.
     Space,
-    HardSpace,
     /// A new line, see [crate::builders::soft_line_break], [crate::builders::hard_line_break], and [crate::builders::soft_line_break_or_space] for documentation.
     Line(LineMode),
 
@@ -71,15 +70,10 @@ pub enum FormatElement<'a> {
     ExpandParent,
 
     /// A ASCII only Token that contains no line breaks or tab characters.
-    Token {
-        text: &'static str,
-    },
+    Token { text: &'static str },
 
     /// An arbitrary text that can contain tabs, newlines, and unicode characters.
-    Text {
-        text: &'a str,
-        width: TextWidth,
-    },
+    Text { text: &'a str, width: TextWidth },
 
     /// Prevents that line suffixes move past this boundary. Forces the printer to print any pending
     /// line suffixes, potentially by inserting a hard line break.
@@ -105,7 +99,7 @@ pub enum FormatElement<'a> {
 impl std::fmt::Debug for FormatElement<'_> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            FormatElement::Space | FormatElement::HardSpace => fmt.write_str("Space"),
+            FormatElement::Space => fmt.write_str("Space"),
             FormatElement::Line(mode) => fmt.debug_tuple("Line").field(mode).finish(),
             FormatElement::ExpandParent => fmt.write_str("ExpandParent"),
             FormatElement::Token { text } => fmt.debug_tuple("Token").field(text).finish(),
@@ -286,7 +280,6 @@ impl FormatElements for FormatElement<'_> {
             | FormatElement::LineSuffixBoundary
             | FormatElement::Space
             | FormatElement::Tag(_)
-            | FormatElement::HardSpace
             | FormatElement::TailwindClass(_) => false,
         }
     }

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -95,7 +95,7 @@ impl<'a> Printer<'a> {
 
         let args = stack.top();
         match element {
-            FormatElement::Space | FormatElement::HardSpace => {
+            FormatElement::Space => {
                 if self.state.line_width > 0 {
                     self.state.pending_space = true;
                 }
@@ -972,12 +972,6 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
             FormatElement::Space => {
                 if self.state.line_width > 0 {
                     self.state.pending_space = true;
-                }
-            }
-            FormatElement::HardSpace => {
-                self.state.line_width += 1;
-                if self.state.line_width > usize::from(self.options().print_width) {
-                    return Ok(Fits::No);
                 }
             }
             FormatElement::Line(line_mode) => {

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -1185,7 +1185,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSParenthesizedType<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeOperator<'a>> {
     fn write(&self, f: &mut Formatter<'_, 'a>) {
-        write!(f, [self.operator().to_str(), hard_space(), self.type_annotation()]);
+        write!(f, [self.operator().to_str(), space(), self.type_annotation()]);
     }
 }
 


### PR DESCRIPTION
Refs: https://github.com/oxc-project/oxc/pull/20954#issuecomment-4175587024

`HardSpace` was only used in one place in `oxc_formatter`: `TSTypeOperator` formatting (`print/mod.rs`).
Replacing it with `Space` caused no issues.

Biome also uses `hard_space` (via `soft_line_indent_or_hard_space`) in only one place in JS formatting. For arrow functions with conditional expression bodies.

> https://github.com/biomejs/biome/blob/main/crates/biome_js_formatter/src/js/expressions/arrow_function_expression.rs#L156

However, `oxc_formatter` already uses `soft_line_indent_or_space` (not `hard_space`) for that same case, with no issues.

---

I also attempted to align the `Space` handling with Ruff's approach, resolving `Space` immediately via `print_text(" ")` / `fits_text(" ")` instead of deferring it through `pending_space`. But this caused significant conformance regressions. 😓 

The root cause appears to be that `oxc_formatter`'s IR generation is less strict about where `Space` elements appear (e.g., trailing spaces in `line_suffix`), relying on the Printer's deferred `pending_space` mechanism to silently discard unresolved spaces.

So, leave it for now.