### PR TITLE
perf(napi/parser, linter/plugins): initialize vars as 0

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -8,8 +8,8 @@ let uint8,
   uint32,
   float64,
   sourceText,
-  sourceStartPos,
-  firstNonAsciiPos,
+  sourceStartPos = 0,
+  firstNonAsciiPos = 0,
   parent = null,
   getLoc;
 

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -1,7 +1,11 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, firstNonAsciiPos;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  firstNonAsciiPos = 0;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -5,7 +5,7 @@ let uint8,
   uint32,
   float64,
   sourceText,
-  firstNonAsciiPos,
+  firstNonAsciiPos = 0,
   parent = null;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -1,7 +1,11 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, firstNonAsciiPos;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  firstNonAsciiPos = 0;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -5,7 +5,7 @@ let uint8,
   uint32,
   float64,
   sourceText,
-  firstNonAsciiPos,
+  firstNonAsciiPos = 0,
   parent = null;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -1,7 +1,11 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, firstNonAsciiPos;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  firstNonAsciiPos = 0;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -5,7 +5,7 @@ let uint8,
   uint32,
   float64,
   sourceText,
-  firstNonAsciiPos,
+  firstNonAsciiPos = 0,
   parent = null;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -1,7 +1,11 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
-let uint8, uint32, float64, sourceText, firstNonAsciiPos;
+let uint8,
+  uint32,
+  float64,
+  sourceText,
+  firstNonAsciiPos = 0;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),
   decodeStr = textDecoder.decode.bind(textDecoder),

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -5,7 +5,7 @@ let uint8,
   uint32,
   float64,
   sourceText,
-  firstNonAsciiPos,
+  firstNonAsciiPos = 0,
   parent = null;
 
 const textDecoder = new TextDecoder("utf-8", { ignoreBOM: true }),

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -143,7 +143,7 @@ fn generate_deserializers(
         import {{ comments, initComments }} from '../plugins/comments.js';
         /* END_IF */
 
-        let uint8, uint32, float64, sourceText, sourceStartPos, firstNonAsciiPos;
+        let uint8, uint32, float64, sourceText, sourceStartPos = 0, firstNonAsciiPos = 0;
 
         let parent = null;
         let getLoc;


### PR DESCRIPTION
Tiny optimization to raw transfer string deserialization. Initialize vars which contain integers as `0`. This may help V8 optimize usage of these variables as they always have SMI type.

The effect, if there is one, is too small to register on benchamarks. But it's certainly not a regression, and may be a tiny gain, so why not?