### PR TITLE
build(apps,napi): add LoongArch64 Linux (linux-loong64) builds

### DIFF
--- a/.github/workflows/release_apps.yml
+++ b/.github/workflows/release_apps.yml
@@ -106,6 +106,15 @@ jobs:
             build: pnpm run build-napi-release --target powerpc64le-unknown-linux-gnu --use-napi-cross
 
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y
+              export TARGET_CC=loongarch64-linux-gnu-gcc-14
+              export CXX=loongarch64-linux-gnu-g++-14
+              pnpm run build-napi-release --target loongarch64-unknown-linux-gnu
+
+          - os: ubuntu-latest
             target: riscv64gc-unknown-linux-gnu
             build: |
               sudo apt-get update
@@ -113,6 +122,15 @@ jobs:
               export TARGET_CC=riscv64-linux-gnu-gcc
               export CXX=riscv64-linux-gnu-g++
               pnpm run build-napi-release --target riscv64gc-unknown-linux-gnu
+
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y
+              export TARGET_CC=loongarch64-linux-gnu-gcc-14
+              export CXX=loongarch64-linux-gnu-g++-14
+              pnpm run build-napi-release --target loongarch64-unknown-linux-musl -x
 
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-musl

--- a/.github/workflows/reusable_release_napi.yml
+++ b/.github/workflows/reusable_release_napi.yml
@@ -91,6 +91,15 @@ jobs:
             build: pnpm build --target aarch64-linux-android
 
           - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y
+              export TARGET_CC=loongarch64-linux-gnu-gcc-14
+              export CXX=loongarch64-linux-gnu-g++-14
+              pnpm build --target loongarch64-unknown-linux-gnu
+
+          - os: ubuntu-latest
             target: riscv64gc-unknown-linux-gnu
             build: |
               sudo apt-get update
@@ -118,6 +127,15 @@ jobs:
           - os: ubuntu-latest
             target: powerpc64le-unknown-linux-gnu
             build: pnpm build --target powerpc64le-unknown-linux-gnu --use-napi-cross
+
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            build: |
+              sudo apt-get update
+              sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu -y
+              export TARGET_CC=loongarch64-linux-gnu-gcc-14
+              export CXX=loongarch64-linux-gnu-g++-14
+              pnpm build --target loongarch64-unknown-linux-musl -x
 
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-musl

--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -51,6 +51,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",

--- a/apps/oxlint/package.json
+++ b/apps/oxlint/package.json
@@ -82,6 +82,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -69,6 +69,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -106,6 +106,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -67,6 +67,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",


### PR DESCRIPTION
Unblocks Vite builds on `linux/loong64` platforms, such as [this one](https://github.com/loongson-community/loongfans/issues/109).

Changes in this PR was made manually by me.

I'll still have to do more tests to confidently mark this PR as ready for review, but I expect the changes to be pretty much complete by now.