### PR TITLE
refactor(napi/parser, linter/plugins): add `int32` buffer view

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.d.ts
+++ b/apps/oxlint/src-js/generated/deserialize.d.ts
@@ -3,7 +3,11 @@
 
 import type { Program } from "./types.d.ts";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserializeProgramOnly(
   buffer: BufferWithArrays,

--- a/apps/oxlint/src-js/package/parse.ts
+++ b/apps/oxlint/src-js/package/parse.ts
@@ -100,6 +100,7 @@ export function initBuffer() {
   const offset = getBufferOffset(new Uint8Array(arrayBuffer));
   buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE) as BufferWithArrays;
   buffer.uint32 = new Uint32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
+  buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
 
   // Store in `buffers`, at index 0

--- a/apps/oxlint/src-js/plugins/lint.ts
+++ b/apps/oxlint/src-js/plugins/lint.ts
@@ -133,6 +133,7 @@ export function lintFileImpl(
     typeAssertIs<BufferWithArrays>(buffer);
     const { buffer: arrayBuffer, byteOffset } = buffer;
     buffer.uint32 = new Uint32Array(arrayBuffer, byteOffset);
+    buffer.int32 = new Int32Array(arrayBuffer, byteOffset);
     buffer.float64 = new Float64Array(arrayBuffer, byteOffset);
 
     for (let i = bufferId - buffers.length; i >= 0; i--) {

--- a/apps/oxlint/src-js/plugins/types.ts
+++ b/apps/oxlint/src-js/plugins/types.ts
@@ -26,5 +26,6 @@ export type NodeOrToken = Node | Token | Comment;
 // Buffer with typed array views of itself stored as properties.
 export interface BufferWithArrays extends Uint8Array {
   uint32: Uint32Array;
+  int32: Int32Array;
   float64: Float64Array;
 }

--- a/napi/parser/src-js/generated/deserialize/js.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/js_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_parent.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/js_range.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_range.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/ts.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/ts_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/ts_range.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_range.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.d.ts
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.d.ts
@@ -3,7 +3,11 @@
 
 import type * as ESTree from "@oxc-project/types";
 
-type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+type BufferWithArrays = Uint8Array & {
+  uint32: Uint32Array;
+  int32: Int32Array;
+  float64: Float64Array;
+};
 
 export declare function deserialize(
   buffer: BufferWithArrays,

--- a/napi/parser/src-js/raw-transfer/common.js
+++ b/napi/parser/src-js/raw-transfer/common.js
@@ -271,6 +271,7 @@ function createBuffer() {
   const offset = getBufferOffset(new Uint8Array(arrayBuffer));
   const buffer = new Uint8Array(arrayBuffer, offset, BUFFER_SIZE);
   buffer.uint32 = new Uint32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
+  buffer.int32 = new Int32Array(arrayBuffer, offset, BUFFER_SIZE / 4);
   buffer.float64 = new Float64Array(arrayBuffer, offset, BUFFER_SIZE / 8);
   return buffer;
 }

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -144,7 +144,7 @@ fn generate_deserializers(
         import {{ getNodeLoc }} from '../plugins/location.js';
         /* END_IF */
 
-        let uint8, uint32, float64, sourceText, sourceTextLatin,
+        let uint8, uint32, int32, float64, sourceText, sourceTextLatin,
             sourceStartPos = 0, sourceEndPos = 0, firstNonAsciiPos = 0;
 
         let parent = null;
@@ -190,6 +190,7 @@ fn generate_deserializers(
         function deserializeWith(buffer, sourceTextInput, sourceByteLen, deserialize) {{
             uint8 = buffer;
             uint32 = buffer.uint32;
+            int32 = buffer.int32;
             float64 = buffer.float64;
 
             sourceText = sourceTextInput;
@@ -232,7 +233,7 @@ fn generate_deserializers(
 
         export function resetBuffer() {{
             // Clear buffer and source text strings to allow them to be garbage collected
-            uint8 = uint32 = float64 = sourceText = sourceTextLatin = undefined;
+            uint8 = uint32 = int32 = float64 = sourceText = sourceTextLatin = undefined;
         }}
     ");
 
@@ -241,7 +242,11 @@ fn generate_deserializers(
     let code_type_definition_linter = "
         import type { Program } from './types.d.ts';
 
-        type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+        type BufferWithArrays = Uint8Array & {
+            uint32: Uint32Array;
+            int32: Int32Array;
+            float64: Float64Array;
+        };
 
         export declare function deserializeProgramOnly(
             buffer: BufferWithArrays,
@@ -258,7 +263,11 @@ fn generate_deserializers(
     let code_type_definition_parser = "
         import type * as ESTree from '@oxc-project/types';
 
-        type BufferWithArrays = Uint8Array & { uint32: Uint32Array; float64: Float64Array };
+        type BufferWithArrays = Uint8Array & {
+            uint32: Uint32Array;
+            int32: Int32Array;
+            float64: Float64Array;
+        };
 
         export declare function deserialize(
             buffer: BufferWithArrays,


### PR DESCRIPTION
Add an `Int32Array` view of the buffer for raw transfer. It will be used in PRs later in this stack.