### PR TITLE
fix(linter): parse `<script>` tag attributes with curly braces in Svelte files

### DIFF
--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -42,8 +42,10 @@ impl PartialLoader {
 /// Find closing angle for situations where there is another `>` in between.
 /// e.g. `<script generic="T extends Record<string, string>">`
 /// or `<script attribute="text with > inside">`
+/// or `<script onload={() => {}}>`
 fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize> {
     let mut open_angle = 0;
+    let mut open_brace = 0;
     let mut in_quote: Option<char> = None;
 
     for (offset, c) in source_text[pointer..].char_indices() {
@@ -53,14 +55,22 @@ fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize>
                     if q == c {
                         in_quote = None;
                     }
-                } else {
+                } else if open_brace == 0 {
                     in_quote = Some(c);
                 }
             }
-            '<' if in_quote.is_none() => {
+            '{' if in_quote.is_none() => {
+                open_brace += 1;
+            }
+            '}' if in_quote.is_none() => {
+                if open_brace > 0 {
+                    open_brace -= 1;
+                }
+            }
+            '<' if in_quote.is_none() && open_brace == 0 => {
                 open_angle += 1;
             }
-            '>' if in_quote.is_none() => {
+            '>' if in_quote.is_none() && open_brace == 0 => {
                 if open_angle == 0 {
                     return Some(offset);
                 }

--- a/crates/oxc_linter/src/loader/partial_loader/mod.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/mod.rs
@@ -62,10 +62,8 @@ fn find_script_closing_angle(source_text: &str, pointer: usize) -> Option<usize>
             '{' if in_quote.is_none() => {
                 open_brace += 1;
             }
-            '}' if in_quote.is_none() => {
-                if open_brace > 0 {
-                    open_brace -= 1;
-                }
+            '}' if in_quote.is_none() && open_brace > 0 => {
+                open_brace -= 1;
             }
             '<' if in_quote.is_none() && open_brace == 0 => {
                 open_angle += 1;

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -143,4 +143,30 @@ mod test {
         );
         assert_eq!(sources[1].source_text.trim(), r#"console.log("hi");"#);
     }
+
+    #[test]
+    fn test_parse_svelte_script_with_callback_attribute() {
+        let source_text = r#"<script>
+let browser = true;
+</script>
+{#if browser}
+  <script src="/" onload={() => {}}></script>
+{/if}"#;
+
+        let sources = SveltePartialLoader::new(source_text).parse();
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].source_text.trim(), "let browser = true;");
+        assert_eq!(sources[1].source_text, "");
+    }
+
+    #[test]
+    fn test_parse_svelte_script_with_callback_attribute_no_component_script() {
+        let source_text = r#"{#if browser}
+  <script src="/" onload={() => {}}></script>
+{/if}"#;
+
+        let sources = SveltePartialLoader::new(source_text).parse();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_text, "");
+    }
 }


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/20349