### PR TITLE
refactor(linter/plugins): import `getNodeLoc` instead of injecting it

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.d.ts
+++ b/apps/oxlint/src-js/generated/deserialize.d.ts
@@ -2,18 +2,14 @@
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/raw_transfer.rs`.
 
 import type { Program } from "./types.d.ts";
-import type { Node } from "../plugins/types.ts";
-import type { Location as SourceLocation } from "../plugins/location.ts";
 
 type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
-type GetLoc = (node: Node) => SourceLocation;
 
 export declare function deserializeProgramOnly(
   buffer: BufferWithArrays,
   sourceText: string,
   sourceStartPosInput: number,
   sourceByteLen: number,
-  getLoc: GetLoc,
 ): Program;
 
 export declare function resetBuffer(): void;

--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -3,6 +3,7 @@
 
 import { tokens, initTokens } from "../plugins/tokens.js";
 import { comments, initComments } from "../plugins/comments.js";
+import { getNodeLoc } from "../plugins/location.js";
 
 let uint8,
   uint32,
@@ -11,8 +12,7 @@ let uint8,
   sourceTextLatin,
   sourceStartPos = 0,
   firstNonAsciiPos = 0,
-  parent = null,
-  getLoc;
+  parent = null;
 
 const { fromCharCode } = String,
   { utf8Slice, latin1Slice } = Buffer.prototype,
@@ -22,24 +22,18 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 const NodeProto = Object.create(Object.prototype, {
   loc: {
     get() {
-      return getLoc(this);
+      return getNodeLoc(this);
     },
     enumerable: true,
   },
 });
 
-export function deserializeProgramOnly(
-  buffer,
-  sourceText,
-  sourceStartPosInput,
-  sourceByteLen,
-  getLoc,
-) {
+export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, sourceByteLen) {
   sourceStartPos = sourceStartPosInput;
-  return deserializeWith(buffer, sourceText, sourceByteLen, getLoc, deserializeProgram);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;
@@ -54,7 +48,6 @@ function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, de
     firstNonAsciiPos = i;
     sourceTextLatin = latin1Slice.call(uint8, sourceStartPos, sourceEndPos);
   }
-  getLoc = getLocInput;
   let data = deserialize(uint32[536870900]);
   resetBuffer();
   return data;

--- a/apps/oxlint/src-js/plugins/source_code.ts
+++ b/apps/oxlint/src-js/plugins/source_code.ts
@@ -15,7 +15,7 @@ import { resetComments } from "./comments.ts";
 import * as commentMethods from "./comments_methods.ts";
 import { ecmaVersion } from "./context.ts";
 import * as locationMethods from "./location.ts";
-import { getNodeLoc, initLines, lines, lineStartIndices, resetLinesAndLocs } from "./location.ts";
+import { initLines, lines, lineStartIndices, resetLinesAndLocs } from "./location.ts";
 import { resetScopeManager, SCOPE_MANAGER } from "./scope.ts";
 import * as scopeMethods from "./scope.ts";
 import { resetTokens } from "./tokens.ts";
@@ -75,7 +75,7 @@ export function initAst(): void {
   debugAssertIsNonNull(sourceText);
   debugAssertIsNonNull(buffer);
 
-  ast = deserializeProgramOnly(buffer, sourceText, sourceStartPos, sourceByteLen, getNodeLoc);
+  ast = deserializeProgramOnly(buffer, sourceText, sourceStartPos, sourceByteLen);
 
   // In conformance tests, fix AST when parsing as ES3
   if (CONFORMANCE) fixES3Ast();

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -16,10 +16,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -17,10 +17,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -16,10 +16,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -17,10 +17,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -16,10 +16,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -17,10 +17,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -16,10 +16,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -17,10 +17,10 @@ for (let i = 0; i <= 64; i++) stringDecodeArrays[i] = Array(i).fill(0);
 
 export function deserialize(buffer, sourceText, sourceByteLen) {
   sourceEndPos = sourceByteLen;
-  return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+  return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
 }
 
-function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {
+function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {
   uint8 = buffer;
   uint32 = buffer.uint32;
   float64 = buffer.float64;

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -141,13 +141,13 @@ fn generate_deserializers(
         /* IF LINTER */
         import {{ tokens, initTokens }} from '../plugins/tokens.js';
         import {{ comments, initComments }} from '../plugins/comments.js';
+        import {{ getNodeLoc }} from '../plugins/location.js';
         /* END_IF */
 
         let uint8, uint32, float64, sourceText, sourceTextLatin,
             sourceStartPos = 0, sourceEndPos = 0, firstNonAsciiPos = 0;
 
         let parent = null;
-        let getLoc;
 
         const {{ fromCharCode }} = String,
             {{ utf8Slice, latin1Slice }} = Buffer.prototype;
@@ -161,12 +161,12 @@ fn generate_deserializers(
             stringDecodeArrays[i] = new Array(i).fill(0);
         }}
 
-        /* IF LOC */
+        /* IF LINTER */
         const NodeProto = Object.create(Object.prototype, {{
             loc: {{
                 // Note: Not configurable
                 get() {{
-                    return getLoc(this);
+                    return getNodeLoc(this);
                 }},
                 enumerable: true,
             }}
@@ -176,18 +176,18 @@ fn generate_deserializers(
         /* IF !LINTER */
         export function deserialize(buffer, sourceText, sourceByteLen) {{
             sourceEndPos = sourceByteLen;
-            return deserializeWith(buffer, sourceText, sourceByteLen, null, deserializeRawTransferData);
+            return deserializeWith(buffer, sourceText, sourceByteLen, deserializeRawTransferData);
         }}
         /* END_IF */
 
         /* IF LINTER */
-        export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, sourceByteLen, getLoc) {{
+        export function deserializeProgramOnly(buffer, sourceText, sourceStartPosInput, sourceByteLen) {{
             sourceStartPos = sourceStartPosInput;
-            return deserializeWith(buffer, sourceText, sourceByteLen, getLoc, deserializeProgram);
+            return deserializeWith(buffer, sourceText, sourceByteLen, deserializeProgram);
         }}
         /* END_IF */
 
-        function deserializeWith(buffer, sourceTextInput, sourceByteLen, getLocInput, deserialize) {{
+        function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {{
             uint8 = buffer;
             uint32 = buffer.uint32;
             float64 = buffer.float64;
@@ -225,8 +225,6 @@ fn generate_deserializers(
                 }}
             }}
 
-            if (LOC) getLoc = getLocInput;
-
             const data = deserialize(uint32[{data_pointer_pos_32}]);
             resetBuffer();
             return data;
@@ -242,18 +240,14 @@ fn generate_deserializers(
     #[rustfmt::skip]
     let code_type_definition_linter = "
         import type { Program } from './types.d.ts';
-        import type { Node } from '../plugins/types.ts';
-        import type { Location as SourceLocation } from '../plugins/location.ts';
 
         type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
-        type GetLoc = (node: Node) => SourceLocation;
 
         export declare function deserializeProgramOnly(
             buffer: BufferWithArrays,
             sourceText: string,
             sourceStartPosInput: number,
             sourceByteLen: number,
-            getLoc: GetLoc
         ): Program;
 
         export declare function resetBuffer(): void;


### PR DESCRIPTION
Refacfor. In a strange pattern, we were injecting `getNodeLoc` into `deserialize.js` module on every call to `deserializeProgramOnly`. It's a static function, so just import it.