### PR TITLE
fix(minifier): preserve `var` inside `catch` with same-named parameter

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1250,6 +1250,13 @@ impl<'a> PeepholeOptimizations {
             let BindingPattern::BindingIdentifier(prev_decl_id) = &prev_decl.id else {
                 return true;
             };
+            // Don't inline `var e` inside `catch (e) { ... }`. Removing the var declarator
+            // would lose the function-scoped hoisting that `var` provides. The catch parameter
+            // and the var share one symbol (with CatchVariable flag) due to the redeclaration
+            // semantics in https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks
+            if ctx.scoping().symbol_flags(prev_decl_id.symbol_id()).is_catch_variable() {
+                return true;
+            }
             if ctx.is_expression_whose_name_needs_to_be_kept(prev_decl_init) {
                 return true;
             }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -4,6 +4,7 @@ use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{CloneIn, TakeIn, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
+use oxc_ecmascript::BoundNames;
 use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{ToJsString, ToNumber, side_effects::MayHaveSideEffects};
@@ -1581,8 +1582,88 @@ impl<'a> PeepholeOptimizations {
             && let Some(param) = &catch.param
             && let BindingPattern::BindingIdentifier(ident) = &param.pattern
             && (catch.body.body.is_empty() || ctx.scoping().symbol_is_unused(ident.symbol_id()))
+            // Don't remove catch parameter when the body has a `var` with the same name.
+            // In `catch (e) { var e = x }`, removing the catch param changes which binding
+            // the assignment targets, because `var e` inside `catch (e)` assigns to the
+            // catch parameter, not the function-scoped hoisted var.
+            && !Self::catch_body_has_var_with_same_name(&catch.body, &ident.name)
         {
             catch.param = None;
+        }
+    }
+
+    /// Check if a catch body (or any nested non-function scope) contains a `var`
+    /// declaration whose bound name matches `name`. Var declarations hoist out of
+    /// blocks/loops/etc. but NOT out of functions.
+    fn catch_body_has_var_with_same_name(body: &BlockStatement<'a>, name: &str) -> bool {
+        body.body.iter().any(|stmt| Self::stmt_has_var_with_name(stmt, name))
+    }
+
+    /// Check whether a `var` declaration binds `name` (handles destructuring patterns).
+    fn var_decl_binds_name(decl: &VariableDeclaration<'a>, name: &str) -> bool {
+        decl.kind.is_var() && {
+            let mut found = false;
+            decl.bound_names(&mut |ident| {
+                if ident.name == name {
+                    found = true;
+                }
+            });
+            found
+        }
+    }
+
+    /// Recursively check if `stmt` contains a `var` declaration binding `name`.
+    /// Only enters statement types where `var` can hoist; stops at function boundaries.
+    fn stmt_has_var_with_name(stmt: &Statement<'a>, name: &str) -> bool {
+        match stmt {
+            Statement::VariableDeclaration(decl) => Self::var_decl_binds_name(decl, name),
+            Statement::BlockStatement(s) => {
+                s.body.iter().any(|s| Self::stmt_has_var_with_name(s, name))
+            }
+            Statement::IfStatement(s) => {
+                Self::stmt_has_var_with_name(&s.consequent, name)
+                    || s.alternate
+                        .as_ref()
+                        .is_some_and(|alt| Self::stmt_has_var_with_name(alt, name))
+            }
+            Statement::ForStatement(s) => {
+                s.init
+                    .as_ref()
+                    .is_some_and(|init| match init {
+                        ForStatementInit::VariableDeclaration(decl) => {
+                            Self::var_decl_binds_name(decl, name)
+                        }
+                        _ => false,
+                    })
+                    || Self::stmt_has_var_with_name(&s.body, name)
+            }
+            Statement::ForInStatement(s) => {
+                matches!(&s.left, ForStatementLeft::VariableDeclaration(decl)
+                    if Self::var_decl_binds_name(decl, name))
+                    || Self::stmt_has_var_with_name(&s.body, name)
+            }
+            Statement::ForOfStatement(s) => {
+                matches!(&s.left, ForStatementLeft::VariableDeclaration(decl)
+                    if Self::var_decl_binds_name(decl, name))
+                    || Self::stmt_has_var_with_name(&s.body, name)
+            }
+            Statement::WhileStatement(s) => Self::stmt_has_var_with_name(&s.body, name),
+            Statement::DoWhileStatement(s) => Self::stmt_has_var_with_name(&s.body, name),
+            Statement::LabeledStatement(s) => Self::stmt_has_var_with_name(&s.body, name),
+            Statement::WithStatement(s) => Self::stmt_has_var_with_name(&s.body, name),
+            Statement::SwitchStatement(s) => s.cases.iter().any(|case| {
+                case.consequent.iter().any(|s| Self::stmt_has_var_with_name(s, name))
+            }),
+            Statement::TryStatement(s) => {
+                s.block.body.iter().any(|s| Self::stmt_has_var_with_name(s, name))
+                    || s.handler.as_ref().is_some_and(|h| {
+                        h.body.body.iter().any(|s| Self::stmt_has_var_with_name(s, name))
+                    })
+                    || s.finalizer.as_ref().is_some_and(|f| {
+                        f.body.iter().any(|s| Self::stmt_has_var_with_name(s, name))
+                    })
+            }
+            _ => false,
         }
     }
 

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -2343,7 +2343,11 @@ fn test_remove_dead_expr_other() {
         "try { throw 1 } catch (x) { y(x); var x = 2; y(x) }",
         "try { throw 1;} catch (x) { y(x); var x = 2; y(x);}",
     );
