### PR TITLE
fix(config): child config is overridden by parent config

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -368,6 +368,9 @@ impl ConfigStore {
             if let Some(config) = self.nested_configs.get(dir) {
                 return Some(config);
             }
+            if self.base.base.config.path.as_ref().is_some_and(|path| path.parent() == current) {
+              return Some(&self.base);
+            }
             current = dir.parent();
         }
         None


### PR DESCRIPTION
Fixes #21030, Fixes #20904

The problem was that when trying to resolve the current config file when linting some file, we walk up that file's ancestors until we find a nested config that applies to that directory, but we don't check whether the base config file applies to it. This means that if the file structure looks something like this:

```
oxlint.config.ts
dir/
  oxlint.config.ts
  file_to_lint.ts     
```

and our cwd was `dir`, and we ran `oxlint file_to_lint.ts`, the base config file would be `dir/oxlint.config.ts` (because it's in the current working directory) and the nested config would be `oxlint.config.ts`, so when resolving the final config file for `file_to_lint.ts`, `dir/oxlint.config.ts` would be skipped (because we don't check whether the base config applies), and thus `oxlint.config.ts` would be the one to take effect.

This pr makes it so we also check whether the base config applies to the current file, as well as nested configs.

