### PR TITLE
fix(linter/no-this-in-sfc): only flag `this` used as member expression object

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
+++ b/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
@@ -71,6 +71,15 @@ impl Rule for NoThisInSfc {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ThisExpression(this_expr) = node.kind() else { return };
 
+        if !matches!(
+            ctx.nodes().parent_kind(node.id()),
+            AstKind::StaticMemberExpression(_)
+                | AstKind::ComputedMemberExpression(_)
+                | AstKind::PrivateFieldExpression(_)
+        ) {
+            return;
+        }
+
         let Some(component_node) = get_parent_function(node, ctx) else { return };
 
         if ctx
@@ -340,6 +349,15 @@ fn test() {
             None,
             None,
         ),
+        (
+            "
+                    const Foo = ({query}) => {
+                      return <div onClick={reopen.bind(this, query)}>click</div>
+                    }
+                  ",
+            None,
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -416,6 +434,15 @@ fn test() {
         ),
         ("const Foo = (props) => <span>{this.props.foo}</span>", None, None),
         ("const Foo = (props) => this.props.foo ? <span>{props.bar}</span> : null;", None, None),
+        (
+            "
+                    function Foo(props) {
+                      return <div>{this[\"props\"].foo}</div>;
+                    }
+                  ",
+            None,
+            None,
+        ),
         (
             "
                     function Foo(props) {

--- a/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
+++ b/crates/oxc_linter/src/rules/react/no_this_in_sfc.rs
@@ -71,12 +71,7 @@ impl Rule for NoThisInSfc {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ThisExpression(this_expr) = node.kind() else { return };
 
-        if !matches!(
-            ctx.nodes().parent_kind(node.id()),
-            AstKind::StaticMemberExpression(_)
-                | AstKind::ComputedMemberExpression(_)
-                | AstKind::PrivateFieldExpression(_)
-        ) {
+        if !ctx.nodes().parent_kind(node.id()).is_member_expression_kind() {
             return;
         }
 

--- a/crates/oxc_linter/src/snapshots/react_no_this_in_sfc.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_this_in_sfc.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint-plugin-react(no-this-in-sfc): Stateless functional components should not use `this`
    ╭─[no_this_in_sfc.tsx:3:39]
  2 │                     function Foo(props) {
@@ -76,6 +75,15 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_this_in_sfc.tsx:1:24]
  1 │ const Foo = (props) => this.props.foo ? <span>{props.bar}</span> : null;
    ·                        ────
+   ╰────
+  help: Use props and context directly as function parameters instead of accessing them through `this`
+
+  ⚠ eslint-plugin-react(no-this-in-sfc): Stateless functional components should not use `this`
+   ╭─[no_this_in_sfc.tsx:3:36]
+ 2 │                     function Foo(props) {
+ 3 │                       return <div>{this["props"].foo}</div>;
+   ·                                    ────
+ 4 │                     }
    ╰────
   help: Use props and context directly as function parameters instead of accessing them through `this`
 

--- a/crates/oxc_linter/src/snapshots/react_no_this_in_sfc.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_this_in_sfc.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-react(no-this-in-sfc): Stateless functional components should not use `this`
    ╭─[no_this_in_sfc.tsx:3:39]
  2 │                     function Foo(props) {


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/20959