### PR TITLE
perf(allocator): add `#[cold]` to to error handling functions

### DIFF
--- a/crates/oxc_allocator/src/bumpalo_alloc.rs
+++ b/crates/oxc_allocator/src/bumpalo_alloc.rs
@@ -37,10 +37,13 @@ use core::usize;
 
 pub use core::alloc::{Layout, LayoutErr};
 
+#[cold]
 fn new_layout_err() -> LayoutErr {
     Layout::from_size_align(1, 3).unwrap_err()
 }
 
+#[cold]
+#[inline(never)]
 pub fn handle_alloc_error(layout: Layout) -> ! {
     panic!("encountered allocation error: {:?}", layout)
 }


### PR DESCRIPTION
Repeat of #18181.

#20963 wiped all changes to `bumpalo_alloc.rs`, going back to a fresh copy of `bumpalo`. Re-apply changes from #18181 which were lost in the process - marking error handling functions as `#[cold]`.

This PR differs from #18181 in one minor respect. `new_layout_err` is not marked `#[inline(never)]` in this PR. The function is a no-op (unconditionally returns a ZST), so we do want it inlined, but with the`#[cold]`attribute to hint to compiler that it's a cold path.