### PR TITLE
feat(linter/jest): implement padding-around-after-all-blocks

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2210,6 +2210,13 @@ impl RuleRunner for crate::rules::jest::no_untyped_mock_factory::NoUntypedMockFa
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner
+    for crate::rules::jest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -240,6 +240,7 @@ pub use crate::rules::jest::no_test_prefixes::NoTestPrefixes as JestNoTestPrefix
 pub use crate::rules::jest::no_test_return_statement::NoTestReturnStatement as JestNoTestReturnStatement;
 pub use crate::rules::jest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as JestNoUnneededAsyncExpectFunction;
 pub use crate::rules::jest::no_untyped_mock_factory::NoUntypedMockFactory as JestNoUntypedMockFactory;
+pub use crate::rules::jest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as JestPaddingAroundAfterAllBlocks;
 pub use crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks as JestPaddingAroundTestBlocks;
 pub use crate::rules::jest::prefer_called_with::PreferCalledWith as JestPreferCalledWith;
 pub use crate::rules::jest::prefer_comparison_matcher::PreferComparisonMatcher as JestPreferComparisonMatcher;
@@ -1070,6 +1071,7 @@ pub enum RuleEnum {
     JestNoTestReturnStatement(JestNoTestReturnStatement),
     JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction),
     JestNoUntypedMockFactory(JestNoUntypedMockFactory),
+    JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks),
     JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks),
     JestPreferCalledWith(JestPreferCalledWith),
     JestPreferComparisonMatcher(JestPreferComparisonMatcher),
@@ -1829,7 +1831,8 @@ const JEST_NO_TEST_PREFIXES_ID: usize = JEST_NO_STANDALONE_EXPECT_ID + 1usize;
 const JEST_NO_TEST_RETURN_STATEMENT_ID: usize = JEST_NO_TEST_PREFIXES_ID + 1usize;
 const JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize = JEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const JEST_NO_UNTYPED_MOCK_FACTORY_ID: usize = JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
-const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_NO_UNTYPED_MOCK_FACTORY_ID + 1usize;
+const JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize = JEST_NO_UNTYPED_MOCK_FACTORY_ID + 1usize;
+const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
 const JEST_PREFER_CALLED_WITH_ID: usize = JEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const JEST_PREFER_COMPARISON_MATCHER_ID: usize = JEST_PREFER_CALLED_WITH_ID + 1usize;
 const JEST_PREFER_EACH_ID: usize = JEST_PREFER_COMPARISON_MATCHER_ID + 1usize;
@@ -2652,6 +2655,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(_) => JEST_NO_TEST_RETURN_STATEMENT_ID,
             Self::JestNoUnneededAsyncExpectFunction(_) => JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID,
             Self::JestNoUntypedMockFactory(_) => JEST_NO_UNTYPED_MOCK_FACTORY_ID,
+            Self::JestPaddingAroundAfterAllBlocks(_) => JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
             Self::JestPaddingAroundTestBlocks(_) => JEST_PADDING_AROUND_TEST_BLOCKS_ID,
             Self::JestPreferCalledWith(_) => JEST_PREFER_CALLED_WITH_ID,
             Self::JestPreferComparisonMatcher(_) => JEST_PREFER_COMPARISON_MATCHER_ID,
