### PR TITLE
docs(allocator, data_structures): correct comments

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -253,7 +253,7 @@ impl Allocator {
     /// [`Vec::new_in`]: crate::Vec::new_in
     /// [`HashMap::new_in`]: crate::HashMap::new_in
     //
-    // `#[inline(always)]` because it's a small function
+    // `#[inline(always)]` because just delegates to `Bump` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn new() -> Self {
@@ -268,7 +268,7 @@ impl Allocator {
     ///
     /// See [`Allocator`] docs for more information on efficient use of [`Allocator`].
     //
-    // `#[inline(always)]` because it's a small function
+    // `#[inline(always)]` because just delegates to `Bump` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn with_capacity(capacity: usize) -> Self {
@@ -506,7 +506,7 @@ impl Allocator {
     /// }
     /// ```
     //
-    // `#[inline(always)]` because it's a small function
+    // `#[inline(always)]` because just delegates to `Bump` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn reset(&mut self) {
@@ -536,7 +536,7 @@ impl Allocator {
     ///
     /// [`used_bytes`]: Allocator::used_bytes
     //
-    // `#[inline(always)]` because it's a small function
+    // `#[inline(always)]` because just delegates to `Bump` method
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn capacity(&self) -> usize {

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -14,7 +14,7 @@ use std::{
 
 use crate::{Allocator, bump::Bump};
 
-/// Minimum alignment for allocator chunks.
+/// Minimum alignment for allocator chunks. Same as for `Bump`.
 const MIN_ALIGN: usize = 16;
 
 const CHUNK_FOOTER_SIZE: usize = size_of::<ChunkFooter>();

--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -58,7 +58,7 @@ use super::{StackCapacity, StackCommon};
 ///    uses 1 less register, but disadvantage that [`last`] and [`last_mut`] are 2 instructions, not 1.
 ///    <https://godbolt.org/z/xnx7YP5de>
 ///
-/// 2. Stack could grow downwards, like a bump allocator does. This would probably make [`pop`] use
+/// 2. Stack could grow downwards, like `bumpalo` does. This would probably make [`pop`] use
 ///    1 less register, but at the cost that: (a) the stack can never grow in place, which would incur
 ///    more memory copies when the stack grows, and (b) [`as_slice`] would have the entries in
 ///    reverse order.


### PR DESCRIPTION
Follow on after #18172.

That PR made changes to comments to remove references to `bumpalo` from the codebase. Correct a few of those comments which were incorrect.