### PR TITLE
test(linter): typecheck files even when zero rules are enabled

### DIFF
--- a/apps/oxlint/fixtures/cli/tsgolint_type_error/config-type-check-zero-rules.json
+++ b/apps/oxlint/fixtures/cli/tsgolint_type_error/config-type-check-zero-rules.json
@@ -1,0 +1,9 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  }
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1393,6 +1393,13 @@ mod test {
 
     #[test]
     #[cfg(not(target_endian = "big"))]
+    fn test_tsgolint_type_check_with_zero_rules_enabled() {
+        let args = &["-c", "config-type-check-zero-rules.json"];
+        Tester::new().with_cwd("fixtures/cli/tsgolint_type_error".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    #[cfg(not(target_endian = "big"))]
     fn test_tsgolint_type_check_false_via_config_file() {
         let args = &["-c", "config-type-check-false.json"];
         Tester::new().with_cwd("fixtures/cli/tsgolint_type_error".into()).test_and_snapshot(args);

--- a/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-zero-rules.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__cli__tsgolint_type_error_-c config-type-check-zero-rules.json@oxlint.snap
@@ -1,0 +1,19 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c config-type-check-zero-rules.json
+working directory: fixtures/cli/tsgolint_type_error
+----------
+
+  x typescript(TS2322): Type 'string' is not assignable to type 'number'.
+   ,-[index.ts:1:7]
+ 1 | const foo: number = "42";
+   :       ^^^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 2 files with 0 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
not sure we had test coverage here previously, but it's important this case doesn't regress