### PR TITLE
fix(linter/no-namespace): support glob pattern matching against basename

### DIFF
--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -100,7 +100,6 @@ impl Rule for NoNamespace {
 
                 if self.ignore.is_empty()
                     || self.ignore.iter().all(|pattern| {
-                        let source = source.trim_start_matches("./");
                         let target = if pattern.contains('/') {
                             source
                         } else {
@@ -144,6 +143,10 @@ fn test() {
             r"import * as schema from '../db/schema'",
             Some(serde_json::json!([{ "ignore": ["*schema"] }])),
         ),
+        (
+            r"import * as schema from './src/db/schema'",
+            Some(serde_json::json!([{ "ignore": ["./src/db/*"] }])),
+        ),
     ];
 
     let fail = vec![
@@ -156,6 +159,10 @@ fn test() {
             import * as DrizzleKit from 'drizzle-kit/api'
             ",
             Some(serde_json::json!([{ "ignore": ["zod"] }])),
+        ),
+        (
+            r"import * as schema from './src/db/schema'",
+            Some(serde_json::json!([{ "ignore": ["src/db/*"] }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -100,7 +100,13 @@ impl Rule for NoNamespace {
 
                 if self.ignore.is_empty()
                     || self.ignore.iter().all(|pattern| {
-                        !glob_match(pattern.as_str(), source.trim_start_matches("./"))
+                        let source = source.trim_start_matches("./");
+                        let target = if pattern.contains('/') {
+                            source
+                        } else {
+                            source.rsplit('/').next().unwrap_or(source)
+                        };
+                        !glob_match(pattern.as_str(), target)
                     })
                 {
                     ctx.diagnostic(no_namespace_diagnostic(entry.local_name.span));
@@ -128,6 +134,15 @@ fn test() {
             r"import * as bar from './ignored-module.js';
               import * as baz from './other-module.ts'",
             Some(serde_json::json!([{ "ignore": ["*.js", "*.ts"] }])),
+        ),
+        // https://github.com/oxc-project/oxc/issues/21011
+        (
+            r"import * as schema from 'src/db/schema'",
+            Some(serde_json::json!([{ "ignore": ["*schema"] }])),
+        ),
+        (
+            r"import * as schema from '../db/schema'",
+            Some(serde_json::json!([{ "ignore": ["*schema"] }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/import_no_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_namespace.snap
@@ -31,3 +31,10 @@ source: crates/oxc_linter/src/tester.rs
  4 │             
    ╰────
   help: Use named or default imports
+
+  ⚠ eslint-plugin-import(no-namespace): Usage of namespaced aka wildcard "*" imports prohibited
+   ╭─[index.js:1:13]
+ 1 │ import * as schema from './src/db/schema'
+   ·             ──────
+   ╰────
+  help: Use named or default imports


### PR DESCRIPTION
https://github.com/oxc-project/oxc/issues/21011