### PR TITLE
fix(formatter): remove extra outer parentheses on return with JSDoc type cast

### DIFF
--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -151,9 +151,10 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
         }
 
         let is_own_line_comment_or_multi_line_comment = |leading_comments: &[Comment]| {
-            leading_comments
-                .iter()
-                .any(|comment| comment.is_multiline_block() || comment.preceded_by_newline())
+            leading_comments.iter().any(|comment| {
+                (comment.is_multiline_block() || comment.preceded_by_newline())
+                    && type_cast_comment_end.is_none_or(|end| comment.span.start < end)
+            })
         };
 
         // Yield expressions only need to check the leading comments on the left side.

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -145,7 +145,7 @@ fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'
 
         if leading_comments.iter().any(|comment| {
             (comment.is_multiline_block() || comment.followed_by_newline())
-                && !type_cast_comment_end.is_some_and(|end| comment.span.start >= end)
+                && type_cast_comment_end.is_none_or(|end| comment.span.start < end)
         }) {
             return true;
         }

--- a/crates/oxc_formatter/src/print/return_or_throw_statement.rs
+++ b/crates/oxc_formatter/src/print/return_or_throw_statement.rs
@@ -131,15 +131,22 @@ impl<'a> Format<'a> for FormatAdjacentArgument<'a, '_> {
 /// Traversing the left nodes is necessary in case the first node is parenthesized because
 /// parentheses will be removed (and be re-added by the return statement, but only if the argument breaks)
 fn has_argument_leading_comments(argument: &AstNode<Expression>, f: &Formatter<'_, '_>) -> bool {
+    let comments = f.context().comments();
+
+    // Comments inside type cast parens (e.g., `/** @type {X} */ (/* here */ expr)`) are handled
+    // by `format_type_cast_comment_node` and should not trigger outer parenthesization.
+    let type_cast_comment_end = comments
+        .get_type_cast_comment_index(argument.span())
+        .map(|idx| comments.unprinted_comments()[idx].span.end);
+
     for left_side in ExpressionLeftSide::from(argument).iter() {
         let start = left_side.span().start;
-        let comments = f.context().comments();
         let leading_comments = comments.comments_before(start);
 
-        if leading_comments
-            .iter()
-            .any(|comment| comment.is_multiline_block() || comment.followed_by_newline())
-        {
+        if leading_comments.iter().any(|comment| {
+            (comment.is_multiline_block() || comment.followed_by_newline())
+                && !type_cast_comment_end.is_some_and(|end| comment.span.start >= end)
+        }) {
             return true;
         }
 

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
@@ -1,0 +1,24 @@
+// https://github.com/oxc-project/oxc/issues/20183
+function get_attributes(element) {
+	return /** @type {Record<string | symbol, unknown>} */ (
+		// @ts-expect-error
+		element.__attributes ??= {
+			[IS_CUSTOM_ELEMENT]: element.nodeName.includes('-'),
+			[IS_HTML]: element.namespaceURI === NAMESPACE_HTML
+		}
+	);
+}
+
+function simple_type_cast() {
+	return /** @type {string} */ (value);
+}
+
+function throw_type_cast() {
+	throw /** @type {Error} */ (err);
+}
+
+function satisfies_type_cast() {
+	return /** @satisfies {Record<string, unknown>} */ ({
+		key: "value"
+	});
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
@@ -22,3 +22,8 @@ function satisfies_type_cast() {
 		key: "value"
 	});
 }
+
+function long_type_cast_in_return() {
+	return (/** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+		(fooBarBaz));
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js
@@ -27,3 +27,13 @@ function long_type_cast_in_return() {
 	return (/** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
 		(fooBarBaz));
 }
+
+function type_cast_member_expression() {
+	return (
+		/** @type {X} */ (
+			obj
+				// comment
+				.prop
+		)
+	);
+}

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
@@ -32,6 +32,16 @@ function long_type_cast_in_return() {
 		(fooBarBaz));
 }
 
+function type_cast_member_expression() {
+	return (
+		/** @type {X} */ (
+			obj
+				// comment
+				.prop
+		)
+	);
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -68,6 +78,14 @@ function long_type_cast_in_return() {
   );
 }
 
+function type_cast_member_expression() {
+  return /** @type {X} */ (
+    obj
+      // comment
+      .prop
+  );
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -100,6 +118,14 @@ function long_type_cast_in_return() {
   return (
     /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
     (fooBarBaz)
+  );
+}
+
+function type_cast_member_expression() {
+  return /** @type {X} */ (
+    obj
+      // comment
+      .prop
   );
 }
 

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
@@ -27,6 +27,11 @@ function satisfies_type_cast() {
 	});
 }
 
+function long_type_cast_in_return() {
+	return (/** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+		(fooBarBaz));
+}
+
 ==================== Output ====================
 ------------------
 { printWidth: 80 }
@@ -56,6 +61,13 @@ function satisfies_type_cast() {
   });
 }
 
+function long_type_cast_in_return() {
+  return (
+    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+    (fooBarBaz)
+  );
+}
+
 -------------------
 { printWidth: 100 }
 -------------------
@@ -82,6 +94,13 @@ function satisfies_type_cast() {
   return /** @satisfies {Record<string, unknown>} */ ({
     key: "value",
   });
+}
+
+function long_type_cast_in_return() {
+  return (
+    /** @type {ThisIsAVeryLongTypeThatShouldTriggerLineWrapping} */
+    (fooBarBaz)
+  );
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
+++ b/crates/oxc_formatter/tests/fixtures/js/comments/return-type-cast.js.snap
@@ -1,0 +1,87 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// https://github.com/oxc-project/oxc/issues/20183
+function get_attributes(element) {
+	return /** @type {Record<string | symbol, unknown>} */ (
+		// @ts-expect-error
+		element.__attributes ??= {
+			[IS_CUSTOM_ELEMENT]: element.nodeName.includes('-'),
+			[IS_HTML]: element.namespaceURI === NAMESPACE_HTML
+		}
+	);
+}
+
+function simple_type_cast() {
+	return /** @type {string} */ (value);
+}
+
+function throw_type_cast() {
+	throw /** @type {Error} */ (err);
+}
+
+function satisfies_type_cast() {
+	return /** @satisfies {Record<string, unknown>} */ ({
+		key: "value"
+	});
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// https://github.com/oxc-project/oxc/issues/20183
+function get_attributes(element) {
+  return /** @type {Record<string | symbol, unknown>} */ (
+    // @ts-expect-error
+    element.__attributes ??= {
+      [IS_CUSTOM_ELEMENT]: element.nodeName.includes("-"),
+      [IS_HTML]: element.namespaceURI === NAMESPACE_HTML,
+    }
+  );
+}
+
+function simple_type_cast() {
+  return /** @type {string} */ (value);
+}
+
+function throw_type_cast() {
+  throw /** @type {Error} */ (err);
+}
+
+function satisfies_type_cast() {
+  return /** @satisfies {Record<string, unknown>} */ ({
+    key: "value",
+  });
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// https://github.com/oxc-project/oxc/issues/20183
+function get_attributes(element) {
+  return /** @type {Record<string | symbol, unknown>} */ (
+    // @ts-expect-error
+    element.__attributes ??= {
+      [IS_CUSTOM_ELEMENT]: element.nodeName.includes("-"),
+      [IS_HTML]: element.namespaceURI === NAMESPACE_HTML,
+    }
+  );
+}
+
+function simple_type_cast() {
+  return /** @type {string} */ (value);
+}
+
+function throw_type_cast() {
+  throw /** @type {Error} */ (err);
+}
+
+function satisfies_type_cast() {
+  return /** @satisfies {Record<string, unknown>} */ ({
+    key: "value",
+  });
+}
+
+===================== End =====================


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/20183