### PR TITLE
fix(oxlint): don't search for nested config outside base config

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -54,9 +54,15 @@ pub fn discover_configs_in_ancestors<P: AsRef<Path>>(
 
     for file in files {
         let path = file.as_ref();
+        let mut base_config_found = false;
         // Start from the file's parent directory and walk up the tree
         let mut current = path.parent();
         while let Some(dir) = current {
+            if base_config_found {
+                // Stop if we've reached the base config file (e.g., root oxlintrc)
+                // to avoid duplicate loading and filling nested config with configs outside from the root config.
+                break;
+            }
             // Stop if we've already checked this directory (and its ancestors)
             let inserted = visited_dirs.insert(dir.to_path_buf());
             if !inserted {
@@ -64,8 +70,8 @@ pub fn discover_configs_in_ancestors<P: AsRef<Path>>(
             }
             for config in find_configs_in_directory(dir) {
                 if config.path() == base_config_path {
-                    // Skip the base config file (e.g., root oxlintrc) to avoid duplicate loading
-                    continue;
+                    base_config_found = true;
+                    break;
                 }
                 config_paths.insert(config);
             }

--- a/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__nested_config__package4-as-cwd_@oxlint.snap
@@ -5,18 +5,8 @@ source: apps/oxlint/src/tester.rs
 arguments: 
 working directory: fixtures/cli/nested_config/package4-as-cwd
 ----------
-
-  x eslint(no-console): Unexpected console statement.
-   ,-[component.js:2:3]
- 1 | export function Component() {
- 2 |   console.log("hello");
-   :   ^^^^^^^^^^^
- 3 | }
-   `----
-  help: Delete this console statement.
-
-Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file using 1 threads.
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 93 rules using 1 threads.
 ----------
-CLI result: LintFoundErrors
+CLI result: LintSucceeded
 ----------


### PR DESCRIPTION
Fixes https://github.com/oxc-project/oxc/issues/21030, Fixes https://github.com/oxc-project/oxc/issues/20904, Obsoletes https://github.com/oxc-project/oxc/pull/21041

Nested config search did include the configs outside the current working directory. Resolving the config did find first the nested config outside the `cwd`, before falling back to the base config. 
