### PR TITLE
perf(allocator): increase initial chunk size from 512B to 16KB

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -518,9 +518,10 @@ const OVERHEAD: usize = match round_up_to(MALLOC_OVERHEAD + FOOTER_SIZE, CHUNK_A
     None => panic!(),
 };
 
-// The target size of our first allocation, including our overhead. The
-// available bump capacity will be smaller.
-const FIRST_ALLOCATION_GOAL: usize = 1 << 9;
+// The target size of our first allocation, including our overhead.
+// The available bump capacity will be slightly smaller.
+// 16 KiB covers the majority of real-world JS/TS files.
+const FIRST_ALLOCATION_GOAL: usize = 16 * 1024;
 
 // The actual size of the first allocation is going to be a bit smaller than the
 // goal. We need to make room for the footer, and we also need take the
@@ -752,7 +753,10 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
 
         let chunk_footer = unsafe {
             Self::new_chunk(
-                Self::new_chunk_memory_details(None, layout).ok_or(AllocErr)?,
+                // `new_size_without_footer` here was `None` in original `bumpalo` code.
+                // Changed to `Some(capacity)` when we increased `FIRST_ALLOCATION_GOAL` to 16 KiB,
+                // to avoid `Bump::with_capacity` allocating 16 KiB even when requested `capacity` is much smaller.
+                Self::new_chunk_memory_details(Some(capacity), layout).ok_or(AllocErr)?,
                 layout,
                 EMPTY_CHUNK.get(),
             )
@@ -2610,7 +2614,12 @@ mod tests {
     // Uses private `DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER` and `FOOTER_SIZE`.
     #[test]
     fn allocated_bytes() {
-        let mut b = Bump::with_capacity(1);
+        let mut b = Bump::new();
+
+        assert_eq!(b.allocated_bytes(), 0);
+        assert_eq!(b.allocated_bytes_including_metadata(), 0);
+
+        b.alloc(0u8);
 
         assert_eq!(b.allocated_bytes(), DEFAULT_CHUNK_SIZE_WITHOUT_FOOTER);
         assert_eq!(

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,14 +1,14 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs | Arena bytes    
 -------------------------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            334 |             37 ||         152659 |          28244
+checker.ts                 | 2.92 MB        ||            333 |             37 ||         152659 |          28244
 
-cal.com.tsx                | 1.06 MB        ||          20244 |             46 ||          37147 |           4570
+cal.com.tsx                | 1.06 MB        ||          20242 |             46 ||          37147 |           4570
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             41 |              6 ||             30 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             34 |              6 ||             30 |              6
 
 pdf.mjs                    | 567.30 kB      ||           3994 |            417 ||          47464 |           7734
 
-antd.js                    | 6.69 MB        ||           7755 |           1657 ||         331673 |          69344
+antd.js                    | 6.69 MB        ||           7751 |           1657 ||         331673 |          69344
 
-binder.ts                  | 193.08 kB      ||             79 |             23 ||           7075 |            824
+binder.ts                  | 193.08 kB      ||             78 |             23 ||           7075 |            824
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -4,7 +4,7 @@ checker.ts                 | 2.92 MB        ||           2281 |             18 |
 
 cal.com.tsx                | 1.06 MB        ||          14966 |             22 ||              0 |              0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             12 |              3 ||              0 |              0
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             10 |              3 ||              0 |              0
 
 pdf.mjs                    | 567.30 kB      ||           1401 |            208 ||              0 |              0
 


### PR DESCRIPTION
Repeat of #18234.

#20963 wiped all changes to `bump.rs`, going back to a fresh copy of `bumpalo`.

Re-apply changes from #18234 which were lost in the process - increasing default arena chunk size to 16 KiB, and altering `try_with_min_align_and_capacity` to respect the requested capacity in `Bump::with_capacity`.

Add a comment to `try_with_min_align_and_capacity` explaining why that change is required.