### PR TITLE
fix(linter/button-has-type): ignore `document.createElement` calls

### DIFF
--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -293,6 +293,9 @@ fn test() {
 			      "#,
             None,
         ),
+        // Issue #20938: document.createElement('button') / document["createElement"]("button") should not raise an error because it object callee is from document
+        (r#"document.createElement("button");"#, None),
+        (r#"document["createElement"]("button");"#, None),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -21,9 +21,25 @@ use crate::{LintContext, OxlintSettings};
 pub fn is_create_element_call(call_expr: &CallExpression) -> bool {
     match &call_expr.callee {
         Expression::StaticMemberExpression(member_expr) => {
+            if member_expr
+                .object
+                .get_identifier_reference()
+                .is_some_and(|object_caller| object_caller.name == "document")
+            {
+                return false;
+            }
+
             member_expr.property.name == "createElement"
         }
         Expression::ComputedMemberExpression(member_expr) => {
+            if member_expr
+                .object
+                .get_identifier_reference()
+                .is_some_and(|object_caller| object_caller.name == "document")
+            {
+                return false;
+            }
+
             member_expr.static_property_name().is_some_and(|name| name == "createElement")
         }
         Expression::Identifier(ident) => ident.name == "createElement",


### PR DESCRIPTION
Fix https://github.com/oxc-project/oxc/issues/20938