### PR TITLE
fix(oxfmt): Propagate file write errors instead of panicking

### DIFF
--- a/apps/oxfmt/src/cli/service.rs
+++ b/apps/oxfmt/src/cli/service.rs
@@ -83,9 +83,22 @@ impl FormatService {
 
             // Write back if needed
             if matches!(self.format_mode, OutputMode::Write) && is_changed {
-                fs::write(path, code)
-                    .map_err(|_| format!("Failed to write to '{}'", path.to_string_lossy()))
-                    .unwrap();
+                match fs::write(path, &code) {
+                    Ok(()) => (),
+                    Err(err) => {
+                        let diagnostics = DiagnosticService::wrap_diagnostics(
+                            self.cwd.clone(),
+                            path,
+                            "",
+                            vec![oxc_diagnostics::OxcDiagnostic::error(format!(
+                                "Failed to save '{}': {err}",
+                                path.display()
+                            ))],
+                        );
+                        tx_error.send(diagnostics).unwrap();
+                        return;
+                    }
+                }
             }
 
             // Report result


### PR DESCRIPTION
For example, in cases where a read-only file is encountered.

- Before: this would trigger a panic
- After: it is reported as a write error, consistent with how parsing errors are handled