### PR TITLE
feat(linter): add --rule CLI flag for inline rule config

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -20,6 +20,10 @@ pub struct LintCommand {
     #[bpaf(external(lint_filter), map(LintFilter::into_tuple), many, hide_usage)]
     pub filter: Vec<(AllowWarnDeny, String)>,
 
+    /// Configure a rule with severity and options (e.g. 'no-var: error' or 'eqeqeq: ["error", "always"]')
+    #[bpaf(long("rule"), argument("RULE_CONFIG"), many, hide_usage)]
+    pub cli_rules: Vec<String>,
+
     #[bpaf(external)]
     pub enable_plugins: EnablePlugins,
 
@@ -614,6 +618,18 @@ mod lint_options {
         assert!(result.is_err_and(
             |err| err.unwrap_stderr() == "couldn't parse `asdf`: 'asdf' is not a known format"
         ));
+    }
+
+    #[test]
+    fn cli_rule_single() {
+        let options = get_lint_options("--rule no-var:error .");
+        assert_eq!(options.cli_rules, vec!["no-var:error"]);
+    }
+
+    #[test]
+    fn cli_rule_multiple() {
+        let options = get_lint_options("--rule no-var:error --rule eqeqeq:warn .");
+        assert_eq!(options.cli_rules, vec!["no-var:error", "eqeqeq:warn"]);
     }
 
     #[test]

--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -20,7 +20,7 @@ pub struct LintCommand {
     #[bpaf(external(lint_filter), map(LintFilter::into_tuple), many, hide_usage)]
     pub filter: Vec<(AllowWarnDeny, String)>,
 
-    /// Configure a rule with severity and options (e.g. 'no-var: error' or 'eqeqeq: ["error", "always"]')
+    /// Configure a rule with severity and options (e.g. `no-var: error` or `eqeqeq: ["error", "always"]`)
     #[bpaf(long("rule"), argument("RULE_CONFIG"), many, hide_usage)]
     pub cli_rules: Vec<String>,
 

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -303,27 +303,19 @@ impl CliRunner {
         let config_builder = if cli_rules.is_empty() {
             config_builder
         } else {
-            let parsed_rules: Vec<_> = {
-                let mut parsed = Vec::with_capacity(cli_rules.len());
-                for rule_str in &cli_rules {
-                    match oxc_linter::parse_cli_rule(rule_str) {
-                        Ok(rule) => parsed.push(rule),
-                        Err(e) => {
-                            print_and_flush_stdout(
-                                stdout,
-                                &format!("Invalid --rule argument: {e}\n"),
-                            );
-                            return CliRunResult::InvalidOptionConfig;
-                        }
+            let mut parsed_rules = Vec::with_capacity(cli_rules.len());
+            for rule_str in &cli_rules {
+                match oxc_linter::parse_cli_rule(rule_str) {
+                    Ok(rule) => parsed_rules.push(rule),
+                    Err(e) => {
+                        print_and_flush_stdout(stdout, &format!("Invalid --rule argument: {e}\n"));
+                        return CliRunResult::InvalidOptionConfig;
                     }
                 }
-                parsed
-            };
+            }
 
-            match config_builder.with_cli_rules(
-                oxc_linter::OxlintRules::new(parsed_rules),
-                &mut external_plugin_store,
-            ) {
+            let cli_oxlint_rules = oxc_linter::OxlintRules::new(parsed_rules);
+            match config_builder.with_cli_rules(&cli_oxlint_rules, &mut external_plugin_store) {
                 Ok(builder) => builder,
                 Err(e) => {
                     print_and_flush_stdout(

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -74,6 +74,7 @@ impl CliRunner {
         let LintCommand {
             paths,
             filter,
+            cli_rules,
             basic_options,
             warning_options,
             ignore_options,
@@ -297,6 +298,45 @@ impl CliRunner {
             }
         }
         .with_filters(&filters);
+
+        // Apply --rule CLI overrides (highest precedence)
+        let config_builder = if cli_rules.is_empty() {
+            config_builder
+        } else {
+            let parsed_rules: Vec<_> = {
+                let mut parsed = Vec::with_capacity(cli_rules.len());
+                for rule_str in &cli_rules {
+                    match oxc_linter::parse_cli_rule(rule_str) {
+                        Ok(rule) => parsed.push(rule),
+                        Err(e) => {
+                            print_and_flush_stdout(
+                                stdout,
+                                &format!("Invalid --rule argument: {e}\n"),
+                            );
+                            return CliRunResult::InvalidOptionConfig;
+                        }
+                    }
+                }
+                parsed
+            };
+
+            match config_builder.with_cli_rules(
+                oxc_linter::OxlintRules::new(parsed_rules),
+                &mut external_plugin_store,
+            ) {
+                Ok(builder) => builder,
+                Err(e) => {
+                    print_and_flush_stdout(
+                        stdout,
+                        &format!(
+                            "Failed to apply --rule options.\n{}\n",
+                            render_report(&handler, &OxcDiagnostic::error(e.to_string()))
+                        ),
+                    );
+                    return CliRunResult::InvalidOptionConfig;
+                }
+            }
+        };
 
         if misc_options.print_config {
             return crate::mode::run_print_config(&config_builder, root_config, stdout);

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -431,7 +431,7 @@ impl ConfigStoreBuilder {
         Ok(self)
     }
 
-    /// Warn/Deny a let of rules based on some predicate. Rules already in `self.rules` get
+    /// Warn/Deny a set of rules based on some predicate. Rules already in `self.rules` get
     /// re-configured, while those that are not are added. Affects rules where `query` returns
     /// `true`.
     fn get_all_rules(&self) -> Vec<RuleEnum> {

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -410,6 +410,27 @@ impl ConfigStoreBuilder {
         self
     }
 
+    /// Apply `--rule` CLI overrides with full rule configuration support.
+    ///
+    /// These are applied with the highest precedence, after config file loading
+    /// and `-D`/`-W`/`-A` filters.
+    pub fn with_cli_rules(
+        mut self,
+        rules: OxlintRules,
+        external_plugin_store: &mut ExternalPluginStore,
+    ) -> Result<Self, ConfigBuilderError> {
+        let all_rules = self.get_all_rules();
+        rules
+            .override_rules(
+                &mut self.rules,
+                &mut self.external_rules,
+                &all_rules,
+                external_plugin_store,
+            )
+            .map_err(|errors| ConfigBuilderError::RuleConfigurationErrors { errors })?;
+        Ok(self)
+    }
+
     /// Warn/Deny a let of rules based on some predicate. Rules already in `self.rules` get
     /// re-configured, while those that are not are added. Affects rules where `query` returns
     /// `true`.

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -416,7 +416,7 @@ impl ConfigStoreBuilder {
     /// and `-D`/`-W`/`-A` filters.
     pub fn with_cli_rules(
         mut self,
-        rules: OxlintRules,
+        rules: &OxlintRules,
         external_plugin_store: &mut ExternalPluginStore,
     ) -> Result<Self, ConfigBuilderError> {
         let all_rules = self.get_all_rules();

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -20,7 +20,7 @@ pub use ignore_matcher::LintIgnoreMatcher;
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
 pub use plugins::LintPlugins;
-pub use rules::{ESLintRule, OxlintRules};
+pub use rules::{ESLintRule, OxlintRules, parse_cli_rule};
 pub use settings::{OxlintSettings, ReactVersion, jsdoc::JSDocPluginSettings};
 
 use crate::config::oxlintrc::OxlintOptions;

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -453,6 +453,42 @@ fn failed_to_parse_rule_value(value: &str, err: &str) -> OxcDiagnostic {
     OxcDiagnostic::error(format!("Failed to rule value {value:?} with error {err:?}"))
 }
 
+/// Parses a `--rule` CLI argument string into an [`ESLintRule`].
+///
+/// Accepts formats like:
+/// - `"no-var: error"`
+/// - `"eqeqeq: [\"error\", \"always\"]"`
+/// - `"import/no-cycle: [\"error\", {\"maxDepth\": 1}]"`
+pub fn parse_cli_rule(input: &str) -> Result<ESLintRule, String> {
+    let colon_pos = input.find(':').ok_or_else(|| {
+        format!(
+            "Invalid --rule format: '{input}'. Expected 'rule-name: severity' or 'rule-name: [severity, ...options]'"
+        )
+    })?;
+
+    let rule_key = input[..colon_pos].trim();
+    let value_str = input[colon_pos + 1..].trim();
+
+    if rule_key.is_empty() {
+        return Err("Rule name cannot be empty".into());
+    }
+    if value_str.is_empty() {
+        return Err(format!("Missing severity for rule '{rule_key}'"));
+    }
+
+    let (plugin_name, rule_name) = parse_rule_key(rule_key);
+
+    // Try to parse as JSON first; if that fails, treat as a bare severity word
+    let json_value = serde_json::from_str::<serde_json::Value>(value_str)
+        .or_else(|_| serde_json::from_str::<serde_json::Value>(&format!("\"{value_str}\"")))
+        .map_err(|e| format!("Failed to parse rule value for '{rule_key}': {e}"))?;
+
+    let (severity, config) = parse_rule_value(json_value)
+        .map_err(|e| format!("Failed to parse severity for '{rule_key}': {e}"))?;
+
+    Ok(ESLintRule { plugin_name, rule_name, severity, config })
+}
+
 impl ESLintRule {
     /// Returns `<plugin_name>/<rule_name>` for non-eslint rules. For eslint rules, returns
     /// `<rule_name>`.
@@ -924,5 +960,77 @@ mod test {
             builtin_rules.iter().any(|(r, _)| r.name() == "forbid-dom-props"),
             "forbid-dom-props should be in the rule set"
         );
+    }
+
+    #[test]
+    fn test_parse_cli_rule_bare_severity() {
+        let rule = super::parse_cli_rule("no-var: error").unwrap();
+        assert_eq!(rule.plugin_name, "eslint");
+        assert_eq!(rule.rule_name, "no-var");
+        assert_eq!(rule.severity, AllowWarnDeny::Deny);
+        assert!(rule.config.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cli_rule_off() {
+        let rule = super::parse_cli_rule("no-var: off").unwrap();
+        assert_eq!(rule.severity, AllowWarnDeny::Allow);
+        assert!(rule.config.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cli_rule_numeric_severity() {
+        let rule = super::parse_cli_rule("no-var: 2").unwrap();
+        assert_eq!(rule.severity, AllowWarnDeny::Deny);
+        assert!(rule.config.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cli_rule_with_options() {
+        let rule = super::parse_cli_rule(r#"eqeqeq: ["error", "always"]"#).unwrap();
+        assert_eq!(rule.plugin_name, "eslint");
+        assert_eq!(rule.rule_name, "eqeqeq");
+        assert_eq!(rule.severity, AllowWarnDeny::Deny);
+        assert_eq!(rule.config.len(), 1);
+        assert_eq!(rule.config[0], json!("always"));
+    }
+
+    #[test]
+    fn test_parse_cli_rule_plugin_prefix() {
+        let rule = super::parse_cli_rule(r#"import/no-cycle: ["error", {"maxDepth": 1}]"#).unwrap();
+        assert_eq!(rule.plugin_name, "import");
+        assert_eq!(rule.rule_name, "no-cycle");
+        assert_eq!(rule.severity, AllowWarnDeny::Deny);
+        assert_eq!(rule.config.len(), 1);
+        assert_eq!(rule.config[0], json!({"maxDepth": 1}));
+    }
+
+    #[test]
+    fn test_parse_cli_rule_typescript_alias() {
+        let rule = super::parse_cli_rule("@typescript-eslint/no-explicit-any: warn").unwrap();
+        assert_eq!(rule.plugin_name, "typescript");
+        assert_eq!(rule.rule_name, "no-explicit-any");
+        assert_eq!(rule.severity, AllowWarnDeny::Warn);
+    }
+
+    #[test]
+    fn test_parse_cli_rule_error_missing_colon() {
+        let result = super::parse_cli_rule("no-var error");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid --rule format"));
+    }
+
+    #[test]
+    fn test_parse_cli_rule_error_empty_name() {
+        let result = super::parse_cli_rule(": error");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Rule name cannot be empty"));
+    }
+
+    #[test]
+    fn test_parse_cli_rule_error_empty_value() {
+        let result = super::parse_cli_rule("no-var:");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing severity"));
     }
 }

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -450,7 +450,7 @@ fn parse_rule_value(
 }
 
 fn failed_to_parse_rule_value(value: &str, err: &str) -> OxcDiagnostic {
-    OxcDiagnostic::error(format!("Failed to rule value {value:?} with error {err:?}"))
+    OxcDiagnostic::error(format!("Failed to parse rule value {value:?} with error {err:?}"))
 }
 
 /// Parses a `--rule` CLI argument string into an [`ESLintRule`].

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -69,7 +69,7 @@ pub use crate::disable_directives::{
 pub use crate::{
     config::{
         Config, ConfigBuilderError, ConfigStore, ConfigStoreBuilder, ESLintRule, LintIgnoreMatcher,
-        LintPlugins, Oxlintrc, ResolvedLinterState,
+        LintPlugins, OxlintRules, Oxlintrc, ResolvedLinterState, parse_cli_rule,
     },
     context::{ContextSubHost, LintContext},
     external_linter::{

--- a/tasks/website_linter/src/snapshots/cli.snap
+++ b/tasks/website_linter/src/snapshots/cli.snap
@@ -151,6 +151,8 @@ Arguments:
 
 
 ## Available options:
+- **`    --rule`**=_`RULE_CONFIG`_ &mdash; 
+  Configure a rule with severity and options (e.g. `no-var: error` or `eqeqeq: ["error", "always"]`)
 - **`    --rules`** &mdash; 
   List all the rules that are currently registered
 - **`    --lsp`** &mdash; 

--- a/tasks/website_linter/src/snapshots/cli_terminal.snap
+++ b/tasks/website_linter/src/snapshots/cli_terminal.snap
@@ -95,6 +95,8 @@ Available positional items:
     PATH                      Single file, single path or list of paths
 
 Available options:
+        --rule=RULE_CONFIG    Configure a rule with severity and options (e.g. `no-var: error` or
+                              `eqeqeq: ["error", "always"]`)
         --rules               List all the rules that are currently registered
         --lsp                 Start the language server
         --disable-nested-config  Disable the automatic loading of nested configuration files


### PR DESCRIPTION
Adds a `--rule` CLI flag to oxlint, similar to [ESLint's `--rule`](https://eslint.org/docs/latest/use/command-line-interface#--rule).

This allows enabling/configuring individual rules from the command line without modifying config files — useful when fixing lint violations one rule at a time across a large codebase.

## Usage

```bash
# Simple severity
oxlint --rule 'no-var: error' --fix src/

# With rule options (JSON format)
oxlint --rule 'eqeqeq: ["error", "always"]' src/

# Multiple rules
oxlint --rule 'no-var: error' --rule 'prefer-const: warn' --fix src/

# Suppress a default rule
oxlint --rule 'no-unused-vars: off' src/

# Plugin rules
oxlint --rule '@typescript-eslint/no-explicit-any: warn' src/
oxlint --rule 'import/no-cycle: ["error", {"maxDepth": 1}]' src/
```

## Behavior

- Can be repeated to configure multiple rules
- Accepts bare severity (`error`, `warn`, `off`, `0`, `1`, `2`) or JSON array with options
- Applied **after** config file loading and `-D`/`-W`/`-A` filters (highest precedence)
- Reuses existing rule validation, plugin aliasing, and option parsing from the config system

## Note

This also re-exports `OxlintRules` and `parse_cli_rule` from the `oxc_linter` crate root (both were already public in `config/mod.rs`, just not re-exported at the crate level).

## AI Disclosure

This PR was authored with assistance from Claude Code (Claude Opus 4.6). All code has been reviewed, tested, and validated by me (@Shinigami92) before submission.

Closes #20956