-    test("try { throw 1 } catch (x) { var x = 2; y(x) }", "try { throw 1;} catch { y(2);}");
+    // `var x` inside `catch (x)` must be kept, because removing it loses hoisting
+    test(
+        "try { throw 1 } catch (x) { var x = 2; y(x) }",
+        "try { throw 1;} catch (x) { var x = 2; y(x);}",
+    );
     test(
         "try { throw 1 } catch (x) { var x = 2; y(x) } console.log(x)",
         "try { throw 1;} catch (x) { var x = 2; y(x);} console.log(x)",

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -740,19 +740,51 @@ fn optional_catch_binding() {
     test_same("try { foo } catch([e]) {}");
     test_same("try { foo } catch({e}) {}");
     test_same("try { foo } catch(e) { var e = baz; bar(e) }");
-    test("try { foo } catch(e) { var e = 2 }", "try { foo } catch { var e = 2 }");
+    // catch param must be kept when body has a same-named var. Removing
+    // the param would change which binding the assignment targets.
+    test_same("try { foo } catch(e) { var e = 2 }");
     test_same("try { foo } catch(e) { var e = 2 } bar(e)");
+    // Same for destructuring var patterns: `var {e}` and `var [e]` also
+    // hoist `e` to function scope and assign to the catch parameter.
+    test_same("try { foo } catch(e) { var {e} = obj }");
+    test_same("try { foo } catch(e) { var [e] = arr }");
+    // var hoists from nested blocks inside catch, so catch param must be kept.
+    test(
+        "try { foo } catch(e) { if (true) { var e = 2 } }",
+        "try { foo } catch(e) { var e = 2 }",
+    );
+    test_same("try { foo } catch(e) { for (var e = 0;;) break }");
+    // var inside a function does NOT interact with the catch parameter;
+    // var doesn't hoist out of functions, so the catch param can be removed.
+    test(
+        "try { foo } catch(e) { (function() { var e = 2 })() }",
+        "try { foo } catch { (function() { var e = 2;})();}",
+    );
+    test(
+        "try { foo } catch(e) { function f() { var e = 2 } }",
+        "try { foo } catch { function f() { var e = 2 } }",
+    );
 
-    // FIXME catch(a) has no references but it cannot be removed.
-    // test_same(
-    // r#"var a = "PASS";
-    // try {
-    // throw "FAIL1";
-    // } catch (a) {
-    // var a = "FAIL2";
-    // }
-    // console.log(a);"#,
-    // );
+    test_same(
+        r#"var a = "PASS";
+    try {
+    throw "FAIL1";
+    } catch (a) {
+    var a = "FAIL2";
+    }
+    console.log(a);"#,
+    );
+
+    // Regression tests for https://github.com/oxc-project/oxc/issues/17307
+    // var inside nested catches must preserve hoisting so outer `e` reference works.
+    test(
+        "try {} catch (e) { try {} catch (e) { var e = 'e'; console.log(e === 'e') } } console.log(e === undefined)",
+        "try {} catch (e) { var e } console.log(e === void 0)",
+    );
+    test(
+        "try { throw 1 } catch (e) { try { throw 2 } catch (e) { var e = 'e'; console.log(e === 'e') } } console.log(e === undefined)",
+        "try { throw 1 } catch (e) { try { throw 2 } catch (e) { var e = 'e'; console.log(e === 'e') } } console.log(e === void 0)",
+    );
 
     test_target_same("try { foo } catch(e) {}", "chrome65");
 }


### PR DESCRIPTION
What
---

Fix bugs involving `var` in catch-clauses. When `var e` appears inside `catch (e)`, the `var` hoists a declaration to function scope while the catch parameter creates a separate catch-scoped binding. The minifier was incorrectly:

1. Inlining the var's init value into subsequent expressions and removing the var declarator, losing the function-scoped hoisting effect.

2. Removing the catch parameter when it appeared "unused", which changes which binding `var e = value` assigns to.

Fixes #17307

How
---

In `substitute_single_use_symbol_in_expression_from_declarators`, block name-based inlining when the var's symbol has the `CatchVariable` flag.

In `substitute_catch_clause`, check whether the catch body contains a `var` with the same name as the catch parameter, before removing it.