### PR TITLE
perf(napi/parser, linter/plugins): clear buffers and source texts earlier

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -55,7 +55,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
   getLoc = getLocInput;
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -16,9 +16,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -35,7 +33,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -17,9 +17,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -36,7 +34,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -16,9 +16,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -35,7 +33,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -17,9 +17,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -36,7 +34,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -16,9 +16,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -35,7 +33,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -17,9 +17,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -36,7 +34,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -16,9 +16,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -35,7 +33,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -17,9 +17,7 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  let data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-  resetBuffer();
-  return data;
+  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
 }
 
 function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
@@ -36,7 +34,9 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, 0, sourceByteLen);
   }
-  return deserialize(uint32[536870900]);
+  let data = deserialize(uint32[536870900]);
+  resetBuffer();
+  return data;
 }
 
 export function resetBuffer() {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -176,9 +176,7 @@ fn generate_deserializers(
         /* IF !LINTER */
         export function deserialize(buffer, sourceText, sourceByteLen) {{
             sourceEndPos = sourceByteLen;
-            const data = deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
-            resetBuffer();
-            return data;
+            return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
         }}
         /* END_IF */
 
@@ -229,7 +227,9 @@ fn generate_deserializers(
 
             if (LOC) getLoc = getLocInput;
 
-            return deserialize(uint32[{data_pointer_pos_32}]);
+            const data = deserialize(uint32[{data_pointer_pos_32}]);
+            resetBuffer();
+            return data;
         }}
 
         export function resetBuffer() {{


### PR DESCRIPTION
There's no need to defer clearing vars containing buffers and source text in raw transfer deserializer module until end of linting. It was a left-over from when this module contained code which lazily deserialized comments, but that's now done elsewhere.

Clear these vars as soon as deserialization is complete. Buffer and `sourceText` are still held in vars in other modules until linting completes, but `sourceTextLatin` (introduced in #21021) can be freed immediately.