### PR TITLE
perf(napi/parser, linter/plugins): raw transfer use `String.fromCharCode` in string decoding

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -16,7 +16,7 @@ let uint8,
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String,
+  { fromCharCode } = String,
   NodeProto = Object.create(Object.prototype, {
     loc: {
       get() {
@@ -5894,7 +5894,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -5,7 +5,7 @@ let uint8, uint32, float64, sourceText, sourceIsAscii, sourceEndPos, firstNonAsc
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -4557,7 +4557,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -12,7 +12,7 @@ let uint8,
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -5094,7 +5094,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -5,7 +5,7 @@ let uint8, uint32, float64, sourceText, sourceIsAscii, sourceEndPos, firstNonAsc
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -5099,7 +5099,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -12,7 +12,7 @@ let uint8,
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -5639,7 +5639,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -5,7 +5,7 @@ let uint8, uint32, float64, sourceText, sourceIsAscii, sourceEndPos, firstNonAsc
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -4866,7 +4866,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -12,7 +12,7 @@ let uint8,
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -5430,7 +5430,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -5,7 +5,7 @@ let uint8, uint32, float64, sourceText, sourceIsAscii, sourceEndPos, firstNonAsc
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -5439,7 +5439,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -12,7 +12,7 @@ let uint8,
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),
-  { fromCodePoint } = String;
+  { fromCharCode } = String;
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
@@ -6003,7 +6003,7 @@ function deserializeStr(pos) {
     c;
   do {
     c = uint8[pos++];
-    if (c < 128) out += fromCodePoint(c);
+    if (c < 128) out += fromCharCode(c);
     else {
       out += decodeStr(uint8.subarray(pos - 1, end));
       break;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -150,7 +150,7 @@ fn generate_deserializers(
 
         const textDecoder = new TextDecoder('utf-8', {{ ignoreBOM: true }}),
             decodeStr = textDecoder.decode.bind(textDecoder),
-            {{ fromCodePoint }} = String;
+            {{ fromCharCode }} = String;
 
         /* IF LOC */
         const NodeProto = Object.create(Object.prototype, {{
@@ -948,7 +948,7 @@ static STR_DESERIALIZER_BODY: &str = "
     do {
         c = uint8[pos++];
         if (c < 0x80) {
-            out += fromCodePoint(c);
+            out += fromCharCode(c);
         } else {
             out += decodeStr(uint8.subarray(pos - 1, end));
             break;


### PR DESCRIPTION
Small optimization to raw transfer string deserialization. Use `String.fromCharCode`instead of `String.fromCodePoint`. [Benchmarking](https://github.com/overlookmotel/oxc-raw-str-bench) showed it's slightly faster, as it's simpler - doesn't need to handle astral code points.