### PR TITLE
refactor(allocator): add generic param to `Bump` in `ChunkIter`

### DIFF
--- a/crates/oxc_allocator/src/bump.rs
+++ b/crates/oxc_allocator/src/bump.rs
@@ -2441,7 +2441,7 @@ impl<const MIN_ALIGN: usize> Bump<MIN_ALIGN> {
 #[derive(Debug)]
 pub struct ChunkIter<'a, const MIN_ALIGN: usize = 1> {
     raw: ChunkRawIter<'a, MIN_ALIGN>,
-    bump: PhantomData<&'a mut Bump>,
+    bump: PhantomData<&'a mut Bump<MIN_ALIGN>>,
 }
 
 impl<'a, const MIN_ALIGN: usize> Iterator for ChunkIter<'a, MIN_ALIGN> {


### PR DESCRIPTION
Refactor. `PhantomData<&'a mut Bump>` -> `PhantomData<&'a mut Bump<MIN_ALIGN>>`. The generic param is not necessary here due to the `PhantomData` wrapper, but it's more explicit and matches `ChunkRawIter`.