### PR TITLE
refactor(allocator): remove unnecessary `pub(crate)` from `mod` statement

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -44,7 +44,7 @@ mod allocator_api2;
 #[cfg(feature = "bitset")]
 mod bitset;
 mod boxed;
-pub(crate) mod bumpalo_alloc;
+mod bumpalo_alloc;
 mod clone_in;
 mod convert;
 #[cfg(feature = "from_raw_parts")]


### PR DESCRIPTION
Partial revert of #18168.

`mod bumpalo_alloc;` does not need to be prefixed with `pub(crate)`, as it's defined in crate root. Remove `pub(crate)`, just because it's a bit confusing one that one module has the prefix and none of the others do.