### PR TITLE
fix(linter/no-array-index-key): false positive when index is inside an expression within a template literal

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -148,7 +148,7 @@ fn expression_uses_index(ctx: &LintContext, symbol_id: SymbolId, expr: &Expressi
     match expr {
         // key={`abc${index}`}
         Expression::TemplateLiteral(tmpl) => {
-            tmpl.expressions.iter().any(|e| expression_uses_index(ctx, symbol_id, e))
+            tmpl.expressions.iter().any(|e| is_index_reference(ctx, symbol_id, e))
         }
         // key={1 + index}
         Expression::BinaryExpression(bin) => binary_expression_uses_index(ctx, symbol_id, bin),
@@ -314,6 +314,23 @@ fn test() {
             React.cloneElement(thing, { key: getKey(thing.id, index) })
           ));
         ",
+        // https://github.com/oxc-project/oxc/issues/21110
+        r"things.map((thing, index) => (
+            <Hello key={`${thing.type + index}`} />
+          ));
+        ",
+        r"things.map((thing, index) => (
+            React.cloneElement(thing, { key: `${thing.type + index}` })
+          ));
+        ",
+        r"things.map((thing, index) => (
+            <Hello key={`abc${String(index)}`} />
+          ));
+        ",
+        r"things.map((thing, index) => (
+            React.cloneElement(thing, { key: `abc${index.toString()}` })
+          ));
+        ",
     ];
 
     let fail = vec![
@@ -396,19 +413,11 @@ fn test() {
           ));
         ",
         r"things.map((thing, index) => (
-            <Hello key={`abc${String(index)}`} />
-          ));
-        ",
-        r"things.map((thing, index) => (
             React.cloneElement(thing, { key: index.toString() })
           ));
         ",
         r"things.map((thing, index) => (
             React.cloneElement(thing, { key: String(index) })
-          ));
-        ",
-        r"things.map((thing, index) => (
-            React.cloneElement(thing, { key: `abc${index.toString()}` })
           ));
         ",
     ];

--- a/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
+
   ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
    ╭─[no_array_index_key.tsx:2:20]
  1 │ things.map((thing, index) => (

--- a/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-
   ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
    ╭─[no_array_index_key.tsx:2:20]
  1 │ things.map((thing, index) => (
@@ -174,15 +173,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a unique data-dependent key to avoid unnecessary rerenders
 
   ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
-   ╭─[no_array_index_key.tsx:2:20]
- 1 │ things.map((thing, index) => (
- 2 │             <Hello key={`abc${String(index)}`} />
-   ·                    ───────────────────────────
- 3 │           ));
-   ╰────
-  help: Use a unique data-dependent key to avoid unnecessary rerenders
-
-  ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
    ╭─[no_array_index_key.tsx:2:41]
  1 │ things.map((thing, index) => (
  2 │             React.cloneElement(thing, { key: index.toString() })
@@ -196,15 +186,6 @@ source: crates/oxc_linter/src/tester.rs
  1 │ things.map((thing, index) => (
  2 │             React.cloneElement(thing, { key: String(index) })
    ·                                         ──────────────────
- 3 │           ));
-   ╰────
-  help: Use a unique data-dependent key to avoid unnecessary rerenders
-
-  ⚠ eslint-plugin-react(no-array-index-key): Usage of Array index in keys is not allowed
-   ╭─[no_array_index_key.tsx:2:41]
- 1 │ things.map((thing, index) => (
- 2 │             React.cloneElement(thing, { key: `abc${index.toString()}` })
-   ·                                         ─────────────────────────────
  3 │           ));
    ╰────
   help: Use a unique data-dependent key to avoid unnecessary rerenders


### PR DESCRIPTION
Closes #21110

Related: #21012

## Summary

The `TemplateLiteral` branch in `expression_uses_index` was calling `expression_uses_index` recursively, so it detected index even when wrapped in a binary expression or function call inside `${...}`. ESLint only checks for direct index references, so replaced with `is_index_reference`.

### ESLint comparison (inside template literals)

| Pattern | ESLint | oxlint (before) | oxlint (after) |
|---|---|---|---|
| `` `abc${index}` `` | error | error | error |
| `` `${item.type + index}` `` | pass | error | pass |
| `` `abc${String(index)}` `` | pass | error | pass |
| `` `abc${index.toString()}` `` | pass | error | pass |