### PR TITLE
fix(linter/unicorn): report on optional `foo?.postMessage` in `require-post-message-target-origin` rule

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
@@ -66,8 +66,17 @@ impl Rule for RequirePostMessageTargetOrigin {
             return;
         }
         let member_expr = match call_expr.callee.get_member_expr() {
-            // ignore "foo[postMessage](message)" and "foo?.postMessage(message)"
-            Some(expr) if !(expr.is_computed() || expr.optional()) => expr,
+            // ignore "foo[postMessage](message)" and optional members with non-identifier objects
+            Some(expr)
+                if !expr.is_computed()
+                    && (!expr.optional()
+                        || matches!(
+                            expr.object().without_parentheses(),
+                            Expression::Identifier(_)
+                        )) =>
+            {
+                expr
+            }
             _ => return,
         };
         if matches!(member_expr.static_property_name(), Some(name) if name == "postMessage") {
@@ -155,8 +164,7 @@ fn test() {
         "self.postMessage(message)",
         "globalThis.postMessage(message)",
         "foo.postMessage(message )",
-        // TODO: Get this passing.
-        // "foo?.postMessage(message )",
+        "foo?.postMessage(message )",
         "foo.postMessage( ((message)) )",
         "foo.postMessage(message,)",
         "foo.postMessage(message , )",
@@ -179,6 +187,7 @@ fn test() {
             "globalThis.postMessage(message, globalThis.location.origin)",
         ),
         ("foo.postMessage(message )", "foo.postMessage(message, foo.location.origin )"),
+        ("foo?.postMessage(message )", "foo?.postMessage(message, foo.location.origin )"),
         ("window.postMessage(message,)", "window.postMessage(message, window.location.origin,)"),
         (
             "window.postMessage(message,                 /** comments */  )",

--- a/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_require_post_message_target_origin.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 444
 ---
 
   ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
@@ -30,6 +31,14 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[require_post_message_target_origin.tsx:1:24]
  1 │ foo.postMessage(message )
    ·                        ▲
+   ╰────
+  help: Insert `, foo.location.origin`
+  note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+
+  ⚠ eslint-plugin-unicorn(require-post-message-target-origin): Missing the `targetOrigin` argument.
+   ╭─[require_post_message_target_origin.tsx:1:25]
+ 1 │ foo?.postMessage(message )
+   ·                         ▲
    ╰────
   help: Insert `, foo.location.origin`
   note: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage


### PR DESCRIPTION
fixes commented out test for optional `foo?.postMessage` in `unicorn/require-post-message-target-origin` rule