### PR TITLE
ci(codeowners): add @leaysgur to codeowners for `oxfmt`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,13 @@
 Cargo.lock
 pnpm-lock.yaml
 
+/apps/oxfmt @leaysgur
 /apps/oxlint @camc314
 /apps/oxlint/src-js @camc314 @overlookmotel
 
 /crates/oxc_allocator @overlookmotel
 /crates/oxc_data_structures @overlookmotel
-/crates/oxc_formatter @dunqing
+/crates/oxc_formatter @dunqing @leaysgur
 /crates/oxc_isolated_declarations @dunqing
 /crates/oxc_language_server @camc314 @sysix
 /crates/oxc_linter @camc314


### PR DESCRIPTION
Not sure why he was missing...