@@ -3473,6 +3477,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(_) => JestNoTestReturnStatement::NAME,
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::NAME,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::NAME,
+            Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::NAME,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::NAME,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::NAME,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::NAME,
@@ -4308,6 +4313,7 @@ impl RuleEnum {
                 JestNoUnneededAsyncExpectFunction::CATEGORY
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::CATEGORY,
+            Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::CATEGORY,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::CATEGORY,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::CATEGORY,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::CATEGORY,
@@ -5148,6 +5154,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(_) => JestNoTestReturnStatement::FIX,
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::FIX,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::FIX,
+            Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::FIX,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::FIX,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::FIX,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::FIX,
@@ -6050,6 +6057,9 @@ impl RuleEnum {
                 JestNoUnneededAsyncExpectFunction::documentation()
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::documentation(),
+            Self::JestPaddingAroundAfterAllBlocks(_) => {
+                JestPaddingAroundAfterAllBlocks::documentation()
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::documentation(),
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::documentation(),
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::documentation(),
@@ -7543,6 +7553,10 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::config_schema(generator)
                 .or_else(|| JestNoUntypedMockFactory::schema(generator)),
+            Self::JestPaddingAroundAfterAllBlocks(_) => {
+                JestPaddingAroundAfterAllBlocks::config_schema(generator)
+                    .or_else(|| JestPaddingAroundAfterAllBlocks::schema(generator))
+            }
             Self::JestPaddingAroundTestBlocks(_) => {
                 JestPaddingAroundTestBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundTestBlocks::schema(generator))
@@ -8946,6 +8960,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(_) => "jest",
             Self::JestNoUnneededAsyncExpectFunction(_) => "jest",
             Self::JestNoUntypedMockFactory(_) => "jest",
+            Self::JestPaddingAroundAfterAllBlocks(_) => "jest",
             Self::JestPaddingAroundTestBlocks(_) => "jest",
             Self::JestPreferCalledWith(_) => "jest",
             Self::JestPreferComparisonMatcher(_) => "jest",
@@ -10427,6 +10442,9 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => Ok(Self::JestNoUntypedMockFactory(
                 JestNoUntypedMockFactory::from_configuration(value)?,
+            )),
+            Self::JestPaddingAroundAfterAllBlocks(_) => Ok(Self::JestPaddingAroundAfterAllBlocks(
+                JestPaddingAroundAfterAllBlocks::from_configuration(value)?,
             )),
             Self::JestPaddingAroundTestBlocks(_) => Ok(Self::JestPaddingAroundTestBlocks(
                 JestPaddingAroundTestBlocks::from_configuration(value)?,
@@ -11953,6 +11971,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.to_configuration(),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.to_configuration(),
             Self::JestNoUntypedMockFactory(rule) => rule.to_configuration(),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.to_configuration(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.to_configuration(),
             Self::JestPreferCalledWith(rule) => rule.to_configuration(),
             Self::JestPreferComparisonMatcher(rule) => rule.to_configuration(),
@@ -12670,6 +12689,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.run(node, ctx),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run(node, ctx),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
@@ -13385,6 +13405,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.run_once(ctx),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_once(ctx),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
             Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
@@ -14168,6 +14189,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -14915,6 +14937,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.should_run(ctx),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.should_run(ctx),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.should_run(ctx),
             Self::JestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.should_run(ctx),
@@ -15784,6 +15807,9 @@ impl RuleEnum {
                 JestNoUnneededAsyncExpectFunction::IS_TSGOLINT_RULE
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::IS_TSGOLINT_RULE,
+            Self::JestPaddingAroundAfterAllBlocks(_) => {
+                JestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::IS_TSGOLINT_RULE,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::IS_TSGOLINT_RULE,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::IS_TSGOLINT_RULE,
@@ -16754,6 +16780,7 @@ impl RuleEnum {
                 JestNoUnneededAsyncExpectFunction::HAS_CONFIG
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::HAS_CONFIG,
+            Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::HAS_CONFIG,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::HAS_CONFIG,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::HAS_CONFIG,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::HAS_CONFIG,
@@ -17541,6 +17568,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.types_info(),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.types_info(),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.types_info(),
             Self::JestPreferCalledWith(rule) => rule.types_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.types_info(),
@@ -18256,6 +18284,7 @@ impl RuleEnum {
             Self::JestNoTestReturnStatement(rule) => rule.run_info(),
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.run_info(),
+            Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_info(),
             Self::JestPreferCalledWith(rule) => rule.run_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.run_info(),
@@ -19057,6 +19086,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestNoTestReturnStatement(JestNoTestReturnStatement::default()),
         RuleEnum::JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction::default()),
         RuleEnum::JestNoUntypedMockFactory(JestNoUntypedMockFactory::default()),
+        RuleEnum::JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks::default()),
         RuleEnum::JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks::default()),
         RuleEnum::JestPreferCalledWith(JestPreferCalledWith::default()),
         RuleEnum::JestPreferComparisonMatcher(JestPreferComparisonMatcher::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -354,6 +354,7 @@ pub(crate) mod jest {
     pub mod no_test_return_statement;
     pub mod no_unneeded_async_expect_function;
     pub mod no_untyped_mock_factory;
+    pub mod padding_around_after_all_blocks;
     pub mod padding_around_test_blocks;
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;

--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -1,24 +1,14 @@
-use std::ops::Deref;
-
-use oxc_ast::{AstKind, ast::Statement};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
-use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
         JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+        report_missing_padding_before_jest_block,
     },
 };
-
-fn padding_around_after_all_blocks_diagnostic(span: Span, name: &CompactStr) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
-        .with_help(format!("Make sure there is an empty new line before the {name} block"))
-        .with_label(span)
-}
 
 #[derive(Debug, Default, Clone)]
 pub struct PaddingAroundAfterAllBlocks;
@@ -76,70 +66,11 @@ impl Rule for PaddingAroundAfterAllBlocks {
         if kind != JestGeneralFnKind::Hook {
             return;
         }
-        let name_str = name.deref();
-        if name_str != "afterAll" {
+        if name != "afterAll" {
             return;
         }
-        let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
-        let prev_statement_span = match scope_node.kind() {
-            AstKind::Program(program) => {
-                get_statement_span_before_node(*node, program.body.as_slice())
-            }
-            AstKind::ArrowFunctionExpression(arrow_func_expr) => {
-                get_statement_span_before_node(*node, arrow_func_expr.body.statements.as_slice())
-            }
-            AstKind::Function(function) => {
-                let Some(body) = &function.body else {
-                    return;
-                };
-                get_statement_span_before_node(*node, body.statements.as_slice())
-            }
-            _ => None,
-        };
-        let Some(prev_statement_span) = prev_statement_span else {
-            return;
-        };
-        let mut comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
-        let mut span_between_start = prev_statement_span.end;
-        let mut span_between_end = node.span().start;
-        if let Some(last_comment_span) = comments_range.next_back().map(|comment| comment.span) {
-            let space_after_last_comment =
-                ctx.source_range(Span::new(last_comment_span.end, node.span().start));
-            let space_before_last_comment =
-                ctx.source_range(Span::new(prev_statement_span.end, last_comment_span.start));
-            if space_after_last_comment.matches('\n').count() > 1
-                || space_before_last_comment.matches('\n').count() == 0
-            {
-                span_between_start = last_comment_span.end;
-            } else {
-                span_between_end = last_comment_span.start;
-            }
-        }
-        let span_between = Span::new(span_between_start, span_between_end);
-        let content = ctx.source_range(span_between);
-        if content.matches('\n').count() < 2 {
-            ctx.diagnostic_with_fix(
-                padding_around_after_all_blocks_diagnostic(
-                    Span::new(span_between_end, span_between_end),
-                    &name.deref().into(),
-                ),
-                |fixer| {
-                    let whitespace_after_last_line =
-                        content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
-                    fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
-                },
-            );
-        }
+        report_missing_padding_before_jest_block(node, ctx, name);
     }
-}
-
-fn get_statement_span_before_node(node: AstNode, statements: &[Statement]) -> Option<Span> {
-    statements
-        .iter()
-        .filter_map(|statement| {
-            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
-        })
-        .next_back()
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_after_all_blocks.rs
@@ -1,0 +1,166 @@
+use std::ops::Deref;
+
+use oxc_ast::{AstKind, ast::Statement};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNode;
+use oxc_span::{CompactStr, GetSpan, Span};
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{
+        JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+    },
+};
+
+fn padding_around_after_all_blocks_diagnostic(span: Span, name: &CompactStr) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
+        .with_help(format!("Make sure there is an empty new line before the {name} block"))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundAfterAllBlocks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule enforces a line of padding before and after 1 or more
+    /// `afterAll` statements.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Inconsistent formatting of code can make the code more difficult to read
+    /// and follow. This rule helps ensure that `afterAll` blocks are visually
+    /// separated from the rest of the code, making them easier to identify while
+    /// looking through test files.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    /// afterAll(() => {});
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const thing = 123;
+    ///
+    /// afterAll(() => {});
+    /// ```
+    PaddingAroundAfterAllBlocks,
+    jest,
+    style,
+    fix
+);
+
+impl Rule for PaddingAroundAfterAllBlocks {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+        let Some(jest_fn_call) = parse_general_jest_fn_call(call_expr, jest_node, ctx) else {
+            return;
+        };
+        let ParsedGeneralJestFnCall { kind, name, .. } = &jest_fn_call;
+        let Some(kind) = kind.to_general() else {
+            return;
+        };
+        if kind != JestGeneralFnKind::Hook {
+            return;
+        }
+        let name_str = name.deref();
+        if name_str != "afterAll" {
+            return;
+        }
+        let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
+        let prev_statement_span = match scope_node.kind() {
+            AstKind::Program(program) => {
+                get_statement_span_before_node(*node, program.body.as_slice())
+            }
+            AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+                get_statement_span_before_node(*node, arrow_func_expr.body.statements.as_slice())
+            }
+            AstKind::Function(function) => {
+                let Some(body) = &function.body else {
+                    return;
+                };
+                get_statement_span_before_node(*node, body.statements.as_slice())
+            }
+            _ => None,
+        };
+        let Some(prev_statement_span) = prev_statement_span else {
+            return;
+        };
+        let mut comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
+        let mut span_between_start = prev_statement_span.end;
+        let mut span_between_end = node.span().start;
+        if let Some(last_comment_span) = comments_range.next_back().map(|comment| comment.span) {
+            let space_after_last_comment =
+                ctx.source_range(Span::new(last_comment_span.end, node.span().start));
+            let space_before_last_comment =
+                ctx.source_range(Span::new(prev_statement_span.end, last_comment_span.start));
+            if space_after_last_comment.matches('\n').count() > 1
+                || space_before_last_comment.matches('\n').count() == 0
+            {
+                span_between_start = last_comment_span.end;
+            } else {
+                span_between_end = last_comment_span.start;
+            }
+        }
+        let span_between = Span::new(span_between_start, span_between_end);
+        let content = ctx.source_range(span_between);
+        if content.matches('\n').count() < 2 {
+            ctx.diagnostic_with_fix(
+                padding_around_after_all_blocks_diagnostic(
+                    Span::new(span_between_end, span_between_end),
+                    &name.deref().into(),
+                ),
+                |fixer| {
+                    let whitespace_after_last_line =
+                        content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
+                    fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
+                },
+            );
+        }
+    }
+}
+
+fn get_statement_span_before_node(node: AstNode, statements: &[Statement]) -> Option<Span> {
+    statements
+        .iter()
+        .filter_map(|statement| {
+            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
+        })
+        .next_back()
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "afterAll(() => {});",
+        "const thing = 123;\n\nafterAll(() => {});",
+        "describe('foo', () => {\nafterAll(() => {});\n});",
+    ];
+
+    let fail = vec!["const thing = 123;\nafterAll(() => {});"];
+
+    let fix = vec![(
+        "const thing = 123;\nafterAll(() => {});",
+        "const thing = 123;\n\nafterAll(() => {});",
+    )];
+
+    Tester::new(PaddingAroundAfterAllBlocks::NAME, PaddingAroundAfterAllBlocks::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -83,7 +83,7 @@ impl Rule for PaddingAroundTestBlocks {
         if kind != JestGeneralFnKind::Test {
             return;
         }
-        report_missing_padding_before_jest_block(node, ctx, name.as_ref());
+        report_missing_padding_before_jest_block(node, ctx, name);
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_test_blocks.rs
@@ -1,24 +1,14 @@
-use std::ops::Deref;
-
-use oxc_ast::{AstKind, ast::Statement};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::AstNode;
-use oxc_span::{CompactStr, GetSpan, Span};
 
 use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
         JestGeneralFnKind, ParsedGeneralJestFnCall, PossibleJestNode, parse_general_jest_fn_call,
+        report_missing_padding_before_jest_block,
     },
 };
-
-fn padding_around_test_blocks_diagnostic(span: Span, name: &CompactStr) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
-        .with_help(format!("Make sure there is an empty new line before the {name} block"))
-        .with_label(span)
-}
 
 #[derive(Debug, Default, Clone)]
 pub struct PaddingAroundTestBlocks;
@@ -93,66 +83,8 @@ impl Rule for PaddingAroundTestBlocks {
         if kind != JestGeneralFnKind::Test {
             return;
         }
-        let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
-        let prev_statement_span = match scope_node.kind() {
-            AstKind::Program(program) => {
-                get_statement_span_before_node(*node, program.body.as_slice())
-            }
-            AstKind::ArrowFunctionExpression(arrow_func_expr) => {
-                get_statement_span_before_node(*node, arrow_func_expr.body.statements.as_slice())
-            }
-            AstKind::Function(function) => {
-                let Some(body) = &function.body else {
-                    return;
-                };
-                get_statement_span_before_node(*node, body.statements.as_slice())
-            }
-            _ => None,
-        };
-        let Some(prev_statement_span) = prev_statement_span else {
-            return;
-        };
-        let mut comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
-        let mut span_between_start = prev_statement_span.end;
-        let mut span_between_end = node.span().start;
-        if let Some(last_comment_span) = comments_range.next_back().map(|comment| comment.span) {
-            let space_after_last_comment =
-                ctx.source_range(Span::new(last_comment_span.end, node.span().start));
-            let space_before_last_comment =
-                ctx.source_range(Span::new(prev_statement_span.end, last_comment_span.start));
-            if space_after_last_comment.matches('\n').count() > 1
-                || space_before_last_comment.matches('\n').count() == 0
-            {
-                span_between_start = last_comment_span.end;
-            } else {
-                span_between_end = last_comment_span.start;
-            }
-        }
-        let span_between = Span::new(span_between_start, span_between_end);
-        let content = ctx.source_range(span_between);
-        if content.matches('\n').count() < 2 {
-            ctx.diagnostic_with_fix(
-                padding_around_test_blocks_diagnostic(
-                    Span::new(span_between_end, span_between_end),
-                    &name.deref().into(),
-                ),
-                |fixer| {
-                    let whitespace_after_last_line =
-                        content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
-                    fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
-                },
-            );
-        }
+        report_missing_padding_before_jest_block(node, ctx, name.as_ref());
     }
-}
-
-fn get_statement_span_before_node(node: AstNode, statements: &[Statement]) -> Option<Span> {
-    statements
-        .iter()
-        .filter_map(|statement| {
-            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
-        })
-        .next_back()
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_after_all_blocks.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ eslint-plugin-jest(padding-around-after-all-blocks): Missing padding before afterAll block
+   ╭─[padding_around_after_all_blocks.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ afterAll(() => {});
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the afterAll block

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -17,7 +17,9 @@ pub use crate::utils::jest::parse_jest_fn::{
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
+pub use padding_around_block::report_missing_padding_before_jest_block;
 
+mod padding_around_block;
 mod parse_jest_fn;
 
 const JEST_METHOD_NAMES: [&str; 19] = [

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -1,0 +1,78 @@
+use oxc_ast::{AstKind, ast::Statement};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_semantic::AstNode;
+use oxc_span::{GetSpan, Span};
+
+use crate::context::LintContext;
+
+fn padding_around_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
+        .with_help(format!("Make sure there is an empty new line before the {name} block"))
+        .with_label(span)
+}
+
+pub fn report_missing_padding_before_jest_block<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    name: &str,
+) {
+    let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
+    let prev_statement_span = match scope_node.kind() {
+        AstKind::Program(program) => get_statement_span_before_node(node, program.body.as_slice()),
+        AstKind::ArrowFunctionExpression(arrow_func_expr) => {
+            get_statement_span_before_node(node, arrow_func_expr.body.statements.as_slice())
+        }
+        AstKind::Function(function) => {
+            let Some(body) = &function.body else {
+                return;
+            };
+            get_statement_span_before_node(node, body.statements.as_slice())
+        }
+        _ => None,
+    };
+    let Some(prev_statement_span) = prev_statement_span else {
+        return;
+    };
+
+    let mut comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
+    let mut span_between_start = prev_statement_span.end;
+    let mut span_between_end = node.span().start;
+    if let Some(last_comment_span) = comments_range.next_back().map(|comment| comment.span) {
+        let space_after_last_comment =
+            ctx.source_range(Span::new(last_comment_span.end, node.span().start));
+        let space_before_last_comment =
+            ctx.source_range(Span::new(prev_statement_span.end, last_comment_span.start));
+        if space_after_last_comment.matches('\n').count() > 1
+            || space_before_last_comment.matches('\n').count() == 0
+        {
+            span_between_start = last_comment_span.end;
+        } else {
+            span_between_end = last_comment_span.start;
+        }
+    }
+
+    let span_between = Span::new(span_between_start, span_between_end);
+    let content = ctx.source_range(span_between);
+    if content.matches('\n').count() < 2 {
+        ctx.diagnostic_with_fix(
+            padding_around_jest_block_diagnostic(
+                Span::new(span_between_end, span_between_end),
+                name,
+            ),
+            |fixer| {
+                let whitespace_after_last_line =
+                    content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
+                fixer.replace(span_between, format!("\n\n{whitespace_after_last_line}"))
+            },
+        );
+    }
+}
+
+fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> Option<Span> {
+    statements
+        .iter()
+        .filter_map(|statement| {
+            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
+        })
+        .next_back()
+}


### PR DESCRIPTION
## Summary
- Implement `jest/padding-around-after-all-blocks` rule
- Enforces padding lines before `afterAll` blocks in test files
- Includes auto-fix support

Part of #492.