### PR TITLE
fix(oxlint): normalize explicit --config paths so overrides resolve from the config dir

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsStr,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::{Arc, mpsc},
 };
 
@@ -261,6 +261,31 @@ pub struct ConfigLoader<'a> {
 }
 
 impl<'a> ConfigLoader<'a> {
+    /// Normalize an explicit config path lexically so later matching against linted
+    /// files uses the config directory without any `.` or `..` segments.
+    fn normalize_explicit_config_path(cwd: &Path, config_path: &Path) -> PathBuf {
+        let joined_path = if config_path.is_absolute() {
+            config_path.to_path_buf()
+        } else {
+            cwd.join(config_path)
+        };
+
+        let mut normalized_path = PathBuf::new();
+        for component in joined_path.components() {
+            match component {
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    normalized_path.pop();
+                }
+                _ => {
+                    normalized_path.push(component.as_os_str());
+                }
+            }
+        }
+
+        normalized_path
+    }
+
     /// Create a new ConfigLoader
     ///
     /// # Arguments
@@ -591,7 +616,8 @@ impl<'a> ConfigLoader<'a> {
         cwd: &Path,
         config_path: &Path,
     ) -> Result<Oxlintrc, OxcDiagnostic> {
-        let full_path = cwd.join(config_path);
+        let full_path = Self::normalize_explicit_config_path(cwd, config_path);
+
         if is_js_config_path(&full_path) {
             return self.load_root_js_config(&full_path)?.ok_or_else(|| {
                 OxcDiagnostic::error(format!(
@@ -885,6 +911,15 @@ mod test {
                 config.path.file_name().unwrap().to_str().unwrap(),
                 "eslintrc.json",
                 "Config file name should be preserved after path resolution"
+            );
+            assert!(
+                !config.path.components().any(|component| {
+                    matches!(
+                        component,
+                        std::path::Component::CurDir | std::path::Component::ParentDir
+                    )
+                }),
+                "Config path should be normalized after path resolution"
             );
         }
     }

--- a/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/files/files/test.js
+++ b/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/files/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/options.json
+++ b/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/options.json
@@ -1,0 +1,4 @@
+{
+  "cwd": "files",
+  "args": ["-c", "../oxlint.config.ts"]
+}

--- a/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/output.snap.md
+++ b/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/output.snap.md
@@ -1,0 +1,19 @@
+# Exit code
+1
+
+# stdout
+```
+  x eslint(no-debugger): `debugger` statement is not allowed
+   ,-[files/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Remove the debugger statement
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 92 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/oxlint.config.ts
+++ b/apps/oxlint/test/fixtures/explicit_config_override_relative_to_config/oxlint.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "#oxlint";
+
+export default defineConfig({
+  rules: {
+    "no-debugger": "off",
+  },
+  overrides: [
+    {
+      files: ["files/**/*.js"],
+      rules: {
+        "no-debugger": "error",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
**Summary**

This fixes a path-resolution bug in `oxlint` when an explicit config is passed from a nested working directory, for example:

```bash
cd files
oxlint -c ../oxlint.config.ts files
```

In that case, the explicit config path was made absolute but not lexically normalized, so it could still contain `..` segments. That broke later override matching, because override globs are resolved relative to the config file’s parent directory. If the stored config path was something like `/repo/foo/files/../oxlint.config.ts`, then matching a lint target like `/repo/foo/files/test.js` against the config parent would fail lexically, and overrides such as `files/**/*.js` would not apply.

In practice, this caused rules configured through overrides to silently not fire, which can also surface as misleading `unused eslint-disable` diagnostics.

**What This Changes**

- Normalize explicit `--config` paths lexically in `ConfigLoader` before loading them.
- Preserve the existing behavior of resolving the config relative to `cwd`, but ensure the stored path no longer contains `.` or `..` components.
- Add a regression e2e fixture covering:
  - running `oxlint` from a nested `cwd`
  - passing `-c ../oxlint.config.ts`
  - relying on an override like `files/**/*.js`
- Strengthen the existing unit test to assert that resolved config paths are normalized.

**Why This Is Correct**

The bug was not in override logic itself, but in the shape of the path data fed into it.

Override application later does path matching relative to `config.path.parent()`. That logic assumes the config path and lint target path are in the same normalized path form. If the config path retains `..` segments while the lint target path does not, `strip_prefix` fails even though both paths refer to the same real location.

Lexically normalizing the explicit config path at load time fixes that mismatch at the source:

- the config continues to resolve relative to the provided `cwd`
- the config directory is stable and comparable
- override glob matching now sees the expected relative path
- no behavior changes for already-normalized paths

This is also the right scope for the fix: explicit config loading is where the inconsistent path form was introduced.

**User-Facing Effect**

This fixes cases where running `oxlint` from a subdirectory with an explicit config path causes override-based rules to stop applying. After this change, those overrides apply correctly, and downstream diagnostics such as `unused eslint-disable` are no longer produced spuriously because the intended rules now run.

**Tests**

- Added an e2e regression fixture reproducing the nested-`cwd` + explicit-config override case.
- Updated the config loader unit test to verify resolved config paths do not retain `.` / `..` components.

**AI Usage**

Used `codex` to help with creating this PR.