### PR TITLE
ci(codeowners): remove codeowners for removed "editors" folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,4 @@ pnpm-lock.yaml
 /crates/oxc_transformer_plugins @overlookmotel @dunqing
 /crates/oxc_traverse @overlookmotel
 
-/editors @camc314
-
 /tasks/ast_tools @overlookmotel


### PR DESCRIPTION
The folder "editors" does not exist anymore on this project. The source code was moved to `oxc-vscode` repo